### PR TITLE
[9.2] update timeout (#141588)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -468,6 +468,7 @@ tests:
   method: testConcurrentStatusFetchWhileTaskCloses
   issue: https://github.com/elastic/elasticsearch/issues/138543
 
+
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -464,9 +464,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/139806
-- class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
-  method: testConcurrentStatusFetchWhileTaskCloses
-  issue: https://github.com/elastic/elasticsearch/issues/138543
 
 
 # Examples:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -465,7 +465,6 @@ tests:
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/139806
 
-
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
@@ -76,7 +76,7 @@ public class AsyncSearchConcurrentStatusIT extends AsyncSearchIntegTestCase {
      * is closing and some status calls may return {@code 410 GONE}.
      */
     public void testConcurrentStatusFetchWhileTaskCloses() throws Exception {
-        final TimeValue timeout = TimeValue.timeValueSeconds(3);
+        final TimeValue timeout = TimeValue.timeValueSeconds(30);
         final String aggName = "terms";
         final SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
             AggregationBuilders.terms(aggName).field("terms.keyword").size(Math.max(1, numKeywords))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [update timeout (#141588)](https://github.com/elastic/elasticsearch/pull/141588)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)