### PR TITLE
ESQL: Avoid a possible NPE by throwing an EIAE instead with more info

### DIFF
--- a/docs/changelog/141711.yaml
+++ b/docs/changelog/141711.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 141267
+pr: 141711
+summary: Avoid a possible NPE by throwing an EIAE instead with more info
+type: bug


### PR DESCRIPTION
Improves the user experience that could lead to a NPE when comparing data types.
Closes https://github.com/elastic/elasticsearch/issues/141267.