### PR TITLE
Add copyTo to Vector to support array copy

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -79,6 +79,11 @@ final class BooleanArrayVector extends AbstractVector implements BooleanVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, boolean[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.BOOLEAN;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -24,6 +24,15 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     ConstantNullVector, org.elasticsearch.compute.data.arrow.BooleanArrowBufVector {
     boolean getBoolean(int position);
 
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, boolean[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = getBoolean(srcPosition + i);
+        }
+    }
+
     @Override
     BooleanBlock asBlock();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -33,6 +35,11 @@ final class ConstantBooleanVector extends AbstractVector implements BooleanVecto
     @Override
     public boolean getBoolean(int position) {
         return value;
+    }
+
+    @Override
+    public void copyTo(int srcPosition, boolean[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -33,6 +35,11 @@ final class ConstantDoubleVector extends AbstractVector implements DoubleVector 
     @Override
     public double getDouble(int position) {
         return value;
+    }
+
+    @Override
+    public void copyTo(int srcPosition, double[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -33,6 +35,11 @@ final class ConstantFloatVector extends AbstractVector implements FloatVector {
     @Override
     public float getFloat(int position) {
         return value;
+    }
+
+    @Override
+    public void copyTo(int srcPosition, float[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -33,6 +35,11 @@ final class ConstantIntVector extends AbstractVector implements IntVector {
     @Override
     public int getInt(int position) {
         return value;
+    }
+
+    @Override
+    public void copyTo(int srcPosition, int[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -33,6 +35,11 @@ final class ConstantLongVector extends AbstractVector implements LongVector {
     @Override
     public long getLong(int position) {
         return value;
+    }
+
+    @Override
+    public void copyTo(int srcPosition, long[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -78,6 +78,11 @@ final class DoubleArrayVector extends AbstractVector implements DoubleVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, double[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.DOUBLE;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -24,6 +24,15 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     ConstantNullVector, org.elasticsearch.compute.data.arrow.DoubleArrowBufVector {
     double getDouble(int position);
 
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, double[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = getDouble(srcPosition + i);
+        }
+    }
+
     @Override
     DoubleBlock asBlock();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
@@ -78,6 +78,11 @@ final class FloatArrayVector extends AbstractVector implements FloatVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, float[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.FLOAT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
@@ -25,6 +25,15 @@ public sealed interface FloatVector extends Vector permits ConstantFloatVector, 
 
     float getFloat(int position);
 
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, float[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = getFloat(srcPosition + i);
+        }
+    }
+
     @Override
     FloatBlock asBlock();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -88,6 +88,11 @@ final class IntArrayVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, int[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -24,6 +24,15 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     ConstantNullVector, org.elasticsearch.compute.data.arrow.IntArrowBufVector {
     int getInt(int position);
 
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, int[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = getInt(srcPosition + i);
+        }
+    }
+
     @Override
     IntBlock asBlock();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -78,6 +78,11 @@ final class LongArrayVector extends AbstractVector implements LongVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, long[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -25,6 +25,15 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
 
     long getLong(int position);
 
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, long[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = getLong(srcPosition + i);
+        }
+    }
+
     @Override
     LongBlock asBlock();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -109,6 +109,36 @@ public final class ConstantNullVector extends AbstractVector
     }
 
     @Override
+    public void copyTo(int srcPosition, long[] dst, int dstPosition, int length) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public void copyTo(int srcPosition, int[] dst, int dstPosition, int length) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public void copyTo(int srcPosition, double[] dst, int dstPosition, int length) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public void copyTo(int srcPosition, float[] dst, int dstPosition, int length) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public void copyTo(int srcPosition, boolean[] dst, int dstPosition, int length) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
     public int min() {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
@@ -41,6 +41,13 @@ final class IntRangeVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public void copyTo(int srcPosition, int[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = startInclusive + srcPosition + i;
+        }
+    }
+
+    @Override
     public IntBlock asBlock() {
         return new IntVectorBlock(this);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -134,6 +134,11 @@ $else$
     public $type$ get$Type$(int position) {
         return values[position];
     }
+
+    @Override
+    public void copyTo(int srcPosition, $type$[] dst, int dstPosition, int length) {
+        System.arraycopy(values, srcPosition, dst, dstPosition, length);
+    }
 $endif$
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -16,6 +16,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.ReleasableIterator;
+
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -50,6 +52,14 @@ $else$
         return value;
 $endif$
     }
+
+$if(BytesRef)$
+$else$
+    @Override
+    public void copyTo(int srcPosition, $type$[] dst, int dstPosition, int length) {
+        Arrays.fill(dst, dstPosition, dstPosition + length, value);
+    }
+$endif$
 
     @Override
     public $Type$Block asBlock() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -45,6 +45,15 @@ $if(BytesRef)$
 
 $else$
     $type$ get$Type$(int position);
+
+    /**
+     * Copies values from this vector into the destination array.
+     */
+    default void copyTo(int srcPosition, $type$[] dst, int dstPosition, int length) {
+        for (int i = 0; i < length; i++) {
+            dst[dstPosition + i] = get$Type$(srcPosition + i);
+        }
+    }
 $endif$
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -2201,6 +2201,141 @@ public class BasicBlockTests extends ESTestCase {
         }
     }
 
+    public void testCopyToLong() {
+        int positionCount = randomIntBetween(1, 1000);
+        try (LongVector.Builder builder = blockFactory.newLongVectorBuilder(positionCount)) {
+            for (int i = 0; i < positionCount; i++) {
+                builder.appendLong(randomLong());
+            }
+            try (LongVector vector = builder.build()) {
+                int srcPosition = randomIntBetween(0, positionCount - 1);
+                int length = randomIntBetween(0, positionCount - srcPosition);
+                int dstPosition = randomIntBetween(0, 10);
+                long sentinel = randomLong();
+                long[] dst = new long[dstPosition + length + randomIntBetween(0, 10)];
+                Arrays.fill(dst, sentinel);
+                vector.copyTo(srcPosition, dst, dstPosition, length);
+                for (int i = 0; i < length; i++) {
+                    assertThat(dst[dstPosition + i], equalTo(vector.getLong(srcPosition + i)));
+                }
+                for (int i = 0; i < dstPosition; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+                for (int i = dstPosition + length; i < dst.length; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+            }
+        }
+    }
+
+    public void testCopyToInt() {
+        int positionCount = randomIntBetween(1, 1000);
+        try (IntVector.Builder builder = blockFactory.newIntVectorBuilder(positionCount)) {
+            for (int i = 0; i < positionCount; i++) {
+                builder.appendInt(randomInt());
+            }
+            try (IntVector vector = builder.build()) {
+                int srcPosition = randomIntBetween(0, positionCount - 1);
+                int length = randomIntBetween(0, positionCount - srcPosition);
+                int dstPosition = randomIntBetween(0, 10);
+                int sentinel = randomInt();
+                int[] dst = new int[dstPosition + length + randomIntBetween(0, 10)];
+                Arrays.fill(dst, sentinel);
+                vector.copyTo(srcPosition, dst, dstPosition, length);
+                for (int i = 0; i < length; i++) {
+                    assertThat(dst[dstPosition + i], equalTo(vector.getInt(srcPosition + i)));
+                }
+                for (int i = 0; i < dstPosition; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+                for (int i = dstPosition + length; i < dst.length; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+            }
+        }
+    }
+
+    public void testCopyToDouble() {
+        int positionCount = randomIntBetween(1, 1000);
+        try (DoubleVector.Builder builder = blockFactory.newDoubleVectorBuilder(positionCount)) {
+            for (int i = 0; i < positionCount; i++) {
+                builder.appendDouble(randomDouble());
+            }
+            try (DoubleVector vector = builder.build()) {
+                int srcPosition = randomIntBetween(0, positionCount - 1);
+                int length = randomIntBetween(0, positionCount - srcPosition);
+                int dstPosition = randomIntBetween(0, 10);
+                double sentinel = randomDouble();
+                double[] dst = new double[dstPosition + length + randomIntBetween(0, 10)];
+                Arrays.fill(dst, sentinel);
+                vector.copyTo(srcPosition, dst, dstPosition, length);
+                for (int i = 0; i < length; i++) {
+                    assertThat(dst[dstPosition + i], equalTo(vector.getDouble(srcPosition + i)));
+                }
+                for (int i = 0; i < dstPosition; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+                for (int i = dstPosition + length; i < dst.length; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+            }
+        }
+    }
+
+    public void testCopyToFloat() {
+        int positionCount = randomIntBetween(1, 1000);
+        try (FloatVector.Builder builder = blockFactory.newFloatVectorBuilder(positionCount)) {
+            for (int i = 0; i < positionCount; i++) {
+                builder.appendFloat(randomFloat());
+            }
+            try (FloatVector vector = builder.build()) {
+                int srcPosition = randomIntBetween(0, positionCount - 1);
+                int length = randomIntBetween(0, positionCount - srcPosition);
+                int dstPosition = randomIntBetween(0, 10);
+                float sentinel = randomFloat();
+                float[] dst = new float[dstPosition + length + randomIntBetween(0, 10)];
+                Arrays.fill(dst, sentinel);
+                vector.copyTo(srcPosition, dst, dstPosition, length);
+                for (int i = 0; i < length; i++) {
+                    assertThat(dst[dstPosition + i], equalTo(vector.getFloat(srcPosition + i)));
+                }
+                for (int i = 0; i < dstPosition; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+                for (int i = dstPosition + length; i < dst.length; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+            }
+        }
+    }
+
+    public void testCopyToBoolean() {
+        int positionCount = randomIntBetween(1, 1000);
+        try (BooleanVector.Builder builder = blockFactory.newBooleanVectorBuilder(positionCount)) {
+            for (int i = 0; i < positionCount; i++) {
+                builder.appendBoolean(randomBoolean());
+            }
+            try (BooleanVector vector = builder.build()) {
+                int srcPosition = randomIntBetween(0, positionCount - 1);
+                int length = randomIntBetween(0, positionCount - srcPosition);
+                int dstPosition = randomIntBetween(0, 10);
+                boolean sentinel = randomBoolean();
+                boolean[] dst = new boolean[dstPosition + length + randomIntBetween(0, 10)];
+                Arrays.fill(dst, sentinel);
+                vector.copyTo(srcPosition, dst, dstPosition, length);
+                for (int i = 0; i < length; i++) {
+                    assertThat(dst[dstPosition + i], equalTo(vector.getBoolean(srcPosition + i)));
+                }
+                for (int i = 0; i < dstPosition; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+                for (int i = dstPosition + length; i < dst.length; i++) {
+                    assertThat(dst[i], equalTo(sentinel));
+                }
+            }
+        }
+    }
+
     /**
      * Build a random valid "mask" of single valued boolean fields that.
      */


### PR DESCRIPTION
This change adds copyTo to Vector to allow copying values from the underlying primitive array to an external primitive array via System.arraycopy. This should help with the follow-up change in the rate aggregation.