### PR TITLE
Return updated offset from `putVInt` etc

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/BufferedStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BufferedStreamOutput.java
@@ -227,7 +227,7 @@ public class BufferedStreamOutput extends StreamOutput {
         if (25 <= Integer.numberOfLeadingZeros(i)) {
             writeByte((byte) i);
         } else if (MAX_VINT_BYTES <= capacity()) {
-            position += putMultiByteVInt(buffer, i, position);
+            position = putMultiByteVInt(buffer, i, position);
         } else {
             writeVIntWithBoundsChecks(i);
         }
@@ -246,9 +246,9 @@ public class BufferedStreamOutput extends StreamOutput {
     public void writeVIntArray(int[] values) throws IOException {
         int position = this.position;
         if ((values.length + 1) * MAX_VINT_BYTES <= endPosition - position) {
-            position += putVInt(buffer, values.length, position);
+            position = putVInt(buffer, values.length, position);
             for (var value : values) {
-                position += putVInt(buffer, value, position);
+                position = putVInt(buffer, value, position);
             }
             this.position = position;
         } else {
@@ -264,7 +264,7 @@ public class BufferedStreamOutput extends StreamOutput {
         int lastSafePosition = this.endPosition - MAX_VINT_BYTES;
         while (i < values.length) {
             while (i < values.length && position <= lastSafePosition) {
-                position += putVInt(buffer, values[i++], position);
+                position = putVInt(buffer, values[i++], position);
             }
             this.position = position;
             while (capacity() < MAX_VINT_BYTES && i < values.length) {
@@ -364,7 +364,7 @@ public class BufferedStreamOutput extends StreamOutput {
         final int charCount = str.length();
         int position = this.position;
         if (MAX_VINT_BYTES + charCount * MAX_CHAR_BYTES <= endPosition - position) {
-            position += putVInt(buffer, charCount, position);
+            position = putVInt(buffer, charCount, position);
             for (int i = 0; i < charCount; i++) {
                 position = putCharUtf8(buffer, str.charAt(i), position);
             }
@@ -383,7 +383,7 @@ public class BufferedStreamOutput extends StreamOutput {
             int position = this.position;
             if (1 + MAX_VINT_BYTES + charCount * MAX_CHAR_BYTES <= endPosition - position) {
                 buffer[position++] = (byte) 1;
-                position += putVInt(buffer, charCount, position);
+                position = putVInt(buffer, charCount, position);
                 for (int i = 0; i < charCount; i++) {
                     position = putCharUtf8(buffer, str.charAt(i), position);
                 }
@@ -401,7 +401,7 @@ public class BufferedStreamOutput extends StreamOutput {
         int position = this.position;
         if (1 + MAX_VINT_BYTES + charCount * MAX_CHAR_BYTES <= endPosition - position) {
             buffer[position++] = (byte) 0;
-            position += putVInt(buffer, charCount, position);
+            position = putVInt(buffer, charCount, position);
             for (int i = 0; i < charCount; i++) {
                 position = putCharUtf8(buffer, str.charAt(i), position);
             }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -196,7 +196,7 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         if (bytesNeeded > remainingBytesInPage) {
             super.writeVInt(i);
         } else {
-            this.currentOffset = currentOffset + StreamOutputHelper.putMultiByteVInt(this.currentBufferPool, i, currentOffset);
+            this.currentOffset = StreamOutputHelper.putMultiByteVInt(this.currentBufferPool, i, currentOffset);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutputHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutputHelper.java
@@ -64,7 +64,7 @@ public enum StreamOutputHelper {
      */
     public static int writeString(String str, byte[] buffer, int prefixLength, OutputStream outputStream) throws IOException {
         final int charCount = str.length();
-        int offset = prefixLength + putVInt(buffer, charCount, prefixLength);
+        int offset = putVInt(buffer, charCount, prefixLength);
         int total = 0;
         for (int i = 0; i < charCount; i++) {
             final int c = str.charAt(i);
@@ -138,12 +138,12 @@ public enum StreamOutputHelper {
      * Put the integer {@code i} into the given {@code buffer} starting at the given {@code offset}, formatted as per
      * {@link StreamOutput#writeVInt}. Performs no bounds checks: callers must verify that there is enough space in {@code buffer} first.
      *
-     * @return number of bytes written.
+     * @return updated offset (original offset plus number of bytes written)
      */
     public static int putVInt(byte[] buffer, int i, int offset) {
         if (Integer.numberOfLeadingZeros(i) >= 25) {
             buffer[offset] = (byte) i;
-            return 1;
+            return offset + 1;
         }
         return putMultiByteVInt(buffer, i, offset);
     }
@@ -152,17 +152,16 @@ public enum StreamOutputHelper {
      * Put the integer {@code i} into the given {@code buffer} starting at the given {@code offset}, formatted as per
      * {@link StreamOutput#writeVInt}. Performs no bounds checks: callers must verify that there is enough space in {@code buffer} first.
      *
-     * @return number of bytes written.
+     * @return updated offset (original offset plus number of bytes written)
      */
     // extracted from putVInt() to allow the hot single-byte path to be inlined
     public static int putMultiByteVInt(byte[] buffer, int i, int offset) {
-        int index = offset;
         do {
-            buffer[index++] = ((byte) ((i & 0x7f) | 0x80));
+            buffer[offset++] = ((byte) ((i & 0x7f) | 0x80));
             i >>>= 7;
         } while ((i & ~0x7F) != 0);
-        buffer[index++] = (byte) i;
-        return index - offset;
+        buffer[offset++] = (byte) i;
+        return offset;
     }
 
 }


### PR DESCRIPTION
The return values of `putVInt` and `putMultiByteVInt` are always used to
update the offset in the buffer, but this is already available in the
method so we may as well just return it directly.