### PR TITLE
Require ReadOnly step to set markVerified to ensure index is flushed during read only step

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStep.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/ReadOnlyStep.java
@@ -52,6 +52,8 @@ public class ReadOnlyStep implements DlmStep {
         AddIndexBlockRequest addIndexBlockRequest = new AddIndexBlockRequest(WRITE, indexName).masterNodeTimeout(
             INFINITE_MASTER_NODE_TIMEOUT
         );
+        // Force a flush while adding the read-only block to ensure all in-flight writes are completed and written to segments
+        addIndexBlockRequest.markVerified(true);
 
         stepContext.executeDeduplicatedRequest(
             addIndexBlockRequest,


### PR DESCRIPTION
This PR enhances the reliability of the read-only transition step for data streams by ensuring all in-flight writes are completed before marking an index as read-only plus tests to ensure markVerified is set on the index block request.
