### PR TITLE
[9.1] Fix cluster name in ECS upgrade (#141792)

### DIFF
--- a/docs/changelog/141792.yaml
+++ b/docs/changelog/141792.yaml
@@ -1,0 +1,5 @@
+area: Infra/Logging
+issues: []
+pr: 141792
+summary: Fix cluster name in ECS upgrade
+type: bug

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLogsTestSetup.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLogsTestSetup.java
@@ -13,6 +13,7 @@ public class JsonLogsTestSetup {
 
     public static void init() {
         if (initialized == false) {
+            LogConfigurator.setClusterName("elasticsearch");
             LogConfigurator.setNodeName("sample-name");
             initialized = true;
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -21,6 +21,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ReleaseVersions;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.logging.LogConfigurator;
@@ -146,6 +147,7 @@ class Elasticsearch {
 
             // DO NOT MOVE THIS
             // Logging must remain the last step of phase 1. Anything init steps needing logging should be in phase 2.
+            LogConfigurator.setClusterName(ClusterName.CLUSTER_NAME_SETTING.get(args.nodeSettings()).value());
             LogConfigurator.setNodeName(Node.NODE_NAME_SETTING.get(args.nodeSettings()));
             LogConfigurator.configure(nodeEnv, args.quiet() == false);
         } catch (Throwable t) {

--- a/server/src/main/java/org/elasticsearch/common/logging/ClusterNamePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ClusterNamePatternConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+import org.apache.lucene.util.SetOnce;
+
+import java.util.Arrays;
+
+/**
+ * Converts {@code %cluster_name} in log4j patterns into the current cluster name.
+ */
+@Plugin(category = PatternConverter.CATEGORY, name = "ClusterNamePatternConverter")
+@ConverterKeys({ "EScluster_name", "cluster_name" })
+public final class ClusterNamePatternConverter extends LogEventPatternConverter {
+    /**
+     * The name of this cluster.
+     */
+    private static final SetOnce<String> CLUSTER_NAME = new SetOnce<>();
+
+    /**
+     * Set the name of this cluster.
+     */
+    static void setClusterName(String clusterName) {
+        CLUSTER_NAME.set(clusterName);
+    }
+
+    /**
+     * Called by log4j2 to initialize this converter.
+     */
+    public static ClusterNamePatternConverter newInstance(final String[] options) {
+        if (options.length > 0) {
+            throw new IllegalArgumentException("no options supported but options provided: " + Arrays.toString(options));
+        }
+        String clusterName = CLUSTER_NAME.get();
+        if (clusterName == null) {
+            throw new IllegalStateException("the cluster name hasn't been set");
+        }
+        return new ClusterNamePatternConverter(clusterName);
+    }
+
+    private final String clusterName;
+
+    private ClusterNamePatternConverter(String clusterName) {
+        super("ClusterName", "cluster_name");
+        this.clusterName = clusterName;
+    }
+
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        toAppendTo.append(clusterName);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
@@ -62,7 +62,7 @@ public class ECSJsonLayout {
                 new KeyValuePair("elasticsearch.cluster.uuid", "%cluster_id"),
                 new KeyValuePair("elasticsearch.node.id", "%node_id"),
                 new KeyValuePair("elasticsearch.node.name", "%ESnode_name"),
-                new KeyValuePair("elasticsearch.cluster.name", "${sys:es.logs.cluster_name}"), };
+                new KeyValuePair("elasticsearch.cluster.name", "%EScluster_name"), };
         }
 
         public String getDataset() {

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -158,6 +158,13 @@ public class LogConfigurator {
     }
 
     /**
+     * Sets the cluster name. This is called before logging is configured.
+     */
+    public static void setClusterName(String clusterName) {
+        ClusterNamePatternConverter.setClusterName(clusterName);
+    }
+
+    /**
      * Sets the node name. This is called before logging is configured if the
      * node name is set in elasticsearch.yml. Otherwise it is called as soon
      * as the node id is available.


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix cluster name in ECS upgrade (#141792)