### PR TITLE
Implement queryDSL percentiles for exponential_histogram

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -42,6 +42,9 @@ public final class SearchFeatures implements FeatureSpecification {
     public static final NodeFeature EXPONENTIAL_HISTOGRAM_QUERYDSL_MIN_MAX = new NodeFeature(
         "search.exponential_histogram_querydsl_min_max"
     );
+    public static final NodeFeature EXPONENTIAL_HISTOGRAM_QUERYDSL_PERCENTILES = new NodeFeature(
+        "search.exponential_histogram_querydsl_percentiles"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -59,7 +62,8 @@ public final class SearchFeatures implements FeatureSpecification {
             NESTED_AGG_TOP_HITS_WITH_INNER_HITS,
             DATE_FORMAT_MISSING_AS_NULL,
             LIMIT_MAX_IDS_FEATURE,
-            EXPONENTIAL_HISTOGRAM_QUERYDSL_MIN_MAX
+            EXPONENTIAL_HISTOGRAM_QUERYDSL_MIN_MAX,
+            EXPONENTIAL_HISTOGRAM_QUERYDSL_PERCENTILES
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
@@ -164,8 +164,6 @@ public class HistogramUnionState implements Releasable, Accountable {
     }
 
     public void add(HistogramUnionState other) {
-        long previousSize = size();
-        long otherSize = other.size();
         if (other.exponentialHistogramState != null) {
             getOrInitializeExponentialHistogramState().addWithoutUpscaling(other.exponentialHistogramState.histogram());
             invalidateCachedCombinedState();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
@@ -127,7 +127,7 @@ public class HistogramUnionState implements Releasable, Accountable {
         if (otherState.tDigestState != null) {
             return wrap(otherState.breaker, TDigestState.createUsingParamsFrom(otherState.tDigestState));
         } else {
-            return createWithEmptyTDigest(otherState.breaker, otherState.tdigestInitParams, otherState.exponentialHistogramState);
+            return createWithEmptyTDigest(otherState.breaker, otherState.tdigestInitParams, null);
         }
     }
 
@@ -164,6 +164,8 @@ public class HistogramUnionState implements Releasable, Accountable {
     }
 
     public void add(HistogramUnionState other) {
+        long previousSize = size();
+        long otherSize = other.size();
         if (other.exponentialHistogramState != null) {
             getOrInitializeExponentialHistogramState().addWithoutUpscaling(other.exponentialHistogramState.histogram());
             invalidateCachedCombinedState();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
@@ -474,4 +474,34 @@ public class HistogramUnionStateTests extends ESTestCase {
         }
     }
 
+    public void testCreateUsingParamsFromEmptyState() {
+        try (HistogramUnionState original = HistogramUnionState.create(breaker(), TDigestState.Type.HYBRID, 42)) {
+            try (HistogramUnionState copy = HistogramUnionState.createUsingParamsFrom(original)) {
+
+                assertThat(copy.compression(), equalTo(42.0));
+
+                // Mutate the copy to ensure that the original is unaffected
+                try(RandomState randomState = randomState()) {
+                    copy.add(randomState.unionState());
+                }
+
+                assertThat(original.size(), equalTo(0L));
+            }
+        }
+    }
+
+    public void testCreateUsingParamsFromPopulatedState() {
+        try (RandomState randomState = randomState()) {
+            HistogramUnionState original = randomState.unionState();
+            try (HistogramUnionState copy = HistogramUnionState.createUsingParamsFrom(original)) {
+
+                assertThat(copy.size(), equalTo(0L));
+                assertThat(copy.compression(), equalTo(original.compression()));
+
+                // Verify original is unchanged
+                assertThat(original.size(), equalTo(randomState.reference().size()));
+            }
+        }
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
@@ -481,7 +481,7 @@ public class HistogramUnionStateTests extends ESTestCase {
                 assertThat(copy.compression(), equalTo(42.0));
 
                 // Mutate the copy to ensure that the original is unaffected
-                try(RandomState randomState = randomState()) {
+                try (RandomState randomState = randomState()) {
                     copy.add(randomState.unionState());
                 }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractTDigestOrExponentialPercentileRanksAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractTDigestOrExponentialPercentileRanksAggregator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
+
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.HistogramUnionState;
+import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class AbstractTDigestOrExponentialPercentileRanksAggregator extends AbstractTDigestOrExponentialMergingAggregator {
+
+    public AbstractTDigestOrExponentialPercentileRanksAggregator(
+        String name,
+        ValuesSourceConfig config,
+        AggregationContext context,
+        Aggregator parent,
+        double[] percents,
+        double compression,
+        TDigestExecutionHint executionHint,
+        boolean keyed,
+        DocValueFormat formatter,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, config, context, parent, percents, compression, executionHint, keyed, formatter, metadata);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        HistogramUnionState state = getState(owningBucketOrdinal);
+        if (state == null) {
+            return buildEmptyAggregation();
+        } else {
+            return new InternalTDigestPercentileRanks(name, keys, state, keyed, formatter, metadata());
+        }
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return InternalTDigestPercentileRanks.empty(name, keys, compression, executionHint, keyed, formatter, metadata());
+    }
+
+    @Override
+    public double metric(String name, long bucketOrd) {
+        HistogramUnionState state = getState(bucketOrd);
+        if (state == null) {
+            return Double.NaN;
+        } else {
+            return InternalTDigestPercentileRanks.percentileRank(state, Double.parseDouble(name));
+        }
+    }
+}

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractTDigestOrExponentialPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractTDigestOrExponentialPercentilesAggregator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
+
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.HistogramUnionState;
+import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class AbstractTDigestOrExponentialPercentilesAggregator extends AbstractTDigestOrExponentialMergingAggregator {
+
+    public AbstractTDigestOrExponentialPercentilesAggregator(
+        String name,
+        ValuesSourceConfig config,
+        AggregationContext context,
+        Aggregator parent,
+        double[] percents,
+        double compression,
+        TDigestExecutionHint executionHint,
+        boolean keyed,
+        DocValueFormat formatter,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, config, context, parent, percents, compression, executionHint, keyed, formatter, metadata);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        HistogramUnionState state = getState(owningBucketOrdinal);
+        if (state == null) {
+            return buildEmptyAggregation();
+        } else {
+            return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, metadata());
+        }
+    }
+
+    @Override
+    public double metric(String name, long bucketOrd) {
+        HistogramUnionState state = getState(bucketOrd);
+        if (state == null) {
+            return Double.NaN;
+        } else {
+            return state.quantile(Double.parseDouble(name) / 100);
+        }
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        HistogramUnionState state = HistogramUnionState.create(HistogramUnionState.NOOP_BREAKER, executionHint, compression);
+        return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, metadata());
+    }
+}

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
@@ -7,19 +7,20 @@
 
 package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
+import org.elasticsearch.index.fielddata.HistogramValues;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.HistogramUnionState;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class HistoBackedTDigestPercentileRanksAggregator extends AbstractHistoBackedTDigestPercentilesAggregator {
+public class HistoBackedTDigestPercentileRanksAggregator extends AbstractTDigestOrExponentialPercentileRanksAggregator {
 
     public HistoBackedTDigestPercentileRanksAggregator(
         String name,
@@ -37,27 +38,8 @@ public class HistoBackedTDigestPercentileRanksAggregator extends AbstractHistoBa
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        HistogramUnionState state = getState(owningBucketOrdinal);
-        if (state == null) {
-            return buildEmptyAggregation();
-        } else {
-            return new InternalTDigestPercentileRanks(name, keys, state, keyed, formatter, metadata());
-        }
-    }
-
-    @Override
-    public InternalAggregation buildEmptyAggregation() {
-        return InternalTDigestPercentileRanks.empty(name, keys, compression, executionHint, keyed, formatter, metadata());
-    }
-
-    @Override
-    public double metric(String name, long bucketOrd) {
-        HistogramUnionState state = getState(bucketOrd);
-        if (state == null) {
-            return Double.NaN;
-        } else {
-            return InternalTDigestPercentileRanks.percentileRank(state, Double.parseDouble(name));
-        }
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        final HistogramValues values = ((HistogramValuesSource.Histogram) valuesSource).getHistogramValues(aggCtx.getLeafReaderContext());
+        return mergingTDigestCollector(sub, values);
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentilesAggregator.java
@@ -7,19 +7,20 @@
 
 package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
+import org.elasticsearch.index.fielddata.HistogramValues;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.HistogramUnionState;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class HistoBackedTDigestPercentilesAggregator extends AbstractHistoBackedTDigestPercentilesAggregator {
+public class HistoBackedTDigestPercentilesAggregator extends AbstractTDigestOrExponentialPercentilesAggregator {
 
     public HistoBackedTDigestPercentilesAggregator(
         String name,
@@ -37,28 +38,8 @@ public class HistoBackedTDigestPercentilesAggregator extends AbstractHistoBacked
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        HistogramUnionState state = getState(owningBucketOrdinal);
-        if (state == null) {
-            return buildEmptyAggregation();
-        } else {
-            return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, metadata());
-        }
-    }
-
-    @Override
-    public double metric(String name, long bucketOrd) {
-        HistogramUnionState state = getState(bucketOrd);
-        if (state == null) {
-            return Double.NaN;
-        } else {
-            return state.quantile(Double.parseDouble(name) / 100);
-        }
-    }
-
-    @Override
-    public InternalAggregation buildEmptyAggregation() {
-        HistogramUnionState state = HistogramUnionState.create(HistogramUnionState.NOOP_BREAKER, executionHint, compression);
-        return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, metadata());
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        final HistogramValues values = ((HistogramValuesSource.Histogram) valuesSource).getHistogramValues(aggCtx.getLeafReaderContext());
+        return mergingTDigestCollector(sub, values);
     }
 }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
@@ -35,7 +35,8 @@ public class ExponentialHistogramMapperPlugin extends Plugin implements MapperPl
             ExponentialHistogramAggregatorsRegistrar::registerAvgAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerHistogramAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerMinAggregator,
-            ExponentialHistogramAggregatorsRegistrar::registerMaxAggregator
+            ExponentialHistogramAggregatorsRegistrar::registerMaxAggregator,
+            ExponentialHistogramAggregatorsRegistrar::registerPercentilesAggregator
         );
     }
 }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
@@ -10,13 +10,20 @@ import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregati
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentileRanksAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
+import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.bucket.histogram.ExponentialHistogramBackedHistogramAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramAvgAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMaxAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMinAggregator;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramPercentileRanksAggregator;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramPercentilesAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramSumAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramValueCountAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSourceType;
@@ -76,6 +83,37 @@ public class ExponentialHistogramAggregatorsRegistrar {
             MaxAggregationBuilder.REGISTRY_KEY,
             ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
             ExponentialHistogramMaxAggregator::new,
+            true
+        );
+    }
+
+    public static void registerPercentilesAggregator(ValuesSourceRegistry.Builder builder) {
+        builder.register(
+            PercentilesAggregationBuilder.REGISTRY_KEY,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
+            (name, config, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
+                if (percentilesConfig.getMethod().equals(PercentilesMethod.TDIGEST)) {
+                    double compression = ((PercentilesConfig.TDigest) percentilesConfig).getCompression();
+                    TDigestExecutionHint executionHint = ((PercentilesConfig.TDigest) percentilesConfig).getExecutionHint(context);
+                    return new ExponentialHistogramPercentilesAggregator(
+                        name,
+                        config,
+                        context,
+                        parent,
+                        percents,
+                        compression,
+                        executionHint,
+                        keyed,
+                        formatter,
+                        metadata
+                    );
+                }
+                throw new IllegalArgumentException(
+                    "Percentiles algorithm "
+                        + percentilesConfig.getMethod().toString()
+                        + " must not be used with exponential_histogram field"
+                );
+            },
             true
         );
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
@@ -10,7 +10,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregati
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.PercentileRanksAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
 import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
@@ -22,7 +21,6 @@ import org.elasticsearch.xpack.exponentialhistogram.aggregations.bucket.histogra
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramAvgAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMaxAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMinAggregator;
-import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramPercentileRanksAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramPercentilesAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramSumAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramValueCountAggregator;
@@ -93,6 +91,7 @@ public class ExponentialHistogramAggregatorsRegistrar {
             ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
             (name, config, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
                 if (percentilesConfig.getMethod().equals(PercentilesMethod.TDIGEST)) {
+                    // We make sure to preserve the t-digest settings, as we might be querying mixed T-Digest / exponential histogram data
                     double compression = ((PercentilesConfig.TDigest) percentilesConfig).getCompression();
                     TDigestExecutionHint executionHint = ((PercentilesConfig.TDigest) percentilesConfig).getExecutionHint(context);
                     return new ExponentialHistogramPercentilesAggregator(

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramPercentilesAggregator.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramPercentilesAggregator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.xpack.analytics.aggregations.metrics.AbstractTDigestOrExponentialPercentilesAggregator;
+import org.elasticsearch.xpack.core.exponentialhistogram.fielddata.ExponentialHistogramValuesReader;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSource;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ExponentialHistogramPercentilesAggregator extends AbstractTDigestOrExponentialPercentilesAggregator {
+
+    public ExponentialHistogramPercentilesAggregator(
+        String name,
+        ValuesSourceConfig config,
+        AggregationContext context,
+        Aggregator parent,
+        double[] percents,
+        double compression,
+        TDigestExecutionHint executionHint,
+        boolean keyed,
+        DocValueFormat formatter,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, config, context, parent, percents, compression, executionHint, keyed, formatter, metadata);
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        final ExponentialHistogramValuesReader values = ((ExponentialHistogramValuesSource.ExponentialHistogram) valuesSource)
+            .getHistogramValues(aggCtx.getLeafReaderContext());
+        return mergingExponentialHistogramCollector(sub, values);
+    }
+}

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramPercentilesAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramPercentilesAggregatorTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogramCircuitBreaker;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogramMerger;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogramQuantile;
+import org.elasticsearch.exponentialhistogram.ExponentialScaleUtils;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
+import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
+import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramFieldMapper;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.ExponentialHistogramAggregatorTestCase;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSourceType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class ExponentialHistogramPercentilesAggregatorTests extends ExponentialHistogramAggregatorTestCase {
+
+    private static final String FIELD_NAME = "my_histogram";
+
+    @Override
+    protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
+        var tdigestConfig = new PercentilesConfig.TDigest();
+        if (randomBoolean()) {
+            tdigestConfig.setCompression(randomDoubleBetween(50, 200, true));
+        }
+        if (randomBoolean()) {
+            tdigestConfig.parseExecutionHint(randomFrom(TDigestExecutionHint.values()).toString());
+        }
+        return new PercentilesAggregationBuilder("my_percentiles").field(fieldName).percentilesConfig(tdigestConfig);
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM
+        );
+    }
+
+    public void testNoDocs() throws IOException {
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> {
+            // Intentionally not writing any docs
+        }, percentiles -> assertFalse(AggregationInspectionHelper.hasValue(percentiles)));
+    }
+
+    public void testNoMatchingField() throws IOException {
+        List<ExponentialHistogram> histograms = createRandomHistograms(10);
+        testCase(
+            Queries.ALL_DOCS_INSTANCE,
+            iw -> histograms.forEach(histo -> addHistogramDoc(iw, "wrong_field", histo)),
+            percentiles -> assertFalse(AggregationInspectionHelper.hasValue(percentiles))
+        );
+    }
+
+    public void testRandomHistograms() throws IOException {
+        List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 100));
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentiles -> {
+            assertThat(AggregationInspectionHelper.hasValue(percentiles), equalTo(anyNonEmpty));
+            verifyPercentiles(percentiles, histograms);
+        });
+    }
+
+    public void testQueryFiltering() throws IOException {
+        List<Map.Entry<ExponentialHistogram, Boolean>> histogramsWithFilter = createRandomHistograms(10).stream()
+            .map(histo -> Map.entry(histo, randomBoolean()))
+            .toList();
+
+        List<ExponentialHistogram> filteredHistograms = histogramsWithFilter.stream()
+            .filter(Map.Entry::getValue)
+            .map(Map.Entry::getKey)
+            .toList();
+
+        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+
+        testCase(
+            new TermQuery(new Term("match", "yes")),
+            iw -> histogramsWithFilter.forEach(
+                entry -> addHistogramDoc(
+                    iw,
+                    FIELD_NAME,
+                    entry.getKey(),
+                    new StringField("match", entry.getValue() ? "yes" : "no", Field.Store.NO)
+                )
+            ),
+            percentiles -> {
+                assertThat(AggregationInspectionHelper.hasValue(percentiles), equalTo(anyMatchingNonEmpty));
+                verifyPercentiles(percentiles, filteredHistograms);
+            }
+        );
+    }
+
+    public void testCustomPercentiles() throws IOException {
+        List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(10, 50));
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+
+        double[] customPercents = new double[] { 1, 10, 25, 50, 75, 90, 99 };
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentiles -> {
+            assertThat(AggregationInspectionHelper.hasValue(percentiles), equalTo(anyNonEmpty));
+            if (anyNonEmpty) {
+                // Verify all requested percentiles are calculable and in order
+                double lastValue = Double.NEGATIVE_INFINITY;
+                for (double percent : customPercents) {
+                    double value = percentiles.percentile(percent);
+                    assertTrue("Percentile " + percent + " should be finite", Double.isFinite(value));
+                    assertTrue("Percentiles should be non-decreasing", value >= lastValue);
+                    lastValue = value;
+                }
+            }
+        }, customPercents);
+    }
+
+    private static void verifyPercentiles(InternalTDigestPercentiles percentiles, List<ExponentialHistogram> referenceHistograms) {
+        ExponentialHistogram reference = ExponentialHistogram.merge(
+            ExponentialHistogramMerger.DEFAULT_MAX_HISTOGRAM_BUCKETS,
+            ExponentialHistogramCircuitBreaker.noop(),
+            referenceHistograms.iterator()
+        );
+
+        double[] percentToTest = new double[] { 25, 50, 75, 99 };
+        for (double percent : percentToTest) {
+            double aggregatedValue = percentiles.percentile(percent);
+            double referenceValue = ExponentialHistogramQuantile.getQuantile(reference, percent / 100.0);
+            if (Double.isNaN(referenceValue)) {
+                // reference is empty
+                assertThat(aggregatedValue, equalTo(Double.NaN));
+            } else {
+                if (Math.abs(referenceValue) <= 2 * reference.zeroBucket().zeroThreshold()) {
+                    // actual should be somewhere in the zero bucket
+                    assertThat(Math.abs(aggregatedValue), lessThanOrEqualTo(2 * reference.zeroBucket().zeroThreshold()));
+                } else {
+                    double relativeError = Math.abs(aggregatedValue - referenceValue) / Math.abs(referenceValue);
+                    double relativeBucketSize = ExponentialScaleUtils.getLowerBucketBoundary(1, reference.scale()) / ExponentialScaleUtils
+                        .getLowerBucketBoundary(0, reference.scale());
+                    double allowedError = Math.max(0.0001, (relativeBucketSize - 1.0) * 1.1);
+                    assertThat(relativeError, lessThan(allowedError)); // within 5% relative error
+                }
+            }
+
+        }
+    }
+
+    private void testCase(
+        Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        Consumer<InternalTDigestPercentiles> verify
+    ) throws IOException {
+        testCase(query, buildIndex, verify, new double[] { 25, 50, 75, 99 });
+    }
+
+    private void testCase(
+        Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        Consumer<InternalTDigestPercentiles> verify,
+        double[] percentiles
+    ) throws IOException {
+        PercentilesAggregationBuilder builder = new PercentilesAggregationBuilder("test").field(FIELD_NAME).percentiles(percentiles);
+
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
+        testCase(buildIndex, verify, new AggTestConfig(builder, fieldType).withQuery(query));
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -149,3 +149,25 @@ setup:
 
   - match: { hits.total.value: 5 }
   - match: { aggregations.max_agg.value: 13000.0 }
+
+---
+"Percentiles aggregation":
+  - do:
+      search:
+        index: test_exponential_histogram
+        size: 0
+        body:
+          aggs:
+            percentiles_agg:
+              percentiles:
+                field: histo
+                percents: [5, 25, 50, 75, 95]
+
+  - match: { hits.total.value: 5 }
+  - match:
+     aggregations.percentiles_agg.values:
+       5.0: -798.1634409365165
+       25.0: 0.0
+       50.0: 6.399999999993667
+       75.0: 2730.66666666983
+       95.0: 10922.666666679323

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -152,6 +152,9 @@ setup:
 
 ---
 "Percentiles aggregation":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_percentiles" ]
+      reason: exponential_histogram percentile aggregations was introduced
   - do:
       search:
         index: test_exponential_histogram

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -167,10 +167,14 @@ setup:
                 percents: [5, 25, 50, 75, 95]
 
   - match: { hits.total.value: 5 }
-  - match:
-     aggregations.percentiles_agg.values:
-       5.0: -798.1634409365165
-       25.0: 0.0
-       50.0: 6.399999999993667
-       75.0: 2730.66666666983
-       95.0: 10922.666666679323
+  # Use range comparisons to handle small numeric errors across different machines
+  - gte: { aggregations.percentiles_agg.values.5\.0: -798.2 }
+  - lte: { aggregations.percentiles_agg.values.5\.0: -798.1 }
+  - gte: { aggregations.percentiles_agg.values.25\.0: -0.01 }
+  - lte: { aggregations.percentiles_agg.values.25\.0: 0.01 }
+  - gte: { aggregations.percentiles_agg.values.50\.0: 6.39 }
+  - lte: { aggregations.percentiles_agg.values.50\.0: 6.41 }
+  - gte: { aggregations.percentiles_agg.values.75\.0: 2730.6 }
+  - lte: { aggregations.percentiles_agg.values.75\.0: 2730.7 }
+  - gte: { aggregations.percentiles_agg.values.95\.0: 10922.6 }
+  - lte: { aggregations.percentiles_agg.values.95\.0: 10922.7 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -171,6 +171,9 @@ setup:
 
 ---
 "Percentiles aggregation over tdigest and exponential_histogram":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_percentiles" ]
+      reason: exponential_histogram percentile aggregations was introduced
   - do:
       search:
         index: test-data-stream

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -186,9 +186,12 @@ setup:
                 percents: [5, 25, 50, 75]
 
   - match: { hits.total.value: 2 }
-  - match:
-      aggregations.percentiles_agg.values:
-        5.0: 0.8999999999986692
-        25.0: 1.0083333333331896
-        50.0: 1.9999999999974785
-        75.0: 2.6666666666697565
+  # Use range comparisons to handle small numeric errors across different machines
+  - gte: { aggregations.percentiles_agg.values.5\.0: 0.899 }
+  - lte: { aggregations.percentiles_agg.values.5\.0: 0.901 }
+  - gte: { aggregations.percentiles_agg.values.25\.0: 1.007 }
+  - lte: { aggregations.percentiles_agg.values.25\.0: 1.009 }
+  - gte: { aggregations.percentiles_agg.values.50\.0: 1.999 }
+  - lte: { aggregations.percentiles_agg.values.50\.0: 2.001 }
+  - gte: { aggregations.percentiles_agg.values.75\.0: 2.665 }
+  - lte: { aggregations.percentiles_agg.values.75\.0: 2.667 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -57,16 +57,15 @@ setup:
         body:
           '@timestamp': "2023-01-02T00:00:00Z"
           tdigest_or_exp_histo:
-            scale: 1
+            scale: 0
             sum: 100.0
             min: 1.0
             max: 10.0
             zero: { count: 1 }
-            positive: { indices: [0,1], counts: [1,2] }
-            negative: { indices: [0], counts: [1] }
+            positive: { indices: [0,1,2], counts: [1,2,1] }
 
 ---
-"Value count aggregation over aggregate_metric_double and exponential_histogram":
+"Value count aggregation over tdigest and exponential_histogram":
   - do:
       search:
         index: test-data-stream
@@ -79,7 +78,7 @@ setup:
   - match: { aggregations.value_count_metric.value: 10.0 }
 
 ---
-"Sum aggregation over aggregate_metric_double and exponential_histogram":
+"Sum aggregation over tdigest and exponential_histogram":
   - do:
       search:
         index: test-data-stream
@@ -92,7 +91,7 @@ setup:
   - match: { aggregations.sum_metric.value: 109.8 }
 
 ---
-"Average aggregation over aggregate_metric_double and exponential_histogram":
+"Average aggregation over tdigest and exponential_histogram":
   - do:
       search:
         index: test-data-stream
@@ -105,7 +104,7 @@ setup:
   - match: { aggregations.avg_metric.value: 10.98 }
 
 ---
-"Min aggregation over aggregate_metric_double and exponential_histogram":
+"Min aggregation over tdigest and exponential_histogram":
   - requires:
       cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
       reason: exponential_histogram min/max aggregations were introduced
@@ -123,7 +122,7 @@ setup:
   - match: { aggregations.min_agg.value: 0.9 }
 
 ---
-"Max aggregation over aggregate_metric_double and exponential_histogram":
+"Max aggregation over tdigest and exponential_histogram":
   - requires:
       cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
       reason: exponential_histogram min/max aggregations were introduced
@@ -139,3 +138,54 @@ setup:
 
   - match: { hits.total.value: 2 }
   - match: { aggregations.max_agg.value: 10.0 }
+
+---
+"Histogram aggregation over tdigest and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            histo_agg:
+              histogram:
+                field: tdigest_or_exp_histo
+                interval: 0.5
+                min_doc_count: 1
+  - match:
+      aggregations.histo_agg.buckets:
+        - key: 0.0
+          doc_count: 1
+        - key: 0.5
+          doc_count: 2
+        - key: 1.0
+          doc_count: 1
+        - key: 2.0
+          doc_count: 2
+        - key: 2.5
+          doc_count: 2
+        - key: 4.0
+          doc_count: 1
+        - key: 5.0
+          doc_count: 1
+
+---
+"Percentiles aggregation over tdigest and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            percentiles_agg:
+              percentiles:
+                field: tdigest_or_exp_histo
+                percents: [5, 25, 50, 75]
+
+  - match: { hits.total.value: 2 }
+  - match:
+      aggregations.percentiles_agg.values:
+        5.0: 0.8999999999986692
+        25.0: 1.0083333333331896
+        50.0: 1.9999999999974785
+        75.0: 2.6666666666697565


### PR DESCRIPTION
Part of #135625.

Adds support for the "percentiles" agg, which includes support for querying mixed exponential_histogram / T-Digest data.
In addition this PR also adds a missing test for the "histogram" agg, which was already added in 9.3.

The tests are randomized. I've run them several 10k times without failures, so they hopefully should not introduce flakes.