### PR TITLE
Add start and end time to new tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
@@ -71,6 +71,9 @@ can't shadow dimensions:
               mode: time_series
               # we use a different routing dimension to ensure that we test the shadowing logic
               routing_path: [routing_dim]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
           mappings:
             properties:
               "@timestamp":
@@ -137,6 +140,9 @@ can't shadow metrics:
               number_of_shards: 2
               mode: time_series
               routing_path: [dim]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
           mappings:
             properties:
               "@timestamp":


### PR DESCRIPTION
It looks like when we run the new tests on backwards compatibility mode in `8.19` the missing start and end time are throwing an exception before the mapping check.

To fix this we added the start and end time, so this check can pass and the dimension and metric shadowing can be verified.

Fixes: #141843 
Fixes: #141844 