### PR TITLE
Docs: Add links in Painless docs to related debugging sections

### DIFF
--- a/docs/reference/scripting-languages/painless/painless-casting.md
+++ b/docs/reference/scripting-languages/painless/painless-casting.md
@@ -12,8 +12,7 @@ products:
 
 A cast converts the value of an original type to the equivalent value of a target type. An implicit cast infers the target type and automatically occurs during certain [operations](/reference/scripting-languages/painless/painless-operators.md). An explicit cast specifies the target type and forcefully occurs as its own operation. Use the `cast operator '()'` to specify an explicit cast. You can also check out the [type casting tutorial](docs-content://explore-analyze/scripting/modules-scripting-type-casting-tutorial.md) for related examples, and for help with troubleshooting refer to "type casting issues" in the Troubleshooting section.
 
-
-Refer to the [cast table](#allowed-casts) for a quick reference on all allowed casts.
+Refer to the [cast table](#allowed-casts) for a quick reference on all allowed casts. To help resolve any issues, check [Debug type casting errors in Painless](docs-content://explore-analyze/scripting/painless-type-casting-issues.md).
 
 **Errors**
 

--- a/docs/reference/scripting-languages/painless/painless-ingest-processor-context.md
+++ b/docs/reference/scripting-languages/painless/painless-ingest-processor-context.md
@@ -17,6 +17,8 @@ Painless scripts run as script processors within ingest pipelines that support s
 
 Ingest pipelines consist of multiple processors that can transform documents sequentially. The script processor allows Painless scripts to access and modify document fields using the `ctx` variable during this transformation process.
 
+For help debugging errors in this context, refer to [Debug ingest pipeline failures in Painless](docs-content://explore-analyze/scripting/painless-ingest-pipeline-failures.md).
+
 ## Processing workflow
 
 The pipelines processing proceeds through four steps.

--- a/docs/reference/scripting-languages/painless/painless-operators-array.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-array.md
@@ -14,7 +14,7 @@ products:
 
 Use the `array initialization operator '[] {}'` to allocate a single-dimensional [array type](/reference/scripting-languages/painless/painless-types.md#array-type) instance to the heap with a set of pre-defined elements. Each value used to initialize an element in the array type instance is cast to the specified element type value upon insertion. The order of specified values is maintained.
 
-% For help with troubleshooting, refer to [Array/List manipulation errors](docs-content://troubleshoot/elasticsearch/painless-array-list-manipulation-errors.md).
+For help with any required debugging, refer to [Debug array manipulation errors in Painless](docs-content://explore-analyze/scripting/painless-array-list-manipulation-errors.md).
 
 **Errors**
 

--- a/docs/reference/scripting-languages/painless/painless-regexes.md
+++ b/docs/reference/scripting-languages/painless/painless-regexes.md
@@ -12,7 +12,7 @@ products:
 
 Regular expression constants are directly supported. To ensure fast performance, this is the only mechanism for creating patterns. Regular expressions are always constants and are compiled a single time for efficiency.
 
-% You can check out the [regular expressions tutorial](docs-content://explore-analyze/scripting/modules-scripting-regular-expressions-tutorial.md) for related examples, and for help with troubleshooting, refer to [regex pattern matching failures](docs-content://troubleshoot/elasticsearch/painless-regex-pattern-matching-failures.md).
+You can check the [regular expressions tutorial](docs-content://explore-analyze/scripting/modules-scripting-regular-expressions-tutorial.md) for related examples, and for help with any required debugging, refer to [Debug regex pattern matching failures in Painless](docs-content://explore-analyze/scripting/painless-regex-pattern-matching-failures.md).
 
 ```painless
 Pattern p = /[aeiou]/

--- a/docs/reference/scripting-languages/painless/painless-score-context.md
+++ b/docs/reference/scripting-languages/painless/painless-score-context.md
@@ -12,7 +12,7 @@ products:
 
 Use a Painless script in a [function score](/reference/query-languages/query-dsl/query-dsl-function-score-query.md) to apply a new score to documents returned from a query.
 
-Check the troubleshooting guide for help with script score calculation errors.
+For help debugging errors in this context, refer to [Debug script score calculation errors in Painless](docs-content://explore-analyze/scripting/painless-script-score-calculation-errors.md).
 
 ## Variables
 

--- a/docs/reference/scripting-languages/painless/painless.md
+++ b/docs/reference/scripting-languages/painless/painless.md
@@ -37,7 +37,7 @@ The reference documentation includes the following resources:
 
 * [**Language specification:**](/reference/scripting-languages/painless/painless-language-specification.md) syntax, operators, data types, and compilation semantics
 * [**Contexts:**](/reference/scripting-languages/painless/painless-contexts.md) Execution environments, available variables, and context-specific APIs  
-* [**API examples:**](/reference/scripting-languages/painless/painless-api-examples.md) Examples of how to run the Painless execute API to build and test scripts.
-* **Debugging & Troubleshooting:** Debugging techniques, common errors, and solutions
+* [**API examples:**](/reference/scripting-languages/painless/painless-api-examples.md) Examples of how to run the Painless execute API to build and test scripts
+* [**Debugging:**](docs-content://explore-analyze/scripting/painless-debugging.md) Debugging techniques, common errors, and solutions
 
 For step-by-step tutorials and real-world examples, refer to [How to write Painless scripts](docs-content://explore-analyze/scripting/modules-scripting-using.md) and [Painless script tutorials](docs-content://explore-analyze/scripting/common-script-uses.md) in the Explore and Analyze section.


### PR DESCRIPTION
This adds links in a few parts of the newly revamped Painless docs, pointing to associated pages in the new [debugging section](https://www.elastic.co/docs/explore-analyze/scripting/painless-debugging).

Rel: https://github.com/elastic/docs-content-internal/issues/299