### PR TITLE
Prevent large CancelTasksRequest descriptions by truncating nodes and actions

### DIFF
--- a/docs/changelog/141815.yaml
+++ b/docs/changelog/141815.yaml
@@ -1,0 +1,5 @@
+pr: 141815
+summary: Prevent large CancelTasksRequest descriptions by truncating nodes and actions
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
@@ -118,9 +118,7 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
             sb.append(values[i]);
         }
 
-        sb.append(", ... (")
-            .append(length - MAX_DESCRIPTION_ITEMS)
-            .append(" more)]");
+        sb.append(", ... (").append(length - MAX_DESCRIPTION_ITEMS).append(" more)]");
 
         return sb.toString();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
@@ -26,6 +26,8 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
     public static final String DEFAULT_REASON = "by user request";
     public static final boolean DEFAULT_WAIT_FOR_COMPLETION = false;
 
+    private static final int MAX_DESCRIPTION_ITEMS = 10;
+
     private String reason = DEFAULT_REASON;
     private boolean waitForCompletion = DEFAULT_WAIT_FOR_COMPLETION;
 
@@ -78,17 +80,48 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
 
     @Override
     public String getDescription() {
-        return "reason["
-            + reason
-            + "], waitForCompletion["
-            + waitForCompletion
-            + "], targetTaskId["
-            + getTargetTaskId()
-            + "], targetParentTaskId["
-            + getTargetParentTaskId()
-            + "], nodes"
-            + Arrays.toString(getNodes())
-            + ", actions"
-            + Arrays.toString(getActions());
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("reason[")
+            .append(reason)
+            .append("], waitForCompletion[")
+            .append(waitForCompletion)
+            .append("], targetTaskId[")
+            .append(getTargetTaskId())
+            .append("], targetParentTaskId[")
+            .append(getTargetParentTaskId())
+            .append("], nodes")
+            .append(truncatedArray(getNodes()))
+            .append(", actions")
+            .append(truncatedArray(getActions()));
+
+        return sb.toString();
+    }
+
+    private static String truncatedArray(String[] values) {
+        if (values == null) {
+            return "[]";
+        }
+
+        int length = values.length;
+        if (length <= MAX_DESCRIPTION_ITEMS) {
+            return Arrays.toString(values);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+
+        for (int i = 0; i < MAX_DESCRIPTION_ITEMS; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(values[i]);
+        }
+
+        sb.append(", ... (")
+            .append(length - MAX_DESCRIPTION_ITEMS)
+            .append(" more)]");
+
+        return sb.toString();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
@@ -14,10 +14,11 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
+import java.util.stream.IntStream;
 
 public class CancelTasksRequestTests extends ESTestCase {
 
-    public void testGetDescription() {
+    public void testGetDescription_NoTruncation() {
         CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
         cancelTasksRequest.setActions("action1", "action2");
         cancelTasksRequest.setNodes("node1", "node2");
@@ -30,5 +31,90 @@ public class CancelTasksRequestTests extends ESTestCase {
         );
         Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
         assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesNodesOnly() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 12).mapToObj(i -> "node" + i).toArray(String[]::new);
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions("action1", "action2");
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (2 more)], "
+                + "actions[action1, action2]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesActionsOnly() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] actions = IntStream.rangeClosed(1, 15).mapToObj(i -> "action" + i).toArray(String[]::new);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setNodes("node1", "node2");
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (5 more)]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesNodesAndActions() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 11).mapToObj(i -> "node" + i).toArray(String[]::new);
+        String[] actions = IntStream.rangeClosed(1, 20).mapToObj(i -> "action" + i).toArray(String[]::new);
+
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (1 more)], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (10 more)]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_ExactlyMaxDoesNotTruncate() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 10).mapToObj(i -> "node" + i).toArray(String[]::new);
+        String[] actions = IntStream.rangeClosed(1, 10).mapToObj(i -> "action" + i).toArray(String[]::new);
+
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10]",
+            cancelTasksRequest.getDescription()
+        );
     }
 }


### PR DESCRIPTION
**Problem**
When cancelling a potentially large number of tasks, CancelTasksRequest#getDescription() may return very large logging the full nodes and actions arrays. This can lead to unnecessary memory usage and increased GC pressure.

This change limits the number of elements included in the description to 10 items per array, appending a "... (N more)" suffix when truncation occurs.

closes #141740