### PR TITLE
Unmute CcsCommonYamlTestSuiteIT "10_basic/Field caps for number field with only doc values"

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -180,9 +180,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
-  issue: https://github.com/elastic/elasticsearch/issues/136244
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
   issue: https://github.com/elastic/elasticsearch/issues/136894


### PR DESCRIPTION
The failure (suite timeout) seems to have been the result of a larger error in the test suite.