### PR TITLE
Fix capability in 46_downsample yaml test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -267,9 +267,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackSubqueryIT
   method: testManyRandomTextFieldsInSubqueryIntermediateResultsWithSortManyFields
   issue: https://github.com/elastic/elasticsearch/issues/140664
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/46_downsample/Stats from downsampled and non-downsampled index simultaneously with implicit casting}
-  issue: https://github.com/elastic/elasticsearch/issues/140774
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesEisChatCompletion_DoesNotRemoveEndpointWhenNoLongerAuthorized
   issue: https://github.com/elastic/elasticsearch/issues/140802

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -260,8 +260,8 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
-      reason: "Support for casting aggregate metric double implicitly when present in aggregations"
+          capabilities: [aggregate_metric_double_default_metric, dense_vector_agg_metric_double_if_version]
+      reason: "Requires default metric to run TS ... | STATS max(agg_metric)"
 
   - do:
       indices.downsample:


### PR DESCRIPTION
During the previous capabilities fiasco (#138865) I missed that
this test now contains a case that requires the default metric
functionality, which should cause it to fail in 9.2.5/other
older versions

Resolves #140774
