### PR TITLE
Clarify documentation for `json` ingest processor

### DIFF
--- a/docs/reference/enrich-processor/index.md
+++ b/docs/reference/enrich-processor/index.md
@@ -199,7 +199,7 @@ Refer to [Enrich your data](docs-content://manage-data/ingest/transform-enrich/d
 :   Runs an ingest processor on each element of an array or object.
 
 [`json` processor](/reference/enrich-processor/json-processor.md)
-:   Converts a JSON string into a structured JSON object.
+:   Parses a string containing JSON data into a structured object, string, or other value.
 
 [`script` processor](/reference/enrich-processor/script-processor.md)
 :   Runs an inline or stored [script](docs-content://explore-analyze/scripting.md) on incoming documents. The script runs in the [painless `ingest` context](/reference/scripting-languages/painless/painless-ingest-processor-context.md).

--- a/docs/reference/enrich-processor/json-processor.md
+++ b/docs/reference/enrich-processor/json-processor.md
@@ -7,14 +7,14 @@ mapped_pages:
 # JSON processor [json-processor]
 
 
-Converts a JSON string into a structured JSON object.
+Parses a string containing JSON data into a structured object, string, or other value.
 
 $$$json-options$$$
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
 | `field` | yes | - | The field to be parsed. |
-| `target_field` | no | `field` | The field that the converted structured object will be written into. Any existing content in this field will be overwritten. |
+| `target_field` | no | `field` | The field that the converted value will be written into. Any existing content in this field will be overwritten. |
 | `add_to_root` | no | false | Flag that forces the parsed JSON to be added at the top level of the document. `target_field` must not be set when this option is chosen. |
 | `add_to_root_conflict_strategy` | no | `replace` | When set to `replace`, root fields that conflict with fields from the parsed JSON will be overridden. When set to `merge`, conflicting fields will be merged. Only applicable if `add_to_root` is set to `true`. |
 | `allow_duplicate_keys` | no | false | When set to `true`, the JSON parser will not fail if the JSON contains duplicate keys. Instead, the last encountered value for any duplicate key wins. |
@@ -93,3 +93,42 @@ it will look like:
 
 This illustrates that, unless it is explicitly named in the processor configuration, the `target_field` is the same field provided in the required `field` configuration.
 
+If the input is the representation of a JSON string (which must be enclosed in double quotes) then the target field will be set to the string value. For example, if the processor above operates on this document:
+
+```js
+{
+  "string_source": "\"some text\""
+}
+```
+% NOTCONSOLE
+
+it will produce this document:
+
+```js
+{
+  "string_source" : "\"some text\"",
+  "json_target" : "some text"
+}
+```
+
+:::{note}
+In all these examples, we are showing JSON representations of the document. So, in the last example, the `string_source` field is a string with the contents `"some text"`, and is shown with the double quotes escaped. The `json_target` field is a string with the contents `some text`.
+:::
+
+If the input is the JSON representation of a number then the target field will be set to that number. For example, if the processor above operates on this document:
+
+```js
+{
+  "string_source": "999"
+}
+```
+% NOTCONSOLE
+
+it will produce this document:
+
+```js
+{
+  "string_source" : "999",
+  "json_target" : 999
+}
+```

--- a/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
@@ -137,7 +137,7 @@ You can then add this object to the document through the context object:
 
 ```painless
 Object json = Processors.json(ctx.inputJsonString);
-ctx.structuredJson = json;
+ctx.parsedJson = json;
 ```
 
 

--- a/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
@@ -93,14 +93,45 @@ String uppercase(String value);
 
 ### JSON parsing [_json_parsing]
 
-Use the [JSON processor](/reference/enrich-processor/json-processor.md) to convert JSON strings to structured JSON objects. The first `json` method accepts a map and a key. The processor converts the JSON string in the map as specified by the `key` parameter to structured JSON content. That content is added directly to the `map` object.
-
-The second `json` method accepts a JSON string in the `value` parameter and returns a structured JSON object.
+Use the [JSON processor](/reference/enrich-processor/json-processor.md) to parse a string containing JSON data into a structured object, string, or other value. There are two `json` methods:
 
 ```painless
 void json(Map<String, Object> map, String key);
 Object json(Object value);
 ```
+
+The first `json` method accepts a map and a key. The processor parses the JSON string in the given map at the given key to a structured object. The entries in that object are added directly to the given map.
+
+For example, if the input document looks like this:
+
+```js
+{
+  "foo": {
+    "inputJsonString": "{\"bar\": 999}"
+  }
+}
+```
+% NOTCONSOLE
+
+then executing this script:
+
+```painless
+Processors.json(ctx.foo, 'inputJsonString')
+```
+
+will result in this document:
+
+```js
+{
+  "foo": {
+    "inputJsonString": "{\"bar\": 999}",
+    "bar" : 999
+  }
+}
+```
+% NOTCONSOLE
+
+The second `json` method accepts a JSON string in the `value` parameter and returns a structured object or other value.
 
 You can then add this object to the document through the context object:
 

--- a/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
@@ -116,7 +116,7 @@ For example, if the input document looks like this:
 then executing this script:
 
 ```painless
-Processors.json(ctx.foo, 'inputJsonString')
+Processors.json(ctx.foo, 'inputJsonString');
 ```
 
 will result in this document:

--- a/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
@@ -136,8 +136,7 @@ The second `json` method accepts a JSON string in the `value` parameter and retu
 You can then add this object to the document through the context object:
 
 ```painless
-Object json = Processors.json(ctx.inputJsonString);
-ctx.parsedJson = json;
+ctx.parsedJson = Processors.json(ctx.inputJsonString);
 ```
 
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
@@ -53,34 +53,32 @@ public final class Processors {
     }
 
     /**
-     * Uses {@link JsonProcessor} to convert a JSON string to a structured JSON
-     * object.
+     * Uses {@link JsonProcessor} to parse a string containing JSON data to a structured object or other value.
      *
-     * @param fieldValue JSON string
-     * @return structured JSON object
+     * @param fieldValue JSON data
+     * @return parsed JSON value
      */
     public static Object json(Object fieldValue) {
         return JsonProcessor.apply(fieldValue, false, true);
     }
 
     /**
-     * Uses {@link JsonProcessor} to convert a JSON string to a structured JSON
-     * object. This method is a more lenient version of {@link #json(Object)}. For example if given fieldValue "123 foo",
+     * Uses {@link JsonProcessor} to parse a string containing JSON data to a structured object or other value.
+     * This method is a more lenient version of {@link #json(Object)}. For example if given fieldValue "123 foo",
      * this method will return 123 rather than throwing an IllegalArgumentException.
      *
-     * @param fieldValue JSON string
-     * @return structured JSON object
+     * @param fieldValue JSON data
+     * @return parsed JSON value
      */
     public static Object jsonLenient(Object fieldValue) {
         return JsonProcessor.apply(fieldValue, false, false);
     }
 
     /**
-     * Uses {@link JsonProcessor} to convert a JSON string to a structured JSON
-     * object.
+     * Uses {@link JsonProcessor} to parse a string containing JSON data to a structured object.
      *
      * @param map map that contains the JSON string and will receive the
-     *            structured JSON content
+     *            structured content
      * @param field key that identifies the entry in <code>map</code> that
      *             contains the JSON string
      */
@@ -89,10 +87,10 @@ public final class Processors {
     }
 
     /**
-     * Uses {@link JsonProcessor} to convert a JSON string to a structured JSON
-     * object. This method is a more lenient version of {@link #json(Map, String)}. For example if given fieldValue
+     * Uses {@link JsonProcessor} to parse a JSON string to a structured object.
+     * This method is a more lenient version of {@link #json(Map, String)}. For example if given fieldValue
      * "{"foo":"bar"} 123",
-     * this method will return a map with key-vale pair "foo" and "bar" rather than throwing an IllegalArgumentException.
+     * this method will return a map with key-value pair "foo" and "bar" rather than throwing an IllegalArgumentException.
      *
      * @param map map that contains the JSON string and will receive the
      *            structured JSON content


### PR DESCRIPTION
Previously, we said in a number of places that it produces a JSON *object*, when in could, in fact, produce a string or other value.

Note that, in the long-form documentation, we do actually say "All JSON-supported types will be parsed (null, boolean, number, array, object, string)". It's just the headlines which were somewhat misleading.

This clarifies the headlines, and also provides more examples in some places.

This also changes from the word "convert" to the word "parse", which is a more precise description of what the processor does.

The javadoc in the `Processors` class is also clarified.