### PR TITLE
Add base class for sparse/dense BinaryDocValues implementations

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -362,9 +362,6 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
   issue: https://github.com/elastic/elasticsearch/issues/141842
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testOptionalLengthReaderSparseToLengthValues
-  issue: https://github.com/elastic/elasticsearch/issues/141853
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/50_index_patterns/disjoint_mappings}
   issue: https://github.com/elastic/elasticsearch/issues/141856

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -748,10 +748,12 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
-    abstract static class DenseBinaryDocValues extends BinaryDocValues
+    abstract static class ES819BinaryDocValues extends BinaryDocValues
         implements
             BlockLoader.OptionalColumnAtATimeReader,
-            BlockLoader.OptionalLengthReader {
+            BlockLoader.OptionalLengthReader {}
+
+    abstract static class DenseBinaryDocValues extends ES819BinaryDocValues {
 
         final int maxDoc;
         int doc = -1;
@@ -864,10 +866,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
-    abstract static class SparseBinaryDocValues extends BinaryDocValues
-        implements
-            BlockLoader.OptionalColumnAtATimeReader,
-            BlockLoader.OptionalLengthReader {
+    abstract static class SparseBinaryDocValues extends ES819BinaryDocValues {
 
         final IndexedDISI disi;
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -49,8 +49,7 @@ import org.elasticsearch.index.codec.tsdb.BinaryDVCompressionMode;
 import org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormatTests;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.BaseDenseNumericValues;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.BaseSortedDocValues;
-import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.DenseBinaryDocValues;
-import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.SparseBinaryDocValues;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.ES819BinaryDocValues;
 import org.elasticsearch.index.mapper.BinaryFieldMapper.CustomBinaryDocValuesField;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockLoader.OptionalColumnAtATimeReader;
@@ -932,8 +931,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
             try (var reader = DirectoryReader.open(iw)) {
                 for (var leaf : reader.leaves()) {
-                    var binaryFixedDV = getDenseBinaryValues(leaf.reader(), binaryFixedField);
-                    var binaryVariableDV = getDenseBinaryValues(leaf.reader(), binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leaf.reader(), binaryVariableField);
 
                     NumericDocValues fixedLengthReader = binaryFixedDV.toLengthValues();
                     NumericDocValues variableLengthReader = binaryVariableDV.toLengthValues();
@@ -992,8 +991,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
             try (var reader = DirectoryReader.open(iw)) {
                 for (var leaf : reader.leaves()) {
-                    var binaryFixedDV = getSparseBinaryValues(leaf.reader(), binaryFixedField);
-                    var binaryVariableDV = getSparseBinaryValues(leaf.reader(), binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leaf.reader(), binaryVariableField);
 
                     NumericDocValues fixedLengthReader = binaryFixedDV.toLengthValues();
                     NumericDocValues variableLengthReader = binaryVariableDV.toLengthValues();
@@ -1054,8 +1053,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
             var factory = TestBlock.factory();
             try (var reader = DirectoryReader.open(iw)) {
                 for (var leaf : reader.leaves()) {
-                    var binaryFixedDV = getDenseBinaryValues(leaf.reader(), binaryFixedField);
-                    var binaryVariableDV = getDenseBinaryValues(leaf.reader(), binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leaf.reader(), binaryVariableField);
 
                     int maxDoc = leaf.reader().maxDoc();
                     for (int i = 0; i < maxDoc;) {
@@ -1100,13 +1099,13 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 int size = maxDoc - randomOffset;
 
                 {
-                    var binaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                    var binaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
                     var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
 
                     // Separate doc values to bulk load and use as expected values
-                    var expectedBinaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                    var expectedBinaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                    var expectedBinaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Test fixed length
                     var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, randomOffset, false);
@@ -1123,12 +1122,12 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     size = docs.count();
 
                     // Doc values to call tryReadLength on:
-                    var binaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                    var binaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Doc values to get expected lengths from
-                    var expectedBinaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                    var expectedBinaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                    var expectedBinaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Test fixed length
                     var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, 0, false);
@@ -1193,13 +1192,13 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 int size = maxDoc - randomOffset;
 
                 {
-                    var binaryFixedDV = getSparseBinaryValues(leafReader, binaryFixedField);
-                    var binaryVariableDV = getSparseBinaryValues(leafReader, binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
                     var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
 
                     // Separate doc values to bulk load and use as expected values
-                    var expectedBinaryFixedDV = getSparseBinaryValues(leafReader, binaryFixedField);
-                    var expectedBinaryVariableDV = getSparseBinaryValues(leafReader, binaryVariableField);
+                    var expectedBinaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Test fixed length
                     var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, randomOffset, false);
@@ -1216,12 +1215,12 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     size = docs.count();
 
                     // Doc values to call tryReadLength on:
-                    var binaryFixedDV = getSparseBinaryValues(leafReader, binaryFixedField);
-                    var binaryVariableDV = getSparseBinaryValues(leafReader, binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Doc values to get expected lengths from
-                    var expectedBinaryFixedDV = getSparseBinaryValues(leafReader, binaryFixedField);
-                    var expectedBinaryVariableDV = getSparseBinaryValues(leafReader, binaryVariableField);
+                    var expectedBinaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                     // Test fixed length
                     var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, 0, false);
@@ -1338,8 +1337,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     var counterDV = getBaseDenseNumericValues(leaf.reader(), counterField);
                     var gaugeDV = getBaseDenseNumericValues(leaf.reader(), gaugeField);
                     var stringCounterDV = getBaseSortedDocValues(leaf.reader(), counterFieldAsString);
-                    var binaryFixedDV = getDenseBinaryValues(leaf.reader(), binaryFixedField);
-                    var binaryVariableDV = getDenseBinaryValues(leaf.reader(), binaryVariableField);
+                    var binaryFixedDV = getES819BinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getES819BinaryValues(leaf.reader(), binaryVariableField);
 
                     int maxDoc = leaf.reader().maxDoc();
                     for (int i = 0; i < maxDoc;) {
@@ -1466,8 +1465,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 var counterDV = getBaseDenseNumericValues(leafReader, counterField);
                 var gaugeDV = getBaseDenseNumericValues(leafReader, gaugeField);
                 var stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
-                var binaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                var binaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                var binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                var binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
 
                 var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
                 int docIdEnd = docs.get(docs.count() - 1);
@@ -1559,9 +1558,9 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 long[] expectedCounters = new long[size];
                 counterDV = getBaseDenseNumericValues(leafReader, counterField);
                 List<BytesRef> expectedFixedBinaryValues = new ArrayList<>();
-                binaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
+                binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
                 List<BytesRef> expectedVariableBinaryValues = new ArrayList<>();
-                binaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
                 final var cdvReader = new CustomBinaryDocValuesReader();
                 for (int i = 0; i < docs.count(); i++) {
                     int docId = docs.get(i);
@@ -1594,8 +1593,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 }
                 counterDV = getBaseDenseNumericValues(leafReader, counterField);
                 stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
-                binaryFixedDV = getDenseBinaryValues(leafReader, binaryFixedField);
-                binaryVariableDV = getDenseBinaryValues(leafReader, binaryVariableField);
+                binaryFixedDV = getES819BinaryValues(leafReader, binaryFixedField);
+                binaryVariableDV = getES819BinaryValues(leafReader, binaryVariableField);
                 {
                     // bulk loading counter field:
                     var block = (TestBlock) counterDV.tryRead(factory, docs, 0, false, null, false, false);
@@ -1784,7 +1783,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
             try (var reader = DirectoryReader.open(iw)) {
                 for (var leaf : reader.leaves()) {
                     int maxDoc = leaf.reader().maxDoc();
-                    var binaryDVField1 = getDenseBinaryValues(leaf.reader(), binaryFieldOne);
+                    var binaryDVField1 = getES819BinaryValues(leaf.reader(), binaryFieldOne);
                     // Randomize start doc, starting from a docid that is part of later blocks triggers:
                     // https://github.com/elastic/elasticsearch/issues/138750
                     var docs = TestBlock.docs(IntStream.range(between(0, maxDoc - 1), maxDoc).toArray());
@@ -1804,7 +1803,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         assertTrue("actual [" + actual + "] not in generated values", binaryValues.contains(actual));
                     }
 
-                    var binaryDVField2 = getDenseBinaryValues(leaf.reader(), binaryFieldTwo);
+                    var binaryDVField2 = getES819BinaryValues(leaf.reader(), binaryFieldTwo);
                     block = (TestBlock) binaryDVField2.tryRead(factory, docs, 0, random().nextBoolean(), null, false, true);
                     for (int j = 0; j < block.size(); j++) {
                         var values = (List<?>) block.get(j);
@@ -1990,7 +1989,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     if (testDocs.isEmpty() == false) {
                         if (denseBinaryData) {
                             {
-                                var dv = getDenseBinaryValues(leafReader, binaryFixedField);
+                                var dv = getES819BinaryValues(leafReader, binaryFixedField);
                                 var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
                                 assertNotNull(block);
                                 for (int i = 0; i < testDocs.size(); i++) {
@@ -1998,7 +1997,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                                 }
                             }
                             {
-                                var dv = getDenseBinaryValues(leafReader, binaryVariableField);
+                                var dv = getES819BinaryValues(leafReader, binaryVariableField);
                                 var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
                                 assertNotNull(block);
                                 for (int i = 0; i < testDocs.size(); i++) {
@@ -2007,12 +2006,12 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                             }
                         } else {
                             {
-                                var dv = getSparseBinaryValues(leafReader, binaryFixedField);
+                                var dv = getES819BinaryValues(leafReader, binaryFixedField);
                                 var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
                                 assertNull(block);
                             }
                             {
-                                var dv = getSparseBinaryValues(leafReader, binaryVariableField);
+                                var dv = getES819BinaryValues(leafReader, binaryVariableField);
                                 var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
                                 assertNull(block);
                             }
@@ -2246,12 +2245,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         }
     }
 
-    private static DenseBinaryDocValues getDenseBinaryValues(LeafReader leafReader, String field) throws IOException {
-        return (DenseBinaryDocValues) leafReader.getBinaryDocValues(field);
-    }
-
-    private static SparseBinaryDocValues getSparseBinaryValues(LeafReader leafReader, String field) throws IOException {
-        return (SparseBinaryDocValues) leafReader.getBinaryDocValues(field);
+    private static ES819BinaryDocValues getES819BinaryValues(LeafReader leafReader, String field) throws IOException {
+        return (ES819BinaryDocValues) leafReader.getBinaryDocValues(field);
     }
 
     private static BaseDenseNumericValues getBaseDenseNumericValues(LeafReader leafReader, String field) throws IOException {


### PR DESCRIPTION
Tests were having to make assumptions about which implementation of 
BinaryDocValues was being produced by ES819TSDBDocValuesProducer, 
which were fragile in the face of random index geometry changes.

This introduces a shared base class for both implementations which 
supports the length reader interfaces that the test needs.

Fixes #141822