### PR TITLE
[8.19] [CI] Cache fallback adoptjdk17 when baking ci images (#141527)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -172,7 +172,7 @@ public class BwcSetupExtension {
     /** A convenience method for getting java home for a version of java and requiring that version for the given task to execute */
     private static Provider<String> getJavaHome(ObjectFactory objectFactory, JavaToolchainService toolChainService, final int version) {
         Property<JavaLanguageVersion> value = objectFactory.property(JavaLanguageVersion.class).value(JavaLanguageVersion.of(version));
-        return toolChainService.launcherFor(javaToolchainSpec -> { javaToolchainSpec.getLanguageVersion().value(value); })
+        return toolChainService.launcherFor(javaToolchainSpec -> javaToolchainSpec.getLanguageVersion().value(value))
             .map(launcher -> launcher.getMetadata().getInstallationPath().getAsFile().getAbsolutePath());
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.internal.test.rest.RestTestBasePlugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
@@ -28,6 +29,8 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+
+import static org.elasticsearch.gradle.util.GradleUtils.withRetries;
 
 public abstract class ResolveAllDependencies extends DefaultTask {
 
@@ -64,8 +67,15 @@ public abstract class ResolveAllDependencies extends DefaultTask {
     @TaskAction
     void resolveAll() {
         if (resolveJavaToolChain) {
-            resolveDefaultJavaToolChain();
+            withRetries(() -> {
+                resolveDefaultJavaToolChain();
+                resolveJdk17FallbackJavaToolChain();
+            });
         }
+    }
+
+    private void resolveJdk17FallbackJavaToolChain() {
+        getJavaToolchainService().launcherFor(RestTestBasePlugin.JAVA_TOOLCHAIN_JDK_ADOPTIUM_SPEC_ACTION).get();
     }
 
     private void resolveDefaultJavaToolChain() {

--- a/build.gradle
+++ b/build.gradle
@@ -488,19 +488,6 @@ allprojects {
     tasks.matching { it.name.equals('integTest') }.configureEach { integTestTask ->
       integTestTask.mustRunAfter tasks.matching { it.name.equals("test") }
     }
-
-/*    configurations.matching { it.canBeResolved }.all { Configuration configuration ->
-      dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
-        Project upstreamProject = dep.dependencyProject
-        if (project.path != upstreamProject?.path) {
-          for (String taskName : ['test', 'integTest']) {
-            project.tasks.matching { it.name == taskName }.configureEach { task ->
-              task.shouldRunAfter(upstreamProject.tasks.matching { upStreamTask -> upStreamTask.name == taskName })
-            }
-          }
-        }
-      }
-    }*/
   }
 
   apply plugin: 'elasticsearch.formatting'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Cache fallback adoptjdk17 when baking ci images (#141527)](https://github.com/elastic/elasticsearch/pull/141527)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)