### PR TITLE
[9.1] Formatting: Keep braces for empty anonymous classes on a single line (#141683)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -96,8 +96,7 @@ public class AggConstructionContentionBenchmark {
     private final Index index = new Index("test", "uuid");
     private final IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(
         Settings.EMPTY,
-        new IndexFieldDataCache.Listener() {
-        }
+        new IndexFieldDataCache.Listener() {}
     );
 
     private CircuitBreakerService breakerService;
@@ -213,8 +212,11 @@ public class AggConstructionContentionBenchmark {
 
         @Override
         protected IndexFieldData<?> buildFieldData(MappedFieldType ft) {
-            IndexFieldDataCache indexFieldDataCache = indicesFieldDataCache.buildIndexFieldDataCache(new IndexFieldDataCache.Listener() {
-            }, index, ft.name());
+            IndexFieldDataCache indexFieldDataCache = indicesFieldDataCache.buildIndexFieldDataCache(
+                new IndexFieldDataCache.Listener() {},
+                index,
+                ft.name()
+            );
             return ft.fielddataBuilder(FieldDataContext.noRuntimeFields("benchmark")).build(indexFieldDataCache, breakerService);
         }
 

--- a/build-conventions/formatterConfig.xml
+++ b/build-conventions/formatterConfig.xml
@@ -65,7 +65,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_if_empty"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -225,8 +225,11 @@ public class RemovePluginActionTests extends ESTestCase {
 
         MockTerminal terminal = MockTerminal.create();
 
-        new MockRemovePluginCommand(env) {
-        }.main(new String[] { "-Epath.home=" + home, "fake" }, terminal, new ProcessInfo(Map.of(), Map.of(), createTempDir()));
+        new MockRemovePluginCommand(env) {}.main(
+            new String[] { "-Epath.home=" + home, "fake" },
+            terminal,
+            new ProcessInfo(Map.of(), Map.of(), createTempDir())
+        );
         try (
             BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()));
             BufferedReader errorReader = new BufferedReader(new StringReader(terminal.getErrorOutput()))

--- a/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -37,8 +37,7 @@ public class TerminalTests extends ESTestCase {
         PrintWriter stdOut = mock("stdOut");
         PrintWriter stdErr = mock("stdErr");
 
-        OutputStream out = new Terminal(mock("reader"), stdOut, stdErr) {
-        }.asLineOutputStream(StandardCharsets.UTF_8);
+        OutputStream out = new Terminal(mock("reader"), stdOut, stdErr) {}.asLineOutputStream(StandardCharsets.UTF_8);
 
         out.write("123".getBytes(StandardCharsets.UTF_8));
         out.write("456".getBytes(StandardCharsets.UTF_8));

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/Util.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/Util.java
@@ -22,8 +22,7 @@ public class Util {
      *
      * @see StackWalker#getCallerClass()
      */
-    public static final Class<?> NO_CLASS = new Object() {
-    }.getClass();
+    public static final Class<?> NO_CLASS = new Object() {}.getClass();
 
     private static final Set<String> skipInternalPackages = Set.of("java.lang.invoke", "java.lang.reflect", "jdk.internal.reflect");
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
@@ -88,8 +88,7 @@ class JvmActions {
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void createLogManager() {
-        new java.util.logging.LogManager() {
-        };
+        new java.util.logging.LogManager() {};
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/simplify/StreamingGeometrySimplifier.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/simplify/StreamingGeometrySimplifier.java
@@ -41,10 +41,8 @@ public abstract class StreamingGeometrySimplifier<T extends Geometry> {
     protected int length;
     protected int objCount = 0;
     protected String description;
-    protected PointConstructor pointConstructor = new PointConstructor() {
-    };
-    protected PointResetter pointResetter = new PointResetter() {
-    };
+    protected PointConstructor pointConstructor = new PointConstructor() {};
+    protected PointResetter pointResetter = new PointResetter() {};
 
     protected final PriorityQueue<PointError> queue = new PriorityQueue<>();
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -675,8 +675,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
 
                     @Override
                     protected void initChannel(SocketChannel ch) {
-                        ch.pipeline().addLast(new ChannelHandlerAdapter() {
-                        });
+                        ch.pipeline().addLast(new ChannelHandlerAdapter() {});
 
                     }
                 })

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
@@ -54,8 +54,7 @@ public class AllocationFailuresResetIT extends ESIntegTestCase {
     }
 
     private void removeAllocationFailuresInjection(String node) {
-        internalCluster().getInstance(MockIndexEventListener.TestEventListener.class, node).setNewDelegate(new IndexEventListener() {
-        });
+        internalCluster().getInstance(MockIndexEventListener.TestEventListener.class, node).setNewDelegate(new IndexEventListener() {});
     }
 
     private void awaitShardAllocMaxRetries() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -1043,10 +1043,8 @@ public class ActionModule extends AbstractModule {
         bind(RestController.class).toInstance(restController);
         bind(ActionFilters.class).toInstance(actionFilters);
         bind(DestructiveOperations.class).toInstance(destructiveOperations);
-        bind(new TypeLiteral<RequestValidators<PutMappingRequest>>() {
-        }).toInstance(mappingRequestValidators);
-        bind(new TypeLiteral<RequestValidators<IndicesAliasesRequest>>() {
-        }).toInstance(indicesAliasesRequestRequestValidators);
+        bind(new TypeLiteral<RequestValidators<PutMappingRequest>>() {}).toInstance(mappingRequestValidators);
+        bind(new TypeLiteral<RequestValidators<IndicesAliasesRequest>>() {}).toInstance(indicesAliasesRequestRequestValidators);
         bind(AutoCreateIndex.class).toInstance(autoCreateIndex);
 
         // register ActionType -> transportAction Map used by NodeClient

--- a/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
@@ -27,8 +27,7 @@ import java.util.Objects;
 public abstract class SearchProgressListener {
     private static final Logger logger = LogManager.getLogger(SearchProgressListener.class);
 
-    public static final SearchProgressListener NOOP = new SearchProgressListener() {
-    };
+    public static final SearchProgressListener NOOP = new SearchProgressListener() {};
 
     private List<SearchShard> shards;
 

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
@@ -24,8 +24,7 @@ import java.io.IOException;
  * in the same generation are either identical or equivalent when synthetic sources are used.
  */
 public abstract class TranslogOperationAsserter {
-    public static final TranslogOperationAsserter DEFAULT = new TranslogOperationAsserter() {
-    };
+    public static final TranslogOperationAsserter DEFAULT = new TranslogOperationAsserter() {};
 
     private TranslogOperationAsserter() {
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -44,8 +44,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
     private final IndicesFieldDataCache indicesFieldDataCache;
     // the below map needs to be modified under a lock
     private final Map<String, IndexFieldDataCache> fieldDataCaches = new HashMap<>();
-    private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {
-    };
+    private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {};
     private volatile IndexFieldDataCache.Listener listener = DEFAULT_NOOP_LISTENER;
 
     public IndexFieldDataService(

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -929,8 +929,7 @@ public class IndicesService extends AbstractLifecycleComponent
     public synchronized void verifyIndexMetadata(IndexMetadata metadata, IndexMetadata metadataUpdate) throws IOException {
         final List<Closeable> closeables = new ArrayList<>();
         try {
-            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             closeables.add(indicesFieldDataCache);
             IndicesQueryCache indicesQueryCache = new IndicesQueryCache(settings);
             closeables.add(indicesQueryCache);

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1486,8 +1486,9 @@ class NodeConstruction {
         // Due to Java's type erasure with generics, the injector can't give us exactly what we need, and we have
         // to resort to some evil casting.
         @SuppressWarnings("rawtypes")
-        Map<ActionType<?>, TransportAction<?, ?>> actions = forciblyCast(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {
-        }));
+        Map<ActionType<?>, TransportAction<?, ?>> actions = forciblyCast(
+            injector.getInstance(new Key<Map<ActionType, TransportAction>>() {})
+        );
 
         client.initialize(
             actions,

--- a/server/src/main/java/org/elasticsearch/plugins/internal/DocumentParsingProvider.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/DocumentParsingProvider.java
@@ -17,8 +17,7 @@ import org.elasticsearch.index.mapper.MapperService;
  * An interface to provide instances of document parsing observer and reporter
  */
 public interface DocumentParsingProvider {
-    DocumentParsingProvider EMPTY_INSTANCE = new DocumentParsingProvider() {
-    };
+    DocumentParsingProvider EMPTY_INSTANCE = new DocumentParsingProvider() {};
 
     /**
      * @return an instance of a reporter to use when parsing has been completed and indexing successful

--- a/server/src/main/java/org/elasticsearch/plugins/internal/DocumentSizeReporter.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/DocumentSizeReporter.java
@@ -18,8 +18,7 @@ public interface DocumentSizeReporter {
     /**
      * a default noop implementation
      */
-    DocumentSizeReporter EMPTY_INSTANCE = new DocumentSizeReporter() {
-    };
+    DocumentSizeReporter EMPTY_INSTANCE = new DocumentSizeReporter() {};
 
     /**
      * An action to be performed upon finished indexing.

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
@@ -12,8 +12,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 
 public interface TransportMessageListener {
 
-    TransportMessageListener NOOP_LISTENER = new TransportMessageListener() {
-    };
+    TransportMessageListener NOOP_LISTENER = new TransportMessageListener() {};
 
     /**
      * Called once a request is received

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -127,8 +127,7 @@ public class TransportService extends AbstractLifecycleComponent
         }
     });
 
-    public static final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
-    };
+    public static final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {};
 
     // tracer log
 

--- a/server/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -37,8 +37,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/id", response.getLocation(null));
         assertEquals("/index/_doc/id?routing=test_routing", response.getLocation("test_routing"));
     }
@@ -51,8 +50,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/%E2%9D%A4", response.getLocation(null));
         assertEquals("/index/_doc/%E2%9D%A4?routing=%C3%A4", response.getLocation("ä"));
     }
@@ -65,8 +63,7 @@ public class DocWriteResponseTests extends ESTestCase {
             17,
             0,
             Result.CREATED
-        ) {
-        };
+        ) {};
         assertEquals("/index/_doc/a+b", response.getLocation(null));
         assertEquals("/index/_doc/a+b?routing=c+d", response.getLocation("c d"));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
@@ -949,8 +949,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var modifiedKeys = putTemplateAction.modifiedKeys(pr);
         assertThat(modifiedKeys, hasSize(1));
 
-        var fakeAction = new ActionWithReservedState<TransportPutComposableIndexTemplateAction.Request>() {
-        };
+        var fakeAction = new ActionWithReservedState<TransportPutComposableIndexTemplateAction.Request>() {};
         assertEquals(
             "Failed to process request [validate_template] with errors: "
                 + "[[composable_index_template:validate_template] set as read-only by [file_settings]]",

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -147,8 +147,7 @@ public final class MockSearchPhaseContext extends AbstractSearchAsyncAction<Sear
         Transport.Connection shard,
         SearchActionListener<SearchPhaseResult> listener
     ) {
-        onShardResult(new SearchPhaseResult() {
-        });
+        onShardResult(new SearchPhaseResult() {});
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -179,8 +179,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
                 circuitBreaker,
                 searchPhaseController,
                 () -> false,
-                new SearchProgressListener() {
-                },
+                new SearchProgressListener() {},
                 10,
                 e -> {}
             )
@@ -228,8 +227,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
                 circuitBreaker,
                 searchPhaseController,
                 () -> false,
-                new SearchProgressListener() {
-                },
+                new SearchProgressListener() {},
                 10,
                 e -> {}
             )

--- a/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
@@ -43,8 +43,7 @@ public class ElasticsearchUncaughtExceptionHandlerTests extends ESTestCase {
             new StackOverflowError(),
             new UnknownError(),
             new IOError(new IOException("fatal")),
-            new Error() {
-            }
+            new Error() {}
         );
         final Thread thread = new Thread(() -> { throw error; });
         final String name = randomAlphaOfLength(10);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/GlobalRoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/GlobalRoutingTableTests.java
@@ -295,8 +295,7 @@ public class GlobalRoutingTableTests extends AbstractWireSerializingTestCase<Glo
 
         final RoutingNodes mutate = routingNodes.mutableCopy();
         final DiscoveryNode targetNode = randomFrom(clusterState.nodes().getNodes().values());
-        final RoutingChangesObserver emptyObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver emptyObserver = new RoutingChangesObserver() {};
 
         final int unassigned = mutate.unassigned().size();
         var unassignedItr = mutate.unassigned().iterator();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -157,8 +157,7 @@ public class DataTierTests extends ESTestCase {
             }
             final Set<DiscoveryNodeRole> roles = new HashSet<>(randomSubsetOf(allRoles));
             if (frequently()) {
-                roles.add(new DiscoveryNodeRole("custom_role", "cr") {
-                });
+                roles.add(new DiscoveryNodeRole("custom_role", "cr") {});
             }
             final DiscoveryNode node = newNode(idGenerator.getAndIncrement(), attributes, roles);
             nodesList.add(node);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexVersionAllocationDeciderTests.java
@@ -652,8 +652,7 @@ public class IndexVersionAllocationDeciderTests extends ESAllocationTestCase {
             )
         );
 
-        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {};
         final RoutingNodes routingNodes = clusterState.mutableRoutingNodes();
         final ShardRouting startedPrimary = routingNodes.startShard(
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -648,8 +648,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             )
         );
 
-        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {
-        };
+        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver() {};
         final RoutingNodes routingNodes = clusterState.mutableRoutingNodes();
         final ShardRouting startedPrimary = routingNodes.startShard(
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
@@ -507,8 +507,13 @@ public class RoutingNodesTests extends ESAllocationTestCase {
 
         var routingNodes = clusterState.getRoutingNodes().mutableCopy();
 
-        routingNodes.relocateShard(routingNodes.node("node-1").getByShardId(shardId), "node-3", 0L, "test", new RoutingChangesObserver() {
-        });
+        routingNodes.relocateShard(
+            routingNodes.node("node-1").getByShardId(shardId),
+            "node-3",
+            0L,
+            "test",
+            new RoutingChangesObserver() {}
+        );
 
         assertThat(routingNodes.node("node-1").getByShardId(shardId).state(), equalTo(RELOCATING));
         assertThat(routingNodes.node("node-2").getByShardId(shardId).state(), equalTo(STARTED));

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -633,8 +633,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
         final int length = randomIntBetween(1, 1024);
         StreamInput delegate = getStreamInput(BytesReference.fromByteBuffer(ByteBuffer.wrap(new byte[length])));
 
-        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {
-        };
+        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {};
         assertEquals(filterInputStream.available(), length);
 
         // read some bytes

--- a/server/src/test/java/org/elasticsearch/features/FeatureServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/features/FeatureServiceTests.java
@@ -43,10 +43,8 @@ public class FeatureServiceTests extends ESTestCase {
 
     public void testFailsDuplicateFeatures() {
         // these all need to be separate classes to trigger the exception
-        FeatureSpecification fs1 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {
-        };
-        FeatureSpecification fs2 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {
-        };
+        FeatureSpecification fs1 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {};
+        FeatureSpecification fs2 = new TestFeatureSpecification(Set.of(new NodeFeature("f1"))) {};
 
         assertThat(
             expectThrows(IllegalArgumentException.class, () -> new FeatureService(List.of(fs1, fs2))).getMessage(),

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -160,8 +160,7 @@ public class IndexModuleTests extends ESTestCase {
         public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths, IndexRemovalReason reason) {}
     };
 
-    private final IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
-    };
+    private final IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {};
     private MapperRegistry mapperRegistry;
     private ThreadPool threadPool;
     private ThreadPoolMergeExecutorService threadPoolMergeExecutorService;

--- a/server/src/test/java/org/elasticsearch/index/analysis/CoreAnalysisFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/CoreAnalysisFactoryTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 public class CoreAnalysisFactoryTests extends AnalysisFactoryTestCase {
     public CoreAnalysisFactoryTests() {
         // Use an empty plugin that doesn't define anything so the test doesn't need a ton of null checks.
-        super(new AnalysisPlugin() {
-        });
+        super(new AnalysisPlugin() {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -373,14 +373,12 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
     public void testFieldDataCacheExpire() {
         {
             Settings settings = Settings.EMPTY;
-            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             assertThat(cache.getCache().getExpireAfterAccessNanos(), equalTo(3_600_000_000_000L));
         }
         {
             Settings settings = Settings.builder().put(IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_EXPIRE.getKey(), "5s").build();
-            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache cache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {});
             assertThat(cache.getCache().getExpireAfterAccessNanos(), equalTo(5_000_000_000L));
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2950,8 +2950,7 @@ public class IndexShardTests extends IndexShardTestCase {
         MappedFieldType foo = shard.mapperService().fieldType("foo");
         IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(
             shard.indexSettings.getNodeSettings(),
-            new IndexFieldDataCache.Listener() {
-            }
+            new IndexFieldDataCache.Listener() {}
         );
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(
             shard.indexSettings,

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -249,8 +249,7 @@ public class IndicesModuleTests extends ESTestCase {
     }
 
     public void testGetFieldFilter() {
-        List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {
-        }, new MapperPlugin() {
+        List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {}, new MapperPlugin() {
             @Override
             public Function<String, FieldPredicate> getFieldFilter() {
                 return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;
@@ -292,8 +291,7 @@ public class IndicesModuleTests extends ESTestCase {
         int numPlugins = randomIntBetween(0, 10);
         List<MapperPlugin> mapperPlugins = new ArrayList<>(numPlugins);
         for (int i = 0; i < numPlugins; i++) {
-            mapperPlugins.add(new MapperPlugin() {
-            });
+            mapperPlugins.add(new MapperPlugin() {});
         }
         IndicesModule indicesModule = new IndicesModule(mapperPlugins);
         Function<String, FieldPredicate> fieldFilter = indicesModule.getMapperRegistry().getFieldFilter();
@@ -301,8 +299,7 @@ public class IndicesModuleTests extends ESTestCase {
     }
 
     public void testNoOpFieldPredicate() {
-        List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {
-        }, new MapperPlugin() {
+        List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {}, new MapperPlugin() {
             @Override
             public Function<String, FieldPredicate> getFieldFilter() {
                 return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -205,8 +205,7 @@ public class ClusterStateChanges {
                 MapperService mapperService = mock(MapperService.class);
                 when(indexService.mapperService()).thenReturn(mapperService);
                 when(mapperService.documentMapper()).thenReturn(null);
-                when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {
-                });
+                when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {});
                 when(indexService.getIndexSortSupplier()).thenReturn(() -> null);
                 return ((CheckedFunction<IndexService, ?, ?>) invocationOnMock.getArguments()[1]).apply(indexService);
             });

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -3416,8 +3416,7 @@ public class IngestServiceTests extends ESTestCase {
         });
         processors.put("remove", (factories, tag, description, config, projectId) -> {
             String field = (String) config.remove("field");
-            return new WrappingProcessorImpl("remove", tag, description, (ingestDocument -> ingestDocument.removeField(field))) {
-            };
+            return new WrappingProcessorImpl("remove", tag, description, (ingestDocument -> ingestDocument.removeField(field))) {};
         });
         return createWithProcessors(processors);
     }

--- a/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
@@ -53,18 +53,15 @@ public class SimulateIngestServiceTests extends ESTestCase {
         Map<String, Processor.Factory> processors = new HashMap<>();
         processors.put(
             "processor1",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor1", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor1", tag, description, ingestDocument -> {}) {}
         );
         processors.put(
             "processor2",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor2", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor2", tag, description, ingestDocument -> {}) {}
         );
         processors.put(
             "processor3",
-            (factories, tag, description, config, projectId) -> new FakeProcessor("processor3", tag, description, ingestDocument -> {}) {
-            }
+            (factories, tag, description, config, projectId) -> new FakeProcessor("processor3", tag, description, ingestDocument -> {}) {}
         );
         final var projectId = randomProjectIdOrDefault();
         IngestService ingestService = createWithProcessors(projectId, processors);

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -568,8 +568,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
     private static final class TestSuggestionEntry extends Suggest.Suggestion.Entry<Suggest.Suggestion.Entry.Option> {
         @Override
         protected Option newOption(StreamInput in) {
-            return new Option(new Text("text"), 1f) {
-            };
+            return new Option(new Text("text"), 1f) {};
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -839,8 +839,7 @@ public final class DataStreamTestHelper {
             when(mapperService.documentMapper()).thenReturn(documentMapper);
             when(indexService.mapperService()).thenReturn(mapperService);
             when(mapperService.mappingLookup()).thenReturn(mappingLookup);
-            when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {
-            });
+            when(indexService.getIndexEventListener()).thenReturn(new IndexEventListener() {});
             when(indexService.getIndexSortSupplier()).thenReturn(() -> null);
             return ((CheckedFunction<IndexService, ?, ?>) invocationOnMock.getArguments()[1]).apply(indexService);
         });

--- a/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
@@ -54,8 +54,7 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
                 assertThat("Couldn't find [" + file + "]", stream, notNullValue());
                 try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, stream)) {
                     // copyCurrentStructure does not property handle filters when it is passed a json parser. So we hide it.
-                    return builder.copyCurrentStructure(new FilterXContentParserWrapper(parser) {
-                    });
+                    return builder.copyCurrentStructure(new FilterXContentParserWrapper(parser) {});
                 }
             }
         };

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -833,8 +833,7 @@ public abstract class EngineTestCase extends ESTestCase {
     ) {
         final IndexWriterConfig iwc = newIndexWriterConfig();
         final TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
-        final Engine.EventListener eventListener = new Engine.EventListener() {
-        }; // we don't need to notify anybody in this test
+        final Engine.EventListener eventListener = new Engine.EventListener() {}; // we don't need to notify anybody in this test
         final List<ReferenceManager.RefreshListener> extRefreshListenerList = externalRefreshListener == null
             ? emptyList()
             : Collections.singletonList(externalRefreshListener);

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -126,8 +126,7 @@ import static org.mockito.Mockito.doAnswer;
  */
 public abstract class IndexShardTestCase extends ESTestCase {
 
-    public static final IndexEventListener EMPTY_EVENT_LISTENER = new IndexEventListener() {
-    };
+    public static final IndexEventListener EMPTY_EVENT_LISTENER = new IndexEventListener() {};
 
     public static final GlobalCheckpointSyncer NOOP_GCP_SYNCER = shardId -> {};
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -505,8 +505,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 bitsetFilterCache::getBitSetProducer,
                 MapperMetrics.NOOP
             );
-            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {
-            });
+            IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {});
             indexFieldDataService = new IndexFieldDataService(idxSettings, indicesFieldDataCache, new NoneCircuitBreakerService());
             if (registerType) {
                 mapperService.merge(

--- a/test/framework/src/main/java/org/elasticsearch/test/MockIndexEventListener.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockIndexEventListener.java
@@ -68,12 +68,10 @@ public final class MockIndexEventListener {
     }
 
     public static class TestEventListener implements IndexEventListener {
-        private volatile IndexEventListener delegate = new IndexEventListener() {
-        };
+        private volatile IndexEventListener delegate = new IndexEventListener() {};
 
         public void setNewDelegate(IndexEventListener listener) {
-            delegate = listener == null ? new IndexEventListener() {
-            } : listener;
+            delegate = listener == null ? new IndexEventListener() {} : listener;
         }
 
         @Override

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -153,8 +153,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         pauseMaintenanceService();
         ensureAllSearchContextsReleased();
 
-        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {
-        });
+        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
         unpauseMaintenanceService();
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -435,8 +435,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     // operations between the local checkpoint and max_seq_no which the recovering replica is waiting for.
                     recoveryFuture = group.asyncRecoverReplica(
                         newReplica,
-                        (shard, sourceNode) -> new RecoveryTarget(shard, sourceNode, 0L, null, null, recoveryListener) {
-                        }
+                        (shard, sourceNode) -> new RecoveryTarget(shard, sourceNode, 0L, null, null, recoveryListener) {}
                     );
                 }
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
@@ -286,8 +286,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
     private void initMapping(String indexKey) throws IOException {
         TestIndexMappingConfig indexMappingConfig = INDICES.get(indexKey);
-        mapperServices.put(indexKey, new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperServices.put(indexKey, new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "key", "integer"); // unique key per-index to use for looking up test values to compare to
             fieldExamples(b, "indexKey", "keyword");  // index name (can be used to choose index-specific test values)
             fieldExamples(b, "int", "integer");
@@ -1272,8 +1271,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
     public void testWithNulls() throws IOException {
         String indexKey = "index1";
-        mapperServices.put(indexKey, new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperServices.put(indexKey, new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "i", "integer");
             fieldExamples(b, "j", "long");
             fieldExamples(b, "d", "double");

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -204,8 +204,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
     }
 
     private void initMapping() throws IOException {
-        mapperService = new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperService = new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "key", "integer");
             fieldExamples(b, "int", "integer");
             fieldExamples(b, "short", "short");
@@ -1467,8 +1466,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
     }
 
     public void testWithNulls() throws IOException {
-        mapperService = new MapperServiceTestCase() {
-        }.createMapperService(MapperServiceTestCase.mapping(b -> {
+        mapperService = new MapperServiceTestCase() {}.createMapperService(MapperServiceTestCase.mapping(b -> {
             fieldExamples(b, "i", "integer");
             fieldExamples(b, "j", "long");
             fieldExamples(b, "d", "double");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionResolutionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionResolutionStrategy.java
@@ -18,8 +18,7 @@ public interface FunctionResolutionStrategy {
     /**
      * Default behavior of standard function calls like {@code ABS(col)}.
      */
-    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {
-    };
+    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {};
 
     /**
      * Build the real function from this one and resolution metadata.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
@@ -235,8 +235,7 @@ public class LookupFromIndexOperatorTests extends OperatorTestCase {
 
     private AbstractLookupService.LookupShardContextFactory lookupShardContextFactory() {
         return shardId -> {
-            MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {
-            };
+            MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
             MapperService mapperService = mapperHelper.createMapperService("""
                 {
                     "doc": { "properties": {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunctionTests.java
@@ -40,8 +40,7 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
     }
 
     private static List<FunctionResolutionStrategy> resolutionStrategies() {
-        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {
-        });
+        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {});
     }
 
     protected List<FunctionResolutionStrategy> pluggableResolutionStrategies() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorFactory.java
@@ -140,7 +140,6 @@ public class FrequentItemSetsAggregatorFactory extends AggregatorFactory {
                 configsAndFilters,
                 documentFilter,
                 ordinalOptimization
-            ) {
-        };
+            ) {};
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
@@ -17,8 +17,7 @@ public interface FunctionResolutionStrategy {
     /**
      * Default behavior of standard function calls like {@code ABS(col)}.
      */
-    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {
-    };
+    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {};
 
     /**
      * Build the real function from this one and resolution metadata.

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
@@ -40,8 +40,7 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
     }
 
     private static List<FunctionResolutionStrategy> resolutionStrategies() {
-        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {
-        });
+        return asList(FunctionResolutionStrategy.DEFAULT, new FunctionResolutionStrategy() {});
     }
 
     protected List<FunctionResolutionStrategy> pluggableResolutionStrategies() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmSettingsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmSettingsTests.java
@@ -441,8 +441,7 @@ public class RealmSettingsTests extends ESTestCase {
 
     private void validate(Settings settings) {
         final Set<Setting<?>> settingsSet = new HashSet<>(InternalRealmsSettings.getSettings());
-        final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingsSet, Setting.Property.NodeScope) {
-        };
+        final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingsSet, Setting.Property.NodeScope) {};
         validator.validate(settings, false);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -1597,8 +1597,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         ObjLongConsumer<ActionListener<Void>> waitForMappingUpdate = (l, mappingVersion) -> l.onResponse(null);
         PlainActionFuture<TransportReplicationAction.PrimaryResult<BulkShardRequest, BulkShardResponse>> future = new PlainActionFuture<>();
         IndexShard indexShard = mock(IndexShard.class);
-        when(indexShard.getBulkOperationListener()).thenReturn(new BulkOperationListener() {
-        });
+        when(indexShard.getBulkOperationListener()).thenReturn(new BulkOperationListener() {});
         TransportShardBulkAction.performOnPrimary(
             request,
             indexShard,

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -619,8 +619,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     interface Disruption {
 
-        Disruption NONE = new Disruption() {
-        };
+        Disruption NONE = new Disruption() {};
 
         default byte[] onRead(byte[] actualContents, long position, long length) throws IOException {
             return actualContents;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
@@ -77,8 +77,7 @@ public class EmbeddedCli implements Closeable {
             new ExternalTerminal("test", "xterm-256color", cliIn, cliOut, StandardCharsets.UTF_8),
             false
         );
-        cli = new Cli(cliTerminal) {
-        };
+        cli = new Cli(cliTerminal) {};
         out = new BufferedWriter(new OutputStreamWriter(outgoing, StandardCharsets.UTF_8));
         in = new BufferedReader(new InputStreamReader(incoming, StandardCharsets.UTF_8));
 

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
@@ -80,8 +80,7 @@ public final class CsvTestUtils {
                 throw new UnsupportedOperationException();
             }
         };
-        return new CsvConnection(tableReader, csvProperties, "") {
-        };
+        return new CsvConnection(tableReader, csvProperties, "") {};
     }
 
     private static Tuple<String, String> extractColumnTypesAndStripCli(String schema, String expectedResults) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Formatting: Keep braces for empty anonymous classes on a single line (#141683)](https://github.com/elastic/elasticsearch/pull/141683)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)