### PR TITLE
[CI] Throttle bwc builds during ci image baking

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -49,6 +49,6 @@ for branch in "${branches[@]}"; do
   rm -rf checkout/$branch
   git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch ${branch} --single-branch checkout/${branch}
   export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
-  ./checkout/${branch}/gradlew --project-dir ./checkout/${branch} --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none
+  ./checkout/${branch}/gradlew --project-dir ./checkout/${branch} --parallel clean -s resolveAllDependencies -Dbwc.throttle.maxParallelUsages=1 -Dorg.gradle.warning.mode=none
   rm -rf ./checkout/${branch}
 done

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -24,6 +24,8 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -42,6 +44,7 @@ public class BwcSetupExtension {
 
     private static final String MINIMUM_COMPILER_VERSION_PATH = "src/main/resources/minimumCompilerVersion";
     private static final Version BUILD_TOOL_MINIMUM_VERSION = Version.fromString("7.14.0");
+    public static final String BWC_THROTTLE_MAX_PARALLEL_USAGES = "bwc.throttle.maxParallelUsages";
     private final Project project;
     private final ObjectFactory objectFactory;
     private final ProviderFactory providerFactory;
@@ -103,7 +106,6 @@ public class BwcSetupExtension {
         return project.getTasks().register(name, LoggedExec.class, loggedExec -> {
             loggedExec.dependsOn("checkoutBwcBranch");
             loggedExec.getWorkingDir().set(checkoutDir.get());
-
             loggedExec.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task task) {
@@ -172,8 +174,31 @@ public class BwcSetupExtension {
                 loggedExec.args("-I", initScript.getAbsolutePath());
             }
             loggedExec.getIndentingConsoleOutput().set(unreleasedVersionInfo.map(v -> v.version().toString()));
+
+            // We wanna have the option to throttle the parallel execution of the bwc tasks themselves
+            // e.g. for CI environments with limited resources or when running ci caching scripts
+            configureBwcThrottle(project, loggedExec);
             configAction.execute(loggedExec);
         });
+    }
+
+    private static void configureBwcThrottle(Project project, LoggedExec loggedExec) {
+        Provider<String> throttleProperty = project.getProviders().systemProperty(BWC_THROTTLE_MAX_PARALLEL_USAGES);
+        if (throttleProperty.isPresent()) {
+            try {
+                int maxParallelUsages = Integer.parseInt(throttleProperty.get());
+                if (maxParallelUsages < 1) {
+                    throw new GradleException("System property 'bwc.throttle.maxParallelUsages' must be >= 1");
+                }
+                Provider<BwcThrottle> throttle = project.getGradle()
+                    .getSharedServices()
+                    .registerIfAbsent("bwcThrottle", BwcThrottle.class, spec -> spec.getMaxParallelUsages().set(maxParallelUsages));
+
+                loggedExec.usesService(throttle);
+            } catch (NumberFormatException e) {
+                throw new GradleException("System property 'bwc.throttle.maxParallelUsages' must be an integer value", e);
+            }
+        }
     }
 
     /** A convenience method for getting java home for a version of java and requiring that version for the given task to execute */
@@ -212,4 +237,6 @@ public class BwcSetupExtension {
             Property<File> getCheckoutDir();
         }
     }
+
+    public abstract class BwcThrottle implements BuildService<BuildServiceParameters.None> {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ import org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin
 import org.elasticsearch.gradle.internal.ResolveAllDependencies
 import org.elasticsearch.gradle.util.GradleUtils
 import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.elasticsearch.gradle.internal.testfixtures.DockerComposeThrottle
 
 import groovy.xml.XmlParser;
 import groovy.xml.XmlNodePrinter;
@@ -349,7 +350,7 @@ allprojects {
     }
     // we run the packer script for all active branches. so we should be able to skip bwc here
     if(project.path.startsWith(":distribution:bwc:")) {
-      enabled = false
+      dependsOn project.tasks.matching { it.name == 'buildBwcLinuxTar' }
     }
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)


### PR DESCRIPTION
We have encountered timeouts when running gradle cache logic
during vm image baking due to parallel bwc builds. This change
throttles the bwc builds in parallel to 1 during caching and enables
bwc build caching in general to bring back more stability on ci images.