### PR TITLE
[PoC] Deprecate default metric in `aggregate_metric_double` and use average instead.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -62,6 +62,7 @@ public final class SearchCapabilities {
     private static final String CLUSTER_STATS_EXTENDED_USAGE = "extended-search-usage-stats";
     private static final String REJECT_INVALID_REVERSE_NESTING = "reject_invalid_reverse_nesting";
     private static final String DENSE_VECTOR_DOCVALUE_FIELDS_FORMAT = "dense_vector_docvalue_fields_format";
+    private static final String AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE = "aggregate_metric_double_defaults_to_average";
 
     public static final Set<String> CAPABILITIES;
     static {
@@ -94,6 +95,7 @@ public final class SearchCapabilities {
         capabilities.add(CLUSTER_STATS_EXTENDED_USAGE);
         capabilities.add(REJECT_INVALID_REVERSE_NESTING);
         capabilities.add(DENSE_VECTOR_DOCVALUE_FIELDS_FORMAT);
+        capabilities.add(AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE);
         CAPABILITIES = Set.copyOf(capabilities);
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScript.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScript.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.aggregatemetric.mapper;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.fielddata.SortedNumericLongValues;
+import org.elasticsearch.index.mapper.OnScriptError;
+import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.field.DoubleDocValuesField;
+import org.elasticsearch.script.field.LongDocValuesField;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+public class AggregateMetricAverageFieldScript extends DoubleFieldScript {
+
+    final DoubleDocValuesField sumDocValuesField;
+    final LongDocValuesField countDocValuesField;
+
+    public AggregateMetricAverageFieldScript(String fieldName, SearchLookup lookup, LeafReaderContext ctx) {
+        super(fieldName, Map.of(), lookup, OnScriptError.FAIL, ctx);
+        try {
+            String sumFieldName = AggregateMetricDoubleFieldMapper.subfieldName(fieldName, AggregateMetricDoubleFieldMapper.Metric.sum);
+            sumDocValuesField = new DoubleDocValuesField(
+                SortedNumericDoubleValues.wrap(DocValues.getSortedNumeric(ctx.reader(), sumFieldName)),
+                sumFieldName
+            );
+            String countFieldName = AggregateMetricDoubleFieldMapper.subfieldName(
+                fieldName,
+                AggregateMetricDoubleFieldMapper.Metric.value_count
+            );
+            countDocValuesField = new LongDocValuesField(
+                SortedNumericLongValues.wrap(DocValues.getSortedNumeric(ctx.reader(), countFieldName)),
+                countFieldName
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load doc values", e);
+        }
+    }
+
+    @Override
+    protected void emitFromObject(Object v) {
+        // we only use doc-values, not _source, so no need to implement this method
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDocument(int docID) {
+        try {
+            sumDocValuesField.setNextDocId(docID);
+            countDocValuesField.setNextDocId(docID);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load doc values", e);
+        }
+    }
+
+    @Override
+    public void execute() {
+        Iterator<Double> sumIterator = sumDocValuesField.iterator();
+        Iterator<Long> countIterator = countDocValuesField.iterator();
+        while (sumIterator.hasNext() && countIterator.hasNext()) {
+            Double sum = sumIterator.next();
+            Long count = countIterator.next();
+            emit(sum / count);
+        }
+    }
+}

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScript.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScript.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-public class AggregateMetricAverageFieldScript extends DoubleFieldScript {
+class AggregateMetricAverageFieldScript extends DoubleFieldScript {
 
     final DoubleDocValuesField sumDocValuesField;
     final LongDocValuesField countDocValuesField;
 
-    public AggregateMetricAverageFieldScript(String fieldName, SearchLookup lookup, LeafReaderContext ctx) {
+    AggregateMetricAverageFieldScript(String fieldName, SearchLookup lookup, LeafReaderContext ctx) {
         super(fieldName, Map.of(), lookup, OnScriptError.FAIL, ctx);
         try {
             String sumFieldName = AggregateMetricDoubleFieldMapper.subfieldName(fieldName, AggregateMetricDoubleFieldMapper.Metric.sum);
@@ -44,6 +44,10 @@ public class AggregateMetricAverageFieldScript extends DoubleFieldScript {
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }
+    }
+
+    static LeafFactory newLeafFactory(String fieldName, SearchLookup lookup) {
+        return ctx -> new AggregateMetricAverageFieldScript(fieldName, lookup, ctx);
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScriptTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricAverageFieldScriptTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.aggregatemetric.mapper;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.DoubleStream;
+
+import static org.hamcrest.Matchers.hasSize;
+
+public class AggregateMetricAverageFieldScriptTests extends ESTestCase {
+
+    public void testAverage() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            FieldType fieldType = new FieldType();
+            fieldType.setDocValuesType(DocValuesType.BINARY);
+            int docCount = randomIntBetween(1, 20);
+            double[] expectedAvg = DoubleStream.generate(() -> randomDoubleBetween(1, 100, false)).limit(docCount).toArray();
+            for (int i = 0; i < docCount; i++) {
+                int count = randomIntBetween(1, 10);
+                iw.addDocument(createDocument(expectedAvg[i] * count, count));
+            }
+            try (DirectoryReader reader = iw.getReader()) {
+                AggregateMetricAverageFieldScript docValues = new AggregateMetricAverageFieldScript(
+                    "test",
+                    new SearchLookup(field -> null, (ft, lookup, ftd) -> null, (ctx, doc) -> null),
+                    reader.leaves().get(0)
+                );
+                List<Double> values = new ArrayList<>();
+                for (int i = 0; i < docCount; i++) {
+                    docValues.runForDoc(i, values::add);
+                }
+                assertThat(values, hasSize(docCount));
+                for (int i = 0; i < docCount; i++) {
+                    assertEquals(expectedAvg[i], values.get(i), 0.000001);
+                }
+            }
+        }
+    }
+
+    private Iterable<IndexableField> createDocument(double sum, int count) {
+        return List.of(
+            new SortedNumericDocValuesField("test.sum", NumericUtils.doubleToSortableLong(sum)),
+            new SortedNumericDocValuesField("test.value_count", count)
+        );
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/10_basic.yml
@@ -58,8 +58,12 @@
 ---
 "Test term query on aggregate metric field":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       indices.create:
@@ -69,7 +73,7 @@
             properties:
               metric:
                 type: aggregate_metric_double
-                metrics: [min, max]
+                metrics: [min, max, sum, value_count]
                 default_metric: max
 
   - do:
@@ -80,6 +84,8 @@
           metric:
             min: 18.2
             max: 100
+            sum: 10000
+            value_count: 10
         refresh: true
 
   - do:
@@ -90,6 +96,8 @@
           metric:
             min: 50
             max: 1000
+            sum: 10000
+            value_count: 100
         refresh: true
 
   - do:
@@ -103,7 +111,7 @@
 
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.0._id: "1" }
 
   - do:
       search:
@@ -116,7 +124,7 @@
 
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0._id: "2" }
 
 
   - do:
@@ -134,8 +142,12 @@
 ---
 "Test range query on aggregate metric field":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       indices.create:
@@ -145,7 +157,7 @@
             properties:
               metric:
                 type: aggregate_metric_double
-                metrics: [min, max]
+                metrics: [min, max, sum, value_count]
                 default_metric: max
 
   - do:
@@ -156,6 +168,8 @@
           metric:
             min: 18.2
             max: 100
+            sum: 10000
+            value_count: 10
         refresh: true
 
   - do:
@@ -166,6 +180,8 @@
           metric:
             min: 50
             max: 1000
+            sum: 10000
+            value_count: 100
         refresh: true
 
   - do:
@@ -180,7 +196,7 @@
 
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.0._id: "1" }
 
   - do:
       search:
@@ -194,7 +210,7 @@
 
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0._id: "2" }
 
   - do:
       search:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/20_min_max_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/20_min_max_agg.yml
@@ -11,7 +11,7 @@ setup:
             properties:
               metric:
                 type: aggregate_metric_double
-                metrics: [min, max]
+                metrics: [min, max, sum, value_count]
                 default_metric: max
 
   - do:
@@ -20,15 +20,15 @@ setup:
         refresh: true
         body:
           - '{"index": {}}'
-          - '{"metric": {"min": 0, "max": 100} }'
+          - '{"metric": {"min": 0, "max": 100, "sum": 10000, "value_count": 100} }'
           - '{"index": {}}'
-          - '{"metric": {"min": 60, "max": 100} }'
+          - '{"metric": {"min": 60, "max": 100, "sum": 6000, "value_count": 60} }'
           - '{"index": {}}'
-          - '{"metric": {"min": -400.50, "max": 1000} }'
+          - '{"metric": {"min": -400.50, "max": 1000, "sum": 2000, "value_count": 2} }'
           - '{"index": {}}'
-          - '{"metric": {"min": 1, "max": 99.3} }'
+          - '{"metric": {"min": 1, "max": 99.3, "sum": 198.6, "value_count": 2} }'
           - '{"index": {}}'
-          - '{"metric": {"min": -100, "max": -40} }'
+          - '{"metric": {"min": -100, "max": -40, "sum": -80, "value_count": 2} }'
 ---
 "Test min_max aggs":
   - requires:
@@ -56,8 +56,12 @@ setup:
 ---
 "Test min_max aggs with query":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       search:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/30_sum_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/30_sum_agg.yml
@@ -18,11 +18,11 @@ setup:
           - '{"index": {}}'
           - '{"metric": {"sum": 10000.45, "value_count": 100} }'
           - '{"index": {}}'
-          - '{"metric": {"sum": 60, "value_count": 20} }'
+          - '{"metric": {"sum": 60, "value_count": 3} }'
           - '{"index": {}}'
           - '{"metric": {"sum": -400.50, "value_count": 1000} }'
           - '{"index": {}}'
-          - '{"metric": {"sum": 1, "value_count": 20} }'
+          - '{"metric": {"sum": 80, "value_count": 4} }'
           - '{"index": {}}'
           - '{"metric": {"sum": -100, "value_count": 40} }'
 ---
@@ -42,13 +42,17 @@ setup:
                 field: metric
 
   - match: { hits.total.value: 5 }
-  - match: { aggregations.sum_agg.value: 9560.95}
+  - match: { aggregations.sum_agg.value: 9639.95}
 
 ---
 "Test sum agg with query":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       search:
@@ -65,4 +69,4 @@ setup:
                 field: metric
 
   - match: { hits.total.value: 2 }
-  - match: { aggregations.sum_agg.value: 61}
+  - match: { aggregations.sum_agg.value: 140}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/40_avg_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/40_avg_agg.yml
@@ -47,8 +47,12 @@ setup:
 ---
 "Test avg agg with query":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       search:
@@ -56,9 +60,10 @@ setup:
         size: 0
         body:
           query:
-            term:
+            range:
               metric:
-                value: 20
+                gte: 2
+                lte: 3
           aggs:
             avg_agg:
               avg:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/50_value_count_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/50_value_count_agg.yml
@@ -47,8 +47,12 @@ setup:
 ---
 "Test value_count agg with query":
   - requires:
-      cluster_features: ["gte_v7.11.0"]
-      reason: "Aggregate metric fields have been added in 7.11"
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ aggregate_metric_double_defaults_to_average ]
+      test_runner_features: capabilities
+      reason: "Aggregate metric double fields use average as default since 9.4"
 
   - do:
       search:
@@ -56,9 +60,10 @@ setup:
         size: 0
         body:
           query:
-            term:
+            range:
               metric:
-                value: 20
+                gte: 2
+                lte: 3
           aggs:
             value_count_agg:
               value_count:


### PR DESCRIPTION
In this PR, we deprecate the `default_metric` in the field type `aggregate_metric_double` and we use average instead. This PR will include the following changes:

- [ ] Deprecate the `default_metric` mapping parameter (https://github.com/elastic/elasticsearch/pull/141877)
- [ ] Use the average in `range`, `term` and `terms` queries in QueryDSL
- [ ] Use average as a default in stats requests in `ES|QL` (https://github.com/elastic/elasticsearch/pull/141331)
- [ ] Update documentation