### PR TITLE
ES|QL: Fix tdigest docs

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/t-digest.md
+++ b/docs/reference/elasticsearch/mapping-reference/t-digest.md
@@ -117,7 +117,7 @@ PUT my-index-000001/_doc/1
 ```console
 POST /_query?format=txt
 {
-	"query": "FROM test | STATS Percentile(99, latency)"
+	"query": "FROM my-index-000001 | STATS Percentile(latency, 99)"
 }
 
 


### PR DESCRIPTION
closes https://github.com/elastic/docs-content/issues/5040

Fixes the ES|QL query example for t-digest.