### PR TITLE
Fix typos: occured -> occurred, seperate -> separate, teh -> the

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/MockServer.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/MockServer.java
@@ -111,7 +111,7 @@ public class MockServer {
     /**
      * Returns all interactions with the mockserver since startup, the last call to {@link #reset()} or the
      * last call to {@link #clearExpectations()}. The JSON returned by the mockserver is flattened, so that
-     * the period-seperated keys in each map represent the structure of the JSON.
+     * the period-separated keys in each map represent the structure of the JSON.
      *
      * @return a list of interactions
      * @throws Exception if anything goes wrong

--- a/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-// It's not possible to suppress teh warning at #realtime(boolean) at a method-level.
+// It's not possible to suppress the warning at #realtime(boolean) at a method-level.
 @SuppressWarnings("unchecked")
 public class MultiTermVectorsRequest extends LegacyActionRequest
     implements

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -46,7 +46,7 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
  * <p>
  * Note, the {@link #index()} and {@link #id(String)} are required.
  */
-// It's not possible to suppress teh warning at #realtime(boolean) at a method-level.
+// It's not possible to suppress the warning at #realtime(boolean) at a method-level.
 @SuppressWarnings("unchecked")
 public final class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> implements RealtimeRequest {
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAutoShardingEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAutoShardingEvent.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.util.function.LongSupplier;
 
 /**
- * Represents the last auto sharding event that occured for a data stream.
+ * Represents the last auto sharding event that occurred for a data stream.
  */
 public record DataStreamAutoShardingEvent(String triggerIndexName, int targetNumberOfShards, long timestamp)
     implements

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -119,7 +119,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
      * Return an iterator for all keys in the given owning bucket, ordered in natural sort order.
      * This is suitable for aligning buckets across different instances of an aggregation.
      *
-     * @param owningBucketOrd Only return keys that occured under this owning bucket
+     * @param owningBucketOrd Only return keys that occurred under this owning bucket
      * @return a sorted iterator of long key values
      */
     public Iterator<Long> keyOrderedIterator(long owningBucketOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/package-info.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/package-info.java
@@ -19,7 +19,7 @@
  *     <li>Bucket aggregations - which group documents (e.g. a histogram)</li>
  *     <li>Metric aggregations - which compute a summary value from several
  *     documents (e.g. a sum)</li>
- *     <li>Pipeline aggregations - which run as a seperate step and compute
+ *     <li>Pipeline aggregations - which run as a separate step and compute
  *     values across buckets</li>
  * </ul>
  * Additionally there is a support sub package, which contains the type checking

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -537,7 +537,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
     }
 
     /**
-     * Tests that teh {@link MapperService} created by {@link IndicesService#createIndexMapperServiceForValidation(IndexMetadata)} contains
+     * Tests that the {@link MapperService} created by {@link IndicesService#createIndexMapperServiceForValidation(IndexMetadata)} contains
      * custom types and similarities registered by plugins
      */
     public void testStandAloneMapperServiceWithPlugins() throws IOException {


### PR DESCRIPTION
Fixes spelling errors in comments and documentation.

## Changes

### occured → occurred
- `DataStreamAutoShardingEvent.java`
- `LongKeyedBucketOrds.java`

### seperate → separate
- `MockServer.java` (period-separated)
- `package-info.java` (aggregations)

### teh → the
- `IndicesServiceTests.java`
- `MultiTermVectorsRequest.java`
- `TermVectorsRequest.java`

Note: Intentionally did not change `"Xor teh Got-Jewel"` in test data as that's intentional test input for spell checking tests.