### PR TITLE
[9.3] Fix GoogleCloudStorageBlobStoreRepositoryTests#testMultipleSnapshotAndRollback (#139578)

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -13,18 +13,23 @@ import fixture.gcs.FakeOAuth2HttpHandler;
 import fixture.gcs.GoogleCloudStorageHttpHandler;
 import fixture.gcs.TestUtils;
 
+import com.google.api.gax.rpc.HeaderProvider;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.StorageRetryStrategy;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.BackoffPolicy;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -74,6 +79,8 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CL
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
 public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTestCase {
+
+    private static final String CLIENT_ID_HEADER = "x-es-test-client-id";
 
     @Override
     protected String repositoryType() {
@@ -277,6 +284,19 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                                 .setJittered(false)
                                 .build()
                         )
+                        .setHeaderProvider(new HeaderProvider() {
+                            /**
+                             * GCS client doesn't implement any way of identifying the client making the request.
+                             * Adding this header makes it easier for us to know how many times it's safe to fail
+                             * a request without exceeding the configured max retries.
+                             */
+                            private final String clientId = randomUUID();
+
+                            @Override
+                            public Map<String, String> getHeaders() {
+                                return Map.of(CLIENT_ID_HEADER, clientId);
+                            }
+                        })
                         .build();
                 }
             };
@@ -346,6 +366,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
     private static class GoogleErroneousHttpHandler extends ErroneousHttpHandler {
 
+        private static final Logger logger = LogManager.getLogger(GoogleErroneousHttpHandler.class);
         private static final String IDEMPOTENCY_TOKEN = "x-goog-gcs-idempotency-token";
 
         GoogleErroneousHttpHandler(final HttpHandler delegate, final int maxErrorsPerRequest) {
@@ -375,13 +396,20 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                 return idempotencyToken;
             }
 
+            String clientId = exchange.getRequestHeaders().getFirst(CLIENT_ID_HEADER);
+            if (clientId == null) {
+                if (exchange.getRequestURI().toString().startsWith("/batch/") == false) {
+                    final String message = Strings.format(
+                        "Missing %s on non-batch request, this may cause issues with fault injection: %s",
+                        CLIENT_ID_HEADER,
+                        exchange.getRequestURI()
+                    );
+                    ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError(message));
+                }
+                clientId = exchange.getRemoteAddress().toString();
+            }
             final String range = exchange.getRequestHeaders().getFirst("Content-Range");
-            return exchange.getRemoteAddress().getHostString()
-                + " "
-                + exchange.getRequestMethod()
-                + " "
-                + exchange.getRequestURI()
-                + (range != null ? " " + range : "");
+            return clientId + " " + exchange.getRequestMethod() + " " + exchange.getRequestURI() + (range != null ? " " + range : "");
         }
 
         @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix GoogleCloudStorageBlobStoreRepositoryTests#testMultipleSnapshotAndRollback (#139578)](https://github.com/elastic/elasticsearch/pull/139578)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)