### PR TITLE
[9.3] Formatting: Keep braces for empty anonymous classes on a single line (#141683)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -96,8 +96,7 @@ public class AggConstructionContentionBenchmark {
     private final Index index = new Index("test", "uuid");
     private final IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(
         Settings.EMPTY,
-        new IndexFieldDataCache.Listener() {
-        }
+        new IndexFieldDataCache.Listener() {}
     );
 
     private CircuitBreakerService breakerService;
@@ -213,8 +212,11 @@ public class AggConstructionContentionBenchmark {
 
         @Override
         protected IndexFieldData<?> buildFieldData(MappedFieldType ft) {
-            IndexFieldDataCache indexFieldDataCache = indicesFieldDataCache.buildIndexFieldDataCache(new IndexFieldDataCache.Listener() {
-            }, index, ft.name());
+            IndexFieldDataCache indexFieldDataCache = indicesFieldDataCache.buildIndexFieldDataCache(
+                new IndexFieldDataCache.Listener() {},
+                index,
+                ft.name()
+            );
             return ft.fielddataBuilder(FieldDataContext.noRuntimeFields("index", "benchmark")).build(indexFieldDataCache, breakerService);
         }
 

--- a/build-conventions/formatterConfig.xml
+++ b/build-conventions/formatterConfig.xml
@@ -65,7 +65,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_if_empty"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -225,8 +225,11 @@ public class RemovePluginActionTests extends ESTestCase {
 
         MockTerminal terminal = MockTerminal.create();
 
-        new MockRemovePluginCommand(env) {
-        }.main(new String[] { "-Epath.home=" + home, "fake" }, terminal, new ProcessInfo(Map.of(), Map.of(), createTempDir()));
+        new MockRemovePluginCommand(env) {}.main(
+            new String[] { "-Epath.home=" + home, "fake" },
+            terminal,
+            new ProcessInfo(Map.of(), Map.of(), createTempDir())
+        );
         try (
             BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()));
             BufferedReader errorReader = new BufferedReader(new StringReader(terminal.getErrorOutput()))

--- a/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -37,8 +37,7 @@ public class TerminalTests extends ESTestCase {
         PrintWriter stdOut = mock("stdOut");
         PrintWriter stdErr = mock("stdErr");
 
-        OutputStream out = new Terminal(mock("reader"), stdOut, stdErr) {
-        }.asLineOutputStream(StandardCharsets.UTF_8);
+        OutputStream out = new Terminal(mock("reader"), stdOut, stdErr) {}.asLineOutputStream(StandardCharsets.UTF_8);
 
         out.write("123".getBytes(StandardCharsets.UTF_8));
         out.write("456".getBytes(StandardCharsets.UTF_8));

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/Util.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/Util.java
@@ -22,8 +22,7 @@ public class Util {
      *
      * @see StackWalker#getCallerClass()
      */
-    public static final Class<?> NO_CLASS = new Object() {
-    }.getClass();
+    public static final Class<?> NO_CLASS = new Object() {}.getClass();
 
     private static final Set<String> skipInternalPackages = Set.of("java.lang.invoke", "java.lang.reflect", "jdk.internal.reflect");
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
@@ -88,8 +88,7 @@ class JvmActions {
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void createLogManager() {
-        new java.util.logging.LogManager() {
-        };
+        new java.util.logging.LogManager() {};
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/simplify/StreamingGeometrySimplifier.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/simplify/StreamingGeometrySimplifier.java
@@ -41,10 +41,8 @@ public abstract class StreamingGeometrySimplifier<T extends Geometry> {
     protected int length;
     protected int objCount = 0;
     protected String description;
-    protected PointConstructor pointConstructor = new PointConstructor() {
-    };
-    protected PointResetter pointResetter = new PointResetter() {
-    };
+    protected PointConstructor pointConstructor = new PointConstructor() {};
+    protected PointResetter pointResetter = new PointResetter() {};
 
     protected final PriorityQueue<PointError> queue = new PriorityQueue<>();
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -676,8 +676,7 @@ public class Netty4HttpServerTransportTests extends ESTestCase {
 
                     @Override
                     protected void initChannel(SocketChannel ch) {
-                        ch.pipeline().addLast(new ChannelHandlerAdapter() {
-                        });
+                        ch.pipeline().addLast(new ChannelHandlerAdapter() {});
 
                     }
                 })

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
@@ -54,8 +54,7 @@ public class AllocationFailuresResetIT extends ESIntegTestCase {
     }
 
     private void removeAllocationFailuresInjection(String node) {
-        internalCluster().getInstance(MockIndexEventListener.TestEventListener.class, node).setNewDelegate(new IndexEventListener() {
-        });
+        internalCluster().getInstance(MockIndexEventListener.TestEventListener.class, node).setNewDelegate(new IndexEventListener() {});
     }
 
     private void awaitShardAllocMaxRetries() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -1085,10 +1085,8 @@ public class ActionModule extends AbstractModule {
         bind(RestController.class).toInstance(restController);
         bind(ActionFilters.class).toInstance(actionFilters);
         bind(DestructiveOperations.class).toInstance(destructiveOperations);
-        bind(new TypeLiteral<RequestValidators<PutMappingRequest>>() {
-        }).toInstance(mappingRequestValidators);
-        bind(new TypeLiteral<RequestValidators<IndicesAliasesRequest>>() {
-        }).toInstance(indicesAliasesRequestRequestValidators);
+        bind(new TypeLiteral<RequestValidators<PutMappingRequest>>() {}).toInstance(mappingRequestValidators);
+        bind(new TypeLiteral<RequestValidators<IndicesAliasesRequest>>() {}).toInstance(indicesAliasesRequestRequestValidators);
         bind(AutoCreateIndex.class).toInstance(autoCreateIndex);
 
         // register ActionType -> transportAction Map used by NodeClient

--- a/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
@@ -27,8 +27,7 @@ import java.util.Objects;
 public abstract class SearchProgressListener {
     private static final Logger logger = LogManager.getLogger(SearchProgressListener.class);
 
-    public static final SearchProgressListener NOOP = new SearchProgressListener() {
-    };
+    public static final SearchProgressListener NOOP = new SearchProgressListener() {};
 
     private List<SearchShard> shards;
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingChangesObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingChangesObserver.java
@@ -13,6 +13,9 @@ package org.elasticsearch.cluster.routing;
  * Records changes made to {@link RoutingNodes} during an allocation round.
  */
 public interface RoutingChangesObserver {
+
+    RoutingChangesObserver NOOP = new RoutingChangesObserver() {};
+
     /**
      * Called when unassigned shard is initialized. Does not include initializing relocation target shards.
      */

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
@@ -24,8 +24,7 @@ import java.io.IOException;
  * in the same generation are either identical or equivalent when synthetic sources are used.
  */
 public abstract class TranslogOperationAsserter {
-    public static final TranslogOperationAsserter DEFAULT = new TranslogOperationAsserter() {
-    };
+    public static final TranslogOperationAsserter DEFAULT = new TranslogOperationAsserter() {};
 
     private TranslogOperationAsserter() {
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -44,8 +44,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
     private final IndicesFieldDataCache indicesFieldDataCache;
     // the below map needs to be modified under a lock
     private final Map<String, IndexFieldDataCache> fieldDataCaches = new HashMap<>();
-    private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {
-    };
+    private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {};
     private volatile IndexFieldDataCache.Listener listener = DEFAULT_NOOP_LISTENER;
 
     public IndexFieldDataService(

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -940,8 +940,7 @@ public class IndicesService extends AbstractLifecycleComponent
     public synchronized void verifyIndexMetadata(IndexMetadata metadata, IndexMetadata metadataUpdate) throws IOException {
         final List<Closeable> closeables = new ArrayList<>();
         try {
-            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             closeables.add(indicesFieldDataCache);
             IndicesQueryCache indicesQueryCache = new IndicesQueryCache(settings);
             closeables.add(indicesQueryCache);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
@@ -22,9 +22,9 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.MetaStateService;
+import org.elasticsearch.index.ActionLoggingFields;
+import org.elasticsearch.index.ActionLoggingFieldsProvider;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.SlowLogFieldProvider;
-import org.elasticsearch.index.SlowLogFields;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.MergeMetrics;
@@ -83,28 +83,7 @@ public class IndicesServiceBuilder {
     MergeMetrics mergeMetrics;
     List<SearchOperationListener> searchOperationListener = List.of();
     QueryRewriteInterceptor queryRewriteInterceptor = null;
-    SlowLogFieldProvider slowLogFieldProvider = new SlowLogFieldProvider() {
-        @Override
-        public SlowLogFields create() {
-            return new SlowLogFields() {
-                @Override
-                public Map<String, String> indexFields() {
-                    return Map.of();
-                }
-
-                @Override
-                public Map<String, String> searchFields() {
-                    return Map.of();
-                }
-            };
-        }
-
-        @Override
-        public SlowLogFields create(IndexSettings indexSettings) {
-            return create();
-        }
-
-    };
+    ActionLoggingFieldsProvider loggingFieldsProvider = (context) -> new ActionLoggingFields(context) {};
 
     public IndicesServiceBuilder settings(Settings settings) {
         this.settings = settings;
@@ -222,8 +201,8 @@ public class IndicesServiceBuilder {
         return this;
     }
 
-    public IndicesServiceBuilder slowLogFieldProvider(SlowLogFieldProvider slowLogFieldProvider) {
-        this.slowLogFieldProvider = slowLogFieldProvider;
+    public IndicesServiceBuilder loggingFieldsProvider(ActionLoggingFieldsProvider loggingFieldsProvider) {
+        this.loggingFieldsProvider = loggingFieldsProvider;
         return this;
     }
 
@@ -253,7 +232,7 @@ public class IndicesServiceBuilder {
         Objects.requireNonNull(mapperMetrics);
         Objects.requireNonNull(mergeMetrics);
         Objects.requireNonNull(searchOperationListener);
-        Objects.requireNonNull(slowLogFieldProvider);
+        Objects.requireNonNull(loggingFieldsProvider);
 
         // collect engine factory providers from plugins
         engineFactoryProviders = pluginsService.filterPlugins(EnginePlugin.class)

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1569,8 +1569,9 @@ class NodeConstruction {
         // Due to Java's type erasure with generics, the injector can't give us exactly what we need, and we have
         // to resort to some evil casting.
         @SuppressWarnings("rawtypes")
-        Map<ActionType<?>, TransportAction<?, ?>> actions = forciblyCast(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {
-        }));
+        Map<ActionType<?>, TransportAction<?, ?>> actions = forciblyCast(
+            injector.getInstance(new Key<Map<ActionType, TransportAction>>() {})
+        );
 
         client.initialize(
             actions,

--- a/server/src/main/java/org/elasticsearch/plugins/internal/DocumentParsingProvider.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/DocumentParsingProvider.java
@@ -17,8 +17,7 @@ import org.elasticsearch.index.mapper.MapperService;
  * An interface to provide instances of document parsing observer and reporter
  */
 public interface DocumentParsingProvider {
-    DocumentParsingProvider EMPTY_INSTANCE = new DocumentParsingProvider() {
-    };
+    DocumentParsingProvider EMPTY_INSTANCE = new DocumentParsingProvider() {};
 
     /**
      * @return an instance of a reporter to use when parsing has been completed and indexing successful

--- a/server/src/main/java/org/elasticsearch/plugins/internal/DocumentSizeReporter.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/DocumentSizeReporter.java
@@ -18,8 +18,7 @@ public interface DocumentSizeReporter {
     /**
      * a default noop implementation
      */
-    DocumentSizeReporter EMPTY_INSTANCE = new DocumentSizeReporter() {
-    };
+    DocumentSizeReporter EMPTY_INSTANCE = new DocumentSizeReporter() {};
 
     /**
      * An action to be performed upon finished indexing.

--- a/server/src/main/java/org/elasticsearch/search/vectors/CachingEnableFilterQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/CachingEnableFilterQuery.java
@@ -61,8 +61,7 @@ public class CachingEnableFilterQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
         var inWeight = in.createWeight(searcher, scoreMode, boost);
-        return new FilterWeight(this, inWeight) {
-        };
+        return new FilterWeight(this, inWeight) {};
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
@@ -12,8 +12,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 
 public interface TransportMessageListener {
 
-    TransportMessageListener NOOP_LISTENER = new TransportMessageListener() {
-    };
+    TransportMessageListener NOOP_LISTENER = new TransportMessageListener() {};
 
     /**
      * Called once a request is received

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -130,8 +130,7 @@ public class TransportService extends AbstractLifecycleComponent
         }
     });
 
-    public static final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
-    };
+    public static final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {};
 
     // tracer log
 

--- a/server/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -37,8 +37,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/id", response.getLocation(null));
         assertEquals("/index/_doc/id?routing=test_routing", response.getLocation("test_routing"));
     }
@@ -51,8 +50,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/%E2%9D%A4", response.getLocation(null));
         assertEquals("/index/_doc/%E2%9D%A4?routing=%C3%A4", response.getLocation("ä"));
     }
@@ -65,8 +63,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/a+b", response.getLocation(null));
         assertEquals("/index/_doc/a+b?routing=c+d", response.getLocation("c d"));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
@@ -954,8 +954,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var modifiedKeys = putTemplateAction.modifiedKeys(pr);
         assertThat(modifiedKeys, hasSize(1));
 
-        var fakeAction = new ActionWithReservedState<TransportPutComposableIndexTemplateAction.Request>() {
-        };
+        var fakeAction = new ActionWithReservedState<TransportPutComposableIndexTemplateAction.Request>() {};
         assertEquals(
             "Failed to process request [validate_template] with errors: "
                 + "[[composable_index_template:validate_template] set as read-only by [file_settings]]",

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -152,8 +152,7 @@ public final class MockSearchPhaseContext extends AbstractSearchAsyncAction<Sear
         Transport.Connection shard,
         SearchActionListener<SearchPhaseResult> listener
     ) {
-        onShardResult(new SearchPhaseResult() {
-        });
+        onShardResult(new SearchPhaseResult() {});
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -180,8 +180,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
                 circuitBreaker,
                 searchPhaseController,
                 () -> false,
-                new SearchProgressListener() {
-                },
+                new SearchProgressListener() {},
                 10,
                 e -> {}
             )
@@ -229,8 +228,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
                 circuitBreaker,
                 searchPhaseController,
                 () -> false,
-                new SearchProgressListener() {
-                },
+                new SearchProgressListener() {},
                 10,
                 e -> {}
             )

--- a/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
@@ -43,8 +43,7 @@ public class ElasticsearchUncaughtExceptionHandlerTests extends ESTestCase {
             new StackOverflowError(),
             new UnknownError(),
             new IOError(new IOException("fatal")),
-            new Error() {
-            }
+            new Error() {}
         );
         final Thread thread = new Thread(() -> { throw error; });
         final String name = randomAlphaOfLength(10);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/GlobalRoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/GlobalRoutingTableTests.java
@@ -295,8 +295,7 @@ public class GlobalRoutingTableTests extends AbstractWireSerializingTestCase<Glo
 
         final RoutingNodes mutate = routingNodes.mutableCopy();
         final DiscoveryNode targetNode = randomFrom(clusterState.nodes().getNodes().values());
-        final RoutingChangesObserver emptyObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver emptyObserver = new RoutingChangesObserver() {};
 
         final int unassigned = mutate.unassigned().size();
         var unassignedItr = mutate.unassigned().iterator();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardMovementWriteLoadSimulatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardMovementWriteLoadSimulatorTests.java
@@ -37,8 +37,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class ShardMovementWriteLoadSimulatorTests extends ESTestCase {
 
-    private static final RoutingChangesObserver NOOP = new RoutingChangesObserver() {
-    };
+    private static final RoutingChangesObserver NOOP = new RoutingChangesObserver() {};
     private static final String[] INDICES = { "indexOne", "indexTwo", "indexThree" };
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -157,8 +157,7 @@ public class DataTierTests extends ESTestCase {
             }
             final Set<DiscoveryNodeRole> roles = new HashSet<>(randomSubsetOf(allRoles));
             if (frequently()) {
-                roles.add(new DiscoveryNodeRole("custom_role", "cr") {
-                });
+                roles.add(new DiscoveryNodeRole("custom_role", "cr") {});
             }
             final DiscoveryNode node = newNode(idGenerator.getAndIncrement(), attributes, roles);
             nodesList.add(node);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexVersionAllocationDeciderTests.java
@@ -652,8 +652,7 @@ public class IndexVersionAllocationDeciderTests extends ESAllocationTestCase {
             )
         );
 
-        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {};
         final RoutingNodes routingNodes = clusterState.mutableRoutingNodes();
         final ShardRouting startedPrimary = routingNodes.startShard(
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -648,8 +648,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             )
         );
 
-        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {};
         final RoutingNodes routingNodes = clusterState.mutableRoutingNodes();
         final ShardRouting startedPrimary = routingNodes.startShard(
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
@@ -507,8 +507,13 @@ public class RoutingNodesTests extends ESAllocationTestCase {
 
         var routingNodes = clusterState.getRoutingNodes().mutableCopy();
 
-        routingNodes.relocateShard(routingNodes.node("node-1").getByShardId(shardId), "node-3", 0L, "test", new RoutingChangesObserver() {
-        });
+        routingNodes.relocateShard(
+            routingNodes.node("node-1").getByShardId(shardId),
+            "node-3",
+            0L,
+            "test",
+            new RoutingChangesObserver() {}
+        );
 
         assertThat(routingNodes.node("node-1").getByShardId(shardId).state(), equalTo(RELOCATING));
         assertThat(routingNodes.node("node-2").getByShardId(shardId).state(), equalTo(STARTED));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationDeciderTests.java
@@ -118,8 +118,7 @@ public class ThrottlingAllocationDeciderTests extends ESAllocationTestCase {
             false // Turn off isSimulating
         );
 
-        final RoutingChangesObserver NOOP = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver NOOP = new RoutingChangesObserver() {};
         Settings settings = Settings.builder()
             .put("cluster.routing.allocation.unthrottle_replica_assignment_in_simulation", randomBoolean() ? true : false)
             .put("cluster.routing.allocation.node_concurrent_recoveries", 1)
@@ -194,8 +193,7 @@ public class ThrottlingAllocationDeciderTests extends ESAllocationTestCase {
             true // Turn on isSimulating
         );
 
-        final RoutingChangesObserver NOOP = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver NOOP = new RoutingChangesObserver() {};
         Settings settings = Settings.builder()
             .put("cluster.routing.allocation.unthrottle_replica_assignment_in_simulation", true)
             .put("cluster.routing.allocation.node_concurrent_recoveries", 1)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -103,8 +103,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
 
-    private static final RoutingChangesObserver NOOP = new RoutingChangesObserver() {
-    };
+    private static final RoutingChangesObserver NOOP = new RoutingChangesObserver() {};
     private static final Settings WITH_DISK_BALANCING = Settings.builder().put(DISK_USAGE_BALANCE_FACTOR_SETTING.getKey(), "1e-9").build();
 
     public void testExplainShardAllocation() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderTests.java
@@ -348,8 +348,7 @@ public class WriteLoadConstraintDeciderTests extends ESAllocationTestCase {
             movedShards.addAll(routingNode.shardsWithState(ShardRoutingState.INITIALIZING).collect(Collectors.toSet()));
         }
         movedShards.forEach(shardRouting -> {
-            routingAllocation.routingNodes().startShard(shardRouting, new RoutingChangesObserver() {
-            }, randomNonNegativeLong());
+            routingAllocation.routingNodes().startShard(shardRouting, new RoutingChangesObserver() {}, randomNonNegativeLong());
             clusterInfoSimulator.simulateShardStarted(shardRouting);
         });
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -630,8 +630,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
         final int length = randomIntBetween(1, 1024);
         StreamInput delegate = getStreamInput(BytesReference.fromByteBuffer(ByteBuffer.wrap(new byte[length])));
 
-        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {
-        };
+        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {};
         assertEquals(filterInputStream.available(), length);
 
         // read some bytes

--- a/server/src/test/java/org/elasticsearch/features/FeatureServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/features/FeatureServiceTests.java
@@ -43,10 +43,8 @@ public class FeatureServiceTests extends ESTestCase {
 
     public void testFailsDuplicateFeatures() {
         // these all need to be separate classes to trigger the exception
-        FeatureSpecification fs1 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {
-        };
-        FeatureSpecification fs2 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {
-        };
+        FeatureSpecification fs1 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {};
+        FeatureSpecification fs2 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {};
 
         assertThat(
             expectThrows(IllegalArgumentException.class, () -> new FeatureService(List.of(fs1, fs2))).getMessage(),

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -160,8 +160,7 @@ public class IndexModuleTests extends ESTestCase {
         public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths, IndexRemovalReason reason) {}
     };
 
-    private final IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
-    };
+    private final IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {};
     private MapperRegistry mapperRegistry;
     private ThreadPool threadPool;
     private ThreadPoolMergeExecutorService threadPoolMergeExecutorService;

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.mock;
 
 public class SearchSlowLogTests extends ESSingleNodeTestCase {
     static MockAppender appender;
@@ -100,11 +99,15 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         };
     }
 
+    public static ActionLoggingFieldsProvider mockLogFieldProvider() {
+        return context -> new ActionLoggingFields(context) {};
+    }
+
     public void testLevelPrecedence() {
         try (SearchContext ctx = searchContextWithSourceAndTask(createIndex("index"))) {
             String uuid = UUIDs.randomBase64UUID();
             IndexSettings settings = new IndexSettings(createIndexMetadata("index", settings(uuid)), Settings.EMPTY);
-            SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
+            SearchSlowLog log = new SearchSlowLog(settings, mockLogFieldProvider());
 
             // For this test, when level is not breached, the level below should be used.
             {
@@ -188,7 +191,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 ),
                 Settings.EMPTY
             );
-            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFields.class));
+            SearchSlowLog log1 = new SearchSlowLog(settings1, mockLogFieldProvider());
 
             IndexSettings settings2 = new IndexSettings(
                 createIndexMetadata(
@@ -201,7 +204,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 ),
                 Settings.EMPTY
             );
-            SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFields.class));
+            SearchSlowLog log2 = new SearchSlowLog(settings2, mockLogFieldProvider());
 
             {
                 // threshold set on WARN only, should not log
@@ -224,7 +227,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
 
         try (SearchContext ctx1 = searchContextWithSourceAndTask(createIndex("index-1"))) {
             IndexSettings settings1 = new IndexSettings(createIndexMetadata("index-1", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
-            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFields.class));
+            SearchSlowLog log1 = new SearchSlowLog(settings1, mockLogFieldProvider());
             int numberOfLoggersBefore = context.getLoggers().size();
 
             try (SearchContext ctx2 = searchContextWithSourceAndTask(createIndex("index-2"))) {
@@ -232,7 +235,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                     createIndexMetadata("index-2", settings(UUIDs.randomBase64UUID())),
                     Settings.EMPTY
                 );
-                SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFields.class));
+                SearchSlowLog log2 = new SearchSlowLog(settings2, mockLogFieldProvider());
 
                 int numberOfLoggersAfter = context.getLoggers().size();
                 assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore));
@@ -324,7 +327,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
+        SearchSlowLog log = new SearchSlowLog(settings, mockLogFieldProvider());
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getQueryTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(200).nanos(), log.getQueryDebugThreshold());
         assertEquals(TimeValue.timeValueMillis(300).nanos(), log.getQueryInfoThreshold());
@@ -355,7 +358,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getQueryWarnThreshold());
 
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new SearchSlowLog(settings, mock(SlowLogFields.class));
+        log = new SearchSlowLog(settings, mockLogFieldProvider());
 
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getQueryTraceThreshold());
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getQueryDebugThreshold());
@@ -430,7 +433,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
+        SearchSlowLog log = new SearchSlowLog(settings, mockLogFieldProvider());
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getFetchTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(200).nanos(), log.getFetchDebugThreshold());
         assertEquals(TimeValue.timeValueMillis(300).nanos(), log.getFetchInfoThreshold());
@@ -461,7 +464,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getFetchWarnThreshold());
 
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new SearchSlowLog(settings, mock(SlowLogFields.class));
+        log = new SearchSlowLog(settings, mockLogFieldProvider());
 
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getFetchTraceThreshold());
         assertEquals(TimeValue.MINUS_ONE.nanos(), log.getFetchDebugThreshold());

--- a/server/src/test/java/org/elasticsearch/index/analysis/CoreAnalysisFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/CoreAnalysisFactoryTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 public class CoreAnalysisFactoryTests extends AnalysisFactoryTestCase {
     public CoreAnalysisFactoryTests() {
         // Use an empty plugin that doesn't define anything so the test doesn't need a ton of null checks.
-        super(new AnalysisPlugin() {
-        });
+        super(new AnalysisPlugin() {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -354,14 +354,12 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
     public void testFieldDataCacheExpire() {
         {
             Settings settings = Settings.EMPTY;
-            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             assertThat(cache.getCache().getExpireAfterAccessNanos(), equalTo(3_600_000_000_000L));
         }
         {
             Settings settings = Settings.builder().put(IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_EXPIRE.getKey(), "5s").build();
-            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             assertThat(cache.getCache().getExpireAfterAccessNanos(), equalTo(5_000_000_000L));
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2971,8 +2971,7 @@ public class IndexShardTests extends IndexShardTestCase {
         MappedFieldType foo = shard.mapperService().fieldType("foo");
         IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(
             shard.indexSettings.getNodeSettings(),
-            new IndexFieldDataCache.Listener() {
-            }
+            new IndexFieldDataCache.Listener() {}
         );
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(
             shard.indexSettings,

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -249,8 +249,7 @@ public class IndicesModuleTests extends ESTestCase {
     }
 
     public void testGetFieldFilter() {
-        List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {
-        }, new MapperPlugin() {
+        List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {}, new MapperPlugin() {
             @Override
             public Function<String, FieldPredicate> getFieldFilter() {
                 return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;
@@ -292,8 +291,7 @@ public class IndicesModuleTests extends ESTestCase {
         int numPlugins = randomIntBetween(0, 10);
         List<MapperPlugin> mapperPlugins = new ArrayList<>(numPlugins);
         for (int i = 0; i < numPlugins; i++) {
-            mapperPlugins.add(new MapperPlugin() {
-            });
+            mapperPlugins.add(new MapperPlugin() {});
         }
         IndicesModule indicesModule = new IndicesModule(mapperPlugins);
         Function<String, FieldPredicate> fieldFilter = indicesModule.getMapperRegistry().getFieldFilter();
@@ -301,8 +299,7 @@ public class IndicesModuleTests extends ESTestCase {
     }
 
     public void testNoOpFieldPredicate() {
-        List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {
-        }, new MapperPlugin() {
+        List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {}, new MapperPlugin() {
             @Override
             public Function<String, FieldPredicate> getFieldFilter() {
                 return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -205,8 +205,7 @@ public class ClusterStateChanges {
                 MapperService mapperService = mock(MapperService.class);
                 when(indexService.mapperService()).thenReturn(mapperService);
                 when(mapperService.documentMapper()).thenReturn(null);
-                when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {
-                });
+                when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {});
                 when(indexService.getIndexSortSupplier()).thenReturn(() -> null);
                 return ((CheckedFunction<IndexService, ?, ?>) invocationOnMock.getArguments()[1]).apply(indexService);
             });

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -3525,8 +3525,7 @@ public class IngestServiceTests extends ESTestCase {
         });
         processors.put("remove", (factories, tag, description, config, projectId) -> {
             String field = (String) config.remove("field");
-            return new WrappingProcessorImpl("remove", tag, description, (ingestDocument -> ingestDocument.removeField(field))) {
-            };
+            return new WrappingProcessorImpl("remove", tag, description, (ingestDocument -> ingestDocument.removeField(field))) {};
         });
         return createWithProcessors(processors);
     }

--- a/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
@@ -55,18 +55,15 @@ public class SimulateIngestServiceTests extends ESTestCase {
         Map<String, Processor.Factory> processors = new HashMap<>();
         processors.put(
             "processor1",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor1", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor1", tag, description, ingestDocument -> {}) {}
         );
         processors.put(
             "processor2",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor2", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor2", tag, description, ingestDocument -> {}) {}
         );
         processors.put(
             "processor3",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor3", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor3", tag, description, ingestDocument -> {}) {}
         );
         final var projectId = randomProjectIdOrDefault();
         IngestService ingestService = createWithProcessors(projectId, processors);

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -568,8 +568,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
     private static final class TestSuggestionEntry extends Suggest.Suggestion.Entry<Suggest.Suggestion.Entry.Option> {
         @Override
         protected Option newOption(StreamInput in) {
-            return new Option(new Text("text"), 1f) {
-            };
+            return new Option(new Text("text"), 1f) {};
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -811,8 +811,7 @@ public final class DataStreamTestHelper {
             when(mapperService.documentMapper()).thenReturn(documentMapper);
             when(indexService.mapperService()).thenReturn(mapperService);
             when(mapperService.mappingLookup()).thenReturn(mappingLookup);
-            when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {
-            });
+            when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {});
             when(indexService.getIndexSortSupplier()).thenReturn(() -> null);
             return ((CheckedFunction<IndexService, ?, ?>) invocationOnMock.getArguments()[1]).apply(indexService);
         });

--- a/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
@@ -54,8 +54,7 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
                 assertThat("Couldn't find [" + file + "]", stream, notNullValue());
                 try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, stream)) {
                     // copyCurrentStructure does not property handle filters when it is passed a json parser. So we hide it.
-                    return builder.copyCurrentStructure(new FilterXContentParserWrapper(parser) {
-                    });
+                    return builder.copyCurrentStructure(new FilterXContentParserWrapper(parser) {});
                 }
             }
         };

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -840,8 +840,7 @@ public abstract class EngineTestCase extends ESTestCase {
     ) {
         final IndexWriterConfig iwc = newIndexWriterConfig();
         final TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
-        final Engine.EventListener eventListener = new Engine.EventListener() {
-        }; // we don't need to notify anybody in this test
+        final Engine.EventListener eventListener = new Engine.EventListener() {}; // we don't need to notify anybody in this test
         final List<ReferenceManager.RefreshListener> extRefreshListenerList = externalRefreshListener == null
             ? emptyList()
             : Collections.singletonList(externalRefreshListener);

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -126,8 +126,7 @@ import static org.mockito.Mockito.doAnswer;
  */
 public abstract class IndexShardTestCase extends ESTestCase {
 
-    public static final IndexEventListener EMPTY_EVENT_LISTENER = new IndexEventListener() {
-    };
+    public static final IndexEventListener EMPTY_EVENT_LISTENER = new IndexEventListener() {};
 
     public static final GlobalCheckpointSyncer NOOP_GCP_SYNCER = shardId -> {};
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -507,8 +507,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 MapperMetrics.NOOP,
                 null
             );
-            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {});
             indexFieldDataService = new IndexFieldDataService(idxSettings, indicesFieldDataCache, new NoneCircuitBreakerService());
             if (registerType) {
                 mapperService.merge(

--- a/test/framework/src/main/java/org/elasticsearch/test/MockIndexEventListener.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockIndexEventListener.java
@@ -68,12 +68,10 @@ public final class MockIndexEventListener {
     }
 
     public static class TestEventListener implements IndexEventListener {
-        private volatile IndexEventListener delegate = new IndexEventListener() {
-        };
+        private volatile IndexEventListener delegate = new IndexEventListener() {};
 
         public void setNewDelegate(IndexEventListener listener) {
-            delegate = listener == null ? new IndexEventListener() {
-            } : listener;
+            delegate = listener == null ? new IndexEventListener() {} : listener;
         }
 
         @Override

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -153,8 +153,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         pauseMaintenanceService();
         ensureAllSearchContextsReleased();
 
-        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {
-        });
+        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
         unpauseMaintenanceService();
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -435,8 +435,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     // operations between the local checkpoint and max_seq_no which the recovering replica is waiting for.
                     recoveryFuture = group.asyncRecoverReplica(
                         newReplica,
-                        (shard, sourceNode) -> new RecoveryTarget(shard, sourceNode, 0L, null, null, recoveryListener) {
-                        }
+                        (shard, sourceNode) -> new RecoveryTarget(shard, sourceNode, 0L, null, null, recoveryListener) {}
                     );
                 }
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RerankRequestChunkerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RerankRequestChunkerTests.java
@@ -116,8 +116,7 @@ public class RerankRequestChunkerTests extends ESTestCase {
             randomBoolean()
         );
 
-        listener.onResponse(new InferenceServiceResults() {
-        });
+        listener.onResponse(new InferenceServiceResults() {});
     }
 
     public void testParseChunkedRerankResultsListener_EmptyInput() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
@@ -289,8 +289,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
     private void initMapping(String indexKey) throws IOException {
         TestIndexMappingConfig indexMappingConfig = INDICES.get(indexKey);
-        mapperServices.put(indexKey, new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperServices.put(indexKey, new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "key", "integer"); // unique key per-index to use for looking up test values to compare to
             fieldExamples(b, "indexKey", "keyword");  // index name (can be used to choose index-specific test values)
             fieldExamples(b, "int", "integer");
@@ -1288,8 +1287,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
     public void testWithNulls() throws IOException {
         String indexKey = "index1";
-        mapperServices.put(indexKey, new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperServices.put(indexKey, new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "i", "integer");
             fieldExamples(b, "j", "long");
             fieldExamples(b, "d", "double");

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -207,8 +207,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
     }
 
     private void initMapping() throws IOException {
-        mapperService = new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperService = new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "key", "integer");
             fieldExamples(b, "int", "integer");
             fieldExamples(b, "short", "short");
@@ -1473,8 +1472,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
     }
 
     public void testWithNulls() throws IOException {
-        mapperService = new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperService = new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "i", "integer");
             fieldExamples(b, "j", "long");
             fieldExamples(b, "d", "double");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionResolutionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionResolutionStrategy.java
@@ -18,8 +18,7 @@ public interface FunctionResolutionStrategy {
     /**
      * Default behavior of standard function calls like {@code ABS(col)}.
      */
-    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {
-    };
+    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {};
 
     /**
      * Build the real function from this one and resolution metadata.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlannerTests.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.enrich;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.OutputOperator;
+import org.elasticsearch.compute.operator.ProjectOperator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.compute.operator.lookup.EnrichQuerySourceOperator;
+import org.elasticsearch.compute.operator.lookup.LookupEnrichQueryGenerator;
+import org.elasticsearch.compute.test.NoOpReleasable;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransport;
+import org.elasticsearch.threadpool.FixedExecutorBuilder;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LookupExecutionPlannerTests extends ESTestCase {
+    private BlockFactory blockFactory;
+    private BigArrays bigArrays;
+    private List<Releasable> releasables;
+    private ClusterService clusterService;
+    private TransportService transportService;
+    private IndicesService indicesService;
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    private ThreadPool threadPool;
+
+    /**
+     * Testable concrete implementation of LookupFromIndexService that captures LookupQueryPlan
+     * instead of starting a driver, allowing tests to inspect the operators.
+     */
+    private static class TestLookupService extends LookupFromIndexService {
+        private LookupFromIndexService.LookupQueryPlan capturedPlan;
+
+        TestLookupService(
+            ClusterService clusterService,
+            IndicesService indicesService,
+            AbstractLookupService.LookupShardContextFactory lookupShardContextFactory,
+            TransportService transportService,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            BigArrays bigArrays,
+            BlockFactory blockFactory,
+            ProjectResolver projectResolver
+        ) {
+            super(
+                clusterService,
+                indicesService,
+                lookupShardContextFactory,
+                transportService,
+                indexNameExpressionResolver,
+                bigArrays,
+                blockFactory,
+                projectResolver
+            );
+        }
+
+        @Override
+        protected LookupEnrichQueryGenerator queryList(
+            TransportRequest request,
+            SearchExecutionContext context,
+            AliasFilter aliasFilter,
+            Warnings warnings
+        ) {
+            return mock(LookupEnrichQueryGenerator.class);
+        }
+
+        @Override
+        protected void startDriver(
+            TransportRequest request,
+            CancellableTask task,
+            ActionListener<List<Page>> listener,
+            LookupQueryPlan lookupQueryPlan
+        ) {
+            // Capture the plan instead of starting the driver
+            // We don't want to actually execute the plan in this test class
+            this.capturedPlan = lookupQueryPlan;
+            // Immediately respond with empty pages to satisfy the listener
+            listener.onResponse(List.of());
+        }
+
+        LookupFromIndexService.LookupQueryPlan getCapturedPlan() {
+            return capturedPlan;
+        }
+    }
+
+    @Before
+    public void setup() {
+        // Enable streaming lookup to test the execution planner code path
+        LookupFromIndexService.USE_STREAMING_LOOKUP = true;
+        blockFactory = TestBlockFactory.getNonBreakingInstance();
+        bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking();
+        releasables = new ArrayList<>();
+
+        // Create minimal mocks for services - we only need these because AbstractLookupService constructor requires them
+        // but startDriver is overridden to do nothing, so they don't need to be fully functional
+        clusterService = mock(ClusterService.class);
+        ProjectId projectId = Metadata.DEFAULT_PROJECT_ID;
+        ClusterState clusterState = ClusterStateCreationUtils.state(projectId, "test-index", 1, 1);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        indicesService = mock(IndicesService.class);
+        when(indicesService.buildAliasFilter(any(), any(), any())).thenReturn(AliasFilter.EMPTY);
+
+        indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
+        when(indexNameExpressionResolver.resolveExpressionsIgnoringRemotes(any(), any())).thenReturn(
+            Set.of(new ResolvedExpression("test-index"))
+        );
+
+        // Create mock transport service - only needed for constructor, startDriver does nothing
+        // Since we override startDriver to do nothing, we don't need a real thread pool
+        // But TransportService requires a ThreadPool, so we create a minimal one
+        threadPool = new TestThreadPool(
+            getTestClass().getSimpleName(),
+            new FixedExecutorBuilder(
+                Settings.EMPTY,
+                EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME,
+                1,
+                1024,
+                "esql",
+                EsExecutors.TaskTrackingConfig.DEFAULT
+            )
+        );
+        MockTransport mockTransport = new MockTransport();
+        transportService = mockTransport.createTransportService(
+            Settings.EMPTY,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundAddress -> null,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            Set.of()
+        );
+        releasables.add(transportService);
+        releasables.add(mockTransport);
+        releasables.add(() -> terminate(threadPool));
+    }
+
+    @After
+    public void cleanup() {
+        // Reset streaming lookup to default
+        LookupFromIndexService.USE_STREAMING_LOOKUP = false;
+        Releasables.close(releasables);
+        blockFactory = null;
+        bigArrays = null;
+        clusterService = null;
+        transportService = null;
+        indicesService = null;
+        indexNameExpressionResolver = null;
+        threadPool = null;
+    }
+
+    public void testLookupJoinNoMerge() throws Exception {
+        // Test lookup join with mergePages=false and no extract fields
+        Page inputPage = createBytesRefPage("a", "b");
+
+        // No extract fields
+        List<NamedExpression> extractFields = Collections.emptyList();
+
+        LookupFromIndexService.LookupQueryPlan queryPlan = generateQueryPlan(inputPage, extractFields);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ProjectOperator -> OutputOperator
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ProjectOperator.class, OutputOperator.class),
+            extractFields,
+            null
+        );
+    }
+
+    public void testLookupJoinNoExtraFields() throws Exception {
+        // Test lookup join where we don't need to get extra fields (no extract fields, no merge)
+        // This is the simplest lookup join case - just joining without extracting additional fields
+        Page inputPage = createBytesRefPage("key1", "key2", "key3");
+
+        // No extract fields - pure lookup join without extra field extraction
+        List<NamedExpression> extractFields = Collections.emptyList();
+
+        LookupFromIndexService.LookupQueryPlan queryPlan = generateQueryPlan(inputPage, extractFields);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ProjectOperator -> OutputOperator
+        // No ValuesSourceReaderOperator (no extract fields)
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ProjectOperator.class, OutputOperator.class),
+            extractFields,
+            null
+        );
+    }
+
+    public void testLookupJoinWithExtractFields() throws Exception {
+        // Test lookup join with extract fields (uses ProjectOperator)
+        Page inputPage = createBytesRefPage("a", "b");
+
+        List<NamedExpression> extractFields = List.of(createFieldAttribute("field1", DataType.KEYWORD));
+
+        LookupFromIndexService.LookupQueryPlan queryPlan = generateQueryPlan(inputPage, extractFields);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ValuesSourceReaderOperator -> ProjectOperator -> OutputOperator
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ValuesSourceReaderOperator.class, ProjectOperator.class, OutputOperator.class),
+            extractFields,
+            null
+        );
+    }
+
+    public void testEnrichWithAllNullInputPage() throws Exception {
+        // Test enrich with input page where all values are null
+        // doLookup() returns early for null input blocks without generating operators
+        Page inputPage = createAllNullBytesRefPage(3);
+
+        List<NamedExpression> extractFields = List.of(createFieldAttribute("field1", DataType.KEYWORD));
+
+        // With all null values, doLookup() returns early without calling startDriver()
+        // Therefore, no operators should be generated
+        LookupFromIndexService.LookupQueryPlan queryPlan = generateQueryPlan(inputPage, extractFields);
+        assertNull("No operators should be generated for all-null input page", queryPlan);
+    }
+
+    // Verification helper methods
+
+    /**
+     * Verifies the complete plan structure with all operators and performs detailed verification.
+     * @param queryPlan The query plan to verify
+     * @param expectedOperators List of expected operator types in order: [source, intermediate1, intermediate2, ..., output]
+     * @param extractFields Extract fields for OutputOperator and ProjectOperator verification
+     * @param inputPage Optional input page for optimization verification
+     */
+    private void verifyCompletePlan(
+        LookupFromIndexService.LookupQueryPlan queryPlan,
+        List<Class<? extends Operator>> expectedOperators,
+        List<NamedExpression> extractFields,
+        Page inputPage
+    ) {
+        if (expectedOperators.size() < 2) {
+            throw new IllegalArgumentException("Expected operators list must have at least 2 elements (source and output)");
+        }
+
+        // Verify source operator (first in list)
+        MatcherAssert.assertThat("Source operator type mismatch", queryPlan.queryOperator(), instanceOf(expectedOperators.get(0)));
+
+        // Verify intermediate operators (middle of list)
+        List<Operator> actualOperators = queryPlan.operators();
+        int expectedIntermediateCount = expectedOperators.size() - 2; // Exclude source and output
+        MatcherAssert.assertThat("Intermediate operators count mismatch", actualOperators.size(), is(expectedIntermediateCount));
+
+        for (int i = 0; i < expectedIntermediateCount; i++) {
+            Class<? extends Operator> expectedType = expectedOperators.get(i + 1); // +1 to skip source
+            MatcherAssert.assertThat(
+                "Operator at index " + i + " should be " + expectedType.getSimpleName(),
+                actualOperators.get(i),
+                instanceOf(expectedType)
+            );
+        }
+
+        // Verify output operator (last in list)
+        MatcherAssert.assertThat(
+            "Output operator type mismatch",
+            queryPlan.outputOperator(),
+            instanceOf(expectedOperators.get(expectedOperators.size() - 1))
+        );
+
+        // Perform detailed verification based on operator types
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+
+        // Verify input page optimization if provided
+        if (inputPage != null) {
+            verifyNoPageOptimization(sourceOp, inputPage.getBlock(0));
+        }
+
+        // Verify intermediate operators
+        int operatorIndex = 0;
+        for (int i = 1; i < expectedOperators.size() - 1; i++) {
+            Class<? extends Operator> expectedType = expectedOperators.get(i);
+            Operator operator = actualOperators.get(operatorIndex);
+
+            if (expectedType == ValuesSourceReaderOperator.class) {
+                verifyValuesSourceReaderOperator(queryPlan, operatorIndex);
+            } else if (expectedType == ProjectOperator.class) {
+                verifyProjectOperator((ProjectOperator) operator, extractFields.size());
+            }
+
+            operatorIndex++;
+        }
+
+        // Always verify OutputOperator
+        verifyOutputOperator(queryPlan, extractFields);
+    }
+
+    /**
+     * Verifies EnrichQuerySourceOperator and returns it.
+     */
+    private EnrichQuerySourceOperator verifyEnrichQuerySourceOperator(LookupFromIndexService.LookupQueryPlan queryPlan) {
+        SourceOperator sourceOp = queryPlan.queryOperator();
+        MatcherAssert.assertThat(sourceOp, notNullValue());
+        MatcherAssert.assertThat(sourceOp, instanceOf(EnrichQuerySourceOperator.class));
+        EnrichQuerySourceOperator enrichOp = (EnrichQuerySourceOperator) sourceOp;
+        Page inputPage = enrichOp.getInputPage();
+        MatcherAssert.assertThat(inputPage, notNullValue());
+        return enrichOp;
+    }
+
+    /**
+     * Verifies ValuesSourceReaderOperator at the specified index.
+     */
+    private ValuesSourceReaderOperator verifyValuesSourceReaderOperator(LookupFromIndexService.LookupQueryPlan queryPlan, int index) {
+        Operator operator = queryPlan.operators().get(index);
+        MatcherAssert.assertThat(operator, instanceOf(ValuesSourceReaderOperator.class));
+        return (ValuesSourceReaderOperator) operator;
+    }
+
+    /**
+     * Verifies ProjectOperator projection.
+     */
+    private void verifyProjectOperator(ProjectOperator projectOp, int extractFieldsCount) {
+        MatcherAssert.assertThat(projectOp, notNullValue());
+        int[] projection = projectOp.getProjection();
+        MatcherAssert.assertThat("Projection should have extractFields.size() + 1 elements", projection.length, is(extractFieldsCount + 1));
+        // Verify projection starts at 1 (skipping doc block at index 0) and contains sequential values
+        for (int i = 0; i < projection.length; i++) {
+            MatcherAssert.assertThat("Projection should contain sequential values starting from 1", projection[i], is(i + 1));
+        }
+    }
+
+    private void verifyNoPageOptimization(EnrichQuerySourceOperator sourceOp, Block expectedInputBlock) {
+        Page sourceInputPage = sourceOp.getInputPage();
+        MatcherAssert.assertThat(
+            "Input page should be the original page when no optimization is used",
+            sourceInputPage.getBlock(0),
+            is(expectedInputBlock)
+        );
+    }
+
+    private void verifyOutputOperator(LookupFromIndexService.LookupQueryPlan queryPlan, List<NamedExpression> extractFields) {
+        OutputOperator outputOp = queryPlan.outputOperator();
+        MatcherAssert.assertThat(outputOp, notNullValue());
+        MatcherAssert.assertThat(outputOp, instanceOf(OutputOperator.class));
+
+        // Build expected columns: lookup joins always include positions
+        List<String> expectedColumns = new ArrayList<>();
+        expectedColumns.add("$$Positions$$");
+        expectedColumns.addAll(extractFields.stream().map(NamedExpression::name).toList());
+
+        // Verify columns
+        List<String> actualColumns = outputOp.getColumns();
+        MatcherAssert.assertThat("OutputOperator columns should match expected columns", actualColumns, is(expectedColumns));
+    }
+
+    /**
+     * Creates a Page with a BytesRefBlock containing the specified string values.
+     */
+    private Page createBytesRefPage(String... values) {
+        BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(values.length);
+        for (String value : values) {
+            builder.appendBytesRef(new BytesRef(value));
+        }
+        BytesRefBlock inputBlock = builder.build();
+        return new Page(inputBlock);
+    }
+
+    /**
+     * Creates a Page with an OrdinalBytesRefBlock (dictionary optimization).
+     * @param dictionary The dictionary values
+     * @param ordinals The ordinal indices into the dictionary
+     */
+    private Page createOrdinalBytesRefPage(String[] dictionary, int[] ordinals) {
+        BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(dictionary.length);
+        for (String value : dictionary) {
+            dictBuilder.appendBytesRef(new BytesRef(value));
+        }
+        BytesRefVector dictionaryVector = dictBuilder.build();
+
+        IntBlock.Builder ordinalsBuilder = blockFactory.newIntBlockBuilder(ordinals.length);
+        for (int ordinal : ordinals) {
+            ordinalsBuilder.appendInt(ordinal);
+        }
+        IntBlock ordinalsBlock = ordinalsBuilder.build();
+
+        OrdinalBytesRefBlock ordinalBlock = new OrdinalBytesRefBlock(ordinalsBlock, dictionaryVector);
+        return new Page(ordinalBlock);
+    }
+
+    /**
+     * Creates a Page with a BytesRefBlock containing all null values.
+     * @param positionCount The number of null positions to create
+     */
+    private Page createAllNullBytesRefPage(int positionCount) {
+        BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(positionCount);
+        for (int i = 0; i < positionCount; i++) {
+            builder.appendNull();
+        }
+        BytesRefBlock inputBlock = builder.build();
+        return new Page(inputBlock);
+    }
+
+    /**
+     * Executes doLookup() and returns the captured LookupQueryPlan.
+     * This is the common pattern used by all test cases.
+     */
+    private LookupFromIndexService.LookupQueryPlan generateQueryPlan(Page inputPage, List<NamedExpression> extractFields) throws Exception {
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+        TestLookupService testService = createTestService(shardContext);
+
+        LookupFromIndexService.Request request = new LookupFromIndexService.Request(
+            "test-session",
+            "test-index",
+            "test-index",
+            List.of(new MatchConfig("test-field", 0, DataType.KEYWORD)),
+            inputPage,
+            extractFields,
+            Source.EMPTY,
+            null,
+            null
+        );
+        LookupFromIndexService.TransportRequest transportRequest = testService.transportRequest(request, new ShardId("test", "n/a", 0));
+
+        testService.doLookup(transportRequest, null, ActionListener.wrap(pages -> {}, e -> {}));
+
+        return testService.getCapturedPlan();
+    }
+
+    private TestLookupService createTestService(AbstractLookupService.LookupShardContext shardContext) {
+        AbstractLookupService.LookupShardContextFactory factory = shardId -> shardContext;
+        // Use TestProjectResolvers which provides a proper implementation
+        ProjectResolver projectResolver = TestProjectResolvers.singleProject(Metadata.DEFAULT_PROJECT_ID);
+        return new TestLookupService(
+            clusterService,
+            indicesService,
+            factory,
+            transportService,
+            indexNameExpressionResolver,
+            bigArrays,
+            blockFactory,
+            projectResolver
+        );
+    }
+
+    private AbstractLookupService.LookupShardContext createMockShardContext() throws IOException {
+        // Create resources lazily when needed
+        Directory directory = newDirectory();
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            writer.commit();
+        }
+        DirectoryReader reader = DirectoryReader.open(directory);
+        MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
+        String mapping = "{\n  \"doc\": { \"properties\": { \"field1\": { \"type\": \"keyword\" } } }\n}";
+        MapperService mapperService = mapperHelper.createMapperService(mapping);
+        SearchExecutionContext executionCtx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(reader));
+
+        // Add cleanup to releasables
+        releasables.add(() -> {
+            try {
+                org.elasticsearch.core.IOUtils.close(reader, mapperService, directory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        EsPhysicalOperationProviders.DefaultShardContext shardContext = new EsPhysicalOperationProviders.DefaultShardContext(
+            0,
+            new NoOpReleasable(),
+            executionCtx,
+            AliasFilter.EMPTY
+        );
+        return new AbstractLookupService.LookupShardContext(
+            shardContext,
+            executionCtx,
+            () -> {} // No-op releasable
+        );
+    }
+
+    private FieldAttribute createFieldAttribute(String name, DataType type) {
+        return new FieldAttribute(
+            Source.EMPTY,
+            name,
+            new EsField(name, type, Collections.emptyMap(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+    }
+
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
@@ -440,8 +440,7 @@ public class LookupFromIndexOperatorTests extends AsyncOperatorTestCase {
 
     private AbstractLookupService.LookupShardContextFactory lookupShardContextFactory() {
         return shardId -> {
-            MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {
-            };
+            MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
             String suffix = (operation == null) ? "" : ("_right");
             StringBuilder props = new StringBuilder();
             props.append(String.format(Locale.ROOT, "\"match0%s\": { \"type\": \"long\" }", suffix));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunctionTests.java
@@ -40,8 +40,7 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
     }
 
     private static List<FunctionResolutionStrategy> resolutionStrategies() {
-        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {
-        });
+        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {});
     }
 
     protected List<FunctionResolutionStrategy> pluggableResolutionStrategies() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLogTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querylog/EsqlQueryLogTests.java
@@ -14,17 +14,20 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.logging.ESLogMessage;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.logging.MockAppender;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
 import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.SlowLogFieldProvider;
-import org.elasticsearch.index.SlowLogFields;
+import org.elasticsearch.index.ActionLoggingFields;
+import org.elasticsearch.index.ActionLoggingFieldsProvider;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.MockAppender;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
+import org.elasticsearch.xpack.esql.action.EsqlQueryProfile;
+import org.elasticsearch.xpack.esql.action.TimeSpan;
+import org.elasticsearch.xpack.esql.action.TimeSpanMarker;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.session.Result;
 import org.elasticsearch.xpack.esql.session.Versioned;
@@ -34,16 +37,15 @@ import org.junit.BeforeClass;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_PLANNING_TOOK;
-import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_PLANNING_TOOK_MILLIS;
+import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_PREFIX;
 import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_QUERY;
 import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_TOOK;
 import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_TOOK_MILLIS;
+import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_TOOK_MILLIS_SUFFIX;
+import static org.elasticsearch.xpack.esql.querylog.EsqlQueryLog.ELASTICSEARCH_QUERYLOG_TOOK_SUFFIX;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -89,8 +91,12 @@ public class EsqlQueryLogTests extends ESTestCase {
         Loggers.setLevel(queryLog, origQueryLogLevel);
     }
 
+    public static ActionLoggingFieldsProvider mockLogFieldProvider() {
+        return context -> new ActionLoggingFields(context) {};
+    }
+
     public void testPrioritiesOnSuccess() {
-        EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockFieldProvider());
+        EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockLogFieldProvider());
         String query = "from " + randomAlphaOfLength(10);
 
         long[] actualTook = {
@@ -99,18 +105,14 @@ public class EsqlQueryLogTests extends ESTestCase {
             randomLongBetween(30_000_000, 40_000_000),
             randomLongBetween(40_000_000, 50_000_000),
             randomLongBetween(0, 9_999_999) };
-        long[] actualPlanningTook = {
-            randomLongBetween(0, 1_000_000),
-            randomLongBetween(0, 1_000_000),
-            randomLongBetween(0, 1_000_000),
-            randomLongBetween(0, 1_000_000),
-            randomLongBetween(0, 1_000_000), };
         Level[] expectedLevel = { Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, null };
-
         for (int i = 0; i < actualTook.length; i++) {
-            EsqlExecutionInfo warnQuery = getEsqlExecutionInfo(actualTook[i], actualPlanningTook[i]);
+            EsqlExecutionInfo warnQuery = getEsqlExecutionInfo(actualTook[i]);
             queryLog.onQueryPhase(
-                new Versioned<>(new Result(List.of(), List.of(), DriverCompletionInfo.EMPTY, warnQuery), TransportVersion.current()),
+                new Versioned<>(
+                    new Result(List.of(), List.of(), EsqlTestUtils.TEST_CFG, DriverCompletionInfo.EMPTY, warnQuery),
+                    TransportVersion.current()
+                ),
                 query
             );
             if (expectedLevel[i] != null) {
@@ -122,47 +124,30 @@ public class EsqlQueryLogTests extends ESTestCase {
                 assertThat(took, is(actualTook[i]));
                 assertThat(tookMillis, is(tookMillisExpected));
 
-                long planningTook = Long.valueOf(msg.get(ELASTICSEARCH_QUERYLOG_PLANNING_TOOK));
-                long planningTookMillisExpected = planningTook / 1_000_000;
-                long planningTookMillis = Long.valueOf(msg.get(ELASTICSEARCH_QUERYLOG_PLANNING_TOOK_MILLIS));
-                assertThat(planningTook, is(actualPlanningTook[i]));
-                assertThat(planningTookMillis, is(planningTookMillisExpected));
-                assertThat(took, greaterThan(planningTook));
+                // Checks values for all planning timespans
+                for (TimeSpanMarker timeSpan : warnQuery.queryProfile().timeSpanMarkers()) {
+                    String tookValue = msg.get(ELASTICSEARCH_QUERYLOG_PREFIX + timeSpan.name() + ELASTICSEARCH_QUERYLOG_TOOK_SUFFIX);
+                    assertNotNull(tookValue);
+                    Long timeSpanTook = Long.valueOf(tookValue);
+                    long timeSpanTookMillisExpected = timeSpanTook / 1_000_000;
+                    String tookValueMillis = msg.get(
+                        ELASTICSEARCH_QUERYLOG_PREFIX + timeSpan.name() + ELASTICSEARCH_QUERYLOG_TOOK_MILLIS_SUFFIX
+                    );
+                    assertNotNull(tookValueMillis);
+                    long timeSpanTookMillis = Long.valueOf(tookValueMillis);
+                    assertThat(timeSpanTookMillis, is(timeSpanTookMillisExpected));
+                }
                 assertThat(msg.get(ELASTICSEARCH_QUERYLOG_QUERY), is(query));
                 assertThat(appender.getLastEventAndReset().getLevel(), equalTo(expectedLevel[i]));
             } else {
                 assertThat(appender.lastEvent(), is(nullValue()));
             }
-
         }
-    }
 
-    private SlowLogFieldProvider mockFieldProvider() {
-        return new SlowLogFieldProvider() {
-            @Override
-            public SlowLogFields create(IndexSettings indexSettings) {
-                return create();
-            }
-
-            @Override
-            public SlowLogFields create() {
-                return new SlowLogFields() {
-                    @Override
-                    public Map<String, String> indexFields() {
-                        return Map.of();
-                    }
-
-                    @Override
-                    public Map<String, String> searchFields() {
-                        return Map.of();
-                    }
-                };
-            }
-        };
     }
 
     public void testPrioritiesOnFailure() {
-        EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockFieldProvider());
+        EsqlQueryLog queryLog = new EsqlQueryLog(settings, mockLogFieldProvider());
         String query = "from " + randomAlphaOfLength(10);
 
         long[] actualTook = {
@@ -186,8 +171,6 @@ public class EsqlQueryLogTests extends ESTestCase {
                 long tookMillis = Long.valueOf(msg.get(ELASTICSEARCH_QUERYLOG_TOOK_MILLIS));
                 assertThat(took, is(actualTook[i]));
                 assertThat(tookMillis, is(tookMillisExpected));
-                assertThat(msg.get(ELASTICSEARCH_QUERYLOG_PLANNING_TOOK), is(nullValue()));
-                assertThat(msg.get(ELASTICSEARCH_QUERYLOG_PLANNING_TOOK_MILLIS), is(nullValue()));
                 assertThat(msg.get(ELASTICSEARCH_QUERYLOG_QUERY), is(query));
                 assertThat(appender.getLastEventAndReset().getLevel(), equalTo(expectedLevel[i]));
             } else {
@@ -196,17 +179,36 @@ public class EsqlQueryLogTests extends ESTestCase {
         }
     }
 
-    private static EsqlExecutionInfo getEsqlExecutionInfo(long tookNanos, long planningTookNanos) {
-        return new EsqlExecutionInfo(Predicates.always(), EsqlExecutionInfo.IncludeExecutionMetadata.CCS_ONLY) {
+    private static EsqlExecutionInfo getEsqlExecutionInfo(long tookNanos) {
+        EsqlExecutionInfo esqlExecutionInfo = new EsqlExecutionInfo(
+            Predicates.always(),
+            EsqlExecutionInfo.IncludeExecutionMetadata.CCS_ONLY
+        ) {
             @Override
             public TimeValue overallTook() {
                 return new TimeValue(tookNanos, TimeUnit.NANOSECONDS);
             }
 
             @Override
-            public TimeValue planningTookTime() {
-                return new TimeValue(planningTookNanos, TimeUnit.NANOSECONDS);
+            public EsqlQueryProfile queryProfile() {
+                return new EsqlQueryProfile(
+                    randomTimeSpan(),
+                    randomTimeSpan(),
+                    randomTimeSpan(),
+                    randomTimeSpan(),
+                    randomTimeSpan(),
+                    randomTimeSpan(),
+                    randomIntBetween(0, 100)
+                );
             }
         };
+
+        return esqlExecutionInfo;
+    }
+
+    private static TimeSpan randomTimeSpan() {
+        long startNanos = randomNonNegativeLong();
+        long stopNanos = startNanos + randomLongBetween(1, 100_000);
+        return new TimeSpan(startNanos / 1_000_000, startNanos, stopNanos / 1_000_000, stopNanos);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -48,8 +48,7 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
         maxMillis = minMillis = dateTimeToLong("2025-01-01T00:00:01");
         maxNanos = minNanos = dateNanosToLong("2025-01-01T00:00:01");
 
-        MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {
-        };
+        MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
         // create one or more index, so that there is one or more SearchExecutionContext in SearchStats
         for (int i = 0; i < indexCount; i++) {
             // Start with millis/nanos, numeric and keyword types in the index mapping, more data types can be covered later if needed.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorFactory.java
@@ -140,7 +140,6 @@ public class FrequentItemSetsAggregatorFactory extends AggregatorFactory {
                 configsAndFilters,
                 documentFilter,
                 ordinalOptimization
-            ) {
-        };
+            ) {};
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
@@ -17,8 +17,7 @@ public interface FunctionResolutionStrategy {
     /**
      * Default behavior of standard function calls like {@code ABS(col)}.
      */
-    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {
-    };
+    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {};
 
     /**
      * Build the real function from this one and resolution metadata.

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
@@ -40,8 +40,7 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
     }
 
     private static List<FunctionResolutionStrategy> resolutionStrategies() {
-        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {
-        });
+        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {});
     }
 
     protected List<FunctionResolutionStrategy> pluggableResolutionStrategies() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmSettingsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmSettingsTests.java
@@ -441,8 +441,7 @@ public class RealmSettingsTests extends ESTestCase {
 
     private void validate(Settings settings) {
         final Set<Setting<?>> settingsSet = new HashSet<>(InternalRealmsSettings.getSettings());
-        final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingsSet, Setting.Property.NodeScope) {
-        };
+        final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingsSet, Setting.Property.NodeScope) {};
         validator.validate(settings, false);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -1790,8 +1790,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         ObjLongConsumer<ActionListener<Void>> waitForMappingUpdate = (l, mappingVersion) -> l.onResponse(null);
         PlainActionFuture<TransportReplicationAction.PrimaryResult<BulkShardRequest, BulkShardResponse>> future = new PlainActionFuture<>();
         IndexShard indexShard = mock(IndexShard.class);
-        when(indexShard.getBulkOperationListener()).thenReturn(new BulkOperationListener() {
-        });
+        when(indexShard.getBulkOperationListener()).thenReturn(new BulkOperationListener() {});
         TransportShardBulkAction.performOnPrimary(
             request,
             indexShard,

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -673,8 +673,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     interface Disruption {
 
-        Disruption NONE = new Disruption() {
-        };
+        Disruption NONE = new Disruption() {};
 
         default byte[] onRead(byte[] actualContents, long position, long length) throws IOException {
             return actualContents;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
@@ -77,8 +77,7 @@ public class EmbeddedCli implements Closeable {
             new ExternalTerminal("test", "xterm-256color", cliIn, cliOut, StandardCharsets.UTF_8),
             false
         );
-        cli = new Cli(cliTerminal) {
-        };
+        cli = new Cli(cliTerminal) {};
         out = new BufferedWriter(new OutputStreamWriter(outgoing, StandardCharsets.UTF_8));
         in = new BufferedReader(new InputStreamReader(incoming, StandardCharsets.UTF_8));
 

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
@@ -80,8 +80,7 @@ public final class CsvTestUtils {
                 throw new UnsupportedOperationException();
             }
         };
-        return new CsvConnection(tableReader, csvProperties, "") {
-        };
+        return new CsvConnection(tableReader, csvProperties, "") {};
     }
 
     private static Tuple<String, String> extractColumnTypesAndStripCli(String schema, String expectedResults) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Formatting: Keep braces for empty anonymous classes on a single line (#141683)](https://github.com/elastic/elasticsearch/pull/141683)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)