### PR TITLE
[8.19] Fix shadowing ts param in non ts mappings (#141549)

### DIFF
--- a/docs/changelog/141549.yaml
+++ b/docs/changelog/141549.yaml
@@ -1,0 +1,6 @@
+area: Mapping
+issues:
+ - 140882
+pr: 141549
+summary: Allow shadowing time series metrics and dimension in non time series indexing
+type: bug

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettingProviders;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -241,7 +242,12 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
                 new MetadataFieldMapper[] { dtfm },
                 Collections.emptyMap()
             );
-            MappingLookup mappingLookup = MappingLookup.fromMappers(mapping, List.of(dtfm, dateFieldMapper), List.of());
+            MappingLookup mappingLookup = MappingLookup.fromMappers(
+                mapping,
+                List.of(dtfm, dateFieldMapper),
+                List.of(),
+                randomFrom(IndexMode.values())
+            );
             indicesService = DataStreamTestHelper.mockIndicesServices(mappingLookup);
         }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -255,8 +255,7 @@ public class Reindexer {
             }
             Settings settings = MetadataIndexTemplateService.resolveSettings(state.metadata(), template);
             // We retrieve the setting without performing any validation because that the template has already been validated
-            String indexMode = settings.get(IndexSettings.MODE.getKey());
-            return indexMode == null ? IndexMode.STANDARD : IndexMode.fromString(indexMode);
+            return IndexMode.fromIndexSettingsWithoutValidation(settings);
         }
 
         @Override

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -248,6 +248,8 @@ tasks.named("precommit").configure {
 tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("indices.sort/10_basic/Index Sort", "warning does not exist for compatibility")
   task.skipTest("search/330_fetch_fields/Test search rewrite", "warning does not exist for compatibility")
+  task.skipTest("tsdb/05_dimension_and_metric_in_non_tsdb_index/can't shadow dimensions", "Dimensions can be shadowed in non tsdb indices")
+  task.skipTest("tsdb/05_dimension_and_metric_in_non_tsdb_index/can't shadow metrics", "Metrics can be shadowed in non tsdb indices")
   task.skipTest("tsdb/20_mapping/stored source is supported", "no longer serialize source_mode")
   task.skipTest("tsdb/20_mapping/Synthetic source", "no longer serialize source_mode")
   task.skipTest("tsdb/20_mapping/nested fields", "nested field support in tsdb indices is now supported")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -56,10 +56,10 @@ add time series mappings:
                               time_series_metric: gauge
 
 ---
-can't shadow dimensions:
+can shadow dimensions:
   - requires:
-      cluster_features: ["gte_v8.1.0"]
-      reason: introduced in 8.1.0
+      cluster_features: ["index.shadowing_dimensions_and_metrics_is_valid_in_non_tsdb"]
+      reason: "Fixed by #141549"
 
   - do:
       indices.create:
@@ -84,16 +84,15 @@ can't shadow dimensions:
                           time_series_dimension: true
 
   - do:
-      catch: /Field \[dim\] attempted to shadow a time_series_dimension/
       indices.put_mapping:
         index: test
         body:
           runtime:
             dim:
               type: keyword
+  - is_true: acknowledged
 
   - do:
-      catch: /Field \[dim\] attempted to shadow a time_series_dimension/
       search:
         index: test
         body:
@@ -102,16 +101,15 @@ can't shadow dimensions:
               type: keyword
 
   - do:
-      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_dimension/
       indices.put_mapping:
         index: test
         body:
           runtime:
             deep.deeper.deepest:
               type: keyword
+  - is_true: acknowledged
 
   - do:
-      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_dimension/
       search:
         index: test
         body:
@@ -121,10 +119,10 @@ can't shadow dimensions:
 
 
 ---
-can't shadow metrics:
+can shadow metrics:
   - requires:
-      cluster_features: ["gte_v8.1.0"]
-      reason: introduced in 8.1.0
+      cluster_features: ["index.shadowing_dimensions_and_metrics_is_valid_in_non_tsdb"]
+      reason: "Fixed by #141549"
 
   - do:
       indices.create:
@@ -149,16 +147,15 @@ can't shadow metrics:
                           time_series_metric: gauge
 
   - do:
-      catch: /Field \[metric\] attempted to shadow a time_series_metric/
       indices.put_mapping:
         index: test
         body:
           runtime:
             metric:
               type: keyword
+  - is_true: acknowledged
 
   - do:
-      catch: /Field \[metric\] attempted to shadow a time_series_metric/
       search:
         index: test
         body:
@@ -167,7 +164,6 @@ can't shadow metrics:
               type: keyword
 
   - do:
-      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_metric/
       indices.put_mapping:
         index: test
         body:
@@ -176,7 +172,6 @@ can't shadow metrics:
               type: keyword
 
   - do:
-      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_metric/
       search:
         index: test
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
@@ -58,3 +58,135 @@ tsdb_execute_painless_api:
                     rx: 430605511
 
   - match: { result: [false] }
+
+---
+can't shadow dimensions:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              number_of_shards: 2
+              mode: time_series
+              # we use a different routing dimension to ensure that we test the shadowing logic
+              routing_path: [routing_dim]
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              dim:
+                type: keyword
+                time_series_dimension: true
+              routing_dim:
+                type: keyword
+                time_series_dimension: true
+              deep:
+                properties:
+                  deeper:
+                    properties:
+                      deepest:
+                        type: keyword
+                        time_series_dimension: true
+
+  - do:
+      catch: /Field \[dim\] attempted to shadow a time_series_dimension/
+      indices.put_mapping:
+        index: test
+        body:
+          runtime:
+            dim:
+              type: keyword
+
+  - do:
+      catch: /Field \[dim\] attempted to shadow a time_series_dimension/
+      search:
+        index: test
+        body:
+          runtime_mappings:
+            dim:
+              type: keyword
+
+  - do:
+      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_dimension/
+      indices.put_mapping:
+        index: test
+        body:
+          runtime:
+            deep.deeper.deepest:
+              type: keyword
+
+  - do:
+      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_dimension/
+      search:
+        index: test
+        body:
+          runtime_mappings:
+            deep.deeper.deepest:
+              type: keyword
+
+
+---
+can't shadow metrics:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              number_of_shards: 2
+              mode: time_series
+              routing_path: [dim]
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              dim:
+                type: keyword
+                time_series_dimension: true
+              metric:
+                type: long
+                time_series_metric: gauge
+              deep:
+                properties:
+                  deeper:
+                    properties:
+                      deepest:
+                        type: long
+                        time_series_metric: gauge
+
+  - do:
+      catch: /Field \[metric\] attempted to shadow a time_series_metric/
+      indices.put_mapping:
+        index: test
+        body:
+          runtime:
+            metric:
+              type: keyword
+
+  - do:
+      catch: /Field \[metric\] attempted to shadow a time_series_metric/
+      search:
+        index: test
+        body:
+          runtime_mappings:
+            metric:
+              type: keyword
+
+  - do:
+      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_metric/
+      indices.put_mapping:
+        index: test
+        body:
+          runtime:
+            deep.deeper.deepest:
+              type: keyword
+
+  - do:
+      catch: /Field \[deep.deeper.deepest\] attempted to shadow a time_series_metric/
+      search:
+        index: test
+        body:
+          runtime_mappings:
+            deep.deeper.deepest:
+              type: keyword

--- a/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
@@ -25,8 +25,15 @@ public class IndexFeatures implements FeatureSpecification {
 
     private static final NodeFeature SYNONYMS_SET_LENIENT_ON_NON_EXISTING = new NodeFeature("index.synonyms_set_lenient_on_non_existing");
 
+    private static final NodeFeature SHADOWING_DIMENSIONS_AND_METRICS_IS_VALID_IN_NON_TSDB = new NodeFeature(
+        "index.shadowing_dimensions_and_metrics_is_valid_in_non_tsdb"
+    );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(LOGSDB_NO_HOST_NAME_FIELD, SYNONYMS_SET_LENIENT_ON_NON_EXISTING);
+        return Set.of(
+            LOGSDB_NO_HOST_NAME_FIELD, SYNONYMS_SET_LENIENT_ON_NON_EXISTING,
+            SHADOWING_DIMENSIONS_AND_METRICS_IS_VALID_IN_NON_TSDB
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
@@ -32,7 +32,8 @@ public class IndexFeatures implements FeatureSpecification {
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
-            LOGSDB_NO_HOST_NAME_FIELD, SYNONYMS_SET_LENIENT_ON_NON_EXISTING,
+            LOGSDB_NO_HOST_NAME_FIELD,
+            SYNONYMS_SET_LENIENT_ON_NON_EXISTING,
             SHADOWING_DIMENSIONS_AND_METRICS_IS_VALID_IN_NON_TSDB
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -555,7 +555,7 @@ public enum IndexMode {
      * Parse a string into an {@link IndexMode}.
      */
     public static IndexMode fromString(String value) {
-        return switch (value) {
+        return switch (value.toLowerCase(Locale.ROOT)) {
             case "standard" -> IndexMode.STANDARD;
             case "time_series" -> IndexMode.TIME_SERIES;
             case "logsdb" -> IndexMode.LOGSDB;
@@ -568,6 +568,15 @@ public enum IndexMode {
                     + "]"
             );
         };
+    }
+
+    /**
+     * Retrieves the `index.mode` setting and parses it to {@link IndexMode}. When missing, it defaults to standard.
+     * Note: This should be used only in cases where it is not relevant to validate the index settings.
+     */
+    public static IndexMode fromIndexSettingsWithoutValidation(Settings settings) {
+        String indexModeLabel = settings.get(IndexSettings.MODE.getKey());
+        return indexModeLabel == null ? IndexMode.STANDARD : IndexMode.fromString(indexModeLabel);
     }
 
     public static IndexMode readFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -50,7 +50,8 @@ public class DocumentMapper {
             mapping.toCompressedXContent(),
             IndexVersion.current(),
             mapperService.getMapperMetrics(),
-            mapperService.index().getName()
+            mapperService.index().getName(),
+            mapperService.getIndexMode()
         );
     }
 
@@ -60,11 +61,12 @@ public class DocumentMapper {
         CompressedXContent source,
         IndexVersion version,
         MapperMetrics mapperMetrics,
-        String indexName
+        String indexName,
+        IndexMode indexMode
     ) {
         this.documentParser = documentParser;
         this.type = mapping.getRoot().fullPath();
-        this.mappingLookup = MappingLookup.fromMapping(mapping);
+        this.mappingLookup = MappingLookup.fromMapping(mapping, indexMode);
         this.mappingSource = source;
         this.mapperMetrics = mapperMetrics;
         this.indexVersion = version;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -177,6 +177,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     private final MappingParser mappingParser;
     private final DocumentParser documentParser;
     private final IndexVersion indexVersionCreated;
+    private final IndexMode indexMode;
     private final MapperRegistry mapperRegistry;
     private final Supplier<MappingParserContext> mappingParserContextSupplier;
     private final Function<Query, BitSetProducer> bitSetProducer;
@@ -229,6 +230,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     ) {
         super(indexSettings);
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
+        // We parse the setting in this way to avoid any index settings validations which are not relevant here.
+        this.indexMode = IndexMode.fromIndexSettingsWithoutValidation(indexSettings.getSettings());
         this.indexAnalyzers = indexAnalyzers;
         this.mapperRegistry = mapperRegistry;
         this.mappingParserContextSupplier = () -> new MappingParserContext(
@@ -601,7 +604,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             mappingSource,
             indexVersionCreated,
             mapperMetrics,
-            index().getName()
+            index().getName(),
+            indexMode
         );
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
@@ -843,5 +847,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public MapperMetrics getMapperMetrics() {
         return mapperMetrics;
+    }
+
+    public IndexMode getIndexMode() {
+        return indexMode;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -79,7 +80,8 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             merged.toCompressedXContent(),
             IndexVersion.current(),
             MapperMetrics.NOOP,
-            "myIndex"
+            "myIndex",
+            randomFrom(IndexMode.values())
         );
         assertThat(mergedMapper.mappers().getMapper("age"), notNullValue());
         assertThat(mergedMapper.mappers().getMapper("obj1.prop1"), notNullValue());

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -2679,7 +2680,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
             newMapping.toCompressedXContent(),
             IndexVersion.current(),
             MapperMetrics.NOOP,
-            "myIndex"
+            "myIndex",
+            randomFrom(IndexMode.values())
         );
         ParsedDocument doc2 = newDocMapper.parse(source("""
             {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -75,7 +76,10 @@ public class DynamicFieldsBuilderTests extends ESTestCase {
         ).build(MapperBuilderContext.root(false, false));
         Mapping mapping = new Mapping(root, new MetadataFieldMapper[] { sourceMapper }, Map.of());
 
-        DocumentParserContext ctx = new TestDocumentParserContext(MappingLookup.fromMapping(mapping), sourceToParse) {
+        DocumentParserContext ctx = new TestDocumentParserContext(
+            MappingLookup.fromMapping(mapping, randomFrom(IndexMode.values())),
+            sourceToParse
+        ) {
             @Override
             public XContentParser parser() {
                 return parser;

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.test.ESTestCase;
@@ -204,6 +205,13 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             new MetadataFieldMapper[0],
             Collections.emptyMap()
         );
-        return MappingLookup.fromMappers(mapping, fieldMappers, objectMappers, fieldAliasMappers, emptyList());
+        return MappingLookup.fromMappers(
+            mapping,
+            fieldMappers,
+            objectMappers,
+            fieldAliasMappers,
+            emptyList(),
+            randomFrom(IndexMode.values())
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -19,11 +19,6 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SearchExecutionContextHelper;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
-
 public class FieldNamesFieldTypeTests extends ESTestCase {
 
     public void testTermQuery() {
@@ -35,8 +30,6 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
             new IndexMetadata.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(),
             settings
         );
-        List<FieldMapper> mappers = Stream.of(fieldNamesFieldType, fieldType).<FieldMapper>map(MockFieldMapper::new).toList();
-        MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList());
         SearchExecutionContext searchExecutionContext = SearchExecutionContextHelper.createSimple(indexSettings, null, null);
         Query termQuery = fieldNamesFieldType.termQuery("field_name", searchExecutionContext);
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -107,7 +108,7 @@ public class MappingParserTests extends MapperServiceTestCase {
             b.endObject();
         });
         Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
-        MappingLookup mappingLookup = MappingLookup.fromMapping(mapping);
+        MappingLookup mappingLookup = MappingLookup.fromMapping(mapping, IndexMode.STANDARD);
         assertNotNull(mappingLookup.getMapper("foo.bar"));
         assertNotNull(mappingLookup.getMapper("foo.baz.deep.field"));
         assertNotNull(mappingLookup.objectMappers().get("foo"));

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -297,7 +298,7 @@ public class SearchExecutionContextTests extends ESTestCase {
             new MetadataFieldMapper[0],
             Collections.emptyMap()
         );
-        return MappingLookup.fromMappers(mapping, mappers, Collections.emptyList());
+        return MappingLookup.fromMappers(mapping, mappers, Collections.emptyList(), IndexMode.STANDARD);
     }
 
     public void testSearchRequestRuntimeFields() {
@@ -389,7 +390,7 @@ public class SearchExecutionContextTests extends ESTestCase {
             new KeywordFieldMapper.Builder("cat", IndexVersion.current()).ignoreAbove(100)
         ).build(MapperBuilderContext.root(true, false));
         Mapping mapping = new Mapping(root, new MetadataFieldMapper[] { sourceMapper }, Map.of());
-        MappingLookup lookup = MappingLookup.fromMapping(mapping);
+        MappingLookup lookup = MappingLookup.fromMapping(mapping, randomFrom(IndexMode.values()));
 
         SearchExecutionContext sec = createSearchExecutionContext("index", "", lookup, Map.of());
         assertTrue(sec.isSourceSynthetic());

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.request.ShardRequestCache;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
@@ -204,7 +205,8 @@ public class IndicesRequestCacheTests extends ESTestCase {
     public void testCacheDifferentMapping() throws Exception {
         IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY);
         MappingLookup.CacheKey mappingKey1 = MappingLookup.EMPTY.cacheKey();
-        MappingLookup.CacheKey mappingKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList()).cacheKey();
+        MappingLookup.CacheKey mappingKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), IndexMode.STANDARD)
+            .cacheKey();
         AtomicBoolean indexShard = new AtomicBoolean(true);
         ShardRequestCache requestCacheStats = new ShardRequestCache();
         Directory dir = newDirectory();
@@ -364,13 +366,15 @@ public class IndicesRequestCacheTests extends ESTestCase {
 
         writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
         DirectoryReader secondReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
-        MappingLookup.CacheKey secondMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList()).cacheKey();
+        MappingLookup.CacheKey secondMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), IndexMode.STANDARD)
+            .cacheKey();
         TestEntity secondEntity = new TestEntity(requestCacheStats, indexShard);
         Loader secondLoader = new Loader(secondReader, 0);
 
         writer.updateDocument(new Term("id", "0"), newDoc(0, "baz"));
         DirectoryReader thirdReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
-        MappingLookup.CacheKey thirdMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList()).cacheKey();
+        MappingLookup.CacheKey thirdMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), IndexMode.STANDARD)
+            .cacheKey();
         AtomicBoolean differentIdentity = new AtomicBoolean(true);
         TestEntity thirdEntity = new TestEntity(requestCacheStats, differentIdentity);
         Loader thirdLoader = new Loader(thirdReader, 0);
@@ -506,7 +510,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         AtomicBoolean trueBoolean = new AtomicBoolean(true);
         AtomicBoolean falseBoolean = new AtomicBoolean(false);
         MappingLookup.CacheKey mKey1 = MappingLookup.EMPTY.cacheKey();
-        MappingLookup.CacheKey mKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList()).cacheKey();
+        MappingLookup.CacheKey mKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), IndexMode.STANDARD).cacheKey();
         Directory dir = newDirectory();
         IndexWriterConfig config = newIndexWriterConfig();
         IndexWriter writer = new IndexWriter(dir, config);

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
@@ -307,7 +308,8 @@ public class SearchServiceTests extends IndexShardTestCase {
         MappingLookup mappingLookup = MappingLookup.fromMappers(
             mapping,
             Collections.singletonList(keywordFieldMapper),
-            Collections.emptyList()
+            Collections.emptyList(),
+            IndexMode.STANDARD
         );
         return new SearchExecutionContext(
             0,

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -169,7 +170,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
                 invocation -> new TestTemplateService.MockTemplateScript.Factory(((Script) invocation.getArguments()[0]).getIdOrCode())
             );
             List<FieldMapper> mappers = Collections.singletonList(new MockFieldMapper(fieldType));
-            MappingLookup lookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList());
+            MappingLookup lookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), randomFrom(IndexMode.values()));
             SearchExecutionContext mockContext = new SearchExecutionContext(
                 0,
                 0,

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -728,7 +728,7 @@ public final class DataStreamTestHelper {
                 new MetadataFieldMapper[] { dtfm },
                 Collections.emptyMap()
             );
-            mappingLookup = MappingLookup.fromMappers(mapping, List.of(dtfm, dateFieldMapper), List.of());
+            mappingLookup = MappingLookup.fromMappers(mapping, List.of(dtfm, dateFieldMapper), List.of(), randomFrom(IndexMode.values()));
         }
         IndicesService indicesService = mockIndicesServices(mappingLookup);
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -74,6 +74,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -384,7 +385,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
             Arrays.stream(fieldTypes)
                 .map(ft -> new FieldAliasMapper(ft.name() + "-alias", ft.name() + "-alias", ft.name()))
                 .collect(toList()),
-            List.of()
+            List.of(),
+            randomFrom(IndexMode.values())
         );
         BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> fieldDataBuilder = (fieldType, context) -> fieldType
             .fielddataBuilder(
@@ -492,7 +494,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
          * of stuff.
          */
         SearchExecutionContext subContext = spy(searchExecutionContext);
-        MappingLookup disableNestedLookup = MappingLookup.fromMappers(Mapping.EMPTY, Set.of(), Set.of());
+        MappingLookup disableNestedLookup = MappingLookup.fromMappers(Mapping.EMPTY, Set.of(), Set.of(), IndexMode.STANDARD);
         doReturn(new NestedDocuments(disableNestedLookup, bitsetFilterCache::getBitSetProducer, indexSettings.getIndexVersionCreated()))
             .when(subContext)
             .getNestedDocuments();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -58,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -574,7 +574,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             types.add(new MockFieldMapper(new KeywordFieldMapper.KeywordFieldType("dne-" + i)));
         }
 
-        MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, types, emptyList());
+        MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, types, List.of(), randomFrom(IndexMode.values()));
 
         final Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
@@ -67,7 +68,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
@@ -521,6 +521,6 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
     private static MappingLookup createMappingLookup(List<MappedFieldType> concreteFields) {
         List<FieldMapper> mappers = concreteFields.stream().map(MockFieldMapper::new).collect(Collectors.toList());
-        return MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList());
+        return MappingLookup.fromMappers(Mapping.EMPTY, mappers, List.of(), randomFrom(IndexMode.values()));
     }
 }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -1087,7 +1088,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             IndexFieldData.Builder builder = fieldType.fielddataBuilder(fdc);
             return builder.build(new IndexFieldDataCache.None(), null);
         };
-        MappingLookup lookup = MappingLookup.fromMapping(Mapping.EMPTY);
+        MappingLookup lookup = MappingLookup.fromMapping(Mapping.EMPTY, randomFrom(IndexMode.values()));
         return new SearchExecutionContext(
             0,
             0,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix shadowing ts param in non ts mappings (#141549)](https://github.com/elastic/elasticsearch/pull/141549)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)