### PR TITLE
build: fix ParallelDetector on multi-socket

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -58,7 +58,7 @@ public class ParallelDetector {
                             // Number of cores not including hyper-threading
                             if (name.equals("cpu cores")) {
                                 assert currentID.isEmpty() == false;
-                                socketToCore.put("currentID", Integer.valueOf(value));
+                                socketToCore.put(currentID, Integer.valueOf(value));
                                 currentID = "";
                             }
                         }


### PR DESCRIPTION
If there are multiple physical CPUs, ParallelDetector will undercount cores since it is counting by a constant rather than the physical ID.