### PR TITLE
[9.3] [Gradle] Fix absolute path references breaking Gradle cache (#141793)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
@@ -57,7 +57,7 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         def options = normalized(file('some-depending-lib/build/tmp/javadoc/javadoc.options').text)
         options.contains('-notimestamp')
         options.contains('-quiet')
-        options.contains("-linkoffline '$expectedLink' './some-lib/build/docs/javadoc/'")
+        options.contains("-linkoffline '$expectedLink' '../some-lib/build/docs/javadoc/'")
 
         where:
         version        | versionType | expectedLink
@@ -131,7 +131,7 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
 
         // normal dependencies handles as usual
         result.task(":some-lib:javadoc").outcome == TaskOutcome.SUCCESS
-        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' './some-lib/build/docs/javadoc/'")
+        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' '../some-lib/build/docs/javadoc/'")
         file('some-depending-lib/build/docs/javadoc/org/acme/Something.html').exists() == false
 
         // source of shadowed dependencies are inlined
@@ -179,7 +179,7 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         def options = normalized(file('some-depending-lib/build/tmp/javadoc/javadoc.options').text)
         options.contains('-notimestamp')
         options.contains('-quiet')
-        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' './some-lib/build/docs/javadoc'") == false
+        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' '../some-lib/build/docs/javadoc'") == false
     }
 
     def "ensures module dependency in javadoc of projects"() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -115,20 +115,21 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
                 var options = (StandardJavadocDocletOptions) javadoc.getOptions();
                 options.linksOffline(
                     artifactHost(project) + "/javadoc/" + artifactPath,
-                    upstreamProject.getBuildDir().getPath() + "/docs/javadoc/"
+                    project.getProjectDir().toPath().relativize(upstreamProject.getBuildDir().toPath()) + "/docs/javadoc/"
                 );
                 /*
                  *some dependent javadoc tasks are explicitly skipped. We need to ignore those external links as
                  * javadoc would fail otherwise.
                  * Using Action here instead of lambda to keep gradle happy and don't trigger deprecation
                  */
+                File projectDir = project.getProjectDir();
                 javadoc.doFirst(new Action<Task>() {
                     @Override
                     public void execute(Task task) {
                         List<JavadocOfflineLink> existingJavadocOfflineLinks = ((StandardJavadocDocletOptions) javadoc.getOptions())
                             .getLinksOffline()
                             .stream()
-                            .filter(javadocOfflineLink -> new File(javadocOfflineLink.getPackagelistLoc()).exists())
+                            .filter(javadocOfflineLink -> new File(projectDir, javadocOfflineLink.getPackagelistLoc()).exists())
                             .toList();
                         ((StandardJavadocDocletOptions) javadoc.getOptions()).setLinksOffline(existingJavadocOfflineLinks);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmptyDirTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmptyDirTask.java
@@ -12,6 +12,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.file.Chmod;
 
 import java.io.File;
@@ -40,6 +41,11 @@ public class EmptyDirTask extends DefaultTask {
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    public BuildLayout getBuildLayout() {
+        throw new UnsupportedOperationException();
+    }
+
     @OutputDirectory
     public File getDir() {
         return dir;
@@ -47,7 +53,8 @@ public class EmptyDirTask extends DefaultTask {
 
     @Input
     public String getDirPath() {
-        return dir.getPath();
+        // ensure @Input is stable by returning path relative to root project
+        return getBuildLayout().getRootDirectory().toPath().relativize(dir.toPath()).toString();
     }
 
     /**

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
@@ -13,9 +13,10 @@ import org.elasticsearch.gradle.util.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -28,8 +29,11 @@ abstract class GenerateProviderManifest extends DefaultTask {
     @Inject
     public GenerateProviderManifest() {}
 
-    @Classpath
+    /**
+     * TODO: Strictly speaking we're not even interested in the files but in the file names.
+     */
     @InputFiles
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     abstract public ConfigurableFileCollection getProviderImplClasspath();
 
     @OutputFile

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -67,6 +67,7 @@ public class JavaModulePrecommitTask extends PrecommitTask {
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public File getResourcesDir() {
         return this.resourcesDir;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonAgainstSchemaTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonAgainstSchemaTask.java
@@ -20,10 +20,13 @@ import com.networknt.schema.ValidationMessage;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
@@ -45,6 +48,7 @@ import java.util.stream.StreamSupport;
 /**
  * Incremental task to validate a set of JSON files against a schema.
  */
+@CacheableTask
 public class ValidateJsonAgainstSchemaTask extends DefaultTask {
     private File jsonSchema;
     private File report;
@@ -52,6 +56,7 @@ public class ValidateJsonAgainstSchemaTask extends DefaultTask {
 
     @Incremental
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileCollection getInputFiles() {
         return inputFiles;
     }
@@ -61,6 +66,7 @@ public class ValidateJsonAgainstSchemaTask extends DefaultTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public File getJsonSchema() {
         return jsonSchema;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
@@ -17,9 +17,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.Incremental;
@@ -46,6 +49,7 @@ import java.util.stream.StreamSupport;
  * `delete` is an operator in JavaScript, but it isn't in the keywords list for JavaScript or
  * TypeScript because it's OK to use `delete` as a method name.
  */
+@CacheableTask
 public class ValidateJsonNoKeywordsTask extends DefaultTask {
 
     private File jsonKeywords;
@@ -54,6 +58,7 @@ public class ValidateJsonNoKeywordsTask extends DefaultTask {
 
     @Incremental
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileCollection getInputFiles() {
         return inputFiles;
     }
@@ -63,6 +68,7 @@ public class ValidateJsonNoKeywordsTask extends DefaultTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public File getJsonKeywords() {
         return jsonKeywords;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -89,6 +91,7 @@ public class CopyRestApiTask extends DefaultTask {
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getInputDir() {
         FileTree coreFileTree = null;
         boolean projectHasYamlRestTests = skipHasRestTestCheck || projectHasYamlRestTests();


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Gradle] Fix absolute path references breaking Gradle cache (#141793)