### PR TITLE
[8.19] build: fix ParallelDetector on multi-socket (#141637)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -58,7 +58,7 @@ public class ParallelDetector {
                             // Number of cores not including hyper-threading
                             if (name.equals("cpu cores")) {
                                 assert currentID.isEmpty() == false;
-                                socketToCore.put("currentID", Integer.valueOf(value));
+                                socketToCore.put(currentID, Integer.valueOf(value));
                                 currentID = "";
                             }
                         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [build: fix ParallelDetector on multi-socket (#141637)](https://github.com/elastic/elasticsearch/pull/141637)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)