### PR TITLE
Added SlowCustomBinaryDocValuesTermInSetQuery to replace separate term queries in TextFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -678,7 +678,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termsQuery(values, context);
             } else if (usesBinaryDocValues) {
-                Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
+                List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return new SlowCustomBinaryDocValuesTermInSetQuery(name(), bytesRefs);
             } else {
                 Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -70,6 +70,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.Utf8CodePointsFro
 import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesWildcardQuery;
 import org.elasticsearch.script.Script;
@@ -86,7 +87,6 @@ import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldRangeQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldRegexpQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldTermQuery;
-import org.elasticsearch.search.runtime.StringScriptFieldTermsQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 import org.elasticsearch.xcontent.Text;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -105,7 +105,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.apache.lucene.index.IndexWriter.MAX_TERM_LENGTH;
 import static org.elasticsearch.core.Strings.format;
@@ -679,12 +678,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termsQuery(values, context);
             } else if (usesBinaryDocValues) {
-                return new StringScriptFieldTermsQuery(
-                    new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
-                    name(),
-                    values.stream().map(this::indexedValueForSearch).map(BytesRef::utf8ToString).collect(Collectors.toSet())
-                );
+                Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
+                return new SlowCustomBinaryDocValuesTermInSetQuery(name(), bytesRefs);
             } else {
                 Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -959,7 +959,9 @@ public final class TextFieldMapper extends FieldMapper {
             if (indexType().hasTerms()) {
                 return super.termQuery(value, context);
             }
+
             failIfNotIndexedNorDocValuesFallback(context);
+
             if (usesBinaryDocValues) {
                 return new SlowCustomBinaryDocValuesTermQuery(name(), indexedValueForSearch(value));
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -977,7 +977,7 @@ public final class TextFieldMapper extends FieldMapper {
 
             failIfNotIndexedNorDocValuesFallback(context);
 
-            Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
+            List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
             if (usesBinaryDocValues) {
                 return new SlowCustomBinaryDocValuesTermInSetQuery(name(), bytesRefs);
             } else {

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQuery.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A query for matching any value from a set of BytesRef values for a specific field.
+ * <p>
+ * This implementation is slow, because it potentially scans binary doc values for each document.
+ */
+public final class SlowCustomBinaryDocValuesTermInSetQuery extends AbstractBinaryDocValuesQuery {
+
+    private final Set<BytesRef> terms;
+
+    public SlowCustomBinaryDocValuesTermInSetQuery(String fieldName, Set<BytesRef> terms) {
+        super(fieldName, terms::contains);
+
+        // verify inputs
+        Objects.requireNonNull(terms);
+        if (terms.isEmpty()) {
+            throw new IllegalArgumentException("terms must not be empty");
+        }
+        for (BytesRef term : terms) {
+            if (term == null) {
+                throw new IllegalArgumentException("terms must not contain null");
+            }
+        }
+
+        this.terms = terms;
+    }
+
+    @Override
+    protected float matchCost() {
+        // SlowCustomBinaryDocValuesTermQuery uses 10 for a single term, and while we have multiple terms, they're contained with a
+        // HashSet, whose look up time is O(1). So, we're only slightly slower than a single term.
+        return 11;
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder sb = new StringBuilder("SlowCustomBinaryDocValuesTermInSetQuery(fieldName=");
+        sb.append(field).append(",terms=[");
+        boolean first = true;
+        for (BytesRef term : terms) {
+            if (first == false) {
+                sb.append(",");
+            }
+            sb.append(term.utf8ToString());
+            first = false;
+        }
+        sb.append("])");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        SlowCustomBinaryDocValuesTermInSetQuery that = (SlowCustomBinaryDocValuesTermInSetQuery) o;
+        return Objects.equals(fieldName, that.fieldName) && Objects.equals(terms, that.terms);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), fieldName, terms);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
+
+    public void testBasics() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            Map<String, Long> expectedCounts = new HashMap<>();
+            expectedCounts.put("a", 2L);
+            expectedCounts.put("b", 5L);
+            expectedCounts.put("c", 1L);
+            expectedCounts.put("d", 3L);
+            expectedCounts.put("e", 10L);
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (var entry : expectedCounts.entrySet()) {
+                    for (int i = 0; i < entry.getValue(); i++) {
+                        Document document = new Document();
+
+                        var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                        field.add(new BytesRef(entry.getKey().getBytes(StandardCharsets.UTF_8)));
+                        var countField = new NumericDocValuesField("field.counts", 1);
+
+                        if (randomBoolean()) {
+                            field.add(new BytesRef("z".getBytes(StandardCharsets.UTF_8)));
+                            countField.setLongValue(field.count());
+                        }
+                        document.add(field);
+                        document.add(countField);
+                        writer.addDocument(document);
+                    }
+                }
+
+                // search with set containing single term
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    for (var entry : expectedCounts.entrySet()) {
+                        Set<BytesRef> terms = Set.of(new BytesRef(entry.getKey()));
+                        long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
+                        assertEquals(entry.getValue().longValue(), count);
+                    }
+                }
+
+                // search with set containing multiple terms
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+
+                    // Query for "a" or "b" should return count of a + count of b
+                    Set<BytesRef> terms = Set.of(new BytesRef("a"), new BytesRef("b"));
+                    long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
+                    assertEquals(expectedCounts.get("a") + expectedCounts.get("b"), count);
+
+                    // Query for "c", "d", "e" should return sum of their counts
+                    Set<BytesRef> terms2 = Set.of(new BytesRef("c"), new BytesRef("d"), new BytesRef("e"));
+                    long count2 = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms2));
+                    assertEquals(expectedCounts.get("c") + expectedCounts.get("d") + expectedCounts.get("e"), count2);
+                }
+
+                // search with set containing non-existent term
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Set<BytesRef> terms = Set.of(new BytesRef("nonexistent"));
+                    long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
+                    assertEquals(0, count);
+                }
+
+                // search with set containing mix of existent and non-existent terms
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Set<BytesRef> terms = Set.of(new BytesRef("a"), new BytesRef("nonexistent"));
+                    long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
+                    assertEquals(expectedCounts.get("a").longValue(), count);
+                }
+            }
+        }
+    }
+
+    public void testNoField() throws IOException {
+        String fieldName = "field";
+
+        // no field in index
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, Set.of(new BytesRef("a")));
+                    assertEquals(0, searcher.count(query));
+                }
+            }
+        }
+
+        // no field in segment
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                Document document = new Document();
+
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                field.add(new BytesRef("a".getBytes(StandardCharsets.UTF_8)));
+                var countField = new NumericDocValuesField("field.counts", 1);
+                document.add(field);
+                document.add(countField);
+
+                writer.addDocument(document);
+                writer.commit();
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, Set.of(new BytesRef("a")));
+                    assertEquals(1, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testEmptySetThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", Set.of()));
+    }
+
+    public void testNullTermsThrows() {
+        expectThrows(NullPointerException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", null));
+    }
+
+    public void testNullTermInSetThrows() {
+        Set<BytesRef> termsWithNull = new HashSet<>();
+        termsWithNull.add(new BytesRef("a"));
+        termsWithNull.add(null);
+        expectThrows(IllegalArgumentException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithNull));
+    }
+
+    public void testEqualsAndHashCode() {
+        String fieldName = "field";
+        Set<BytesRef> terms1 = Set.of(new BytesRef("a"), new BytesRef("b"));
+        Set<BytesRef> terms2 = Set.of(new BytesRef("a"), new BytesRef("b"));
+        Set<BytesRef> terms3 = Set.of(new BytesRef("a"), new BytesRef("c"));
+
+        SlowCustomBinaryDocValuesTermInSetQuery query1 = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms1);
+        SlowCustomBinaryDocValuesTermInSetQuery query2 = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms2);
+        SlowCustomBinaryDocValuesTermInSetQuery query3 = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms3);
+        SlowCustomBinaryDocValuesTermInSetQuery query4 = new SlowCustomBinaryDocValuesTermInSetQuery("other", terms1);
+
+        // Same terms, same field
+        assertEquals(query1, query2);
+        assertEquals(query1.hashCode(), query2.hashCode());
+
+        // Different terms
+        assertNotEquals(query1, query3);
+
+        // Different field
+        assertNotEquals(query1, query4);
+
+        // Self equality
+        assertEquals(query1, query1);
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
 
@@ -61,7 +60,7 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
-                        Set<BytesRef> terms = Set.of(new BytesRef(entry.getKey()));
+                        List<BytesRef> terms = List.of(new BytesRef(entry.getKey()));
                         long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
                         assertEquals(entry.getValue().longValue(), count);
                     }
@@ -72,28 +71,28 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
 
                     // Query for "a" or "b" should return count of a + count of b
-                    Set<BytesRef> terms = Set.of(new BytesRef("a"), new BytesRef("b"));
+                    List<BytesRef> terms = List.of(new BytesRef("a"), new BytesRef("b"));
                     long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
                     assertEquals(expectedCounts.get("a") + expectedCounts.get("b"), count);
 
                     // Query for "c", "d", "e" should return sum of their counts
-                    Set<BytesRef> terms2 = Set.of(new BytesRef("c"), new BytesRef("d"), new BytesRef("e"));
+                    List<BytesRef> terms2 = List.of(new BytesRef("c"), new BytesRef("d"), new BytesRef("e"));
                     long count2 = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms2));
                     assertEquals(expectedCounts.get("c") + expectedCounts.get("d") + expectedCounts.get("e"), count2);
                 }
 
-                // search with set containing non-existent term
+                // search with list containing non-existent term
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Set<BytesRef> terms = Set.of(new BytesRef("nonexistent"));
+                    List<BytesRef> terms = List.of(new BytesRef("nonexistent"));
                     long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
                     assertEquals(0, count);
                 }
 
-                // search with set containing mix of existent and non-existent terms
+                // search with list containing mix of existent and non-existent terms
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Set<BytesRef> terms = Set.of(new BytesRef("a"), new BytesRef("nonexistent"));
+                    List<BytesRef> terms = List.of(new BytesRef("a"), new BytesRef("nonexistent"));
                     long count = searcher.count(new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms));
                     assertEquals(expectedCounts.get("a").longValue(), count);
                 }
@@ -110,7 +109,7 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, Set.of(new BytesRef("a")));
+                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, List.of(new BytesRef("a")));
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -132,7 +131,7 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, Set.of(new BytesRef("a")));
+                    Query query = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, List.of(new BytesRef("a")));
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -145,9 +144,9 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
 
     public void testEqualsAndHashCode() {
         String fieldName = "field";
-        Set<BytesRef> terms1 = Set.of(new BytesRef("a"), new BytesRef("b"));
-        Set<BytesRef> terms2 = Set.of(new BytesRef("a"), new BytesRef("b"));
-        Set<BytesRef> terms3 = Set.of(new BytesRef("a"), new BytesRef("c"));
+        List<BytesRef> terms1 = List.of(new BytesRef("a"), new BytesRef("b"));
+        List<BytesRef> terms2 = List.of(new BytesRef("a"), new BytesRef("b"));
+        List<BytesRef> terms3 = List.of(new BytesRef("a"), new BytesRef("c"));
 
         SlowCustomBinaryDocValuesTermInSetQuery query1 = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms1);
         SlowCustomBinaryDocValuesTermInSetQuery query2 = new SlowCustomBinaryDocValuesTermInSetQuery(fieldName, terms2);
@@ -177,7 +176,7 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
             new BytesRef("b"),
             new BytesRef("a")
         );
-        Set<BytesRef> termsWithoutDuplicates = Set.of(new BytesRef("a"), new BytesRef("b"));
+        List<BytesRef> termsWithoutDuplicates = List.of(new BytesRef("a"), new BytesRef("b"));
 
         SlowCustomBinaryDocValuesTermInSetQuery query1 = new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithDuplicates);
         SlowCustomBinaryDocValuesTermInSetQuery query2 = new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithoutDuplicates);

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
@@ -21,8 +21,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -138,19 +139,8 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
         }
     }
 
-    public void testEmptySetThrows() {
-        expectThrows(IllegalArgumentException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", Set.of()));
-    }
-
     public void testNullTermsThrows() {
         expectThrows(NullPointerException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", null));
-    }
-
-    public void testNullTermInSetThrows() {
-        Set<BytesRef> termsWithNull = new HashSet<>();
-        termsWithNull.add(new BytesRef("a"));
-        termsWithNull.add(null);
-        expectThrows(IllegalArgumentException.class, () -> new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithNull));
     }
 
     public void testEqualsAndHashCode() {
@@ -176,6 +166,24 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
 
         // Self equality
         assertEquals(query1, query1);
+    }
+
+    public void testDeduplication() {
+        // query with duplicates should equal query without duplicates
+        List<BytesRef> termsWithDuplicates = Arrays.asList(
+            new BytesRef("a"),
+            new BytesRef("b"),
+            new BytesRef("a"),
+            new BytesRef("b"),
+            new BytesRef("a")
+        );
+        Set<BytesRef> termsWithoutDuplicates = Set.of(new BytesRef("a"), new BytesRef("b"));
+
+        SlowCustomBinaryDocValuesTermInSetQuery query1 = new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithDuplicates);
+        SlowCustomBinaryDocValuesTermInSetQuery query2 = new SlowCustomBinaryDocValuesTermInSetQuery("field", termsWithoutDuplicates);
+
+        assertEquals(query1, query2);
+        assertEquals(query1.hashCode(), query2.hashCode());
     }
 
 }


### PR DESCRIPTION
Addresses https://github.com/elastic/logs-program/issues/36