### PR TITLE
Fix bbq_hnsw yaml test vector scores

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -356,9 +356,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrTimeSeriesDataStreamsIT
   method: testCrossClusterReplicationForTSDBWithSyntheticId
   issue: https://github.com/elastic/elasticsearch/issues/141796
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/141842
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/50_index_patterns/disjoint_mappings}
   issue: https://github.com/elastic/elasticsearch/issues/141856

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -362,9 +362,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.diskbbq.PreconditionerTests
   method: testRandomProviderConfigurations
   issue: https://github.com/elastic/elasticsearch/issues/141748
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/141842
 
 # Examples:
 #

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -125,4 +125,5 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   // Expected deprecation warning to compat yaml tests:
   task.addAllowedWarningRegex("Use of the \\[max_size\\] rollover condition has been deprecated in favour of the \\[max_primary_shard_size\\] condition and will be removed in a later version")
   task.skipTest("search.vectors/42_knn_search_bbq_flat/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
+  task.skipTest("search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
 })

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -111,7 +111,7 @@ setup:
 "Vector rescoring has same scoring as exact search for kNN section":
   - requires:
       reason: 'Quantized vector rescoring is required'
-      test_runner_features: [capabilities]
+      test_runner_features: [capabilities, close_to]
       capabilities:
         - method: GET
           path: /_search
@@ -172,9 +172,9 @@ setup:
 
   # Compare scores as hit IDs may change depending on how things are distributed
   - match: { hits.total: 3 }
-  - match: { hits.hits.0._score: $rescore_score0 }
-  - match: { hits.hits.1._score: $rescore_score1 }
-  - match: { hits.hits.2._score: $rescore_score2 }
+  - close_to: { hits.hits.0._score: { value: $rescore_score0, error: 0.00001 }}
+  - close_to: { hits.hits.1._score: { value: $rescore_score1, error: 0.00001 }}
+  - close_to: { hits.hits.2._score: { value: $rescore_score2, error: 0.00001 }}
 
 ---
 "Test bad quantization parameters":


### PR DESCRIPTION
Update a test missed by https://github.com/elastic/elasticsearch/pull/139893

Fixes #141842
Fixes #141850