### PR TITLE
ES|QL: Fix release tests failure for VerifierTests.testFuse

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2932,11 +2932,13 @@ public class VerifierTests extends ESTestCase {
             )
         );
 
-        assertThat(error("""
-            FROM (FROM test METADATA _index, _id, _score | EVAL label = "query1"),
-                 (FROM test METADATA _index, _id, _score | EVAL label = "query2" | LIMIT 10)
-            | FUSE GROUP BY label
-            """), containsString("FUSE can only be used on a limited number of rows. Consider adding a LIMIT before FUSE."));
+        if (EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled()) {
+            assertThat(error("""
+                FROM (FROM test METADATA _index, _id, _score | EVAL label = "query1"),
+                     (FROM test METADATA _index, _id, _score | EVAL label = "query2" | LIMIT 10)
+                | FUSE GROUP BY label
+                """), containsString("FUSE can only be used on a limited number of rows. Consider adding a LIMIT before FUSE."));
+        }
     }
 
     public void testNoMetricInStatsByClause() {


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/141934

I forgot to add a capability check https://github.com/elastic/elasticsearch/pull/141523 for a test case that was using subqueries and FUSE.