### PR TITLE
[9.1] Create fewer objects when an ILM policy is not used (#140705)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
@@ -27,6 +26,8 @@ import java.util.Set;
  * A class encapsulating the usage of a particular "thing" by something else
  */
 public class ItemUsage implements Writeable, ToXContentObject {
+
+    public static final ItemUsage EMPTY = new ItemUsage(null, null, null);
 
     private final Set<String> indices;
     private final Set<String> dataStreams;
@@ -46,24 +47,6 @@ public class ItemUsage implements Writeable, ToXContentObject {
         this.composableTemplates = composableTemplates == null ? null : new HashSet<>(composableTemplates);
     }
 
-    public ItemUsage(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            this.indices = in.readCollectionAsSet(StreamInput::readString);
-        } else {
-            this.indices = null;
-        }
-        if (in.readBoolean()) {
-            this.dataStreams = in.readCollectionAsSet(StreamInput::readString);
-        } else {
-            this.dataStreams = null;
-        }
-        if (in.readBoolean()) {
-            this.composableTemplates = in.readCollectionAsSet(StreamInput::readString);
-        } else {
-            this.composableTemplates = null;
-        }
-    }
-
     public Set<String> getIndices() {
         return indices;
     }
@@ -79,15 +62,9 @@ public class ItemUsage implements Writeable, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (this.indices != null) {
-            builder.stringListField("indices", this.indices);
-        }
-        if (this.dataStreams != null) {
-            builder.stringListField("data_streams", this.dataStreams);
-        }
-        if (this.composableTemplates != null) {
-            builder.stringListField("composable_templates", this.composableTemplates);
-        }
+        builder.stringListField("indices", this.indices != null ? this.indices : Set.of());
+        builder.stringListField("data_streams", this.dataStreams != null ? this.dataStreams : Set.of());
+        builder.stringListField("composable_templates", this.composableTemplates != null ? this.composableTemplates : Set.of());
         builder.endObject();
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ItemUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ItemUsageTests.java
@@ -10,11 +10,17 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.AbstractWireTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class ItemUsageTests extends AbstractWireTestCase<ItemUsage> {
 
@@ -44,5 +50,17 @@ public class ItemUsageTests extends AbstractWireTestCase<ItemUsage> {
     @Override
     protected ItemUsage mutateInstance(ItemUsage instance) {
         return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+    }
+
+    // We test this in a unit test and not a yml test because it is not required by API,
+    // but it has been existing behavior that we chose to preserve.
+    public void testEmptyInstanceXContent() throws IOException {
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.humanReadable(true);
+            String json = Strings.toString(ItemUsage.EMPTY.toXContent(builder, ToXContent.EMPTY_PARAMS));
+            assertThat(json, containsString("\"indices\":[]"));
+            assertThat(json, containsString("\"data_streams\":[]"));
+            assertThat(json, containsString("\"composable_templates\":[]"));
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
@@ -107,11 +107,13 @@ public class LifecyclePolicyUsageCalculator {
      * Retrieves the pre-calculated indices, data streams, and composable templates that use the given policy.
      */
     public ItemUsage retrieveCalculatedUsage(String policyName) {
-        return new ItemUsage(
-            policyToIndices.getOrDefault(policyName, List.of()),
-            policyToDataStreams.getOrDefault(policyName, List.of()),
-            policyToTemplates.getOrDefault(policyName, List.of())
-        );
+        List<String> indices = policyToIndices.get(policyName);
+        List<String> dataStreams = policyToDataStreams.get(policyName);
+        List<String> composableTemplates = policyToTemplates.get(policyName);
+        if (indices == null && dataStreams == null && composableTemplates == null) {
+            return ItemUsage.EMPTY;
+        }
+        return new ItemUsage(indices, dataStreams, composableTemplates);
     }
 
     private boolean doesPolicyMatchAnyName(String policyName, List<String> names) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
 
@@ -46,7 +47,7 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
         final var project = ProjectMetadata.builder(randomProjectIdOrDefault()).build();
         assertThat(
             new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
-            equalTo(new ItemUsage(List.of(), List.of(), List.of()))
+            sameInstance(ItemUsage.EMPTY)
         );
     }
 
@@ -64,7 +65,7 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
 
         assertThat(
             new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
-            equalTo(new ItemUsage(List.of(), List.of(), List.of()))
+            sameInstance(ItemUsage.EMPTY)
         );
     }
 
@@ -86,7 +87,7 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
 
         assertThat(
             new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
-            equalTo(new ItemUsage(List.of("myindex"), List.of(), List.of()))
+            equalTo(new ItemUsage(List.of("myindex"), null, null))
         );
     }
 
@@ -123,7 +124,7 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
 
         assertThat(
             new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
-            equalTo(new ItemUsage(List.of("myindex"), List.of(), List.of("mytemplate")))
+            equalTo(new ItemUsage(List.of("myindex"), null, List.of("mytemplate")))
         );
     }
 
@@ -215,7 +216,7 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
         // Test where policy exists and is used by an index, datastream, and template
         assertThat(
             new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
-            equalTo(new ItemUsage(List.of("myindex"), List.of(), List.of("mytemplate")))
+            equalTo(new ItemUsage(List.of("myindex"), null, List.of("mytemplate")))
         );
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Create fewer objects when an ILM policy is not used (#140705)