### PR TITLE
Require ReadOnly step to set markVerified to ensure index is flushed when setting read only

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStep.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStep.java
@@ -52,6 +52,8 @@ public class ReadOnlyStep implements DlmStep {
         AddIndexBlockRequest addIndexBlockRequest = new AddIndexBlockRequest(WRITE, indexName).masterNodeTimeout(
             INFINITE_MASTER_NODE_TIMEOUT
         );
+        // Force a flush while adding the read-only block to ensure all in-flight writes are completed and written to segments
+        addIndexBlockRequest.markVerified(true);
 
         stepContext.executeDeduplicatedRequest(
             addIndexBlockRequest,

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStepTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStepTests.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.WRITE;
@@ -63,6 +64,7 @@ public class ReadOnlyStepTests extends ESTestCase {
     private DataStreamLifecycleErrorStore errorStore;
     private ResultDeduplicator<Tuple<ProjectId, TransportRequest>, Void> deduplicator;
     private AtomicReference<ActionListener<AddIndexBlockResponse>> capturedListener;
+    private AtomicReference<AddIndexBlockRequest> capturedRequest;
 
     @Before
     public void setup() {
@@ -74,6 +76,7 @@ public class ReadOnlyStepTests extends ESTestCase {
         errorStore = new DataStreamLifecycleErrorStore(System::currentTimeMillis);
         deduplicator = new ResultDeduplicator<>(threadPool.getThreadContext());
         capturedListener = new AtomicReference<>();
+        capturedRequest = new AtomicReference<>();
 
         client = new NoOpClient(threadPool, TestProjectResolvers.usingRequestHeader(threadPool.getThreadContext())) {
             @Override
@@ -84,6 +87,7 @@ public class ReadOnlyStepTests extends ESTestCase {
                 ActionListener<Response> listener
             ) {
                 if (request instanceof AddIndexBlockRequest) {
+                    capturedRequest.set((AddIndexBlockRequest) request);
                     capturedListener.set((ActionListener<AddIndexBlockResponse>) listener);
                 }
             }
@@ -180,7 +184,7 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        assertThat(errorStore.getError(projectId, indexName).error(), containsString("not acknowledged"));
+        assertThat(Objects.requireNonNull(errorStore.getError(projectId, indexName)).error(), containsString("not acknowledged"));
     }
 
     public void testExecuteWithUnacknowledgedResponseWithIndexResult() {
@@ -215,7 +219,7 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        assertThat(errorStore.getError(projectId, indexName).error(), containsString("global failure"));
+        assertThat(Objects.requireNonNull(errorStore.getError(projectId, indexName)).error(), containsString("global failure"));
     }
 
     public void testExecuteWithShardFailuresInBlockResult() {
@@ -242,7 +246,7 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded with shard failure details
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        assertThat(errorStore.getError(projectId, indexName).error(), containsString("shard failure"));
+        assertThat(Objects.requireNonNull(errorStore.getError(projectId, indexName)).error(), containsString("shard failure"));
     }
 
     public void testExecuteWithIndexNotFoundExceptionClearsError() {
@@ -271,7 +275,7 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        assertThat(errorStore.getError(projectId, indexName).error(), containsString("some error"));
+        assertThat(Objects.requireNonNull(errorStore.getError(projectId, indexName)).error(), containsString("some error"));
     }
 
     public void testStepCompletedWithDifferentBlocks() {
@@ -330,7 +334,7 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded with both shard failures
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        String errorMessage = errorStore.getError(projectId, indexName).error();
+        String errorMessage = Objects.requireNonNull(errorStore.getError(projectId, indexName)).error();
         assertThat(errorMessage, containsString("shard 0 failure"));
         assertThat(errorMessage, containsString("shard 1 failure"));
     }
@@ -356,7 +360,17 @@ public class ReadOnlyStepTests extends ESTestCase {
 
         // Error should be recorded because response was not acknowledged
         assertThat(errorStore.getError(projectId, indexName), is(notNullValue()));
-        assertThat(errorStore.getError(projectId, indexName).error(), containsString("not acknowledged"));
+        assertThat(Objects.requireNonNull(errorStore.getError(projectId, indexName)).error(), containsString("not acknowledged"));
+    }
+
+    public void testAddIndexBlockRequestHasVerifiedSetToTrue() {
+        ProjectState projectState = createProjectState();
+        DlmStepContext stepContext = createStepContext(projectState);
+
+        readOnlyStep.execute(stepContext);
+
+        assertThat(capturedRequest.get(), is(notNullValue()));
+        assertTrue("AddIndexBlockRequest should have verified set to true", capturedRequest.get().markVerified());
     }
 
     private ProjectState createProjectState() {


### PR DESCRIPTION


<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
