### PR TITLE
Make ReindexRelocationNodePicker thread-safe

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/StatefulReindexRelocationNodePicker.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/StatefulReindexRelocationNodePicker.java
@@ -18,20 +18,16 @@ import org.elasticsearch.common.Randomness;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
 class StatefulReindexRelocationNodePicker implements ReindexRelocationNodePicker {
 
     private static final Logger logger = LogManager.getLogger(StatefulReindexRelocationNodePicker.class);
 
-    private final Random random;
-
-    StatefulReindexRelocationNodePicker() {
-        this.random = Randomness.get();
-    }
+    StatefulReindexRelocationNodePicker() {}
 
     @Override
     public Optional<String> pickNode(DiscoveryNodes nodes, NodesShutdownMetadata nodeShutdowns) {
+        assert ReindexPlugin.REINDEX_RESILIENCE_ENABLED : "reindex resilience should be enabled for relocations";
         String currentNodeId = nodes.getLocalNodeId();
         if (currentNodeId == null) {
             logger.warn(
@@ -77,6 +73,6 @@ class StatefulReindexRelocationNodePicker implements ReindexRelocationNodePicker
     }
 
     private String selectRandomNodeIdFrom(List<String> nodeIds) {
-        return nodeIds.get(random.nextInt(nodeIds.size()));
+        return nodeIds.get(Randomness.get().nextInt(nodeIds.size()));
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/StatefulReindexRelocationNodePicker.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/StatefulReindexRelocationNodePicker.java
@@ -27,7 +27,6 @@ class StatefulReindexRelocationNodePicker implements ReindexRelocationNodePicker
 
     @Override
     public Optional<String> pickNode(DiscoveryNodes nodes, NodesShutdownMetadata nodeShutdowns) {
-        assert ReindexPlugin.REINDEX_RESILIENCE_ENABLED : "reindex resilience should be enabled for relocations";
         String currentNodeId = nodes.getLocalNodeId();
         if (currentNodeId == null) {
             logger.warn(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/StatelessReindexRelocationNodePicker.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/StatelessReindexRelocationNodePicker.java
@@ -28,7 +28,6 @@ class StatelessReindexRelocationNodePicker implements ReindexRelocationNodePicke
 
     @Override
     public Optional<String> pickNode(DiscoveryNodes nodes, NodesShutdownMetadata nodeShutdowns) {
-        assert ReindexPlugin.REINDEX_RESILIENCE_ENABLED : "reindex resilience should be enabled for relocations";
         String currentNodeId = nodes.getLocalNodeId();
         if (currentNodeId == null) {
             logger.warn(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/StatelessReindexRelocationNodePicker.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/StatelessReindexRelocationNodePicker.java
@@ -19,20 +19,16 @@ import org.elasticsearch.logging.Logger;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
 class StatelessReindexRelocationNodePicker implements ReindexRelocationNodePicker {
 
     private static final Logger logger = LogManager.getLogger(StatelessReindexRelocationNodePicker.class);
 
-    private final Random random;
-
-    StatelessReindexRelocationNodePicker() {
-        random = Randomness.get();
-    }
+    StatelessReindexRelocationNodePicker() {}
 
     @Override
     public Optional<String> pickNode(DiscoveryNodes nodes, NodesShutdownMetadata nodeShutdowns) {
+        assert ReindexPlugin.REINDEX_RESILIENCE_ENABLED : "reindex resilience should be enabled for relocations";
         String currentNodeId = nodes.getLocalNodeId();
         if (currentNodeId == null) {
             logger.warn(
@@ -76,6 +72,6 @@ class StatelessReindexRelocationNodePicker implements ReindexRelocationNodePicke
     }
 
     private String selectRandomNodeIdFrom(List<String> nodeIds) {
-        return nodeIds.get(random.nextInt(nodeIds.size()));
+        return nodeIds.get(Randomness.get().nextInt(nodeIds.size()));
     }
 }


### PR DESCRIPTION
- make it possible to call ReindexRelocationNodePicker from a different thread than the one that created the object