### PR TITLE
[9.3] Fix ILM's skipping policy logging level (#141876) (#141890)

### DIFF
--- a/docs/changelog/141890.yaml
+++ b/docs/changelog/141890.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 141876
+pr: 141890
+summary: "Fix ILM's 'skipping policy' logging level"
+type: enhancement

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -179,7 +179,7 @@ class IndexLifecycleRunner {
     void runPeriodicStep(ProjectState state, String policy, IndexMetadata indexMetadata) {
         String index = indexMetadata.getIndex().getName();
         if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexMetadata.getSettings())) {
-            logger.info("[{}] skipping policy [{}] because [{}] is true", index, policy, LifecycleSettings.LIFECYCLE_SKIP);
+            logger.debug("[{}] skipping policy [{}] because [{}] is true", index, policy, LifecycleSettings.LIFECYCLE_SKIP);
             return;
         }
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix ILM's skipping policy logging level (#141876) (#141890)