### PR TITLE
[8.19] Fix handling empty collapse construct (#141973)

### DIFF
--- a/docs/changelog/141973.yaml
+++ b/docs/changelog/141973.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 139299
+pr: 141973
+summary: Fix handling empty collapse construct
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -202,6 +202,9 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
     }
 
     public CollapseContext build(SearchExecutionContext searchExecutionContext) {
+        if (field == null) {
+            throw new IllegalArgumentException("no collapse field specified");
+        }
         MappedFieldType fieldType = searchExecutionContext.getFieldType(field);
         if (fieldType == null) {
             throw new IllegalArgumentException("no mapping found for `" + field + "` in order to collapse on");

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -159,7 +160,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
-            assertEquals(exc.getMessage(), "cannot collapse on field `field` without `doc_values`");
+            assertEquals("cannot collapse on field `field` without `doc_values`", exc.getMessage());
 
             numberFieldType = new NumberFieldMapper.NumberFieldType(
                 "field",
@@ -180,8 +181,8 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
             builder.setInnerHits(new InnerHitBuilder().setName("field"));
             exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
             assertEquals(
-                exc.getMessage(),
-                "cannot expand `inner_hits` for collapse field `field`, only indexed field can retrieve `inner_hits`"
+                "cannot expand `inner_hits` for collapse field `field`, only indexed field can retrieve `inner_hits`",
+                exc.getMessage()
             );
 
             MappedFieldType keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field");
@@ -193,15 +194,15 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
             keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field", true, false, Collections.emptyMap());
             when(searchExecutionContext.getFieldType("field")).thenReturn(keywordFieldType);
             exc = expectThrows(IllegalArgumentException.class, () -> kbuilder.build(searchExecutionContext));
-            assertEquals(exc.getMessage(), "cannot collapse on field `field` without `doc_values`");
+            assertEquals("cannot collapse on field `field` without `doc_values`", exc.getMessage());
 
             keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field", false, true, Collections.emptyMap());
             when(searchExecutionContext.getFieldType("field")).thenReturn(keywordFieldType);
             kbuilder.setInnerHits(new InnerHitBuilder().setName("field"));
             exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
             assertEquals(
-                exc.getMessage(),
-                "cannot expand `inner_hits` for collapse field `field`, only indexed field can retrieve `inner_hits`"
+                "cannot expand `inner_hits` for collapse field `field`, only indexed field can retrieve `inner_hits`",
+                exc.getMessage()
             );
 
         }
@@ -212,7 +213,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
         {
             CollapseBuilder builder = new CollapseBuilder("unknown_field");
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
-            assertEquals(exc.getMessage(), "no mapping found for `unknown_field` in order to collapse on");
+            assertEquals("no mapping found for `unknown_field` in order to collapse on", exc.getMessage());
         }
 
         {
@@ -239,7 +240,17 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
             when(searchExecutionContext.getFieldType("field")).thenReturn(fieldType);
             CollapseBuilder builder = new CollapseBuilder("field");
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
-            assertEquals(exc.getMessage(), "collapse is not supported for the field [field] of the type [some_type]");
+            assertEquals("collapse is not supported for the field [field] of the type [some_type]", exc.getMessage());
+        }
+    }
+
+    public void testBuildWithNullField() throws IOException {
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        String json = "{}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            CollapseBuilder builder = CollapseBuilder.fromXContent(parser);
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
+            assertEquals("no collapse field specified", exc.getMessage());
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix handling empty collapse construct (#141973)](https://github.com/elastic/elasticsearch/pull/141973)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)