### PR TITLE
Update to new release API endpoints

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -16,7 +16,7 @@ echo "Selecting the most recent build from branch [$BUILDKITE_BRANCH]."
 # Select the most recent build from the current branch.
 # We collect snapshots, order by date, then collect BCs, order by date, and concat them; then we select the last.
 # So if we have one (or more) BC, we will always prefer to use that. Otherwise we will use the latest snapshot.
-MANIFEST_URL="$(curl -s https://artifacts.elastic.co/releases/TfEVhiaBGqR64ie0g0r0uUwNAbEQMu1Z/future-releases/stack.json |
+MANIFEST_URL="$(curl -s https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json |
 jq ".releases[] |
 select(.branch == \"$BUILDKITE_BRANCH\") |
 select(.active_release == true) |


### PR DESCRIPTION
Release API migration to new endpoints is now complete.

Past Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json
Future Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json

This PR updates the old Release API endpoints to new one's

More Info:
https://groups.google.com/a/elastic.co/g/release-eng-team/c/qgXaCX-y29k/m/jzm2S8MeAwAJ

**Note to Reviewers:**
Please add labels / backports accordingly, thank you
