### PR TITLE
[9.3] rest-api-spec: fix visibility for esql.get_views API (#141354)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
@@ -5,8 +5,7 @@
       "description": "Get a specific running ES|QL query information"
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "esql_views",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
Backports the following commits to 9.3:
 - rest-api-spec: fix visibility for esql.get_views API (#141354)