### PR TITLE
Add yaml test for exists queryDSL queries on exponential histograms

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -178,3 +178,16 @@ setup:
   - lte: { aggregations.percentiles_agg.values.75\.0: 2730.7 }
   - gte: { aggregations.percentiles_agg.values.95\.0: 10922.6 }
   - lte: { aggregations.percentiles_agg.values.95\.0: 10922.7 }
+
+---
+"Exists query":
+  - do:
+      search:
+        index: test_exponential_histogram
+        body:
+          query:
+            exists:
+              field: histo
+
+  - match: { hits.total.value: 5 }
+

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
@@ -143,3 +143,16 @@ setup:
 
   - match: { hits.total.value: 2 }
   - match: { aggregations.max_agg.value: 10.0 }
+
+---
+"Exists query over aggregate_metric_double and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        body:
+          query:
+            exists:
+              field: histo_or_aggregate_metric
+
+  - match: { hits.total.value: 2 }
+

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -195,3 +195,16 @@ setup:
   - lte: { aggregations.percentiles_agg.values.50\.0: 2.001 }
   - gte: { aggregations.percentiles_agg.values.75\.0: 2.665 }
   - lte: { aggregations.percentiles_agg.values.75\.0: 2.667 }
+
+---
+"Exists query over tdigest and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        body:
+          query:
+            exists:
+              field: tdigest_or_exp_histo
+
+  - match: { hits.total.value: 2 }
+


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch/issues/135625.

As it turns out, `exists` is already supported via the doc-values based default implementation in `MappedFieldType` and also already unit test through the `MapperTestCase`.

This PR adds corresponding yaml rest tests, also verifying the compatibility with mixed data.
There is no test node feature check required here, as the modified yamls already have a check on the availability of the `exponential_histogram` type in general and exists was already supported from the start.