### PR TITLE
Adds ml-cpp release notes for 9.3

### DIFF
--- a/docs/changelog/141598.yaml
+++ b/docs/changelog/141598.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 141598
+summary: DiskBBQ - Always block encode doc vectors
+type: enhancement

--- a/docs/changelog/141815.yaml
+++ b/docs/changelog/141815.yaml
@@ -1,0 +1,5 @@
+pr: 141815
+summary: Prevent large CancelTasksRequest descriptions by truncating nodes and actions
+area: Search
+type: bug
+issues: []

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -296,6 +296,7 @@ Machine Learning:
 * Nightly maintenance for anomaly detection results indices to keep to manageable size. [#136065](https://github.com/elastic/elasticsearch/pull/136065)
 * Require basic licence for the Elastic Inference Service [#137434](https://github.com/elastic/elasticsearch/pull/137434)
 * Transition EIS auth polling to persistent task on a single node [#136713](https://github.com/elastic/elasticsearch/pull/136713)
+* Downgrade log severity for a batch of recoverable errors [#2889](https://github.com/elastic/ml-cpp/pull/2889)
 
 Mapping:
 * Add `index.mapping.nested_parents.limit` and raise nested fields limit to 100 [#138961](https://github.com/elastic/elasticsearch/pull/138961)

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESNextOSQVectorsScorer.java
@@ -236,6 +236,31 @@ public class ESNextOSQVectorsScorer {
         float centroidDp,
         float[] scores
     ) throws IOException {
+        return scoreBulk(
+            q,
+            queryLowerInterval,
+            queryUpperInterval,
+            queryComponentSum,
+            queryAdditionalCorrection,
+            similarityFunction,
+            centroidDp,
+            scores,
+            bulkSize
+        );
+    }
+
+    public float scoreBulk(
+        byte[] q,
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores,
+        int bulkSize
+    ) throws IOException {
+        assert bulkSize <= this.bulkSize : "supplied bulkSize > this scorer's bulkSize";
         quantizeScoreBulk(q, bulkSize, scores);
         in.readFloats(lowerIntervals, 0, bulkSize);
         in.readFloats(upperIntervals, 0, bulkSize);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSBitToInt4ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSBitToInt4ESNextOSQVectorsScorer.java
@@ -392,7 +392,8 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         assert q.length == length * 4;
         // 128 / 8 == 16
@@ -414,7 +415,8 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
                         queryAdditionalCorrection,
                         similarityFunction,
                         centroidDp,
-                        scores
+                        scores,
+                        bulkSize
                     );
                 } else if (PanamaESVectorUtilSupport.VECTOR_BITSIZE == 128) {
                     return score128Bulk(
@@ -424,7 +426,8 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
                         queryAdditionalCorrection,
                         similarityFunction,
                         centroidDp,
-                        scores
+                        scores,
+                        bulkSize
                     );
                 }
             }
@@ -439,7 +442,8 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         int limit = FLOAT_SPECIES_128.loopBound(bulkSize);
         int i = 0;
@@ -501,6 +505,21 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
                 }
             }
         }
+        if (limit < bulkSize) {
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
         return maxScore;
     }
@@ -512,7 +531,8 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         int limit = FLOAT_SPECIES_256.loopBound(bulkSize);
         int i = 0;
@@ -574,7 +594,82 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
                 }
             }
         }
+        if (limit < bulkSize) {
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
+        return maxScore;
+    }
+
+    float scoreTailIndividually(
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores,
+        int bulkSize,
+        int limit,
+        long offset,
+        float ay,
+        float ly,
+        float y1,
+        float maxScore
+    ) {
+        for (int j = limit; j < bulkSize; j++) {
+            float ax = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + (long) j * Float.BYTES
+            );
+
+            float lx = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 4L * bulkSize + (long) j * Float.BYTES
+            ) - ax;
+
+            int targetComponentSum = memorySegment.get(
+                ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 8L * bulkSize + (long) j * Integer.BYTES
+            );
+
+            float additionalCorrection = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 12L * bulkSize + (long) j * Float.BYTES
+            );
+
+            float qcDist = scores[j];
+
+            float res = ax * ay * dimensions + lx * ay * targetComponentSum + ax * ly * y1 + lx * ly * qcDist;
+
+            if (similarityFunction == EUCLIDEAN) {
+                res = res * -2f + additionalCorrection + queryAdditionalCorrection + 1f;
+                res = Math.max(1f / res, 0f);
+                scores[j] = res;
+                maxScore = Math.max(maxScore, res);
+            } else {
+                res = res + queryAdditionalCorrection + additionalCorrection - centroidDp;
+
+                if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
+                    res = VectorUtil.scaleMaxInnerProductScore(res);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                } else {
+                    res = Math.max((res + 1f) * 0.5f, 0f);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                }
+            }
+        }
         return maxScore;
     }
 }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSDibitToInt4ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSDibitToInt4ESNextOSQVectorsScorer.java
@@ -284,7 +284,8 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         assert q.length == length * 2;
         // 128 / 8 == 16
@@ -306,7 +307,8 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
                         queryAdditionalCorrection,
                         similarityFunction,
                         centroidDp,
-                        scores
+                        scores,
+                        bulkSize
                     );
                 } else if (PanamaESVectorUtilSupport.VECTOR_BITSIZE == 128) {
                     return score128Bulk(
@@ -316,7 +318,8 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
                         queryAdditionalCorrection,
                         similarityFunction,
                         centroidDp,
-                        scores
+                        scores,
+                        bulkSize
                     );
                 }
             }
@@ -331,7 +334,8 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         int limit = FLOAT_SPECIES_128.loopBound(bulkSize);
         int i = 0;
@@ -393,6 +397,22 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
                 }
             }
         }
+        if (limit < bulkSize) {
+            // missing vectors to score
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
         return maxScore;
     }
@@ -404,7 +424,8 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         int limit = FLOAT_SPECIES_256.loopBound(bulkSize);
         int i = 0;
@@ -466,7 +487,84 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
                 }
             }
         }
+        if (limit < bulkSize) {
+            // missing vectors to score
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
+        return maxScore;
+    }
+
+    private float scoreTailIndividually(
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores,
+        int bulkSize,
+        int limit,
+        long offset,
+        float ay,
+        float ly,
+        float y1,
+        float maxScore
+    ) {
+        for (int j = limit; j < bulkSize; j++) {
+            float ax = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + (long) j * Float.BYTES
+            );
+
+            float lx = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 4L * bulkSize + (long) j * Float.BYTES
+            );
+            lx = (lx - ax) * TWO_BIT_SCALE;
+
+            int targetComponentSum = memorySegment.get(
+                ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 8L * bulkSize + (long) j * Integer.BYTES
+            );
+
+            float additionalCorrection = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 12L * bulkSize + (long) j * Float.BYTES
+            );
+
+            float qcDist = scores[j];
+
+            float res = ax * ay * dimensions + lx * ay * targetComponentSum + ax * ly * y1 + lx * ly * qcDist;
+
+            if (similarityFunction == EUCLIDEAN) {
+                res = res * -2f + additionalCorrection + queryAdditionalCorrection + 1f;
+                res = Math.max(1f / res, 0f);
+                scores[j] = res;
+                maxScore = Math.max(maxScore, res);
+            } else {
+                res = res + queryAdditionalCorrection + additionalCorrection - centroidDp;
+
+                if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
+                    res = VectorUtil.scaleMaxInnerProductScore(res);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                } else {
+                    res = Math.max((res + 1f) * 0.5f, 0f);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                }
+            }
+        }
         return maxScore;
     }
 }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSInt4SymmetricESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSInt4SymmetricESNextOSQVectorsScorer.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.VectorUtil;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
 
 import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
@@ -234,7 +235,8 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         assert q.length == length;
         // 128 / 8 == 16
@@ -248,7 +250,8 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
                     queryAdditionalCorrection,
                     similarityFunction,
                     centroidDp,
-                    scores
+                    scores,
+                    bulkSize
                 );
             } else if (PanamaESVectorUtilSupport.VECTOR_BITSIZE == 128) {
                 return score128Bulk(
@@ -259,7 +262,8 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
                     queryAdditionalCorrection,
                     similarityFunction,
                     centroidDp,
-                    scores
+                    scores,
+                    bulkSize
                 );
             }
         }
@@ -274,7 +278,8 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         quantizeScore128Bulk(q, bulkSize, scores);
         int limit = FLOAT_SPECIES_128.loopBound(bulkSize);
@@ -337,6 +342,22 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
                 }
             }
         }
+        if (limit < bulkSize) {
+            // missing vectors to score
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
         return maxScore;
     }
@@ -349,7 +370,8 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
         float queryAdditionalCorrection,
         VectorSimilarityFunction similarityFunction,
         float centroidDp,
-        float[] scores
+        float[] scores,
+        int bulkSize
     ) throws IOException {
         quantizeScore256Bulk(q, bulkSize, scores);
         int limit = FLOAT_SPECIES_256.loopBound(bulkSize);
@@ -412,7 +434,84 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
                 }
             }
         }
+        if (limit < bulkSize) {
+            // missing vectors to score
+            maxScore = scoreTailIndividually(
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                bulkSize,
+                limit,
+                offset,
+                ay,
+                ly,
+                y1,
+                maxScore
+            );
+        }
         in.seek(offset + 16L * bulkSize);
+        return maxScore;
+    }
+
+    private float scoreTailIndividually(
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores,
+        int bulkSize,
+        int limit,
+        long offset,
+        float ay,
+        float ly,
+        float y1,
+        float maxScore
+    ) {
+        for (int j = limit; j < bulkSize; j++) {
+            float ax = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + (long) j * Float.BYTES
+            );
+
+            float lx = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 4L * bulkSize + (long) j * Float.BYTES
+            );
+            lx = (lx - ax) * FOUR_BIT_SCALE;
+
+            int targetComponentSum = memorySegment.get(
+                ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 8L * bulkSize + (long) j * Integer.BYTES
+            );
+
+            float additionalCorrection = memorySegment.get(
+                ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
+                offset + 12L * bulkSize + (long) j * Float.BYTES
+            );
+
+            float qcDist = scores[j];
+
+            float res = ax * ay * dimensions + lx * ay * targetComponentSum + ax * ly * y1 + lx * ly * qcDist;
+
+            if (similarityFunction == EUCLIDEAN) {
+                res = res * -2f + additionalCorrection + queryAdditionalCorrection + 1f;
+                res = Math.max(1f / res, 0f);
+                scores[j] = res;
+                maxScore = Math.max(maxScore, res);
+            } else {
+                res = res + queryAdditionalCorrection + additionalCorrection - centroidDp;
+
+                if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
+                    res = VectorUtil.scaleMaxInnerProductScore(res);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                } else {
+                    res = Math.max((res + 1f) * 0.5f, 0f);
+                    scores[j] = res;
+                    maxScore = Math.max(maxScore, res);
+                }
+            }
+        }
         return maxScore;
     }
 }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentESNextOSQVectorsScorer.java
@@ -101,6 +101,45 @@ public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsS
         );
     }
 
+    @Override
+    public float scoreBulk(
+        byte[] q,
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores,
+        int bulkSize
+    ) throws IOException {
+        float score = scorer.scoreBulk(
+            q,
+            queryLowerInterval,
+            queryUpperInterval,
+            queryComponentSum,
+            queryAdditionalCorrection,
+            similarityFunction,
+            centroidDp,
+            scores,
+            bulkSize
+        );
+        if (score != Float.NEGATIVE_INFINITY) {
+            return score;
+        }
+        return super.scoreBulk(
+            q,
+            queryLowerInterval,
+            queryUpperInterval,
+            queryComponentSum,
+            queryAdditionalCorrection,
+            similarityFunction,
+            centroidDp,
+            scores,
+            bulkSize
+        );
+    }
+
     abstract static sealed class MemorySegmentScorer permits MSBitToInt4ESNextOSQVectorsScorer, MSDibitToInt4ESNextOSQVectorsScorer,
         MSInt4SymmetricESNextOSQVectorsScorer {
 
@@ -141,7 +180,7 @@ public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsS
 
         abstract boolean quantizeScoreBulk(byte[] q, int count, float[] scores) throws IOException;
 
-        abstract float scoreBulk(
+        float scoreBulk(
             byte[] q,
             float queryLowerInterval,
             float queryUpperInterval,
@@ -150,6 +189,30 @@ public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsS
             VectorSimilarityFunction similarityFunction,
             float centroidDp,
             float[] scores
+        ) throws IOException {
+            return scoreBulk(
+                q,
+                queryLowerInterval,
+                queryUpperInterval,
+                queryComponentSum,
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                scores,
+                BULK_SIZE
+            );
+        }
+
+        abstract float scoreBulk(
+            byte[] q,
+            float queryLowerInterval,
+            float queryUpperInterval,
+            int queryComponentSum,
+            float queryAdditionalCorrection,
+            VectorSimilarityFunction similarityFunction,
+            float centroidDp,
+            float[] scores,
+            int bulkSize
         ) throws IOException;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
@@ -26,6 +26,8 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
     public static final String DEFAULT_REASON = "by user request";
     public static final boolean DEFAULT_WAIT_FOR_COMPLETION = false;
 
+    private static final int MAX_DESCRIPTION_ITEMS = 10;
+
     private String reason = DEFAULT_REASON;
     private boolean waitForCompletion = DEFAULT_WAIT_FOR_COMPLETION;
 
@@ -78,17 +80,46 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
 
     @Override
     public String getDescription() {
-        return "reason["
-            + reason
-            + "], waitForCompletion["
-            + waitForCompletion
-            + "], targetTaskId["
-            + getTargetTaskId()
-            + "], targetParentTaskId["
-            + getTargetParentTaskId()
-            + "], nodes"
-            + Arrays.toString(getNodes())
-            + ", actions"
-            + Arrays.toString(getActions());
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("reason[")
+            .append(reason)
+            .append("], waitForCompletion[")
+            .append(waitForCompletion)
+            .append("], targetTaskId[")
+            .append(getTargetTaskId())
+            .append("], targetParentTaskId[")
+            .append(getTargetParentTaskId())
+            .append("], nodes")
+            .append(truncatedArray(getNodes()))
+            .append(", actions")
+            .append(truncatedArray(getActions()));
+
+        return sb.toString();
+    }
+
+    private static String truncatedArray(String[] values) {
+        if (values == null) {
+            return "[]";
+        }
+
+        int length = values.length;
+        if (length <= MAX_DESCRIPTION_ITEMS) {
+            return Arrays.toString(values);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+
+        for (int i = 0; i < MAX_DESCRIPTION_ITEMS; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(values[i]);
+        }
+
+        sb.append(", ... (").append(length - MAX_DESCRIPTION_ITEMS).append(" more)]");
+
+        return sb.toString();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -357,6 +357,15 @@ public final class IndexSortConfig {
         return sortSpecs.length > 0 && sortSpecs[0].field.equals(field);
     }
 
+    public boolean containsDescendingTimestampSort() {
+        for (FieldSortSpec sort : sortSpecs) {
+            if (sort.order == SortOrder.DESC && sort.field.equals("@timestamp")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Builds the {@link Sort} order from the settings for this index
      * or returns null if this index has no sort.

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -704,10 +704,10 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
             return vectors;
         }
 
-        private float scoreIndividually() throws IOException {
+        private float scoreIndividually(int bulkSize) throws IOException {
             float maxScore = Float.NEGATIVE_INFINITY;
             // score individually, first the quantized byte chunk
-            for (int j = 0; j < BULK_SIZE; j++) {
+            for (int j = 0; j < bulkSize; j++) {
                 int doc = docIdsScratch[j];
                 if (doc != -1) {
                     float qcDist = osqVectorsScorer.quantizeScore(queryQuantizer.getQuantizedTarget());
@@ -717,14 +717,14 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
                 }
             }
             // read in all corrections
-            indexInput.readFloats(correctionsLower, 0, BULK_SIZE);
-            indexInput.readFloats(correctionsUpper, 0, BULK_SIZE);
-            for (int j = 0; j < BULK_SIZE; j++) {
+            indexInput.readFloats(correctionsLower, 0, bulkSize);
+            indexInput.readFloats(correctionsUpper, 0, bulkSize);
+            for (int j = 0; j < bulkSize; j++) {
                 correctionsSum[j] = indexInput.readInt();
             }
-            indexInput.readFloats(correctionsAdd, 0, BULK_SIZE);
+            indexInput.readFloats(correctionsAdd, 0, bulkSize);
             // Now apply corrections
-            for (int j = 0; j < BULK_SIZE; j++) {
+            for (int j = 0; j < bulkSize; j++) {
                 int doc = docIdsScratch[j];
                 if (doc != -1) {
                     scores[j] = osqVectorsScorer.score(
@@ -748,10 +748,10 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
             return maxScore;
         }
 
-        private static int docToBulkScore(int[] docIds, Bits acceptDocs) {
+        private static int docToBulkScore(int[] docIds, Bits acceptDocs, int bulkSize) {
             assert acceptDocs != null : "acceptDocs must not be null";
-            int docToScore = BULK_SIZE;
-            for (int i = 0; i < BULK_SIZE; i++) {
+            int docToScore = bulkSize;
+            for (int i = 0; i < bulkSize; i++) {
                 if (acceptDocs.get(docIds[i]) == false) {
                     docIds[i] = -1;
                     docToScore--;
@@ -760,8 +760,8 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
             return docToScore;
         }
 
-        private void collectBulk(KnnCollector knnCollector, float[] scores) {
-            for (int i = 0; i < BULK_SIZE; i++) {
+        private void collectBulk(KnnCollector knnCollector, float[] scores, int bulkSize) {
+            for (int i = 0; i < bulkSize; i++) {
                 final int doc = docIdsScratch[i];
                 if (doc != -1) {
                     knnCollector.collect(doc, scores[i]);
@@ -789,7 +789,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
             for (; i < limit; i += BULK_SIZE) {
                 // read the doc ids
                 readDocIds(BULK_SIZE);
-                final int docsToBulkScore = acceptDocs == null ? BULK_SIZE : docToBulkScore(docIdsScratch, acceptDocs);
+                final int docsToBulkScore = acceptDocs == null ? BULK_SIZE : docToBulkScore(docIdsScratch, acceptDocs, BULK_SIZE);
                 if (docsToBulkScore == 0) {
                     indexInput.skipBytes(quantizedByteLength * BULK_SIZE);
                     continue;
@@ -797,7 +797,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
                 queryQuantizer.quantizeQueryIfNecessary();
                 final float maxScore;
                 if (docsToBulkScore < BULK_SIZE / 2) {
-                    maxScore = scoreIndividually();
+                    maxScore = scoreIndividually(BULK_SIZE);
                 } else {
                     maxScore = osqVectorsScorer.scoreBulk(
                         queryQuantizer.getQuantizedTarget(),
@@ -811,40 +811,39 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader implements Vect
                     );
                 }
                 if (knnCollector.minCompetitiveSimilarity() < maxScore) {
-                    collectBulk(knnCollector, scores);
+                    collectBulk(knnCollector, scores, BULK_SIZE);
                 }
                 scoredDocs += docsToBulkScore;
             }
-            // process tail
-            // read the doc ids
+            // bulk process tail
             if (i < vectors) {
-                readDocIds(vectors - i);
-            }
-            int count = 0;
-            for (; i < vectors; i++) {
-                int doc = docIdsScratch[count++];
-                if (acceptDocs == null || acceptDocs.get(doc)) {
-                    queryQuantizer.quantizeQueryIfNecessary();
-                    float qcDist = osqVectorsScorer.quantizeScore(queryQuantizer.getQuantizedTarget());
-                    indexInput.readFloats(correctiveValues, 0, 3);
-                    final int quantizedComponentSum = indexInput.readInt();
-                    float score = osqVectorsScorer.score(
-                        queryQuantizer.getQueryCorrections().lowerInterval(),
-                        queryQuantizer.getQueryCorrections().upperInterval(),
-                        queryQuantizer.getQueryCorrections().quantizedComponentSum(),
-                        queryQuantizer.getQueryCorrections().additionalCorrection(),
-                        fieldInfo.getVectorSimilarityFunction(),
-                        centroidDp,
-                        correctiveValues[0],
-                        correctiveValues[1],
-                        quantizedComponentSum,
-                        correctiveValues[2],
-                        qcDist
-                    );
-                    scoredDocs++;
-                    knnCollector.collect(doc, score);
+                int tailSize = vectors - i;
+                readDocIds(tailSize);
+                final int docsToBulkScore = acceptDocs == null ? tailSize : docToBulkScore(docIdsScratch, acceptDocs, tailSize);
+                if (docsToBulkScore == 0) {
+                    indexInput.skipBytes(quantizedByteLength * tailSize);
                 } else {
-                    indexInput.skipBytes(quantizedByteLength);
+                    queryQuantizer.quantizeQueryIfNecessary();
+                    final float maxScore;
+                    if (docsToBulkScore < tailSize / 2) {
+                        maxScore = scoreIndividually(tailSize);
+                    } else {
+                        maxScore = osqVectorsScorer.scoreBulk(
+                            queryQuantizer.getQuantizedTarget(),
+                            queryQuantizer.getQueryCorrections().lowerInterval(),
+                            queryQuantizer.getQueryCorrections().upperInterval(),
+                            queryQuantizer.getQueryCorrections().quantizedComponentSum(),
+                            queryQuantizer.getQueryCorrections().additionalCorrection(),
+                            fieldInfo.getVectorSimilarityFunction(),
+                            centroidDp,
+                            scores,
+                            tailSize
+                        );
+                    }
+                    if (knnCollector.minCompetitiveSimilarity() < maxScore) {
+                        collectBulk(knnCollector, scores, tailSize);
+                    }
+                    scoredDocs += docsToBulkScore;
                 }
             }
             if (scoredDocs > 0) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsWriter.java
@@ -234,7 +234,7 @@ public class ESNextDiskBBQVectorsWriter extends IVFVectorsWriter {
         // write the posting lists
         final PackedLongValues.Builder offsets = PackedLongValues.monotonicBuilder(PackedInts.COMPACT);
         final PackedLongValues.Builder lengths = PackedLongValues.monotonicBuilder(PackedInts.COMPACT);
-        DiskBBQBulkWriter bulkWriter = DiskBBQBulkWriter.fromBitSize(quantEncoding.bits(), BULK_SIZE, postingsOutput, false, true);
+        DiskBBQBulkWriter bulkWriter = DiskBBQBulkWriter.fromBitSize(quantEncoding.bits(), BULK_SIZE, postingsOutput, true, true);
         OnHeapQuantizedVectors onHeapQuantizedVectors = new OnHeapQuantizedVectors(
             floatVectorValues,
             quantEncoding,
@@ -386,7 +386,7 @@ public class ESNextDiskBBQVectorsWriter extends IVFVectorsWriter {
                 quantEncoding,
                 fieldInfo.getVectorDimension()
             );
-            DiskBBQBulkWriter bulkWriter = DiskBBQBulkWriter.fromBitSize(quantEncoding.bits(), BULK_SIZE, postingsOutput, false, true);
+            DiskBBQBulkWriter bulkWriter = DiskBBQBulkWriter.fromBitSize(quantEncoding.bits(), BULK_SIZE, postingsOutput, true, true);
             final ByteBuffer buffer = ByteBuffer.allocate(fieldInfo.getVectorDimension() * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
             // write the posting lists
             final int[] docIds = new int[maxPostingListSize];

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -17,8 +17,10 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.action.ActionListener;
@@ -36,6 +38,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
@@ -84,6 +87,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.LongSupplier;
@@ -772,6 +776,33 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public Query query() {
         return this.query;
+    }
+
+    @Override
+    public Query rewrittenQuery() {
+        Query query = super.rewrittenQuery();
+        maybeMarkAsMatchTail();
+        return query;
+    }
+
+    private void maybeMarkAsMatchTail() {
+        if (rewriteQuery instanceof MatchAllDocsQuery == false || this.searchAfter() != null || this.size == 0) {
+            return;
+        }
+        if (indexService.getIndexSettings().getIndexSortConfig().containsDescendingTimestampSort() == false) {
+            return;
+        }
+        SortAndFormats sort = sort();
+        if (sort == null) {
+            return;
+        }
+        SortField primarySort = sort.sort.getSort()[0];
+        if (primarySort.getReverse() || Objects.equals(primarySort.getField(), "@timestamp") == false) {
+            return;
+        }
+        if (primarySort.getComparatorSource() instanceof LongValuesComparatorSource source) {
+            source.setMatchTailQuery();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -85,7 +85,7 @@ public abstract class SearchContext implements Releasable {
     }
     private InnerHitsContext innerHitsContext;
 
-    private Query rewriteQuery;
+    protected Query rewriteQuery;
 
     protected SearchContext() {}
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
@@ -14,10 +14,11 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
+import java.util.stream.IntStream;
 
 public class CancelTasksRequestTests extends ESTestCase {
 
-    public void testGetDescription() {
+    public void testGetDescription_NoTruncation() {
         CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
         cancelTasksRequest.setActions("action1", "action2");
         cancelTasksRequest.setNodes("node1", "node2");
@@ -30,5 +31,90 @@ public class CancelTasksRequestTests extends ESTestCase {
         );
         Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
         assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesNodesOnly() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 12).mapToObj(i -> "node" + i).toArray(String[]::new);
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions("action1", "action2");
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (2 more)], "
+                + "actions[action1, action2]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesActionsOnly() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] actions = IntStream.rangeClosed(1, 15).mapToObj(i -> "action" + i).toArray(String[]::new);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setNodes("node1", "node2");
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (5 more)]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_TruncatesNodesAndActions() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 11).mapToObj(i -> "node" + i).toArray(String[]::new);
+        String[] actions = IntStream.rangeClosed(1, 20).mapToObj(i -> "action" + i).toArray(String[]::new);
+
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (1 more)], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (10 more)]",
+            cancelTasksRequest.getDescription()
+        );
+
+        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
+        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
+    }
+
+    public void testGetDescription_ExactlyMaxDoesNotTruncate() {
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+
+        String[] nodes = IntStream.rangeClosed(1, 10).mapToObj(i -> "node" + i).toArray(String[]::new);
+        String[] actions = IntStream.rangeClosed(1, 10).mapToObj(i -> "action" + i).toArray(String[]::new);
+
+        cancelTasksRequest.setNodes(nodes);
+        cancelTasksRequest.setActions(actions);
+        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
+        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
+
+        assertEquals(
+            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
+                + "targetParentTaskId[node1:0], "
+                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10], "
+                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10]",
+            cancelTasksRequest.getDescription()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.Column;
@@ -1227,16 +1228,40 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             if (score instanceof UnresolvedAttribute) {
                 score = maybeResolveAttribute((UnresolvedAttribute) score, childrenOutput);
             }
+            if (score instanceof UnresolvedAttribute ua && score.name().equals(MetadataAttribute.SCORE)) {
+                score = ua.withUnresolvedMessage(
+                    "FUSE requires a score column, default [" + MetadataAttribute.SCORE + "] column not found."
+                );
+            }
 
             Attribute discriminator = fuse.discriminator();
             if (discriminator instanceof UnresolvedAttribute) {
                 discriminator = maybeResolveAttribute((UnresolvedAttribute) discriminator, childrenOutput);
             }
+            if (discriminator instanceof UnresolvedAttribute ua && discriminator.name().equals(Fork.FORK_FIELD)) {
+                discriminator = ua.withUnresolvedMessage(
+                    "FUSE requires a column to group by, default [" + Fork.FORK_FIELD + "] column not found."
+                );
+            }
 
-            List<NamedExpression> keys = fuse.keys()
-                .stream()
-                .map(attr -> attr instanceof UnresolvedAttribute ? maybeResolveAttribute((UnresolvedAttribute) attr, childrenOutput) : attr)
-                .toList();
+            List<NamedExpression> keys = fuse.keys().stream().map(attr -> {
+                if (attr.resolved()) {
+                    return attr;
+                }
+                attr = maybeResolveAttribute((UnresolvedAttribute) attr, childrenOutput);
+
+                if (attr instanceof UnresolvedAttribute ua && ua.name().equals(IdFieldMapper.NAME)) {
+                    return ua.withUnresolvedMessage("FUSE requires a key column, default [" + IdFieldMapper.NAME + "] column not found");
+                }
+
+                if (attr instanceof UnresolvedAttribute ua && ua.name().equals(MetadataAttribute.INDEX)) {
+                    return ua.withUnresolvedMessage(
+                        "FUSE requires a key column, default [" + MetadataAttribute.INDEX + "] column not found"
+                    );
+                }
+
+                return attr;
+            }).toList();
 
             // some attributes were unresolved or the wrong type
             // we return Fuse here so that the Verifier can raise an error message

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3744,16 +3744,18 @@ public class AnalyzerTests extends ESTestCase {
             from test
             | fuse
             """));
-        assertThat(e.getMessage(), containsString("Unknown column [_score]"));
-        assertThat(e.getMessage(), containsString("Unknown column [_fork]"));
+        assertThat(e.getMessage(), containsString("FUSE requires a score column, default [_score] column not found."));
+        assertThat(e.getMessage(), containsString("FUSE requires a column to group by, default [_fork] column not found."));
+        assertThat(e.getMessage(), containsString("FUSE requires a key column, default [_index] column not found"));
+        assertThat(e.getMessage(), containsString("FUSE requires a key column, default [_id] column not found"));
 
         e = expectThrows(VerificationException.class, () -> analyze("""
-            from test
+            from test metadata _id, _index
             | FORK ( WHERE emp_no == 1 )
                    ( WHERE emp_no > 1 )
             | FUSE
             """));
-        assertThat(e.getMessage(), containsString("Unknown column [_score]"));
+        assertThat(e.getMessage(), containsString("FUSE requires a score column, default [_score] column not found."));
 
         e = expectThrows(VerificationException.class, () -> analyze("""
             from test metadata _score, _id
@@ -3761,7 +3763,7 @@ public class AnalyzerTests extends ESTestCase {
                    ( WHERE emp_no > 1 )
             | FUSE
             """));
-        assertThat(e.getMessage(), containsString("Unknown column [_index]"));
+        assertThat(e.getMessage(), containsString("FUSE requires a key column, default [_index] column not found"));
 
         e = expectThrows(VerificationException.class, () -> analyze("""
             from test metadata _score, _index
@@ -3769,7 +3771,7 @@ public class AnalyzerTests extends ESTestCase {
                    ( WHERE emp_no > 1 )
             | FUSE
             """));
-        assertThat(e.getMessage(), containsString("Unknown column [_id]"));
+        assertThat(e.getMessage(), containsString("FUSE requires a key column, default [_id] column not found"));
     }
 
     // TODO There's too much boilerplate involved here! We need a better way of creating FieldCapabilitiesResponses from a mapping or index.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2922,6 +2922,16 @@ public class VerifierTests extends ESTestCase {
             containsString("FUSE can only be used on a limited number of rows. Consider adding a LIMIT before FUSE.")
         );
 
+        assertThat(
+            error("FROM test | LIMIT 10 | FUSE"),
+            equalTo(
+                "1:24: FUSE requires a score column, default [_score] column not found.\n"
+                    + "line 1:24: FUSE requires a column to group by, default [_fork] column not found.\n"
+                    + "line 1:24: FUSE requires a key column, default [_id] column not found\n"
+                    + "line 1:24: FUSE requires a key column, default [_index] column not found"
+            )
+        );
+
         assertThat(error("""
             FROM (FROM test METADATA _index, _id, _score | EVAL label = "query1"),
                  (FROM test METADATA _index, _id, _score | EVAL label = "query2" | LIMIT 10)


### PR DESCRIPTION
This PR adds the [ML-CPP](https://github.com/elastic/ml-cpp/blob/main/docs/CHANGELOG.asciidoc) to the Elasticsearch release notes for 9.3.