### PR TITLE
Fail realtime get request if it is stale due to resharding

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
@@ -72,7 +72,8 @@ public class TransportGetFromTranslogAction extends HandledTransportAction<
                         getRequest.version(),
                         getRequest.versionType(),
                         getRequest.fetchSourceContext(),
-                        getRequest.isForceSyntheticSource()
+                        getRequest.isForceSyntheticSource(),
+                        getRequest.getSplitShardCountSummary()
                     );
                 long segmentGeneration = -1;
                 if (result == null) {

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportActions;
+import org.elasticsearch.cluster.routing.SplitShardCountSummary;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -75,7 +76,8 @@ public class TransportShardMultiGetFomTranslogAction extends HandledTransportAct
                                 item.version(),
                                 item.versionType(),
                                 item.fetchSourceContext(),
-                                multiGetShardRequest.isForceSyntheticSource()
+                                multiGetShardRequest.isForceSyntheticSource(),
+                                SplitShardCountSummary.UNSET
                             );
                         GetResponse getResponse = null;
                         if (result == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -276,7 +276,8 @@ public abstract class IndexRouting {
         @Override
         public int getShard(String id, @Nullable String routing) {
             checkRoutingRequired(id, routing);
-            return shardId(id, routing);
+            int shardId = shardId(id, routing);
+            return rerouteSearchIfResharding(shardId);
         }
 
         private void checkRoutingRequired(String id, @Nullable String routing) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
@@ -850,7 +850,7 @@ public class IndexRoutingTests extends ESTestCase {
         );
     }
 
-    public void testCollectSearchShardsUnpartitionedWithResharding() throws IOException {
+    public void testCollectSearchShardsUnpartitionedAndGetWithResharding() {
         int shards = 1;
         int newShardCount = 2;
         var initialRouting = IndexRouting.fromIndexMetadata(
@@ -885,6 +885,7 @@ public class IndexRoutingTests extends ESTestCase {
             assertEquals(1, collectedShards.size());
             // Rerouting is in effect due to resharding metadata having a shard in CLONE state.
             assertEquals(0, collectedShards.get(0));
+            assertEquals(0, initialReshardingRouting.getShard(shardAndRouting.getValue(), null));
         }
 
         var reshardingRoutingWithShardInHandoff = IndexRouting.fromIndexMetadata(
@@ -903,8 +904,9 @@ public class IndexRoutingTests extends ESTestCase {
             var collectedShards = new ArrayList<>();
             reshardingRoutingWithShardInHandoff.collectSearchShards(shardAndRouting.getValue(), collectedShards::add);
             assertEquals(1, collectedShards.size());
-            // Rerouting is in effect due to resharding metadata having a shard in CLONE state.
+            // Rerouting is in effect due to resharding metadata having a shard in HANDOFF state.
             assertEquals(0, collectedShards.get(0));
+            assertEquals(0, reshardingRoutingWithShardInHandoff.getShard(shardAndRouting.getValue(), null));
         }
 
         var reshardingRoutingWithShardInSplit = IndexRouting.fromIndexMetadata(
@@ -926,6 +928,7 @@ public class IndexRoutingTests extends ESTestCase {
             assertEquals(1, collectedShards.size());
             // Rerouting is no longer in effect since resharding metadata has SPLIT state for this shard
             assertEquals(shardAndRouting.getKey(), collectedShards.get(0));
+            assertEquals(shardAndRouting.getKey().intValue(), reshardingRoutingWithShardInSplit.getShard(shardAndRouting.getValue(), null));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
@@ -363,7 +363,16 @@ public class ShardGetServiceTests extends IndexShardTestCase {
 
         // Issue a get that would enforce safe access mode and switches the maps from unsafe to safe
         var getResult = primary.getService()
-            .getFromTranslog("2", new String[] { "foo" }, true, 1, VersionType.INTERNAL, FetchSourceContext.FETCH_SOURCE, false);
+            .getFromTranslog(
+                "2",
+                new String[] { "foo" },
+                true,
+                1,
+                VersionType.INTERNAL,
+                FetchSourceContext.FETCH_SOURCE,
+                false,
+                SplitShardCountSummary.UNSET
+            );
         assertNull(getResult);
         var lastUnsafeGeneration = engine.getLastUnsafeSegmentGenerationForGets();
         // last unsafe generation is set to last committed gen after the refresh triggered by realtime get
@@ -387,7 +396,8 @@ public class ShardGetServiceTests extends IndexShardTestCase {
                 1,
                 VersionType.INTERNAL,
                 FetchSourceContext.FETCH_SOURCE,
-                false
+                false,
+                SplitShardCountSummary.UNSET
             );
         assertNull(getResult);
         // But normal get would still work!
@@ -413,11 +423,29 @@ public class ShardGetServiceTests extends IndexShardTestCase {
         indexDoc(primary, "1", "{\"foo\" : \"baz\"}", XContentType.JSON, "foobar");
         // The first get in safe mode, would trigger a refresh, since we need to start tracking translog locations in the live version map
         getResult = primary.getService()
-            .getFromTranslog("1", new String[] { "foo" }, true, 1, VersionType.INTERNAL, FetchSourceContext.FETCH_SOURCE, false);
+            .getFromTranslog(
+                "1",
+                new String[] { "foo" },
+                true,
+                1,
+                VersionType.INTERNAL,
+                FetchSourceContext.FETCH_SOURCE,
+                false,
+                SplitShardCountSummary.UNSET
+            );
         assertTrue(getResult.isExists());
         assertEquals(engine.getLastUnsafeSegmentGenerationForGets(), lastUnsafeGeneration);
         getResult = primary.getService()
-            .getFromTranslog("2", new String[] { "foo" }, true, 1, VersionType.INTERNAL, FetchSourceContext.FETCH_SOURCE, false);
+            .getFromTranslog(
+                "2",
+                new String[] { "foo" },
+                true,
+                1,
+                VersionType.INTERNAL,
+                FetchSourceContext.FETCH_SOURCE,
+                false,
+                SplitShardCountSummary.UNSET
+            );
         assertNull(getResult);
         assertEquals(engine.getLastUnsafeSegmentGenerationForGets(), lastUnsafeGeneration);
 
@@ -435,7 +463,16 @@ public class ShardGetServiceTests extends IndexShardTestCase {
         assertFalse(LiveVersionMapTestUtils.isSafeAccessRequired(map));
         assertTrue(LiveVersionMapTestUtils.isUnsafe(map));
         getResult = primary.getService()
-            .getFromTranslog("2", new String[] { "foo" }, true, 1, VersionType.INTERNAL, FetchSourceContext.FETCH_SOURCE, false);
+            .getFromTranslog(
+                "2",
+                new String[] { "foo" },
+                true,
+                1,
+                VersionType.INTERNAL,
+                FetchSourceContext.FETCH_SOURCE,
+                false,
+                SplitShardCountSummary.UNSET
+            );
         assertNull(getResult);
         var lastUnsafeGeneration2 = engine.getLastUnsafeSegmentGenerationForGets();
         assertTrue(lastUnsafeGeneration2 > lastUnsafeGeneration);


### PR DESCRIPTION
During resharding, a get request may become stale if the shard that owns the requested document changes between the time that the request is formed and when it is processed. We can detect whether this has happened by comparing the current routing of the document based on the routing table to the shard that has actually processed the document. If there is a mismatch, we fail the request.

Later this failure should be handled by internally retrying the request with a fresh route, but for correctness we do need to start by rejecting the request if it has been routed to the wrong shard.
