### PR TITLE
Fix ClassCastException when merging TopHits with mixed sort field types

### DIFF
--- a/docs/changelog/141919.yaml
+++ b/docs/changelog/141919.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 141714
+pr: 141919
+summary: Fix `ClassCastException` when merging `TopHits` with mixed sort field types
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -64,6 +64,21 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
         this.rawSortValues = rawSortValues;
     }
 
+    /**
+     * Build sort values from pre-formatted and raw arrays. Use this when the formatted values
+     * were produced with the correct per-field format (e.g. from a shard hit) and must not be
+     * re-formatted with a single format like RAW, which would fail for non-UTF-8 BytesRefs
+     * (e.g. version field).
+     */
+    public static SearchSortValues fromFormattedAndRaw(Object[] formattedSortValues, Object[] rawSortValues) {
+        Objects.requireNonNull(formattedSortValues);
+        Objects.requireNonNull(rawSortValues);
+        if (formattedSortValues.length != rawSortValues.length) {
+            throw new IllegalArgumentException("formattedSortValues and rawSortValues must have the same length");
+        }
+        return new SearchSortValues(formattedSortValues, rawSortValues);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(Lucene::writeSortValue, this.formattedSortValues);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.sort.SortFieldValidation;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -131,7 +132,19 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
                     shardDocs = new TopFieldDocs[aggregations.size()];
                     maxScore = reduceAndFindMaxScore(aggregations, shardDocs);
                     Sort sort = SortFieldValidation.validateAndMaybeRewrite(Arrays.asList(shardDocs), topFieldDocs.fields);
-                    reducedTopDocs = TopDocs.merge(sort, from, size, (TopFieldDocs[]) shardDocs);
+                    try {
+                        reducedTopDocs = TopDocs.merge(sort, from, size, (TopFieldDocs[]) shardDocs);
+                    } catch (ClassCastException e) {
+                        // This can happen during upgrades when sort field types are incompatible across shards
+                        // even after validation. Wrap in a more descriptive error message.
+                        throw new IllegalArgumentException(
+                            "Failed to merge top_hits aggregation results from different shards due to incompatible "
+                                + "sort field types. This can occur during upgrades when field mappings differ across shards. "
+                                + "Original error: "
+                                + e.getMessage(),
+                            e
+                        );
+                    }
                 } else {
                     shardDocs = new TopDocs[aggregations.size()];
                     maxScore = reduceAndFindMaxScore(aggregations, shardDocs);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -10,11 +10,11 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits.Relation;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
@@ -191,10 +191,7 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
                     // Preserve the shard's formatted values for BytesRef fields (e.g. version, keyword)
                     // so we don't format them with RAW, which assumes UTF-8 and fails on version encoding.
                     hit.sortValues(
-                        SearchSortValues.fromFormattedAndRaw(
-                            buildFormattedSortValues(fieldDoc.fields, existingFormatted),
-                            fieldDoc.fields
-                        )
+                        SearchSortValues.fromFormattedAndRaw(buildFormattedSortValues(fieldDoc.fields, existingFormatted), fieldDoc.fields)
                     );
                 } else {
                     DocValueFormat[] formats = new DocValueFormat[fieldDoc.fields.length];

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
@@ -22,6 +23,7 @@ import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchSortValues;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -135,12 +137,12 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
                     try {
                         reducedTopDocs = TopDocs.merge(sort, from, size, (TopFieldDocs[]) shardDocs);
                     } catch (ClassCastException e) {
-                        // This can happen during upgrades when sort field types are incompatible across shards
-                        // even after validation. Wrap in a more descriptive error message.
+                        // This can happen when sort field types are incompatible across shards even after validation,
+                        // e.g. during upgrades or when aggregating across indices with different field mappings.
                         throw new IllegalArgumentException(
                             "Failed to merge top_hits aggregation results from different shards due to incompatible "
-                                + "sort field types. This can occur during upgrades when field mappings differ across shards. "
-                                + "Original error: "
+                                + "sort field types. This can occur during upgrades or when aggregating across indices "
+                                + "whose field mappings differ. Original error: "
                                 + e.getMessage(),
                             e
                         );
@@ -183,14 +185,43 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
             } while (topDocsForShard.scoreDocs[position] != scoreDoc);
             SearchHit hit = aggregations.get(shardIndex).searchHits.getAt(position);
             if (scoreDoc instanceof FieldDoc fieldDoc && fieldDoc.fields != null && fieldDoc.fields.length > 0) {
-                DocValueFormat[] formats = new DocValueFormat[fieldDoc.fields.length];
-                Arrays.fill(formats, DocValueFormat.RAW);
-                hit.sortValues(fieldDoc.fields, formats);
+                Object[] existingFormatted = hit.getSortValues();
+                boolean hasBytesRef = Arrays.stream(fieldDoc.fields).anyMatch(f -> f instanceof BytesRef);
+                if (hasBytesRef && existingFormatted != null && existingFormatted.length == fieldDoc.fields.length) {
+                    // Preserve the shard's formatted values for BytesRef fields (e.g. version, keyword)
+                    // so we don't format them with RAW, which assumes UTF-8 and fails on version encoding.
+                    hit.sortValues(
+                        SearchSortValues.fromFormattedAndRaw(
+                            buildFormattedSortValues(fieldDoc.fields, existingFormatted),
+                            fieldDoc.fields
+                        )
+                    );
+                } else {
+                    DocValueFormat[] formats = new DocValueFormat[fieldDoc.fields.length];
+                    Arrays.fill(formats, DocValueFormat.RAW);
+                    hit.sortValues(fieldDoc.fields, formats);
+                }
             }
             hits[i] = hit;
             assert hits[i].isPooled() == false;
         }
         return SearchHits.unpooled(hits, reducedTopDocs.totalHits, maxScore);
+    }
+
+    /**
+     * Build formatted sort values: use existing formatted value for BytesRef (e.g. version) fields
+     * to avoid re-formatting with RAW (UTF-8), and use RAW for numeric types.
+     */
+    private static Object[] buildFormattedSortValues(Object[] rawValues, Object[] existingFormatted) {
+        Object[] formatted = new Object[rawValues.length];
+        for (int i = 0; i < rawValues.length; i++) {
+            if (rawValues[i] instanceof BytesRef && existingFormatted != null && i < existingFormatted.length) {
+                formatted[i] = existingFormatted[i];
+            } else {
+                formatted[i] = DocValueFormat.RAW.formatSortValue(rawValues[i]);
+            }
+        }
+        return formatted;
     }
 
     private static float reduceAndFindMaxScore(List<InternalTopHits> aggregations, TopDocs[] shardDocs) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -19,9 +19,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.sort.SortFieldValidation;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -181,7 +181,13 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
             do {
                 position = tracker[shardIndex]++;
             } while (topDocsForShard.scoreDocs[position] != scoreDoc);
-            hits[i] = aggregations.get(shardIndex).searchHits.getAt(position);
+            SearchHit hit = aggregations.get(shardIndex).searchHits.getAt(position);
+            if (scoreDoc instanceof FieldDoc fieldDoc && fieldDoc.fields != null && fieldDoc.fields.length > 0) {
+                DocValueFormat[] formats = new DocValueFormat[fieldDoc.fields.length];
+                Arrays.fill(formats, DocValueFormat.RAW);
+                hit.sortValues(fieldDoc.fields, formats);
+            }
+            hits[i] = hit;
             assert hits[i].isPooled() == false;
         }
         return SearchHits.unpooled(hits, reducedTopDocs.totalHits, maxScore);

--- a/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
@@ -39,6 +39,9 @@ public final class SortFieldValidation {
         SortField.Type[] firstTypes = null;
         boolean isFirstResult = true;
         Set<Integer> fieldIdsWithMixedIntAndLongSorts = new HashSet<>();
+        Set<Integer> fieldIdsWithMixedNumericSorts = new HashSet<>();
+        // Track which fields have floating point types to determine if we need DOUBLE conversion
+        Set<Integer> fieldIdsWithFloatingPointTypes = new HashSet<>();
         for (TopDocs topDocs : results) {
             // We don't actually merge in empty score docs, so ignore potentially mismatched types if there are no docs
             if (topDocs == null || topDocs.scoreDocs == null || topDocs.scoreDocs.length == 0) {
@@ -54,6 +57,10 @@ public final class SortFieldValidation {
                         // for custom types that we can't resolve, we can't do the check
                         return sort;
                     }
+                    // Track if this field has floating point types
+                    if (firstTypes[i] == SortField.Type.FLOAT || firstTypes[i] == SortField.Type.DOUBLE) {
+                        fieldIdsWithFloatingPointTypes.add(i);
+                    }
                 }
                 isFirstResult = false;
             } else {
@@ -64,8 +71,22 @@ public final class SortFieldValidation {
                             // for custom types that we can't resolve, we can't do the check
                             return sort;
                         }
+                        // Track if this field has floating point types
+                        if (curType == SortField.Type.FLOAT || curType == SortField.Type.DOUBLE) {
+                            fieldIdsWithFloatingPointTypes.add(i);
+                        }
+                        // Check if we are mixing INT and LONG sort types (without floating point)
                         if (mixIntAndLong(firstTypes[i], curType)) {
-                            fieldIdsWithMixedIntAndLongSorts.add(i);
+                            // Only add to INT/LONG mixing if there's no floating point type for this field
+                            if (fieldIdsWithFloatingPointTypes.contains(i) == false) {
+                                fieldIdsWithMixedIntAndLongSorts.add(i);
+                            } else {
+                                // If floating point exists, convert everything to DOUBLE
+                                fieldIdsWithMixedNumericSorts.add(i);
+                            }
+                        } else if (isNumericType(firstTypes[i]) && isNumericType(curType)) {
+                            // Mixing numeric types (FLOAT/LONG/DOUBLE) - convert to DOUBLE
+                            fieldIdsWithMixedNumericSorts.add(i);
                         } else {
                             throw new IllegalArgumentException(
                                 "Can't sort on field ["
@@ -81,8 +102,13 @@ public final class SortFieldValidation {
                 }
             }
         }
+        // Remove fields from INT/LONG mixing if they also need DOUBLE conversion
+        fieldIdsWithMixedIntAndLongSorts.removeAll(fieldIdsWithMixedNumericSorts);
         if (fieldIdsWithMixedIntAndLongSorts.isEmpty() == false) {
             sort = rewriteSortAndResultsToLong(sort, results, fieldIdsWithMixedIntAndLongSorts);
+        }
+        if (fieldIdsWithMixedNumericSorts.isEmpty() == false) {
+            sort = rewriteSortAndResultsToDouble(sort, results, fieldIdsWithMixedNumericSorts);
         }
         return sort;
     }
@@ -120,6 +146,48 @@ public final class SortFieldValidation {
             }
         }
         return new Sort(newSortFields);
+    }
+
+    /**
+     * Rewrite Sort objects and shard results for double sort for mixed numeric fields:
+     * convert Sort to Double sort and convert fields' values to Double values.
+     * This handles FLOAT/LONG/DOUBLE mixing by converting all to DOUBLE.
+     */
+    private static Sort rewriteSortAndResultsToDouble(
+        Sort sort,
+        Collection<? extends TopDocs> results,
+        Set<Integer> fieldIdsWithMixedNumericSorts
+    ) {
+        SortField[] newSortFields = sort.getSort();
+        for (int fieldIdx : fieldIdsWithMixedNumericSorts) {
+            // Rewrite the sort field to DOUBLE
+            SortField originalField = newSortFields[fieldIdx];
+            SortField doubleField = new SortField(originalField.getField(), SortField.Type.DOUBLE, originalField.getReverse());
+            doubleField.setMissingValue(originalField.getMissingValue());
+            newSortFields[fieldIdx] = doubleField;
+
+            // Convert all sort values to Double
+            for (TopDocs topDocs : results) {
+                if (topDocs == null || topDocs.scoreDocs == null || topDocs.scoreDocs.length == 0) {
+                    continue;
+                }
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    FieldDoc fieldDoc = (FieldDoc) scoreDoc;
+                    Object value = fieldDoc.fields[fieldIdx];
+                    if (value != null && value instanceof Number) {
+                        fieldDoc.fields[fieldIdx] = ((Number) value).doubleValue();
+                    }
+                }
+            }
+        }
+        return new Sort(newSortFields);
+    }
+
+    private static boolean isNumericType(SortField.Type type) {
+        return type == SortField.Type.INT
+            || type == SortField.Type.LONG
+            || type == SortField.Type.FLOAT
+            || type == SortField.Type.DOUBLE;
     }
 
     private static SortField.Type getType(SortField sortField) {

--- a/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
@@ -84,20 +84,22 @@ public final class SortFieldValidation {
                                 // If floating point exists, convert everything to DOUBLE
                                 fieldIdsWithMixedNumericSorts.add(i);
                             }
-                        } else if (isNumericType(firstTypes[i]) && isNumericType(curType)) {
-                            // Mixing numeric types (FLOAT/LONG/DOUBLE) - convert to DOUBLE
-                            fieldIdsWithMixedNumericSorts.add(i);
-                        } else {
-                            throw new IllegalArgumentException(
-                                "Can't sort on field ["
-                                    + curSortFields[i].getField()
-                                    + "]; the field has incompatible sort types: ["
-                                    + firstTypes[i]
-                                    + "] and ["
-                                    + curType
-                                    + "] across shards!"
-                            );
-                        }
+                        } else if (isNumericType(firstTypes[i])
+                            && isNumericType(curType)
+                            && involvesFloatingPoint(firstTypes[i], curType)) {
+                                // Only convert to DOUBLE when the mix involves FLOAT or DOUBLE (never pure INT/LONG).
+                                fieldIdsWithMixedNumericSorts.add(i);
+                            } else {
+                                throw new IllegalArgumentException(
+                                    "Can't sort on field ["
+                                        + curSortFields[i].getField()
+                                        + "]; the field has incompatible sort types: ["
+                                        + firstTypes[i]
+                                        + "] and ["
+                                        + curType
+                                        + "] across shards!"
+                                );
+                            }
                     }
                 }
             }
@@ -105,6 +107,12 @@ public final class SortFieldValidation {
         // Remove fields from INT/LONG mixing if they also need DOUBLE conversion
         fieldIdsWithMixedIntAndLongSorts.removeAll(fieldIdsWithMixedNumericSorts);
         if (fieldIdsWithMixedIntAndLongSorts.isEmpty() == false) {
+            // Ensure INT/LONG-only fields are rewritten to LONG, never to DOUBLE
+            for (int fieldIdx : fieldIdsWithMixedIntAndLongSorts) {
+                SortField.Type type = firstTypes[fieldIdx];
+                assert type == SortField.Type.INT || type == SortField.Type.LONG
+                    : "INT/LONG mix must be rewritten to LONG, not DOUBLE; field " + fieldIdx + " had type " + type;
+            }
             sort = rewriteSortAndResultsToLong(sort, results, fieldIdsWithMixedIntAndLongSorts);
         }
         if (fieldIdsWithMixedNumericSorts.isEmpty() == false) {
@@ -116,6 +124,14 @@ public final class SortFieldValidation {
     private static boolean mixIntAndLong(SortField.Type firstType, SortField.Type currentType) {
         return (firstType == SortField.Type.INT && currentType == SortField.Type.LONG)
             || (firstType == SortField.Type.LONG && currentType == SortField.Type.INT);
+    }
+
+    /**
+     * True when at least one type is FLOAT or DOUBLE. Used to ensure we only add to the
+     * DOUBLE-rewrite set when the mix involves floating point, never for pure INT/LONG.
+     */
+    private static boolean involvesFloatingPoint(SortField.Type a, SortField.Type b) {
+        return (a == SortField.Type.FLOAT || a == SortField.Type.DOUBLE) || (b == SortField.Type.FLOAT || b == SortField.Type.DOUBLE);
     }
 
     /**
@@ -184,10 +200,7 @@ public final class SortFieldValidation {
     }
 
     private static boolean isNumericType(SortField.Type type) {
-        return type == SortField.Type.INT
-            || type == SortField.Type.LONG
-            || type == SortField.Type.FLOAT
-            || type == SortField.Type.DOUBLE;
+        return type == SortField.Type.INT || type == SortField.Type.LONG || type == SortField.Type.FLOAT || type == SortField.Type.DOUBLE;
     }
 
     private static SortField.Type getType(SortField sortField) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.ESTestCase;
@@ -59,7 +60,10 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTopHits> {
@@ -278,6 +282,56 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         hits = SearchHits.unpooled(new SearchHit[] { hit, hit }, null, 0);
         InternalTopHits internalTopHits3 = new InternalTopHits("test", 0, 0, null, hits, null);
         expectThrows(IllegalArgumentException.class, () -> internalTopHits3.getProperty(List.of("foo")));
+    }
+
+    public void testReduceWithMixedSortFieldTypes() {
+        AggregationBuilder builder = mock(AggregationBuilder.class);
+        AggregationReduceContext reduceContext = InternalAggregationTestCase.mockReduceContext(builder).forFinalReduction();
+
+        // Test FLOAT/LONG mixing - should convert to DOUBLE and merge successfully without ClassCastException
+        // Before the fix, this would throw ClassCastException when merging TopDocs.
+        InternalTopHits floatShard = createTopHitsWithSortType("test", SortField.Type.FLOAT, 1.5f, 0);
+        InternalTopHits longShard = createTopHitsWithSortType("test", SortField.Type.LONG, 2L, 1);
+        // This should not throw ClassCastException - the fix converts incompatible types
+        InternalTopHits reduced = (InternalTopHits) InternalAggregationTestCase.reduce(List.of(floatShard, longShard), reduceContext);
+        assertNotNull("Reduced result should not be null", reduced);
+        // Each shard has size=1, so merged result should have at least 1 hit (the top one)
+        assertThat("Should have at least one merged result", reduced.getHits().getHits().length, greaterThanOrEqualTo(1));
+
+        // Test INT/LONG mixing - should convert to LONG and merge successfully
+        InternalTopHits intShard = createTopHitsWithSortType("test", SortField.Type.INT, 1, 0);
+        InternalTopHits longShard2 = createTopHitsWithSortType("test", SortField.Type.LONG, 2L, 1);
+        InternalTopHits reduced2 = (InternalTopHits) InternalAggregationTestCase.reduce(List.of(intShard, longShard2), reduceContext);
+        assertNotNull("Reduced result should not be null", reduced2);
+        assertThat("Should have at least one merged result", reduced2.getHits().getHits().length, greaterThanOrEqualTo(1));
+
+        // Test incompatible types - should throw IllegalArgumentException with clear error message
+        InternalTopHits stringShard = createTopHitsWithSortType("test", SortField.Type.STRING, new BytesRef("a"), 0);
+        InternalTopHits longShard3 = createTopHitsWithSortType("test", SortField.Type.LONG, 1L, 1);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> InternalAggregationTestCase.reduce(List.of(stringShard, longShard3), reduceContext)
+        );
+        assertThat(e.getMessage(), containsString("incompatible sort types"));
+    }
+
+    private InternalTopHits createTopHitsWithSortType(String name, SortField.Type type, Object sortValue, int shardIndex) {
+        SortField sortField = new SortField("field", type);
+        FieldDoc fieldDoc = new FieldDoc(0, 1.0f, new Object[] { sortValue });
+        TopFieldDocs topFieldDocs = new TopFieldDocs(
+            new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+            new FieldDoc[] { fieldDoc },
+            new SortField[] { sortField }
+        );
+        fieldDoc.shardIndex = shardIndex;
+
+        SearchHit hit = SearchHit.unpooled(0, "doc" + shardIndex);
+        hit.score(1.0f);
+        hit.sortValues(new Object[] { sortValue }, new DocValueFormat[] { DocValueFormat.RAW });
+        SearchHits searchHits = SearchHits.unpooled(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+
+        TopDocsAndMaxScore topDocsAndMaxScore = new TopDocsAndMaxScore(topFieldDocs, 1.0f);
+        return new InternalTopHits(name, 0, 1, topDocsAndMaxScore, searchHits, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -63,6 +63,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
@@ -298,12 +299,15 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         // Each shard has size=1, so merged result should have at least 1 hit (the top one)
         assertThat("Should have at least one merged result", reduced.getHits().getHits().length, greaterThanOrEqualTo(1));
 
-        // Test INT/LONG mixing - should convert to LONG and merge successfully
+        // Test INT/LONG mixing - should convert to LONG (not DOUBLE) and merge successfully
         InternalTopHits intShard = createTopHitsWithSortType("test", SortField.Type.INT, 1, 0);
         InternalTopHits longShard2 = createTopHitsWithSortType("test", SortField.Type.LONG, 2L, 1);
         InternalTopHits reduced2 = (InternalTopHits) InternalAggregationTestCase.reduce(List.of(intShard, longShard2), reduceContext);
         assertNotNull("Reduced result should not be null", reduced2);
         assertThat("Should have at least one merged result", reduced2.getHits().getHits().length, greaterThanOrEqualTo(1));
+        // Ensure INT/LONG mix was rewritten to LONG, not DOUBLE
+        Object sortValue = reduced2.getHits().getHits()[0].getSortValues()[0];
+        assertThat("Sort value after INT/LONG reduce should be Long, not Double", sortValue, instanceOf(Long.class));
 
         // Test incompatible types - should throw IllegalArgumentException with clear error message
         InternalTopHits stringShard = createTopHitsWithSortType("test", SortField.Type.STRING, new BytesRef("a"), 0);


### PR DESCRIPTION
Prevents ClassCastException when merging TopDocs from different shards with incompatible sort field types (e.g., Float vs Long). Handles type mixing by converting INT/LONG to LONG and FLOAT/LONG/DOUBLE to DOUBLE.

Closes https://github.com/elastic/elasticsearch/issues/141714