### PR TITLE
[9.3] Preserve chunking settings during endpoint update

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -205,7 +205,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
      * @param serviceName
      * @return a new object representing the updated model
      */
-    private Model combineExistingModelWithNewSettings(
+    protected Model combineExistingModelWithNewSettings(
         Model existingParsedModel,
         UpdateInferenceModelAction.Settings settingsToUpdate,
         String serviceName,
@@ -238,7 +238,8 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
             existingParsedModel.getTaskType(),
             serviceName,
             newServiceSettings,
-            newTaskSettings
+            newTaskSettings,
+            existingConfigs.getChunkingSettings()
         );
 
         return new Model(newModelConfigs, new ModelSecrets(newSecretSettings));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
@@ -419,7 +419,7 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
     }
 
     public void testCombineExistingModelWithNewSettings_NewServiceAndTaskSettings_UpdatesConfig() {
-        Map<String, Object> newServiceSettingsMap = Map.of("some_service_key", "some_service_value", "num_allocations", 5);
+        Map<String, Object> newServiceSettingsMap = Map.of("some_service_key", "some_service_value");
         var originalServiceSettings = mock(ServiceSettings.class);
         var updatedServiceSettings = mock(ServiceSettings.class);
         when(originalServiceSettings.updateServiceSettings(newServiceSettingsMap)).thenReturn(updatedServiceSettings);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
@@ -175,7 +175,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
         mockLicenseStateIsAllowed(true);
         var model = createModel();
         mockParsePersistedConfigWithSecretsToReturnModel(model);
-        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
 
         var simulatedException = new RuntimeException("update failed");
         doAnswer(invocationOnMock -> {
@@ -199,7 +198,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
         mockLicenseStateIsAllowed(true);
         var model = createModel();
         mockParsePersistedConfigWithSecretsToReturnModel(model);
-        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
 
         mockUpdateModelTransactionToReturnBoolean(false, model);
 
@@ -218,7 +216,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
         mockLicenseStateIsAllowed(true);
         var model = createModel();
         mockParsePersistedConfigWithSecretsToReturnModel(model);
-        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
         mockUpdateModelTransactionToReturnBoolean(true, model);
 
         mockModelRegistryGetModelToReturnUnparsedModel(null);
@@ -238,7 +235,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
         mockLicenseStateIsAllowed(true);
         var model = createModel();
         mockParsePersistedConfigWithSecretsToReturnModel(model);
-        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
         mockUpdateModelTransactionToReturnBoolean(true, model);
 
         var simulatedException = new RuntimeException("updated model not found");
@@ -262,7 +258,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
         mockLicenseStateIsAllowed(true);
         var model = createModel();
         mockParsePersistedConfigWithSecretsToReturnModel(model);
-        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
         mockUpdateModelTransactionToReturnBoolean(true, model);
         mockModelRegistryGetModelToReturnUnparsedModel(unparsedModel);
         mockParsePersistedConfigToReturnModel(model);
@@ -322,12 +317,6 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
 
     private void mockServiceRegistryToReturnService(InferenceService service) {
         when(mockInferenceServiceRegistry.getService(SERVICE_NAME_VALUE)).thenReturn(Optional.ofNullable(service));
-    }
-
-    private void mockUpdateModelWithEmbeddingDetailsToReturnSameModel() {
-        when(service.updateModelWithEmbeddingDetails(any(GoogleVertexAiEmbeddingsModel.class), eq(3))).thenAnswer(
-            invocationOnMock -> invocationOnMock.getArgument(0)
-        );
     }
 
     private void mockUpdateModelTransactionToReturnBoolean(boolean result, GoogleVertexAiEmbeddingsModel model) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.inference.action;
 
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -16,11 +18,21 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.SecretSettings;
+import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -28,38 +40,58 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
+import org.elasticsearch.xpack.core.inference.chunking.NoneChunkingSettings;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiSecretSettings;
+import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModel;
+import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsTaskSettings;
 import org.junit.Before;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class TransportUpdateInferenceModelActionTests extends ESTestCase {
 
+    private static final String INFERENCE_ENTITY_ID_VALUE = "some_inference_entity_id";
+    private static final String LOCATION_INITIAL_VALUE = "some_location";
+    private static final String PROJECT_ID_INITIAL_VALUE = "some_project";
+    private static final String MODEL_ID_INITIAL_VALUE = "some_model";
+    private static final String SERVICE_ACCOUNT_JSON_INITIAL_VALUE = "some_service_account";
+    private static final String SERVICE_NAME_VALUE = "some_service_name";
+    private static final InputType INPUT_TYPE_INITIAL_VALUE = InputType.SEARCH;
+    private static final Boolean AUTO_TRUNCATE_INITIAL_VALUE = Boolean.FALSE;
+
     private MockLicenseState licenseState;
     private TransportUpdateInferenceModelAction action;
-    private ThreadPool threadPool;
     private ModelRegistry mockModelRegistry;
     private InferenceServiceRegistry mockInferenceServiceRegistry;
+    private InferenceService service;
 
     @Before
     public void createAction() throws Exception {
         super.setUp();
-        threadPool = mock(ThreadPool.class);
         mockModelRegistry = mock(ModelRegistry.class);
         mockInferenceServiceRegistry = mock(InferenceServiceRegistry.class);
         licenseState = MockLicenseState.createMock();
+        service = mock(InferenceService.class);
+        when(service.name()).thenReturn(SERVICE_NAME_VALUE);
         action = new TransportUpdateInferenceModelAction(
             mock(TransportService.class),
             mock(ClusterService.class),
-            threadPool,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             licenseState,
             mockModelRegistry,
@@ -67,20 +99,286 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
             mock(Client.class),
             TestProjectResolvers.DEFAULT_PROJECT_ONLY
         );
-
     }
 
-    public void testLicenseCheck_NotAllowed() {
-        mocks("enterprise_licensed_service", false);
+    public void testMasterOperation_ResourceNotFoundExceptionThrown_ThrowsElasticsearchStatusException() {
+        mockGetModelWithSecretsToFailWithException(new ResourceNotFoundException("Model not found"));
 
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(
+            exception.getMessage(),
+            is(Strings.format("The inference endpoint [%s] does not exist and cannot be updated", INFERENCE_ENTITY_ID_VALUE))
+        );
+        verifyNoModelRegistryMutations();
+    }
+
+    public void testMasterOperation_RuntimeExceptionThrown_ThrowsSameException() {
+        var simulatedException = new RuntimeException("Model not found");
+        mockGetModelWithSecretsToFailWithException(simulatedException);
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(simulatedException));
+        verifyNoModelRegistryMutations();
+    }
+
+    public void testMasterOperation_NullReturned_ThrowsElasticsearchStatusException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(null);
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(
+            exception.getMessage(),
+            is(Strings.format("The inference endpoint [%s] does not exist and cannot be updated", INFERENCE_ENTITY_ID_VALUE))
+        );
+        verifyNoModelRegistryMutations();
+    }
+
+    public void testMasterOperation_ServiceNotFoundInRegistry_ThrowsElasticsearchStatusException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+
+        mockServiceRegistryToReturnService(null);
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is(Strings.format("Service [%s] not found", SERVICE_NAME_VALUE)));
+        verifyNoModelRegistryMutations();
+    }
+
+    public void testMasterOperation_LicenseCheckFailed_ThrowsSecurityException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+        mockServiceRegistryToReturnService(service);
+
+        // return false for license check, so the action fails before any other processing
+        mockLicenseStateIsAllowed(false);
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchSecurityException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is("current license is non-compliant for [inference]"));
+        verifyNoModelRegistryMutations();
+    }
+
+    public void testMasterOperation_UpdateModelTransactionFailedDueToRuntimeException_ThrowsSameException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+        mockServiceRegistryToReturnService(service);
+        mockLicenseStateIsAllowed(true);
+        var model = createModel();
+        mockParsePersistedConfigWithSecretsToReturnModel(model);
+        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
+
+        var simulatedException = new RuntimeException("update failed");
+        doAnswer(invocationOnMock -> {
+            ActionListener<Boolean> listener = invocationOnMock.getArgument(2);
+            listener.onFailure(simulatedException);
+            return Void.TYPE;
+        }).when(mockModelRegistry).updateModelTransaction(any(Model.class), eq(model), any());
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(simulatedException));
+        verifyModelRegistryUpdateInvoked();
+    }
+
+    public void testMasterOperation_UpdateModelTransactionReturnedFalse_ThrowsElasticsearchStatusException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+        mockServiceRegistryToReturnService(service);
+        mockLicenseStateIsAllowed(true);
+        var model = createModel();
+        mockParsePersistedConfigWithSecretsToReturnModel(model);
+        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
+
+        mockUpdateModelTransactionToReturnBoolean(false, model);
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is("Failed to update model"));
+        verifyModelRegistryUpdateInvoked();
+    }
+
+    public void testMasterOperation_GetModelReturnedNull_ThrowsElasticsearchStatusException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+        mockServiceRegistryToReturnService(service);
+        mockLicenseStateIsAllowed(true);
+        var model = createModel();
+        mockParsePersistedConfigWithSecretsToReturnModel(model);
+        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
+        mockUpdateModelTransactionToReturnBoolean(true, model);
+
+        mockModelRegistryGetModelToReturnUnparsedModel(null);
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is("Failed to update model, updated model not found"));
+        verifyModelRegistryUpdateInvoked();
+    }
+
+    public void testMasterOperation_GetModelThrownException_ThrowsSameException() {
+        mockGetModelWithSecretsToReturnUnparsedModel(
+            new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of())
+        );
+        mockServiceRegistryToReturnService(service);
+        mockLicenseStateIsAllowed(true);
+        var model = createModel();
+        mockParsePersistedConfigWithSecretsToReturnModel(model);
+        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
+        mockUpdateModelTransactionToReturnBoolean(true, model);
+
+        var simulatedException = new RuntimeException("updated model not found");
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onFailure(simulatedException);
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModel(eq(INFERENCE_ENTITY_ID_VALUE), any());
+
+        var listener = callMasterOperationWithActionFuture();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(simulatedException));
+        verifyModelRegistryUpdateInvoked();
+    }
+
+    public void testMasterOperation_UpdatesModelSettingsSuccessfully() {
+        var unparsedModel = new UnparsedModel(INFERENCE_ENTITY_ID_VALUE, TaskType.TEXT_EMBEDDING, SERVICE_NAME_VALUE, Map.of(), Map.of());
+        mockGetModelWithSecretsToReturnUnparsedModel(unparsedModel);
+        mockServiceRegistryToReturnService(service);
+        mockLicenseStateIsAllowed(true);
+        var model = createModel();
+        mockParsePersistedConfigWithSecretsToReturnModel(model);
+        mockUpdateModelWithEmbeddingDetailsToReturnSameModel();
+        mockUpdateModelTransactionToReturnBoolean(true, model);
+        mockModelRegistryGetModelToReturnUnparsedModel(unparsedModel);
+        mockParsePersistedConfigToReturnModel(model);
+
+        var listener = callMasterOperationWithActionFuture();
+        var response = listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT);
+        assertThat(response.getModel(), is(model.getConfigurations()));
+        verifyModelRegistryUpdateInvoked();
+    }
+
+    private static GoogleVertexAiEmbeddingsModel createModel() {
+        return new GoogleVertexAiEmbeddingsModel(
+            INFERENCE_ENTITY_ID_VALUE,
+            TaskType.TEXT_EMBEDDING,
+            SERVICE_NAME_VALUE,
+            new GoogleVertexAiEmbeddingsServiceSettings(
+                LOCATION_INITIAL_VALUE,
+                PROJECT_ID_INITIAL_VALUE,
+                MODEL_ID_INITIAL_VALUE,
+                Boolean.FALSE,
+                null,
+                null,
+                null,
+                null,
+                null
+            ),
+            new GoogleVertexAiEmbeddingsTaskSettings(AUTO_TRUNCATE_INITIAL_VALUE, INPUT_TYPE_INITIAL_VALUE),
+            NoneChunkingSettings.INSTANCE,
+            new GoogleVertexAiSecretSettings(new SecureString(SERVICE_ACCOUNT_JSON_INITIAL_VALUE.toCharArray()))
+        );
+    }
+
+    private void mockGetModelWithSecretsToFailWithException(RuntimeException exception) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onFailure(exception);
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModelWithSecrets(eq(INFERENCE_ENTITY_ID_VALUE), any());
+    }
+
+    private void mockGetModelWithSecretsToReturnUnparsedModel(UnparsedModel result) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(result);
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModelWithSecrets(eq(INFERENCE_ENTITY_ID_VALUE), any());
+    }
+
+    private void mockLicenseStateIsAllowed(boolean value) {
+        when(licenseState.isAllowed(any(LicensedFeature.class))).thenReturn(value);
+    }
+
+    private void mockParsePersistedConfigWithSecretsToReturnModel(GoogleVertexAiEmbeddingsModel model) {
+        when(service.parsePersistedConfigWithSecrets(eq(INFERENCE_ENTITY_ID_VALUE), eq(TaskType.TEXT_EMBEDDING), anyMap(), anyMap()))
+            .thenReturn(model);
+    }
+
+    private void mockServiceRegistryToReturnService(InferenceService service) {
+        when(mockInferenceServiceRegistry.getService(SERVICE_NAME_VALUE)).thenReturn(Optional.ofNullable(service));
+    }
+
+    private void mockUpdateModelWithEmbeddingDetailsToReturnSameModel() {
+        when(service.updateModelWithEmbeddingDetails(any(GoogleVertexAiEmbeddingsModel.class), eq(3))).thenAnswer(
+            invocationOnMock -> invocationOnMock.getArgument(0)
+        );
+    }
+
+    private void mockUpdateModelTransactionToReturnBoolean(boolean result, GoogleVertexAiEmbeddingsModel model) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<Boolean> listener = invocationOnMock.getArgument(2);
+            listener.onResponse(result);
+            return Void.TYPE;
+        }).when(mockModelRegistry).updateModelTransaction(any(Model.class), eq(model), any());
+    }
+
+    private void mockParsePersistedConfigToReturnModel(GoogleVertexAiEmbeddingsModel model) {
+        when(service.parsePersistedConfig(eq(INFERENCE_ENTITY_ID_VALUE), eq(TaskType.TEXT_EMBEDDING), anyMap())).thenReturn(model);
+    }
+
+    private void verifyNoModelRegistryMutations() {
+        verify(mockModelRegistry, never()).storeModel(any(), any(), any());
+        verify(mockModelRegistry, never()).updateModelTransaction(any(), any(), any());
+    }
+
+    private void verifyModelRegistryUpdateInvoked() {
+        verify(mockModelRegistry).updateModelTransaction(any(), any(), any());
+    }
+
+    private void mockModelRegistryGetModelToReturnUnparsedModel(UnparsedModel result) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(result);
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModel(eq(INFERENCE_ENTITY_ID_VALUE), any());
+    }
+
+    private PlainActionFuture<UpdateInferenceModelAction.Response> callMasterOperationWithActionFuture() {
         var listener = new PlainActionFuture<UpdateInferenceModelAction.Response>();
 
-        String requestBody = "{\"service_settings\": {\"api_key\": \"<API_KEY>\"}}";
+        var requestBody = """
+            {
+                "task_type": "text_embedding",
+                "service_settings": {
+                    "service_account_json": "some_new_service_account",
+                    "max_batch_size": 16
+                },
+                "task_settings": {
+                    "input_type": "ingest",
+                    "auto_truncate": true
+                }
+            }""";
 
         action.masterOperation(
             mock(Task.class),
             new UpdateInferenceModelAction.Request(
-                "model-id",
+                INFERENCE_ENTITY_ID_VALUE,
                 new BytesArray(requestBody),
                 XContentType.JSON,
                 TaskType.TEXT_EMBEDDING,
@@ -89,22 +387,95 @@ public class TransportUpdateInferenceModelActionTests extends ESTestCase {
             ClusterState.EMPTY_STATE,
             listener
         );
-
-        var exception = expectThrows(ElasticsearchSecurityException.class, () -> listener.actionGet(TimeValue.timeValueSeconds(5)));
-        assertThat(exception.getMessage(), is("current license is non-compliant for [inference]"));
+        return listener;
     }
 
-    private void mocks(String serviceName, boolean isAllowed) {
-        doAnswer(invocationOnMock -> {
-            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
-            listener.onResponse(new UnparsedModel("model_id", TaskType.COMPLETION, serviceName, Map.of(), Map.of()));
-            return Void.TYPE;
-        }).when(mockModelRegistry).getModelWithSecrets(anyString(), any());
+    public void testCombineExistingModelWithNewSettings_NewConfigMapsAreNull_ReturnsExistingConfigs() {
+        var serviceSettings = mock(ServiceSettings.class);
+        var taskSettings = mock(TaskSettings.class);
+        var secretSettings = mock(SecretSettings.class);
 
-        var mockService = mock(InferenceService.class);
-        when(mockService.name()).thenReturn(serviceName);
-        when(mockInferenceServiceRegistry.getService(anyString())).thenReturn(Optional.of(mockService));
+        var model = createMockedModel(serviceSettings, taskSettings, secretSettings);
+        var resultModelConfigurations = action.combineExistingModelWithNewSettings(
+            model,
+            new UpdateInferenceModelAction.Settings(null, null, TaskType.TEXT_EMBEDDING),
+            SERVICE_NAME_VALUE,
+            TaskType.TEXT_EMBEDDING
+        );
+        verifyNoInteractions(serviceSettings);
+        verifyNoInteractions(taskSettings);
+        verifyNoInteractions(secretSettings);
 
-        when(licenseState.isAllowed(any())).thenReturn(isAllowed);
+        assertThat(resultModelConfigurations.getInferenceEntityId(), sameInstance(model.getInferenceEntityId()));
+        assertThat(resultModelConfigurations.getTaskType(), sameInstance(model.getTaskType()));
+        assertThat(resultModelConfigurations.getConfigurations().getService(), sameInstance(SERVICE_NAME_VALUE));
+        assertThat(resultModelConfigurations.getServiceSettings(), sameInstance(model.getConfigurations().getServiceSettings()));
+        assertThat(resultModelConfigurations.getTaskSettings(), sameInstance(model.getConfigurations().getTaskSettings()));
+        // chunking settings should remain unchanged
+        assertThat(
+            resultModelConfigurations.getConfigurations().getChunkingSettings(),
+            sameInstance(model.getConfigurations().getChunkingSettings())
+        );
+    }
+
+    public void testCombineExistingModelWithNewSettings_NewServiceAndTaskSettings_UpdatesConfig() {
+        Map<String, Object> newServiceSettingsMap = Map.of("some_service_key", "some_service_value", "num_allocations", 5);
+        var originalServiceSettings = mock(ServiceSettings.class);
+        var updatedServiceSettings = mock(ServiceSettings.class);
+        when(originalServiceSettings.updateServiceSettings(newServiceSettingsMap)).thenReturn(updatedServiceSettings);
+
+        Map<String, Object> newTaskSettingsMap = Map.of("some_task_key", "some_task_value");
+        var originalTaskSettings = mock(TaskSettings.class);
+        var updatedTaskSettings = mock(TaskSettings.class);
+        when(originalTaskSettings.updatedTaskSettings(newTaskSettingsMap)).thenReturn(updatedTaskSettings);
+
+        var originalSecretSettings = mock(SecretSettings.class);
+        var updatedSecretSettings = mock(SecretSettings.class);
+        when(originalSecretSettings.newSecretSettings(newServiceSettingsMap)).thenReturn(updatedSecretSettings);
+
+        var originalModel = createMockedModel(originalServiceSettings, originalTaskSettings, originalSecretSettings);
+        var resultModel = action.combineExistingModelWithNewSettings(
+            originalModel,
+            new UpdateInferenceModelAction.Settings(newServiceSettingsMap, newTaskSettingsMap, TaskType.TEXT_EMBEDDING),
+            SERVICE_NAME_VALUE,
+            TaskType.TEXT_EMBEDDING
+        );
+
+        verify(originalServiceSettings).updateServiceSettings(newServiceSettingsMap);
+        verify(originalTaskSettings).updatedTaskSettings(newTaskSettingsMap);
+        verify(originalSecretSettings).newSecretSettings(newServiceSettingsMap);
+
+        assertThat(resultModel.getInferenceEntityId(), sameInstance(originalModel.getInferenceEntityId()));
+        assertThat(resultModel.getTaskType(), sameInstance(originalModel.getTaskType()));
+        assertThat(resultModel.getConfigurations().getService(), sameInstance(SERVICE_NAME_VALUE));
+        assertThat(resultModel.getServiceSettings(), sameInstance(updatedServiceSettings));
+        assertThat(resultModel.getTaskSettings(), sameInstance(updatedTaskSettings));
+        assertThat(resultModel.getSecretSettings(), sameInstance(updatedSecretSettings));
+        // chunking settings should remain unchanged
+        assertThat(
+            resultModel.getConfigurations().getChunkingSettings(),
+            sameInstance(originalModel.getConfigurations().getChunkingSettings())
+        );
+    }
+
+    private static Model createMockedModel(
+        ServiceSettings originalServiceSettings,
+        TaskSettings originalTaskSettings,
+        SecretSettings originalSecretSettings
+    ) {
+        // Mock ModelConfigurations
+        var modelConfigurations = mock(ModelConfigurations.class);
+        when(modelConfigurations.getServiceSettings()).thenReturn(originalServiceSettings);
+        when(modelConfigurations.getTaskSettings()).thenReturn(originalTaskSettings);
+        when(modelConfigurations.getChunkingSettings()).thenReturn(mock(ChunkingSettings.class));
+
+        // Mock Model
+        var model = mock(Model.class);
+        when(model.getInferenceEntityId()).thenReturn(INFERENCE_ENTITY_ID_VALUE);
+        when(model.getTaskType()).thenReturn(TaskType.TEXT_EMBEDDING);
+        when(model.getConfigurations()).thenReturn(modelConfigurations);
+        when(model.getSecretSettings()).thenReturn(originalSecretSettings);
+
+        return model;
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/elastic/elasticsearch/issues/139574 issue for 9.3 version. Issue is with the chunking settings for the updated model kept resetting during the update. Now we include chunking settings from the existing model into the new updated model.
For main version this change is done in scope of https://github.com/elastic/elasticsearch/pull/140003/

- [X] - Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] - Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [X] - If submitting code, have you built your formula locally prior to submission with `gradle check`?
- [X] - If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [X] - If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [X] - If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.