### PR TITLE
[9.3] ESQL: Avoid a possible NPE by throwing an EIAE instead with more info (#141711)

### DIFF
--- a/docs/changelog/141711.yaml
+++ b/docs/changelog/141711.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 141267
+pr: 141711
+summary: Avoid a possible NPE by throwing an EIAE instead with more info
+type: bug


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: Avoid a possible NPE by throwing an EIAE instead with more info (#141711)