### PR TITLE
Refactor how method handles for BBQ native vector methods are specified

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctions.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctions.java
@@ -39,19 +39,7 @@ public interface VectorSimilarityFunctions {
         /**
          * 4-byte float. Single vector score returns results as a float.
          */
-        FLOAT32(Float.BYTES),
-        /**
-         * 1-bit data, 4-bit queries. Single vector score returns results as a long.
-         * <p>
-         * Checks are special-cased, so {@link #bytes()} is not called
-         */
-        I1I4(Byte.BYTES),
-        /**
-         * 2-bit data, 4-bit queries. Single vector score returns results as a long.
-         * <p>
-         * Checks are special-cased, so {@link #bytes()} is not called
-         */
-        I2I4(Byte.BYTES);
+        FLOAT32(Float.BYTES);
 
         private final int bytes;
 
@@ -61,6 +49,34 @@ public interface VectorSimilarityFunctions {
 
         public int bytes() {
             return bytes;
+        }
+    }
+
+    /**
+     * The various flavors of BBQ indices. Single vector score returns results as a long.
+     */
+    enum BBQType {
+        /**
+         * 1-bit data, 4-bit queries
+         */
+        I1I4((byte) 1),
+        /**
+         * 2-bit data, 4-bit queries
+         */
+        I2I4((byte) 2);
+
+        private final byte dataBits;
+
+        BBQType(byte dataBits) {
+            this.dataBits = dataBits;
+        }
+
+        public byte dataBits() {
+            return dataBits;
+        }
+
+        public byte queryBits() {
+            return 4;
         }
     }
 
@@ -108,4 +124,6 @@ public interface VectorSimilarityFunctions {
     }
 
     MethodHandle getHandle(Function function, DataType dataType, Operation operation);
+
+    MethodHandle getHandle(Function function, BBQType bbqType, Operation operation);
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
+import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.BBQType;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.DataType;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.Function;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.Operation;
@@ -41,11 +42,11 @@ public final class JdkVectorLibrary implements VectorLibrary {
 
     static final Logger logger = LogManager.getLogger(JdkVectorLibrary.class);
 
-    private record OperationSignature(Function function, DataType dataType, Operation operation) {}
+    private record OperationSignature<E extends Enum<E>>(Function function, E dataType, Operation operation) {}
 
-    private static final Map<OperationSignature, MethodHandle> HANDLES;
+    private static final Map<OperationSignature<?>, MethodHandle> HANDLES;
 
-    public static final JdkVectorSimilarityFunctions INSTANCE;
+    private static final JdkVectorSimilarityFunctions INSTANCE;
 
     /**
      * Native functions in the native simdvec library can have multiple implementations, one for each "capability level".
@@ -81,7 +82,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
     static {
         LoaderHelper.loadLibrary("vec");
         MethodHandle vecCaps$mh = downcallHandle("vec_caps", FunctionDescriptor.of(JAVA_INT));
-        Map<OperationSignature, MethodHandle> handles = new HashMap<>();
+        Map<OperationSignature<?>, MethodHandle> handles = new HashMap<>();
 
         try {
             int caps = (int) vecCaps$mh.invokeExact();
@@ -107,36 +108,49 @@ public final class JdkVectorLibrary implements VectorLibrary {
                         case SQUARE_DISTANCE -> "sqr";
                     };
 
-                    for (DataType type : DataType.values()) {
-                        String typeName = switch (type) {
-                            case INT7 -> "7u";
-                            case FLOAT32 -> "f32";
-                            case I1I4 -> "_int1_int4";
-                            case I2I4 -> "_int2_int4";
+                    for (Operation op : Operation.values()) {
+                        String opName = switch (op) {
+                            case SINGLE -> "";
+                            case BULK -> "_bulk";
+                            case BULK_OFFSETS -> "_bulk_offsets";
                         };
 
-                        // not implemented yet...
-                        if ((type == DataType.I1I4 || type == DataType.I2I4) && f == Function.SQUARE_DISTANCE) continue;
-
-                        for (Operation op : Operation.values()) {
-                            String opName = switch (op) {
-                                case SINGLE -> "";
-                                case BULK -> "_bulk";
-                                case BULK_OFFSETS -> "_bulk_offsets";
+                        for (DataType type : DataType.values()) {
+                            String typeName = switch (type) {
+                                case INT7 -> "7u";
+                                case FLOAT32 -> "f32";
                             };
 
                             FunctionDescriptor descriptor = switch (op) {
                                 case SINGLE -> switch (type) {
                                     case INT7 -> intSingle;
                                     case FLOAT32 -> floatSingle;
-                                    case I1I4, I2I4 -> longSingle;
                                 };
                                 case BULK -> bulk;
                                 case BULK_OFFSETS -> bulkOffsets;
                             };
 
                             MethodHandle handle = bindFunction("vec_" + funcName + typeName + opName, caps, descriptor);
-                            handles.put(new OperationSignature(f, type, op), handle);
+                            handles.put(new OperationSignature<>(f, type, op), handle);
+                        }
+
+                        for (BBQType type : BBQType.values()) {
+                            // not implemented yet...
+                            if (f == Function.SQUARE_DISTANCE) continue;
+
+                            String typeName = switch (type) {
+                                case I1I4 -> "_int1_int4";
+                                case I2I4 -> "_int2_int4";
+                            };
+
+                            FunctionDescriptor descriptor = switch (op) {
+                                case SINGLE -> longSingle;
+                                case BULK -> bulk;
+                                case BULK_OFFSETS -> bulkOffsets;
+                            };
+
+                            MethodHandle handle = bindFunction("vec_" + funcName + typeName + opName, caps, descriptor);
+                            handles.put(new OperationSignature<>(f, type, op), handle);
                         }
                     }
                 }
@@ -251,28 +265,18 @@ public final class JdkVectorLibrary implements VectorLibrary {
             return true;
         }
 
-        static boolean checkI1I4Bulk(
+        static boolean checkBBQBulk(
+            int dataBits,
             MemorySegment dataset,
             MemorySegment query,
             int datasetVectorLengthInBytes,
             int count,
             MemorySegment result
         ) {
+            final int queryBits = 4;
             Objects.checkFromIndexSize(0, datasetVectorLengthInBytes * count, (int) dataset.byteSize());
-            Objects.checkFromIndexSize(0, datasetVectorLengthInBytes * 4L, (int) query.byteSize());
-            Objects.checkFromIndexSize(0, count * Float.BYTES, (int) result.byteSize());
-            return true;
-        }
-
-        static boolean checkI2I4Bulk(
-            MemorySegment dataset,
-            MemorySegment query,
-            int datasetVectorLengthInBytes,
-            int count,
-            MemorySegment result
-        ) {
-            Objects.checkFromIndexSize(0, datasetVectorLengthInBytes * count, (int) dataset.byteSize());
-            Objects.checkFromIndexSize(0, datasetVectorLengthInBytes * 2L, (int) query.byteSize());
+            // 1 bit data -> x4 bits query, 2 bit data -> x2 bits query
+            Objects.checkFromIndexSize(0, datasetVectorLengthInBytes * (queryBits / dataBits), (int) query.byteSize());
             Objects.checkFromIndexSize(0, count * Float.BYTES, (int) result.byteSize());
             return true;
         }
@@ -292,19 +296,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
             return true;
         }
 
-        static boolean checkI1I4BulkOffsets(
-            MemorySegment a,
-            MemorySegment b,
-            int length,
-            int pitch,
-            MemorySegment offsets,
-            int count,
-            MemorySegment result
-        ) {
-            return true;
-        }
-
-        static boolean checkI2I4BulkOffsets(
+        static boolean checkBBQBulkOffsets(
             MemorySegment a,
             MemorySegment b,
             int length,
@@ -317,7 +309,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle dot7uHandle = HANDLES.get(
-            new OperationSignature(Function.DOT_PRODUCT, DataType.INT7, Operation.SINGLE)
+            new OperationSignature<>(Function.DOT_PRODUCT, DataType.INT7, Operation.SINGLE)
         );
 
         static int dotProduct7u(MemorySegment a, MemorySegment b, int length) {
@@ -327,7 +319,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle square7uHandle = HANDLES.get(
-            new OperationSignature(Function.SQUARE_DISTANCE, DataType.INT7, Operation.SINGLE)
+            new OperationSignature<>(Function.SQUARE_DISTANCE, DataType.INT7, Operation.SINGLE)
         );
 
         static int squareDistance7u(MemorySegment a, MemorySegment b, int length) {
@@ -337,7 +329,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle dotF32Handle = HANDLES.get(
-            new OperationSignature(Function.DOT_PRODUCT, DataType.FLOAT32, Operation.SINGLE)
+            new OperationSignature<>(Function.DOT_PRODUCT, DataType.FLOAT32, Operation.SINGLE)
         );
 
         static float dotProductF32(MemorySegment a, MemorySegment b, int elementCount) {
@@ -347,7 +339,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle squareF32Handle = HANDLES.get(
-            new OperationSignature(Function.SQUARE_DISTANCE, DataType.FLOAT32, Operation.SINGLE)
+            new OperationSignature<>(Function.SQUARE_DISTANCE, DataType.FLOAT32, Operation.SINGLE)
         );
 
         static float squareDistanceF32(MemorySegment a, MemorySegment b, int elementCount) {
@@ -357,7 +349,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle dotI1I4Handle = HANDLES.get(
-            new OperationSignature(Function.DOT_PRODUCT, DataType.I1I4, Operation.SINGLE)
+            new OperationSignature<>(Function.DOT_PRODUCT, BBQType.I1I4, Operation.SINGLE)
         );
 
         /**
@@ -374,7 +366,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         }
 
         private static final MethodHandle dotI2I4Handle = HANDLES.get(
-            new OperationSignature(Function.DOT_PRODUCT, DataType.I2I4, Operation.SINGLE)
+            new OperationSignature<>(Function.DOT_PRODUCT, BBQType.I2I4, Operation.SINGLE)
         );
 
         /**
@@ -396,13 +388,13 @@ public final class JdkVectorLibrary implements VectorLibrary {
             }
         }
 
-        private static final Map<OperationSignature, MethodHandle> HANDLES_WITH_CHECKS;
+        private static final Map<OperationSignature<?>, MethodHandle> HANDLES_WITH_CHECKS;
 
         static {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
 
             try {
-                Map<OperationSignature, MethodHandle> handlesWithChecks = new HashMap<>();
+                Map<OperationSignature<?>, MethodHandle> handlesWithChecks = new HashMap<>();
 
                 for (var op : HANDLES.entrySet()) {
                     switch (op.getKey().operation()) {
@@ -412,69 +404,92 @@ public final class JdkVectorLibrary implements VectorLibrary {
                             // So have specific hard-coded check methods rather than use guardWithTest
                             // to create the check-and-call methods dynamically
                             MethodHandle handleWithChecks = switch (op.getKey().dataType()) {
-                                case INT7 -> {
-                                    MethodType type = MethodType.methodType(int.class, MemorySegment.class, MemorySegment.class, int.class);
-                                    yield switch (op.getKey().function()) {
-                                        case DOT_PRODUCT -> lookup.findStatic(JdkVectorSimilarityFunctions.class, "dotProduct7u", type);
-                                        case SQUARE_DISTANCE -> lookup.findStatic(
-                                            JdkVectorSimilarityFunctions.class,
-                                            "squareDistance7u",
-                                            type
+                                case DataType dt -> switch (dt) {
+                                    case INT7 -> {
+                                        MethodType type = MethodType.methodType(
+                                            int.class,
+                                            MemorySegment.class,
+                                            MemorySegment.class,
+                                            int.class
                                         );
-                                    };
-                                }
-                                case FLOAT32 -> {
-                                    MethodType type = MethodType.methodType(
-                                        float.class,
-                                        MemorySegment.class,
-                                        MemorySegment.class,
-                                        int.class
-                                    );
-                                    yield switch (op.getKey().function()) {
-                                        case DOT_PRODUCT -> lookup.findStatic(JdkVectorSimilarityFunctions.class, "dotProductF32", type);
-                                        case SQUARE_DISTANCE -> lookup.findStatic(
-                                            JdkVectorSimilarityFunctions.class,
-                                            "squareDistanceF32",
-                                            type
+                                        yield switch (op.getKey().function()) {
+                                            case DOT_PRODUCT -> lookup.findStatic(JdkVectorSimilarityFunctions.class, "dotProduct7u", type);
+                                            case SQUARE_DISTANCE -> lookup.findStatic(
+                                                JdkVectorSimilarityFunctions.class,
+                                                "squareDistance7u",
+                                                type
+                                            );
+                                        };
+                                    }
+                                    case FLOAT32 -> {
+                                        MethodType type = MethodType.methodType(
+                                            float.class,
+                                            MemorySegment.class,
+                                            MemorySegment.class,
+                                            int.class
                                         );
-                                    };
-                                }
-                                case I1I4 -> {
-                                    MethodType type = MethodType.methodType(
-                                        long.class,
-                                        MemorySegment.class,
-                                        MemorySegment.class,
-                                        int.class
-                                    );
-                                    yield switch (op.getKey().function()) {
-                                        case DOT_PRODUCT -> lookup.findStatic(JdkVectorSimilarityFunctions.class, "dotProductI1I4", type);
-                                        case SQUARE_DISTANCE -> throw new UnsupportedOperationException("Not implemented");
-                                    };
-                                }
-                                case I2I4 -> {
-                                    MethodType type = MethodType.methodType(
-                                        long.class,
-                                        MemorySegment.class,
-                                        MemorySegment.class,
-                                        int.class
-                                    );
-                                    yield switch (op.getKey().function()) {
-                                        case DOT_PRODUCT -> lookup.findStatic(JdkVectorSimilarityFunctions.class, "dotProductI2I4", type);
-                                        case SQUARE_DISTANCE -> throw new UnsupportedOperationException("Not implemented");
-                                    };
-                                }
+                                        yield switch (op.getKey().function()) {
+                                            case DOT_PRODUCT -> lookup.findStatic(
+                                                JdkVectorSimilarityFunctions.class,
+                                                "dotProductF32",
+                                                type
+                                            );
+                                            case SQUARE_DISTANCE -> lookup.findStatic(
+                                                JdkVectorSimilarityFunctions.class,
+                                                "squareDistanceF32",
+                                                type
+                                            );
+                                        };
+                                    }
+                                };
+                                case BBQType bbq -> switch (bbq) {
+                                    case I1I4 -> {
+                                        MethodType type = MethodType.methodType(
+                                            long.class,
+                                            MemorySegment.class,
+                                            MemorySegment.class,
+                                            int.class
+                                        );
+                                        yield switch (op.getKey().function()) {
+                                            case DOT_PRODUCT -> lookup.findStatic(
+                                                JdkVectorSimilarityFunctions.class,
+                                                "dotProductI1I4",
+                                                type
+                                            );
+                                            case SQUARE_DISTANCE -> throw new UnsupportedOperationException("Not implemented");
+                                        };
+                                    }
+                                    case I2I4 -> {
+                                        MethodType type = MethodType.methodType(
+                                            long.class,
+                                            MemorySegment.class,
+                                            MemorySegment.class,
+                                            int.class
+                                        );
+                                        yield switch (op.getKey().function()) {
+                                            case DOT_PRODUCT -> lookup.findStatic(
+                                                JdkVectorSimilarityFunctions.class,
+                                                "dotProductI2I4",
+                                                type
+                                            );
+                                            case SQUARE_DISTANCE -> throw new UnsupportedOperationException("Not implemented");
+                                        };
+                                    }
+                                };
+                                default -> throw new IllegalArgumentException("Unknown handle type " + op.getKey().dataType());
                             };
 
                             handlesWithChecks.put(op.getKey(), handleWithChecks);
                         }
                         case BULK -> {
                             MethodHandle handleWithChecks = switch (op.getKey().dataType()) {
-                                case I1I4, I2I4 -> {
+                                case BBQType bbq -> {
                                     MethodHandle checkMethod = lookup.findStatic(
                                         JdkVectorSimilarityFunctions.class,
-                                        "check" + op.getKey().dataType() + "Bulk",
+                                        "checkBBQBulk",
                                         MethodType.methodType(
                                             boolean.class,
+                                            int.class,
                                             MemorySegment.class,
                                             MemorySegment.class,
                                             int.class,
@@ -483,12 +498,12 @@ public final class JdkVectorLibrary implements VectorLibrary {
                                         )
                                     );
                                     yield MethodHandles.guardWithTest(
-                                        checkMethod,
+                                        MethodHandles.insertArguments(checkMethod, 0, bbq.dataBits()),
                                         op.getValue(),
                                         MethodHandles.empty(op.getValue().type())
                                     );
                                 }
-                                default -> {
+                                case DataType dt -> {
                                     MethodHandle checkMethod = lookup.findStatic(
                                         JdkVectorSimilarityFunctions.class,
                                         "checkBulk",
@@ -503,21 +518,22 @@ public final class JdkVectorLibrary implements VectorLibrary {
                                         )
                                     );
                                     yield MethodHandles.guardWithTest(
-                                        MethodHandles.insertArguments(checkMethod, 0, op.getKey().dataType().bytes()),
+                                        MethodHandles.insertArguments(checkMethod, 0, dt.bytes()),
                                         op.getValue(),
                                         MethodHandles.empty(op.getValue().type())
                                     );
                                 }
+                                default -> throw new IllegalArgumentException("Unknown handle type " + op.getKey().dataType());
                             };
 
                             handlesWithChecks.put(op.getKey(), handleWithChecks);
                         }
                         case BULK_OFFSETS -> {
                             MethodHandle handleWithChecks = switch (op.getKey().dataType()) {
-                                case I1I4, I2I4 -> {
+                                case BBQType _ -> {
                                     MethodHandle checkMethod = lookup.findStatic(
                                         JdkVectorSimilarityFunctions.class,
-                                        "check" + op.getKey().dataType() + "BulkOffsets",
+                                        "checkBBQBulkOffsets",
                                         MethodType.methodType(
                                             boolean.class,
                                             MemorySegment.class,
@@ -535,7 +551,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
                                         MethodHandles.empty(op.getValue().type())
                                     );
                                 }
-                                default -> {
+                                case DataType dt -> {
                                     MethodHandle checkMethod = lookup.findStatic(
                                         JdkVectorSimilarityFunctions.class,
                                         "checkBulkOffsets",
@@ -552,11 +568,12 @@ public final class JdkVectorLibrary implements VectorLibrary {
                                         )
                                     );
                                     yield MethodHandles.guardWithTest(
-                                        MethodHandles.insertArguments(checkMethod, 0, op.getKey().dataType().bytes()),
+                                        MethodHandles.insertArguments(checkMethod, 0, dt.bytes()),
                                         op.getValue(),
                                         MethodHandles.empty(op.getValue().type())
                                     );
                                 }
+                                default -> throw new IllegalArgumentException("Unknown handle type " + op.getKey().dataType());
                             };
 
                             handlesWithChecks.put(op.getKey(), handleWithChecks);
@@ -572,7 +589,15 @@ public final class JdkVectorLibrary implements VectorLibrary {
 
         @Override
         public MethodHandle getHandle(Function function, DataType dataType, Operation operation) {
-            OperationSignature key = new OperationSignature(function, dataType, operation);
+            OperationSignature<?> key = new OperationSignature<>(function, dataType, operation);
+            MethodHandle mh = HANDLES_WITH_CHECKS.get(key);
+            if (mh == null) throw new IllegalArgumentException("Signature not implemented: " + key);
+            return mh;
+        }
+
+        @Override
+        public MethodHandle getHandle(Function function, BBQType bbqType, Operation operation) {
+            OperationSignature<?> key = new OperationSignature<>(function, bbqType, operation);
             MethodHandle mh = HANDLES_WITH_CHECKS.get(key);
             if (mh == null) throw new IllegalArgumentException("Signature not implemented: " + key);
             return mh;

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt4Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt4Tests.java
@@ -30,24 +30,16 @@ import static org.hamcrest.Matchers.containsString;
 
 public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
 
-    private final VectorSimilarityFunctions.DataType type;
-    private final byte indexBits;
-    private static final byte queryBits = 4;
+    private final VectorSimilarityFunctions.BBQType type;
 
     private final byte maxQueryValue;
     private final byte maxIndexValue;
 
-    public JDKVectorLibraryInt4Tests(
-        VectorSimilarityFunctions.DataType type,
-        byte indexBits,
-        VectorSimilarityFunctions.Function function,
-        int size
-    ) {
+    public JDKVectorLibraryInt4Tests(VectorSimilarityFunctions.BBQType type, VectorSimilarityFunctions.Function function, int size) {
         super(function, size);
         this.type = type;
-        this.indexBits = indexBits;
-        this.maxQueryValue = (1 << queryBits) - 1;
-        this.maxIndexValue = (byte) ((1 << indexBits) - 1);
+        this.maxQueryValue = (byte) ((1 << type.queryBits()) - 1);
+        this.maxIndexValue = (byte) ((1 << type.dataBits()) - 1);
     }
 
     @ParametersFactory
@@ -59,12 +51,10 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         baseParams.removeIf(os -> os[0] == VectorSimilarityFunctions.Function.SQUARE_DISTANCE);
 
         // duplicate for int1 & int2
-        return () -> Stream.concat(
-            baseParams.stream()
-                .map(os -> CollectionUtils.concatLists(List.of(VectorSimilarityFunctions.DataType.I1I4, (byte) 1), Arrays.asList(os))),
-            baseParams.stream()
-                .map(os -> CollectionUtils.concatLists(List.of(VectorSimilarityFunctions.DataType.I2I4, (byte) 2), Arrays.asList(os)))
-        ).map(List::toArray).iterator();
+        return () -> Stream.of(VectorSimilarityFunctions.BBQType.values())
+            .flatMap(bbq -> baseParams.stream().map(os -> CollectionUtils.concatLists(List.of(bbq), Arrays.asList(os))))
+            .map(List::toArray)
+            .iterator();
     }
 
     @BeforeClass
@@ -82,8 +72,8 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         final int dims = size;
         final int numVecs = randomIntBetween(2, 101);
 
-        final int indexVectorBytes = numBytes(dims, indexBits);
-        final int queryVectorBytes = numBytes(dims, queryBits);
+        final int indexVectorBytes = numBytes(dims, type.dataBits());
+        final int queryVectorBytes = numBytes(dims, type.queryBits());
 
         var unpackedIndexVectors = new byte[numVecs][dims];
         var unpackedQueryVectors = new byte[numVecs][dims];
@@ -99,8 +89,8 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
             randomBytesBetween(unpackedIndexVectors[i], (byte) 0, maxIndexValue);
             randomBytesBetween(unpackedQueryVectors[i], (byte) 0, maxQueryValue);
 
-            pack(unpackedIndexVectors[i], indexVectors[i], indexBits);
-            pack(unpackedQueryVectors[i], queryVectors[i], queryBits);
+            pack(unpackedIndexVectors[i], indexVectors[i], type.dataBits());
+            pack(unpackedQueryVectors[i], queryVectors[i], type.queryBits());
 
             MemorySegment.copy(indexVectors[i], 0, indexSegment, ValueLayout.JAVA_BYTE, (long) i * indexVectorBytes, indexVectorBytes);
             MemorySegment.copy(queryVectors[i], 0, querySegment, ValueLayout.JAVA_BYTE, (long) i * queryVectorBytes, queryVectorBytes);
@@ -154,12 +144,12 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         return new TestOffsets(offsets, offsetsSegment);
     }
 
-    static TestData createTestData(final int numVecs, final int dims, final byte indexBits, final long extraData) {
-        final byte maxQueryValue = (1 << queryBits) - 1;
-        final byte maxIndexValue = (byte) ((1 << indexBits) - 1);
+    static TestData createTestData(final int numVecs, final int dims, final VectorSimilarityFunctions.BBQType type, final long extraData) {
+        final byte maxIndexValue = (byte) ((1 << type.dataBits()) - 1);
+        final byte maxQueryValue = (byte) ((1 << type.queryBits()) - 1);
 
-        final int indexVectorBytes = numBytes(dims, indexBits);
-        final int queryVectorBytes = numBytes(dims, queryBits);
+        final int indexVectorBytes = numBytes(dims, type.dataBits());
+        final int queryVectorBytes = numBytes(dims, type.queryBits());
 
         var unpackedIndexVectors = new byte[numVecs][dims];
         var unpackedQueryVector = new byte[dims];
@@ -174,12 +164,12 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         var querySegment = arena.allocate(queryVectorBytes);
 
         randomBytesBetween(unpackedQueryVector, (byte) 0, maxQueryValue);
-        pack(unpackedQueryVector, queryVector, queryBits);
+        pack(unpackedQueryVector, queryVector, type.queryBits());
         MemorySegment.copy(queryVector, 0, querySegment, ValueLayout.JAVA_BYTE, 0L, queryVectorBytes);
 
         for (int i = 0; i < numVecs; i++) {
             randomBytesBetween(unpackedIndexVectors[i], (byte) 0, maxIndexValue);
-            pack(unpackedIndexVectors[i], indexVectors[i], indexBits);
+            pack(unpackedIndexVectors[i], indexVectors[i], type.dataBits());
             MemorySegment.copy(indexVectors[i], 0, indexSegment, ValueLayout.JAVA_BYTE, (long) i * indexLineLength, indexVectorBytes);
         }
 
@@ -194,15 +184,15 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         );
     }
 
-    static TestData createTestData(final int numVecs, final int dims, final byte indexBits) {
-        return createTestData(numVecs, dims, indexBits, 0);
+    static TestData createTestData(final int numVecs, final int dims, final VectorSimilarityFunctions.BBQType type) {
+        return createTestData(numVecs, dims, type, 0);
     }
 
     public void testInt4Bulk() {
         assumeTrue(notSupportedMsg(), supported());
 
         final int numVecs = randomIntBetween(2, 101);
-        final TestData testData = createTestData(numVecs, size, indexBits);
+        final TestData testData = createTestData(numVecs, size, type);
 
         float[] expectedScores = new float[numVecs];
         scalarSimilarityBulk(testData.unpackedQueryVector, testData.unpackedIndexVectors, expectedScores);
@@ -228,7 +218,7 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
         assumeTrue(notSupportedMsg(), supported());
 
         final int numVecs = randomIntBetween(2, 101);
-        final TestData testData = createTestData(numVecs, size, indexBits);
+        final TestData testData = createTestData(numVecs, size, type);
         final TestOffsets testOffsets = createTestOffsets(numVecs);
 
         float[] expectedScores = new float[numVecs];
@@ -253,7 +243,7 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
 
         final int numVecs = randomIntBetween(2, 101);
 
-        final TestData testData = createTestData(numVecs, size, indexBits, Float.BYTES);
+        final TestData testData = createTestData(numVecs, size, type, Float.BYTES);
         final TestOffsets testOffsets = createTestOffsets(numVecs);
 
         float[] expectedScores = new float[numVecs];
@@ -280,7 +270,7 @@ public class JDKVectorLibraryInt4Tests extends VectorSimilarityFunctionsTests {
 
         final int numVecs = randomIntBetween(2, 101);
 
-        final TestData testData = createTestData(numVecs, size, indexBits);
+        final TestData testData = createTestData(numVecs, size, type);
         final TestOffsets testOffsets = createTestOffsets(numVecs);
 
         float[] expectedScores = new float[numVecs];

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/Similarities.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/Similarities.java
@@ -11,6 +11,7 @@ package org.elasticsearch.simdvec.internal;
 
 import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
+import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.BBQType;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.DataType;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.Function;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions.Operation;
@@ -39,19 +40,19 @@ public class Similarities {
         Operation.BULK_OFFSETS
     );
 
-    static final MethodHandle DOT_PRODUCT_I1I4 = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.I1I4, Operation.SINGLE);
-    static final MethodHandle DOT_PRODUCT_I1I4_BULK = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.I1I4, Operation.BULK);
+    static final MethodHandle DOT_PRODUCT_I1I4 = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, BBQType.I1I4, Operation.SINGLE);
+    static final MethodHandle DOT_PRODUCT_I1I4_BULK = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, BBQType.I1I4, Operation.BULK);
     static final MethodHandle DOT_PRODUCT_I1I4_BULK_WITH_OFFSETS = DISTANCE_FUNCS.getHandle(
         Function.DOT_PRODUCT,
-        DataType.I1I4,
+        BBQType.I1I4,
         Operation.BULK_OFFSETS
     );
 
-    static final MethodHandle DOT_PRODUCT_I2I4 = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.I2I4, Operation.SINGLE);
-    static final MethodHandle DOT_PRODUCT_I2I4_BULK = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.I2I4, Operation.BULK);
+    static final MethodHandle DOT_PRODUCT_I2I4 = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, BBQType.I2I4, Operation.SINGLE);
+    static final MethodHandle DOT_PRODUCT_I2I4_BULK = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, BBQType.I2I4, Operation.BULK);
     static final MethodHandle DOT_PRODUCT_I2I4_BULK_WITH_OFFSETS = DISTANCE_FUNCS.getHandle(
         Function.DOT_PRODUCT,
-        DataType.I2I4,
+        BBQType.I2I4,
         Operation.BULK_OFFSETS
     );
 


### PR DESCRIPTION
Create a new `BBQType` to represent BBQ methods, which operate on bits, not bytes