### PR TITLE
[9.3] [CI] Fix fixture publishing for oidc on ci (#141727)

### DIFF
--- a/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
+++ b/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
@@ -4,8 +4,10 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 -t <tag> .
 #
 # NOTE: c2id/c2id-server-demo only provides amd64 images, so we force the platform
-# for that stage. The extract and final stages use the build target platform.
-FROM --platform=linux/amd64 c2id/c2id-server-demo:16.1.1 AS c2id
+# for the COPY stage via build-arg (avoids BuildKit FromPlatformFlagConstDisallowed).
+# The runtime stage uses the native platform.
+ARG C2ID_PLATFORM=linux/amd64
+FROM --platform=${C2ID_PLATFORM} c2id/c2id-server-demo:16.1.1 AS c2id
 
 # Extract WAR using JDK's jar (avoids apt-get + unzip in final image).
 # No platform pin: uses build target so we get native arm64 or amd64 image.

--- a/x-pack/test/idp-fixture/src/main/resources/oidc/build.sh
+++ b/x-pack/test/idp-fixture/src/main/resources/oidc/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License
@@ -7,7 +8,6 @@
 # Build-time script: runs during "docker build" to prepare the image.
 # Run logic (wait for config, start Tomcat) lives in entrypoint.sh.
 
-#!/bin/bash
 set -e
 
 # Ensure config directory exists so the runtime can write override.properties there

--- a/x-pack/test/idp-fixture/src/main/resources/oidc/entrypoint.sh
+++ b/x-pack/test/idp-fixture/src/main/resources/oidc/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License
@@ -7,7 +8,6 @@
 # Run-time script: container entrypoint. Waits for override.properties (written
 # by the test via copyFileToContainer after the container starts), then starts Tomcat.
 
-#!/bin/bash
 set -e
 
 until [ -f /config/c2id/override.properties ]; do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Fix fixture publishing for oidc on ci (#141727)](https://github.com/elastic/elasticsearch/pull/141727)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)