### PR TITLE
Fix overflow in `BoundedDelimitedStringCollector`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -594,7 +594,7 @@ public class Strings {
         public BoundedDelimitedStringCollector(StringBuilder stringBuilder, String delimiter, int appendLimit) {
             this.stringBuilder = stringBuilder;
             this.delimiter = delimiter;
-            this.lengthLimit = stringBuilder.length() + appendLimit; // long to avoid overflow
+            this.lengthLimit = (long) stringBuilder.length() + appendLimit; // long to avoid overflow
         }
 
         /**

--- a/server/src/test/java/org/elasticsearch/common/BoundedDelimitedStringCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/BoundedDelimitedStringCollectorTests.java
@@ -131,4 +131,18 @@ public class BoundedDelimitedStringCollectorTests extends ESTestCase {
         assertThat(testHarness.getResult(strings, delimiter, limit), equalTo(fullDescription));
     }
 
+    public void testLimitOverflow() {
+        final var stringBuilder = new StringBuilder("nonempty prefix");
+        final var collector = new Strings.BoundedDelimitedStringCollector(
+            stringBuilder,
+            "",
+            Integer.MAX_VALUE - between(0, stringBuilder.length() - 1)
+        );
+
+        collector.appendItem(", item");
+        collector.finish();
+
+        assertEquals("nonempty prefix, item", stringBuilder.toString());
+    }
+
 }


### PR DESCRIPTION
The comment lies, the overflow happens before up-casting to `long`.