### PR TITLE
Refactor service settings parsing to reuse XContent framework

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/ServiceSettings.java
+++ b/server/src/main/java/org/elasticsearch/inference/ServiceSettings.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.inference;
 
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -70,5 +71,9 @@ public interface ServiceSettings extends ToXContentObject, VersionedNamedWriteab
 
     default ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
         return this;
+    }
+
+    default ValidationException validate() {
+        return new ValidationException();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParser.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.inference.common.configuration;
 
-import org.elasticsearch.common.Strings;
-
-import org.elasticsearch.common.ValidationException;
-
 import software.amazon.awssdk.utils.ImmutableMap;
 
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.TaskType;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParser.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common.configuration;
+
+import org.elasticsearch.common.Strings;
+
+import org.elasticsearch.common.ValidationException;
+
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import org.elasticsearch.common.util.CachedSupplier;
+import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
+import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record InferenceConfigParser(String id, TaskType taskType, String service, Map<String, Object> serviceSettings)
+    implements
+        ToXContentObject {
+
+    private static final ParseField TASK_TYPE_FIELD = new ParseField("task_type");
+    private static final ParseField SERVICE_FIELD = new ParseField("service");
+    private static final ParseField SERVICE_SETTINGS_FIELD = new ParseField("service_settings");
+
+    private record ParserRegistryKey(String name, TaskType taskType, ConfigurationParseContext context) {};
+
+    private static final Map<
+        ParserRegistryKey,
+        CachedSupplier<ConstructingObjectParser<? extends ServiceSettings, Void>>> serviceSettingsParserRegistry;
+
+    static {
+        ImmutableMap.Builder<
+            ParserRegistryKey,
+            CachedSupplier<ConstructingObjectParser<? extends ServiceSettings, Void>>> serviceSettingsParserRegistryBuilder = ImmutableMap
+                .builder();
+        registerServiceSettingsParser(
+            serviceSettingsParserRegistryBuilder,
+            ElasticInferenceService.NAME,
+            TaskType.SPARSE_EMBEDDING,
+            ElasticInferenceServiceSparseEmbeddingsServiceSettings::createParser
+        );
+        serviceSettingsParserRegistry = serviceSettingsParserRegistryBuilder.build();
+    }
+
+    private static <T extends ServiceSettings> void registerServiceSettingsParser(
+        ImmutableMap.Builder<ParserRegistryKey, CachedSupplier<ConstructingObjectParser<? extends ServiceSettings, Void>>> map,
+        String name,
+        TaskType taskType,
+        Function<ConfigurationParseContext, ConstructingObjectParser<T, Void>> parserSupplier
+    ) {
+        map.put(
+            new ParserRegistryKey(name, taskType, ConfigurationParseContext.REQUEST),
+            CachedSupplier.wrap(() -> parserSupplier.apply(ConfigurationParseContext.REQUEST))
+        );
+        map.put(
+            new ParserRegistryKey(name, taskType, ConfigurationParseContext.PERSISTENT),
+            CachedSupplier.wrap(() -> parserSupplier.apply(ConfigurationParseContext.PERSISTENT))
+        );
+    }
+
+    public static InferenceConfigParser parse(String id, XContentParser parser) {
+        return createParser(id).apply(parser, null).build();
+    }
+
+    public static ObjectParser<InferenceConfigParser.Builder, Void> createParser(String id) {
+        ObjectParser<InferenceConfigParser.Builder, Void> parser = new ObjectParser<>(
+            "inference_endpoint_config",
+            false,
+            () -> new Builder(id)
+        );
+        parser.declareField(
+            InferenceConfigParser.Builder::setTaskType,
+            p -> TaskType.fromString(p.text()),
+            TASK_TYPE_FIELD,
+            ObjectParser.ValueType.STRING
+        );
+        parser.declareString(InferenceConfigParser.Builder::setService, SERVICE_FIELD);
+        parser.declareObject(InferenceConfigParser.Builder::setServiceSettings, (p, c) -> p.map(), SERVICE_SETTINGS_FIELD);
+        return parser;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(TASK_TYPE_FIELD.getPreferredName(), taskType.toString());
+        builder.field(SERVICE_FIELD.getPreferredName(), service);
+        builder.field(SERVICE_SETTINGS_FIELD.getPreferredName(), serviceSettings);
+        builder.endObject();
+        return builder;
+    }
+
+    public <T extends ServiceSettings> T parseServiceSettings(Class<T> expectedClass, ConfigurationParseContext context) {
+        CachedSupplier<ConstructingObjectParser<? extends ServiceSettings, Void>> parserSupplier = serviceSettingsParserRegistry.get(
+            new ParserRegistryKey(service, taskType, context)
+        );
+        if (parserSupplier == null) {
+            throw new IllegalStateException("No parser registered for service [" + service + "] and task type [" + taskType + "]");
+        }
+
+        ConstructingObjectParser<? extends ServiceSettings, Void> parser = parserSupplier.get();
+
+        try (XContentBuilder xContent = XContentBuilder.builder(JsonXContent.jsonXContent).map(serviceSettings)) {
+            try (
+                XContentParser xContentParser = JsonXContent.jsonXContent.createParser(
+                    XContentParserConfiguration.EMPTY,
+                    Strings.toString(xContent)
+                )
+            ) {
+                ServiceSettings parsed = parser.apply(xContentParser, null);
+                if (expectedClass.isInstance(parsed) == false) {
+                    throw new IllegalStateException(
+                        "Parsed service settings type ["
+                            + parsed.getClass().getName()
+                            + "] did not match expected type ["
+                            + expectedClass.getName()
+                            + "]"
+                    );
+                }
+                if (context == ConfigurationParseContext.REQUEST) {
+                    ValidationException validationException = parsed.validate();
+                    if (validationException.validationErrors().isEmpty() == false) {
+                        throw validationException;
+                    }
+                }
+                return expectedClass.cast(parsed);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse service settings", e);
+        }
+    }
+
+    private static class Builder {
+        private String id;
+        private TaskType taskType;
+        private String service;
+        private Map<String, Object> serviceSettings;
+
+        Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        Builder setTaskType(TaskType taskType) {
+            this.taskType = taskType;
+            return this;
+        }
+
+        Builder setService(String service) {
+            this.service = service;
+            return this;
+        }
+
+        Builder setServiceSettings(Map<String, Object> serviceSettings) {
+            this.serviceSettings = serviceSettings;
+            return this;
+        }
+
+        InferenceConfigParser build() {
+            return new InferenceConfigParser(id, taskType, service, serviceSettings);
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.InferenceUtils;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
-import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceRateLimitServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSettingsUtils;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
@@ -15,8 +15,13 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.InferenceUtils;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceRateLimitServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSettingsUtils;
@@ -28,6 +33,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
@@ -37,13 +44,28 @@ import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenc
 public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends FilteredXContentObject
     implements
         ServiceSettings,
-        ElasticInferenceServiceRateLimitServiceSettings {
+        ElasticInferenceServiceRateLimitServiceSettings,
+        ToXContentObject {
 
     public static final String NAME = "elastic_inference_service_sparse_embeddings_service_settings";
 
     private static final TransportVersion INFERENCE_API_DISABLE_EIS_RATE_LIMITING = TransportVersion.fromName(
         "inference_api_disable_eis_rate_limiting"
     );
+
+    public static ConstructingObjectParser<ElasticInferenceServiceSparseEmbeddingsServiceSettings, Void> createParser(
+        ConfigurationParseContext context
+    ) {
+        var parser = new ConstructingObjectParser<ElasticInferenceServiceSparseEmbeddingsServiceSettings, Void>(
+            NAME,
+            context == ConfigurationParseContext.PERSISTENT ? true : false,
+            args -> new ElasticInferenceServiceSparseEmbeddingsServiceSettings((String) args[0], (Integer) args[1], (Integer) args[2])
+        );
+        parser.declareString(constructorArg(), new ParseField(MODEL_ID));
+        parser.declareInt(optionalConstructorArg(), new ParseField(MAX_INPUT_TOKENS));
+        parser.declareInt(optionalConstructorArg(), new ParseField(MAX_BATCH_SIZE));
+        return parser;
+    }
 
     public static ElasticInferenceServiceSparseEmbeddingsServiceSettings fromMap(
         Map<String, Object> map,
@@ -105,6 +127,22 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
         } else {
             this.maxBatchSize = null;
         }
+    }
+
+    @Override
+    public ValidationException validate() {
+        ValidationException validationException = new ValidationException();
+        if (maxInputTokens != null && maxInputTokens <= 0) {
+            validationException.addValidationError(
+                InferenceUtils.mustBeAPositiveIntegerErrorMessage(MAX_INPUT_TOKENS, ModelConfigurations.SERVICE_SETTINGS, maxInputTokens)
+            );
+        }
+        if (maxBatchSize != null && maxBatchSize <= 0) {
+            validationException.addValidationError(
+                InferenceUtils.mustBeAPositiveIntegerErrorMessage(MAX_BATCH_SIZE, ModelConfigurations.SERVICE_SETTINGS, maxBatchSize)
+            );
+        }
+        return validationException;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/configuration/InferenceConfigParserTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common.configuration;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests;
+import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class InferenceConfigParserTests extends AbstractXContentTestCase<InferenceConfigParser> {
+
+    private String id = randomAlphaOfLength(10);
+
+    @Override
+    protected InferenceConfigParser doParseInstance(XContentParser parser) throws IOException {
+        return InferenceConfigParser.parse(id, parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected InferenceConfigParser createTestInstance() {
+        TaskType taskType = randomFrom(TaskType.values());
+        String service = randomAlphaOfLength(10);
+        Map<String, Object> serviceSettings = randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(10), randomAlphaOfLength(10)));
+        return new InferenceConfigParser(id, taskType, service, serviceSettings);
+    }
+
+    public void testParseServiceSettings() throws IOException {
+        var eisSparseSettings = ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests.createRandom();
+
+        InferenceConfigParser parser = new InferenceConfigParser(
+            id,
+            TaskType.SPARSE_EMBEDDING,
+            "elastic",
+            XContentTestUtils.convertToMap(eisSparseSettings)
+        );
+        ElasticInferenceServiceSparseEmbeddingsServiceSettings parsedServiceSettings = parser.parseServiceSettings(
+            ElasticInferenceServiceSparseEmbeddingsServiceSettings.class,
+            ConfigurationParseContext.PERSISTENT
+        );
+        assertThat(parsedServiceSettings, equalTo(eisSparseSettings));
+    }
+}


### PR DESCRIPTION
This is a draft PR simply to demonstrate how this approach would work.

The idea is that we reuse the `XContent` parsing framework for `ServiceSettings` (and also `TaskSettings` would follow in a similar manner) in order to avoid having these passed around as maps and reduce the code needed for parsing from maps.

---
Relates to elastic/search-team#13002