### PR TITLE
[9.2] Preserve chunking settings during endpoint update

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -206,7 +206,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
      * @param serviceName
      * @return a new object representing the updated model
      */
-    private Model combineExistingModelWithNewSettings(
+    protected Model combineExistingModelWithNewSettings(
         Model existingParsedModel,
         UpdateInferenceModelAction.Settings settingsToUpdate,
         String serviceName,
@@ -239,7 +239,8 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
             existingParsedModel.getTaskType(),
             serviceName,
             newServiceSettings,
-            newTaskSettings
+            newTaskSettings,
+            existingConfigs.getChunkingSettings()
         );
 
         return new Model(newModelConfigs, new ModelSecrets(newSecretSettings));


### PR DESCRIPTION
This PR fixes https://github.com/elastic/elasticsearch/issues/139574 issue for 9.2 version. Issue is with the chunking settings for the updated model kept resetting during the update. Now we include chunking settings from the existing model into the new updated model.
For main version this change is done in scope of https://github.com/elastic/elasticsearch/pull/140003/

- [X] - Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] - Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [X] - If submitting code, have you built your formula locally prior to submission with `gradle check`?
- [X] - If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [X] - If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [X] - If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.