### PR TITLE
[9.3] ESQL fix TO_IP leading_zeros=octal parsing (#141776)

### DIFF
--- a/docs/changelog/141776.yaml
+++ b/docs/changelog/141776.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 141627
+pr: 141776
+summary: ESQL fix TO_IP leading_zeros=octal parsing
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -297,6 +297,23 @@ s:keyword | ip:ip
 // end::to_ip_leading_zeros_octal-result[]
 ;
 
+convertFromStringLeadingZerosInvalidIpAddress
+required_capability: fix_to_ip_leading_zeros_octal
+ROW 
+  input = "192.400.168.1"
+| EVAL octal = TO_IP(input, {"leading_zeros":"octal"})
+| EVAL decimal = TO_IP(input, {"leading_zeros":"decimal"})
+| EVAL reject = TO_IP(input, {"leading_zeros":"reject"})
+;
+warningRegex:evaluation of \[TO_IP\(input, \{\\\"leading_zeros\\\":\\\"octal\\\"\}\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:evaluation of \[TO_IP\(input, \{\\\"leading_zeros\\\":\\\"decimal\\\"\}\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:evaluation of \[TO_IP\(input, \{\\\"leading_zeros\\\":\\\"reject\\\"\}\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.IllegalArgumentException: '192.400.168.1' is not an IP string literal.
+
+input:keyword | octal:ip | decimal:ip | reject:ip
+192.400.168.1 | null     | null       | null
+;
+
 convertFromStringFancy
 required_capability: to_ip_leading_zeros
 FROM logs

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1863,6 +1863,12 @@ public class EsqlCapabilities {
         RATE_FIX_RESETS_MULTIPLE_SEGMENTS,
 
         /**
+         * Fix for <a href="https://github.com/elastic/elasticsearch/issues/141627">141627</a>,
+         * TO_IP with leading_zeros=octal generates proper warning and returns null when given invalid input.
+         */
+        FIX_TO_IP_LEADING_ZEROS_OCTAL,
+
+        /**
          * Fix bug with TS command where you can't group on aliases (i.e. `by c = cluster`)
          */
         TS_COMMAND_GROUP_ON_ALIASES,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java
@@ -206,6 +206,9 @@ public class ParseIp {
                 }
                 offset++;
             }
+            if (v > 255) {
+                throw invalid(string);
+            }
             scratch.bytes()[dest] = (byte) v;
         }
         return scratch.bytesRefView();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ESQL fix TO_IP leading_zeros=octal parsing (#141776)](https://github.com/elastic/elasticsearch/pull/141776)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)