### PR TITLE
[9.3] [CI] Cache fallback adoptjdk17 when baking ci images (#141527)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -179,7 +179,7 @@ public class BwcSetupExtension {
     /** A convenience method for getting java home for a version of java and requiring that version for the given task to execute */
     private static Provider<String> getJavaHome(ObjectFactory objectFactory, JavaToolchainService toolChainService, final int version) {
         Property<JavaLanguageVersion> value = objectFactory.property(JavaLanguageVersion.class).value(JavaLanguageVersion.of(version));
-        return toolChainService.launcherFor(javaToolchainSpec -> { javaToolchainSpec.getLanguageVersion().value(value); })
+        return toolChainService.launcherFor(javaToolchainSpec -> javaToolchainSpec.getLanguageVersion().value(value))
             .map(launcher -> launcher.getMetadata().getInstallationPath().getAsFile().getAbsolutePath());
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.internal.test.rest.RestTestBasePlugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
@@ -28,6 +29,8 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+
+import static org.elasticsearch.gradle.util.GradleUtils.withRetries;
 
 public abstract class ResolveAllDependencies extends DefaultTask {
 
@@ -64,8 +67,15 @@ public abstract class ResolveAllDependencies extends DefaultTask {
     @TaskAction
     void resolveAll() {
         if (resolveJavaToolChain) {
-            resolveDefaultJavaToolChain();
+            withRetries(() -> {
+                resolveDefaultJavaToolChain();
+                resolveJdk17FallbackJavaToolChain();
+            });
         }
+    }
+
+    private void resolveJdk17FallbackJavaToolChain() {
+        getJavaToolchainService().launcherFor(RestTestBasePlugin.JAVA_TOOLCHAIN_JDK_ADOPTIUM_SPEC_ACTION).get();
     }
 
     private void resolveDefaultJavaToolChain() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.util.Collection;
@@ -87,6 +88,10 @@ public class RestTestBasePlugin implements Plugin<Project> {
     private static final String DEFAULT_DISTRO_FEATURES_METADATA_CONFIGURATION = "defaultDistrofeaturesMetadataDeps";
     private static final String TESTS_FEATURES_METADATA_PATH = "tests.features.metadata.path";
     private static final String MINIMUM_WIRE_COMPATIBLE_VERSION_SYSPROP = "tests.minimum.wire.compatible";
+    public static final Action<JavaToolchainSpec> JAVA_TOOLCHAIN_JDK_ADOPTIUM_SPEC_ACTION = spec -> {
+        spec.getVendor().set(JvmVendorSpec.ADOPTIUM);
+        spec.getLanguageVersion().set(JavaLanguageVersion.of(17));
+    };
 
     private final ProviderFactory providerFactory;
 
@@ -299,10 +304,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
     private static void handleJdkIncompatibleWithOS(Version version, Project project, StandaloneRestIntegTestTask task) {
         if (jdkIsIncompatibleWithOS(version)) {
             var toolChainService = project.getExtensions().getByType(JavaToolchainService.class);
-            var fallbackJdk17Launcher = toolChainService.launcherFor(spec -> {
-                spec.getVendor().set(JvmVendorSpec.ADOPTIUM);
-                spec.getLanguageVersion().set(JavaLanguageVersion.of(17));
-            });
+            var fallbackJdk17Launcher = toolChainService.launcherFor(JAVA_TOOLCHAIN_JDK_ADOPTIUM_SPEC_ACTION);
             task.environment(
                 "ES_FALLBACK_JAVA_HOME",
                 fallbackJdk17Launcher.get().getMetadata().getInstallationPath().getAsFile().getPath()

--- a/build.gradle
+++ b/build.gradle
@@ -443,19 +443,6 @@ allprojects {
     tasks.matching { it.name.equals('integTest') }.configureEach { integTestTask ->
       integTestTask.mustRunAfter tasks.matching { it.name.equals("test") }
     }
-
-/*    configurations.matching { it.canBeResolved }.all { Configuration configuration ->
-      dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
-        Project upstreamProject = dep.dependencyProject
-        if (project.path != upstreamProject?.path) {
-          for (String taskName : ['test', 'integTest']) {
-            project.tasks.matching { it.name == taskName }.configureEach { task ->
-              task.shouldRunAfter(upstreamProject.tasks.matching { upStreamTask -> upStreamTask.name == taskName })
-            }
-          }
-        }
-      }
-    }*/
   }
 
   apply plugin: 'elasticsearch.formatting'


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [CI] Cache fallback adoptjdk17 when baking ci images (#141527)