### PR TITLE
[9.3] Fix handling empty collapse construct (#141973)

### DIFF
--- a/docs/changelog/141973.yaml
+++ b/docs/changelog/141973.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 139299
+pr: 141973
+summary: Fix handling empty collapse construct
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -202,6 +202,9 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
     }
 
     public CollapseContext build(SearchExecutionContext searchExecutionContext) {
+        if (field == null) {
+            throw new IllegalArgumentException("no collapse field specified");
+        }
         MappedFieldType fieldType = searchExecutionContext.getFieldType(field);
         if (fieldType == null) {
             throw new IllegalArgumentException("no mapping found for `" + field + "` in order to collapse on");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix handling empty collapse construct (#141973)](https://github.com/elastic/elasticsearch/pull/141973)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)