### PR TITLE
[9.3] rest-api-spec: add options to cat.circuit_breaker (#141346)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.circuit_breaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.circuit_breaker.json
@@ -65,7 +65,18 @@
       },
       "h": {
         "type": "list",
-        "description": "Comma-separated list of column names to display"
+        "description": "Comma-separated list of column names to display",
+        "options": [
+          "breaker",
+          "estimated",
+          "estimated_bytes",
+          "limit",
+          "limit_bytes",
+          "node_id",
+          "node_name",
+          "overhead",
+          "tripped"
+        ]
       },
       "help": {
         "type": "boolean",


### PR DESCRIPTION
Backports the following commits to 9.3:
 - rest-api-spec: add options to cat.circuit_breaker (#141346)