### PR TITLE
Revert "[8.19] rest-api-spec: fix knn_search visibility (#141356)"

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
@@ -9,7 +9,7 @@
       "version": "8.4.0",
       "description": "The kNN search API has been replaced by the `knn` option in the search API."
     },
-    "visibility": "private",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
Reverts elastic/elasticsearch#141380

It's not actually private in 8.19, only deprecated.