### PR TITLE
[9.3] Fix testReadBlobWithReadTimeouts retries count (#139999)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/RetryingInputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/RetryingInputStream.java
@@ -189,9 +189,12 @@ public abstract class RetryingInputStream<V> extends InputStream {
         }
     }
 
+    public long meaningfulProgressSize() {
+        return blobStoreServices.getMeaningfulProgressSize();
+    }
+
     private <T extends Exception> void reopenStreamOrFail(T e) throws T, IOException {
-        final long meaningfulProgressSize = blobStoreServices.getMeaningfulProgressSize();
-        if (currentStreamProgress() >= meaningfulProgressSize) {
+        if (currentStreamProgress() >= meaningfulProgressSize()) {
             failuresAfterMeaningfulProgress += 1;
         }
         final long delayInMillis = maybeLogAndComputeRetryDelay(READ, e);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -17,6 +17,7 @@ import org.apache.http.HttpStatus;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.blobstore.RetryingInputStream;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -36,7 +37,10 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -248,7 +252,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
     public void testReadBlobWithReadTimeouts() {
         final int maxRetries = randomInt(5);
         final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
-        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
+        final ByteSizeValue bufferSize = ByteSizeValue.ofMb(between(10, 20));
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries)
+            .bufferSize(bufferSize)
+            .readTimeout(readTimeout)
+            .build();
 
         // HTTP server does not send a response
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_unresponsive"), exchange -> {});
@@ -260,21 +268,29 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         assertThat(exception.getMessage().toLowerCase(Locale.ROOT), containsString("read timed out"));
         assertThat(exception.getCause(), instanceOf(SocketTimeoutException.class));
 
+        // A list to track response sizes, some streams (i.e. RetryingInputStream) allow more retries when meaningful amount of bytes
+        // is transferred in a single try. See below.
+        final List<Long> retryContentSizes = Collections.synchronizedList(new ArrayList<>());
+
         // HTTP server sends a partial response
         final byte[] bytes = randomBlobContent();
         httpServer.createContext(
             downloadStorageEndpoint(blobContainer, "read_blob_incomplete"),
-            exchange -> sendIncompleteContent(exchange, bytes)
+            exchange -> retryContentSizes.add((long) sendIncompleteContent(exchange, bytes))
         );
 
         final int position = randomIntBetween(0, bytes.length - 1);
         final int length = randomIntBetween(1, randomBoolean() ? bytes.length : Integer.MAX_VALUE);
+        final AtomicLong meaningfulProgressSize = new AtomicLong(Long.MAX_VALUE);
         exception = expectThrows(Exception.class, () -> {
             try (
                 InputStream stream = randomBoolean()
                     ? blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete")
                     : blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete", position, length)
             ) {
+                if (stream instanceof RetryingInputStream<?> ris) {
+                    meaningfulProgressSize.set(ris.meaningfulProgressSize());
+                }
                 Streams.readFully(stream);
             }
         });
@@ -288,7 +304,10 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 containsString("unexpected end of file from server")
             )
         );
-        assertThat(exception.getSuppressed().length, getMaxRetriesMatcher(maxRetries));
+        int meaningfulProgressRetries = Math.toIntExact(
+            retryContentSizes.stream().filter(contentSize -> contentSize >= meaningfulProgressSize.get()).count()
+        );
+        assertEquals(exception.getSuppressed().length, maxRetries + meaningfulProgressRetries);
     }
 
     protected org.hamcrest.Matcher<Integer> getMaxRetriesMatcher(int maxRetries) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix testReadBlobWithReadTimeouts retries count (#139999)](https://github.com/elastic/elasticsearch/pull/139999)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)