### PR TITLE
[9.3] Allow include_source_on_error param on logs streams (#141391)

### DIFF
--- a/docs/changelog/141391.yaml
+++ b/docs/changelog/141391.yaml
@@ -1,0 +1,6 @@
+pr: 141391
+summary: Allow `include_source_on_error` param on logs streams
+area: Data streams
+type: bug
+issues:
+ - 141360

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -78,6 +78,7 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
             add("refresh");
             add("require_data_stream");
             add("timeout");
+            add("include_source_on_error");
             // Add internal marker params
             addAll(INTERNAL_MARKER_REQUEST_PARAMETERS);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Allow include_source_on_error param on logs streams (#141391)](https://github.com/elastic/elasticsearch/pull/141391)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)