### PR TITLE
[ES-13920] Fixing resolution of exponential-histogram in example-plugins

### DIFF
--- a/libs/exponential-histogram/build.gradle
+++ b/libs/exponential-histogram/build.gradle
@@ -9,7 +9,6 @@
 
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.build'
-apply plugin: 'elasticsearch.internal-test-artifact'
 
 dependencies {
   api project(':libs:core')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -78,10 +78,6 @@ dependencies {
     // tests use the locally compiled version of server
     exclude group: 'org.elasticsearch', module: 'server'
   }
-  testImplementation(testArtifact(project(":libs:exponential-histogram"))) {
-    // The test framework is manually included with excludes above
-    exclude group: 'org.elasticsearch.test', module: 'framework'
-  }
 
   internalClusterTestImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'server'


### PR DESCRIPTION
Exponential Histogram Lib is not publishing to maven causing gradle build issues for example-plugins. The working theory is that this is due to the label as an internal-test-dep. 

Also found duplicate logic of ignoring test artifacts within :server: gradle build. 

This change should allow exponential-histogram to publish to Maven shapshots. 