### PR TITLE
Lower partial aggregation emit unique threshold

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
@@ -89,7 +89,7 @@ public class PlannerSettings {
      */
     public static final Setting<Double> PARTIAL_AGGREGATION_EMIT_UNIQUENESS_THRESHOLD = Setting.doubleSetting(
         "esql.partial_agg_emit_unique_threshold",
-        0.5,
+        0.1,
         0.0,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic


### PR DESCRIPTION
During an investigation into the performance of queries with a high number of grouping keys, I found that partial aggregation results were not being emitted incrementally as frequently as expected. The reason is the partial aggregation emission uniqueness threshold being set too high at 50%. This change adjusts the threshold down to 10%, which provides a better balance between keeping the hash tables performant, reducing memory usage, enabling incremental final work, and ensuring we don't emit the same keys multiple times, given this setting is used in combination with the 100K grouping limit.