### PR TITLE
[8.19] Reduce cancellation check interval in CancellableBulkScorer for better responsiveness (#141747)

### DIFF
--- a/docs/changelog/141747.yaml
+++ b/docs/changelog/141747.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues: []
+pr: 141747
+summary: Reduce cancellation check interval in `CancellableBulkScorer` for better
+  responsiveness
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/internal/CancellableBulkScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/CancellableBulkScorer.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.Bits;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link BulkScorer} wrapper that runs a {@link Runnable} on a regular basis
@@ -26,8 +27,10 @@ public final class CancellableBulkScorer extends BulkScorer {
     // slow down boolean queries
     private static final int INITIAL_INTERVAL = 1 << 11;
 
-    // No point in having intervals that are larger than 1M
-    private static final int MAX_INTERVAL = 1 << 20;
+    private static final int MAX_INTERVAL = 1 << 14;
+
+    // Threshold for adaptive interval growth, only increase the interval if the previous batch completed faster than this.
+    private static final long INTERVAL_GROWTH_THRESHOLD_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     private final BulkScorer scorer;
     private final Runnable checkCancelled;
@@ -40,11 +43,19 @@ public final class CancellableBulkScorer extends BulkScorer {
     @Override
     public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
         int interval = INITIAL_INTERVAL;
+        long lastCheckTime = System.nanoTime();
+
         while (min < max) {
             checkCancelled.run();
+            lastCheckTime = System.nanoTime();
+
             final int newMax = (int) Math.min((long) min + interval, max);
             min = scorer.score(collector, acceptDocs, min, newMax);
-            interval = Math.min(interval << 1, MAX_INTERVAL);
+
+            long elapsed = System.nanoTime() - lastCheckTime;
+            if (elapsed < INTERVAL_GROWTH_THRESHOLD_NANOS) {
+                interval = Math.min(interval << 1, MAX_INTERVAL);
+            }
         }
         checkCancelled.run();
         return min;
@@ -55,4 +66,8 @@ public final class CancellableBulkScorer extends BulkScorer {
         return scorer.cost();
     }
 
+    // exposed for testing
+    static int getMaxInterval() {
+        return MAX_INTERVAL;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/internal/CancellableBulkScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/CancellableBulkScorerTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class CancellableBulkScorerTests extends ESTestCase {
+
+    /**
+     * Verifies multiple cancellation checks occur during scoring (not just start/end).
+     */
+    public void testCancellationIsCheckedRegularly() throws IOException {
+        AtomicInteger cancellationChecks = new AtomicInteger(0);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        Runnable checkCancelled = () -> {
+            cancellationChecks.incrementAndGet();
+            if (cancelled.get()) {
+                throw new TaskCancelledException("cancelled");
+            }
+        };
+
+        int totalDocs = 100_000;
+        BulkScorer scorer = new BulkScorer() {
+            @Override
+            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) {
+                return max;
+            }
+
+            @Override
+            public long cost() {
+                return totalDocs;
+            }
+        };
+
+        CancellableBulkScorer cancellableBulkScorer = new CancellableBulkScorer(scorer, checkCancelled);
+        cancellableBulkScorer.score(createNoOpCollector(), null, 0, totalDocs);
+        assertThat("Should have multiple cancellation checks", cancellationChecks.get(), equalTo(9));
+    }
+
+    /**
+     * Verifies that after cancellation is requested, at most MAX_INTERVAL additional documents are processed before scoring stops.
+     */
+    public void testCancellationStopsScoring() throws IOException {
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicInteger docsScored = new AtomicInteger(0);
+
+        Runnable checkCancelled = () -> {
+            if (cancelled.get()) {
+                throw new TaskCancelledException("cancelled");
+            }
+        };
+
+        int totalDocs = 100_000;
+        int cancellationPoint = 10_000;
+        BulkScorer scorer = new BulkScorer() {
+            @Override
+            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                for (int i = min; i < max; i++) {
+                    docsScored.incrementAndGet();
+                    if (docsScored.get() == cancellationPoint) {
+                        cancelled.set(true);
+                    }
+                }
+                return max;
+            }
+
+            @Override
+            public long cost() {
+                return totalDocs;
+            }
+        };
+
+        CancellableBulkScorer cancellableBulkScorer = new CancellableBulkScorer(scorer, checkCancelled);
+        expectThrows(TaskCancelledException.class, () -> cancellableBulkScorer.score(createNoOpCollector(), null, 0, totalDocs));
+
+        assertThat(
+            "Should stop within MAX_INTERVAL of cancellation point",
+            docsScored.get(),
+            lessThan(cancellationPoint + CancellableBulkScorer.getMaxInterval())
+        );
+    }
+
+    /**
+     * Verifies intervals still grow for efficiency, but never exceed MAX_INTERVAL.
+     * Ensures we didn't break the optimization for fast queries.
+     */
+    public void testIntervalGrowsGeometrically() throws IOException {
+        AtomicInteger checkCount = new AtomicInteger(0);
+        List<Integer> intervals = new ArrayList<>();
+
+        BulkScorer scorer = new BulkScorer() {
+            @Override
+            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) {
+                intervals.add(max - min);
+                return max;
+            }
+
+            @Override
+            public long cost() {
+                return 1_000_000;
+            }
+        };
+
+        Runnable checkCancelled = checkCount::incrementAndGet;
+        CancellableBulkScorer cancellableBulkScorer = new CancellableBulkScorer(scorer, checkCancelled);
+        cancellableBulkScorer.score(createNoOpCollector(), null, 0, 200_000);
+
+        for (int i = 1; i < intervals.size() - 1; i++) {
+            assertTrue(
+                "Intervals should grow: intervals["
+                    + i
+                    + "]="
+                    + intervals.get(i)
+                    + " should be >= intervals["
+                    + (i - 1)
+                    + "]="
+                    + intervals.get(i - 1),
+                intervals.get(i) >= intervals.get(i - 1)
+            );
+        }
+
+        for (int interval : intervals) {
+            assertThat("No interval should exceed MAX_INTERVAL", interval, lessThanOrEqualTo(CancellableBulkScorer.getMaxInterval()));
+        }
+    }
+
+    private LeafCollector createNoOpCollector() {
+        return new LeafCollector() {
+            @Override
+            public void setScorer(Scorable scorer) {}
+
+            @Override
+            public void collect(int doc) {}
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/internal/CancellableBulkScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/CancellableBulkScorerTests.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -57,7 +57,7 @@ public class CancellableBulkScorerTests extends ESTestCase {
 
         CancellableBulkScorer cancellableBulkScorer = new CancellableBulkScorer(scorer, checkCancelled);
         cancellableBulkScorer.score(createNoOpCollector(), null, 0, totalDocs);
-        assertThat("Should have multiple cancellation checks", cancellationChecks.get(), equalTo(9));
+        assertThat("Should have multiple cancellation checks", cancellationChecks.get(), greaterThan(8));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Reduce cancellation check interval in CancellableBulkScorer for better responsiveness (#141747)