### PR TITLE
Rename Reindexer.execute to executeWithScroll

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -113,7 +113,12 @@ public class Reindexer {
         BulkByScrollParallelizationHelper.initTaskState(task, request, client, listener);
     }
 
-    public void execute(BulkByScrollTask task, ReindexRequest request, Client bulkClient, ActionListener<BulkByScrollResponse> listener) {
+    public void executeWithScroll(
+        BulkByScrollTask task,
+        ReindexRequest request,
+        Client bulkClient,
+        ActionListener<BulkByScrollResponse> listener
+    ) {
         long startTime = System.nanoTime();
 
         BulkByScrollParallelizationHelper.executeSlicedAction(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -111,7 +111,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         reindexer.initTask(
             bulkByScrollTask,
             request,
-            listener.delegateFailure((l, v) -> reindexer.execute(bulkByScrollTask, request, getBulkClient(), l))
+            listener.delegateFailure((l, v) -> reindexer.executeWithScroll(bulkByScrollTask, request, getBulkClient(), l))
         );
     }
 


### PR DESCRIPTION
Renames the `Reindexer.execute` method to `Reindexer.executeWithScroll` in preparation for the arrival of `executeWithPit` which will encapsulate the new PIT logic.

Relates elastic/elasticsearch-team/issues/2088
