### PR TITLE
Refactor OTLP endpoint for extensibility for other signals

### DIFF
--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPIndexingRestIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+public abstract class AbstractOTLPIndexingRestIT extends ESRestTestCase {
+
+    protected static final String USER = "test_admin";
+    protected static final String PASS = "x-pack-test-password";
+    protected static final Resource TEST_RESOURCE = Resource.create(Attributes.of(stringKey("service.name"), "elasticsearch"));
+    protected static final InstrumentationScopeInfo TEST_SCOPE = InstrumentationScopeInfo.create("io.opentelemetry.example.metrics");
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .user(USER, PASS, "superuser", false)
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.security.autoconfiguration.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.ml.enabled", "false")
+        .setting("xpack.watcher.enabled", "false")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    protected Settings restClientSettings() {
+        String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
+        return Settings.builder().put(super.restClientSettings()).put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/metrics-otel@template"))));
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+}

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
@@ -32,15 +31,9 @@ import io.opentelemetry.sdk.resources.Resource;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
-import org.elasticsearch.common.settings.SecureString;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -63,38 +56,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 
-public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
+public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
 
-    private static final String USER = "test_admin";
-    private static final String PASS = "x-pack-test-password";
-    private static final Resource TEST_RESOURCE = Resource.create(Attributes.of(stringKey("service.name"), "elasticsearch"));
-    private static final InstrumentationScopeInfo TEST_SCOPE = InstrumentationScopeInfo.create("io.opentelemetry.example.metrics");
     private OtlpHttpMetricExporter exporter;
     private SdkMeterProvider meterProvider;
 
-    @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
-        .user(USER, PASS, "superuser", false)
-        .setting("xpack.security.enabled", "true")
-        .setting("xpack.security.autoconfiguration.enabled", "false")
-        .setting("xpack.license.self_generated.type", "trial")
-        .setting("xpack.ml.enabled", "false")
-        .setting("xpack.watcher.enabled", "false")
-        .build();
-
-    @Override
-    protected String getTestRestCluster() {
-        return cluster.getHttpAddresses();
-    }
-
-    protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
-        return Settings.builder().put(super.restClientSettings()).put(ThreadContext.PREFIX + ".Authorization", token).build();
-    }
-
     @Before
-    public void beforeTest() throws Exception {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         exporter = OtlpHttpMetricExporter.builder()
             .setEndpoint(getClusterHosts().getFirst().toURI() + "/_otlp/v1/metrics")
             .addHeader("Authorization", "ApiKey " + createApiKey())
@@ -107,7 +77,6 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
                     .build()
             )
             .build();
-        assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/metrics-otel@template"))));
     }
 
     private static String createApiKey() throws IOException {
@@ -147,6 +116,7 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
         assertOK(client().performRequest(request));
     }
 
+    @After
     @Override
     public void tearDown() throws Exception {
         meterProvider.close();

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -67,7 +67,7 @@ public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
         super.setUp();
         exporter = OtlpHttpMetricExporter.builder()
             .setEndpoint(getClusterHosts().getFirst().toURI() + "/_otlp/v1/metrics")
-            .addHeader("Authorization", "ApiKey " + createApiKey())
+            .addHeader("Authorization", "ApiKey " + createApiKey("metrics-*"))
             .build();
         meterProvider = SdkMeterProvider.builder()
             .registerMetricReader(
@@ -77,28 +77,6 @@ public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
                     .build()
             )
             .build();
-    }
-
-    private static String createApiKey() throws IOException {
-        // Create API key with create_doc privilege for metrics-* index
-        Request createApiKeyRequest = new Request("POST", "/_security/api_key");
-        createApiKeyRequest.setJsonEntity("""
-            {
-              "name": "otel-metrics-test-key",
-              "role_descriptors": {
-                "metrics_writer": {
-                  "index": [
-                    {
-                      "names": ["metrics-*"],
-                      "privileges": ["create_doc", "auto_configure"]
-                    }
-                  ]
-                }
-              }
-            }
-            """);
-        ObjectPath createApiKeyResponse = ObjectPath.createFromResponse(client().performRequest(createApiKeyRequest));
-        return createApiKeyResponse.evaluate("encoded");
     }
 
     /**

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.GeneratedMessage;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestResponseListener;
+
+import java.io.IOException;
+
+public abstract class AbstractOTLPRestAction extends BaseRestHandler {
+
+    private final ActionType<OTLPActionResponse> type;
+    private final BytesArray emptyResponse;
+
+    public AbstractOTLPRestAction(ActionType<OTLPActionResponse> type, GeneratedMessage emptyResponse) {
+        this.type = type;
+        this.emptyResponse = new BytesArray(emptyResponse.toByteArray());
+    }
+
+    @Override
+    public final boolean mediaTypesValid(RestRequest request) {
+        return request.getXContentType() == null
+            && request.getParsedContentType().mediaTypeWithoutParameters().equals("application/x-protobuf");
+    }
+
+    @Override
+    protected final RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (request.hasContent()) {
+            var transportRequest = new OTLPActionRequest(request.content().retain());
+            return channel -> client.execute(
+                type,
+                transportRequest,
+                ActionListener.releaseBefore(request.content(), new RestResponseListener<>(channel) {
+                    @Override
+                    public RestResponse buildResponse(OTLPActionResponse r) {
+                        return new RestResponse(r.getStatus(), "application/x-protobuf", r.getResponse());
+                    }
+                })
+            );
+        }
+
+        // If the server receives an empty request
+        // (a request that does not carry any telemetry data)
+        // the server SHOULD respond with success.
+        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
+        return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "application/x-protobuf", emptyResponse));
+    }
+
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.MessageLite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class AbstractOTLPTransportAction extends HandledTransportAction<OTLPActionRequest, OTLPActionResponse> {
+
+    private static final Logger logger = LogManager.getLogger(AbstractOTLPTransportAction.class);
+    public static final int IGNORED_DATA_POINTS_MESSAGE_LIMIT = 10;
+    private final Client client;
+
+    @Inject
+    public AbstractOTLPTransportAction(
+        String name,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        Client client
+    ) {
+        super(name, transportService, actionFilters, OTLPActionRequest::new, threadPool.executor(ThreadPool.Names.WRITE));
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, OTLPActionRequest request, ActionListener<OTLPActionResponse> listener) {
+        ProcessingContext context = ProcessingContext.EMPTY;
+        try {
+            BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+            context = prepareBulkRequest(request, bulkRequestBuilder);
+            if (bulkRequestBuilder.numberOfActions() == 0) {
+                if (context.getIgnoredDataPoints() == 0) {
+                    handleEmptyRequest(listener);
+                } else {
+                    // all data points were ignored
+                    handlePartialSuccess(listener, context);
+                }
+                return;
+            }
+
+            ProcessingContext finalContext = context;
+            bulkRequestBuilder.execute(new ActionListener<>() {
+                @Override
+                public void onResponse(BulkResponse bulkItemResponses) {
+                    if (bulkItemResponses.hasFailures() || finalContext.getIgnoredDataPoints() > 0) {
+                        handlePartialSuccess(bulkItemResponses, finalContext, listener);
+                    } else {
+                        handleSuccess(listener);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    handleFailure(listener, e, finalContext);
+                }
+            });
+
+        } catch (Exception e) {
+            logger.error("failed to execute otlp metrics request", e);
+            handleFailure(listener, e, context);
+        }
+    }
+
+    /**
+     * Tracks the outcome of processing an OTLP export request, including the total number of items processed,
+     * how many were ignored, and any associated error messages. This information is used to build
+     * OTLP partial success and failure responses.
+     *
+     * @see <a href="https://opentelemetry.io/docs/specs/otlp/#partial-success-1">OTLP Partial Success</a>
+     */
+    public interface ProcessingContext {
+
+        ProcessingContext EMPTY = () -> 0;
+
+        int totalDataPoints();
+
+        default int getIgnoredDataPoints() {
+            return 0;
+        }
+
+        default String getIgnoredDataPointsMessage(int limit) {
+            return "";
+        }
+    }
+
+    /**
+     * Parses the OTLP export request and populates the given bulk request builder with the corresponding index operations.
+     *
+     * @param request            the incoming OTLP export request
+     * @param bulkRequestBuilder the bulk request builder to populate with index operations
+     * @return a {@link ProcessingContext} summarizing the outcome, including total and rejected item counts
+     * @throws IOException if creating the source for the bulk request fails
+     */
+    protected abstract ProcessingContext prepareBulkRequest(OTLPActionRequest request, BulkRequestBuilder bulkRequestBuilder)
+        throws IOException;
+
+    public void handleSuccess(ActionListener<OTLPActionResponse> listener) {
+        listener.onResponse(new OTLPActionResponse(RestStatus.OK, emptyResponse()));
+    }
+
+    public void handleEmptyRequest(ActionListener<OTLPActionResponse> listener) {
+        // If the server receives an empty request
+        // (a request that does not carry any telemetry data)
+        // the server SHOULD respond with success.
+        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
+        handleSuccess(listener);
+    }
+
+    public void handlePartialSuccess(ActionListener<OTLPActionResponse> listener, ProcessingContext context) {
+        // If the request is only partially accepted
+        // (i.e. when the server accepts only parts of the data and rejects the rest),
+        // the server MUST respond with HTTP 200 OK.
+        // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
+        MessageLite response = responseWithRejectedDataPoints(
+            context.getIgnoredDataPoints(),
+            context.getIgnoredDataPointsMessage(IGNORED_DATA_POINTS_MESSAGE_LIMIT)
+        );
+        listener.onResponse(new OTLPActionResponse(RestStatus.BAD_REQUEST, response));
+    }
+
+    private void handlePartialSuccess(
+        BulkResponse bulkItemResponses,
+        ProcessingContext context,
+        ActionListener<OTLPActionResponse> listener
+    ) {
+        // index -> status -> failure group
+        Map<String, Map<RestStatus, FailureGroup>> failureGroups = new HashMap<>();
+        // If the request is only partially accepted
+        // (i.e. when the server accepts only parts of the data and rejects the rest),
+        // the server MUST respond with HTTP 200 OK.
+        // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
+        RestStatus status = RestStatus.OK;
+        int failures = 0;
+        for (BulkItemResponse bulkItemResponse : bulkItemResponses.getItems()) {
+            BulkItemResponse.Failure failure = bulkItemResponse.getFailure();
+            if (failure != null) {
+                // we're counting each document as one data point here
+                // which is an approximation since one document can represent multiple data points
+                failures++;
+                if (failure.getStatus() == RestStatus.TOO_MANY_REQUESTS) {
+                    // If the server receives more requests than the client is allowed or the server is overloaded,
+                    // the server SHOULD respond with HTTP 429 Too Many Requests or HTTP 503 Service Unavailable
+                    // and MAY include “Retry-After” header with a recommended time interval in seconds to wait before retrying.
+                    // https://opentelemetry.io/docs/specs/otlp/#otlphttp-throttling
+                    status = RestStatus.TOO_MANY_REQUESTS;
+                }
+                FailureGroup failureGroup = failureGroups.computeIfAbsent(failure.getIndex(), k -> new HashMap<>())
+                    .computeIfAbsent(failure.getStatus(), k -> new FailureGroup(new AtomicInteger(0), failure.getMessage()));
+                failureGroup.failureCount().incrementAndGet();
+            }
+        }
+        if (bulkItemResponses.getItems().length == failures) {
+            // all data points failed, so we report total data points as failures
+            failures = context.totalDataPoints();
+        }
+        StringBuilder failureMessageBuilder = new StringBuilder();
+        for (Map.Entry<String, Map<RestStatus, FailureGroup>> indexEntry : failureGroups.entrySet()) {
+            String indexName = indexEntry.getKey();
+            for (Map.Entry<RestStatus, FailureGroup> statusEntry : indexEntry.getValue().entrySet()) {
+                RestStatus restStatus = statusEntry.getKey();
+                FailureGroup failureGroup = statusEntry.getValue();
+                failureMessageBuilder.append("Index [")
+                    .append(indexName)
+                    .append("] returned status [")
+                    .append(restStatus)
+                    .append("] for ")
+                    .append(failureGroup.failureCount())
+                    .append(" documents. Sample error message: ");
+                failureMessageBuilder.append(failureGroup.failureMessageSample());
+                failureMessageBuilder.append("\n");
+            }
+        }
+        failureMessageBuilder.append(context.getIgnoredDataPointsMessage(10));
+        MessageLite response = responseWithRejectedDataPoints(failures + context.getIgnoredDataPoints(), failureMessageBuilder.toString());
+        listener.onResponse(new OTLPActionResponse(status, response));
+    }
+
+    record FailureGroup(AtomicInteger failureCount, String failureMessageSample) {}
+
+    public void handleFailure(ActionListener<OTLPActionResponse> listener, Exception e, ProcessingContext context) {
+        // https://opentelemetry.io/docs/specs/otlp/#failures-1
+        // If the processing of the request fails,
+        // the server MUST respond with appropriate HTTP 4xx or HTTP 5xx status code.
+        listener.onResponse(
+            new OTLPActionResponse(ExceptionsHelper.status(e), responseWithRejectedDataPoints(context.totalDataPoints(), e.getMessage()))
+        );
+    }
+
+    abstract MessageLite emptyResponse();
+
+    abstract MessageLite responseWithRejectedDataPoints(int rejectedDataPoints, String message);
+
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
@@ -82,7 +82,7 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
             });
 
         } catch (Exception e) {
-            logger.error("failed to execute otlp metrics request", e);
+            logger.error("failed to execute otlp request", e);
             handleFailure(listener, e, context);
         }
     }
@@ -98,6 +98,17 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
 
         ProcessingContext EMPTY = () -> 0;
 
+        /**
+         * Creates a ProcessingContext that only tracks the total number of data points processed
+         * and does not track any ignored data points or error messages.
+         *
+         * @param totalDataPoints the total number of data points processed
+         * @return a ProcessingContext instance with the specified total data points and no ignored data points or error messages
+         */
+        static ProcessingContext withTotalDataPoints(int totalDataPoints) {
+            return new WithTotalDataPoints(totalDataPoints);
+        }
+
         int totalDataPoints();
 
         default int getIgnoredDataPoints() {
@@ -107,6 +118,12 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
         default String getIgnoredDataPointsMessage(int limit) {
             return "";
         }
+
+        /**
+         * A simple implementation of ProcessingContext that only tracks the total number of data points processed
+         * and does not track any ignored data points or error messages.
+         */
+        record WithTotalDataPoints(int totalDataPoints) implements ProcessingContext {}
     }
 
     /**

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+public class OTLPActionRequest extends ActionRequest implements CompositeIndicesRequest {
+    private final BytesReference request;
+
+    public OTLPActionRequest(StreamInput in) throws IOException {
+        super(in);
+        request = in.readBytesReference();
+    }
+
+    public OTLPActionRequest(BytesReference request) {
+        this.request = request;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public BytesReference getRequest() {
+        return request;
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
@@ -18,9 +18,12 @@ import java.io.IOException;
 public class OTLPActionRequest extends ActionRequest implements CompositeIndicesRequest {
     private final BytesReference request;
 
+    // This constructor is required by the HandledTransportAction API but is never used at runtime.
+    // The REST handler creates the request locally and the transport action processes it on the same node,
+    // so node-to-node serialization does not occur. A matching writeTo is intentionally omitted.
     public OTLPActionRequest(StreamInput in) throws IOException {
         super(in);
-        request = in.readBytesReference();
+        throw new UnsupportedOperationException("OTLPActionRequest should not be deserialized from a stream");
     }
 
     public OTLPActionRequest(BytesReference request) {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.MessageLite;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+public class OTLPActionResponse extends ActionResponse {
+    private final BytesReference response;
+    private final RestStatus status;
+
+    public OTLPActionResponse(RestStatus status, MessageLite response) {
+        this(status, new BytesArray(response.toByteArray()));
+    }
+
+    public OTLPActionResponse(RestStatus status, BytesReference response) {
+        this.response = response;
+        this.status = status;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBytesReference(response);
+        out.writeEnum(status);
+    }
+
+    public BytesReference getResponse() {
+        return response;
+    }
+
+    public RestStatus getStatus() {
+        return status;
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
@@ -30,10 +30,11 @@ public class OTLPActionResponse extends ActionResponse {
         this.status = status;
     }
 
+    // writeTo is required by the ActionResponse contract but is never used at runtime.
+    // The response is created and consumed locally on the same node, so node-to-node serialization does not occur.
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeBytesReference(response);
-        out.writeEnum(status);
+        throw new UnsupportedOperationException("OTLPActionResponse should not be serialized to a stream");
     }
 
     public BytesReference getResponse() {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsRestAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsRestAction.java
@@ -9,24 +9,19 @@ package org.elasticsearch.xpack.oteldata.otlp;
 
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestResponseListener;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 @ServerlessScope(Scope.PUBLIC)
-public class OTLPMetricsRestAction extends BaseRestHandler {
+public class OTLPMetricsRestAction extends AbstractOTLPRestAction {
+    public OTLPMetricsRestAction() {
+        super(OTLPMetricsTransportAction.TYPE, ExportMetricsServiceResponse.newBuilder().build());
+    }
+
     @Override
     public String getName() {
         return "otlp_metrics_action";
@@ -35,41 +30,6 @@ public class OTLPMetricsRestAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(new Route(POST, "/_otlp/v1/metrics"));
-    }
-
-    @Override
-    public boolean mediaTypesValid(RestRequest request) {
-        return request.getXContentType() == null
-            && request.getParsedContentType().mediaTypeWithoutParameters().equals("application/x-protobuf");
-    }
-
-    @Override
-    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (request.hasContent()) {
-            var transportRequest = new OTLPMetricsTransportAction.MetricsRequest(request.content().retain());
-            return channel -> client.execute(
-                OTLPMetricsTransportAction.TYPE,
-                transportRequest,
-                ActionListener.releaseBefore(request.content(), new RestResponseListener<>(channel) {
-                    @Override
-                    public RestResponse buildResponse(OTLPMetricsTransportAction.MetricsResponse r) {
-                        return new RestResponse(r.getStatus(), "application/x-protobuf", r.getResponse());
-                    }
-                })
-            );
-        }
-
-        // If the server receives an empty request
-        // (a request that does not carry any telemetry data)
-        // the server SHOULD respond with success.
-        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
-        return channel -> channel.sendResponse(
-            new RestResponse(
-                RestStatus.OK,
-                "application/x-protobuf",
-                new BytesArray(ExportMetricsServiceResponse.newBuilder().build().toByteArray())
-            )
-        );
     }
 
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
@@ -11,35 +11,18 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsPartialSuccess;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.injection.guice.Inject;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -51,9 +34,7 @@ import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Transport action for handling OpenTelemetry Protocol (OTLP) Metrics requests.
@@ -64,16 +45,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @see <a href="https://opentelemetry.io/docs/specs/otlp">OTLP Specification</a>
  */
-public class OTLPMetricsTransportAction extends HandledTransportAction<
-    OTLPMetricsTransportAction.MetricsRequest,
-    OTLPMetricsTransportAction.MetricsResponse> {
+public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
 
     public static final String NAME = "indices:data/write/otlp/metrics";
-    public static final ActionType<MetricsResponse> TYPE = new ActionType<>(NAME);
-
-    private static final Logger logger = LogManager.getLogger(OTLPMetricsTransportAction.class);
-    public static final int IGNORED_DATA_POINTS_MESSAGE_LIMIT = 10;
-    private final Client client;
+    public static final ActionType<OTLPActionResponse> TYPE = new ActionType<>(NAME);
 
     // visible for testing
     volatile MappingHints defaultMappingHints;
@@ -86,8 +61,7 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         Client client,
         ClusterService clusterService
     ) {
-        super(NAME, transportService, actionFilters, MetricsRequest::new, threadPool.executor(ThreadPool.Names.WRITE));
-        this.client = client;
+        super(NAME, transportService, actionFilters, threadPool, client);
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         defaultMappingHints = MappingHints.fromSettings(clusterSettings.get(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE));
         clusterSettings.addSettingsUpdateConsumer(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE, histogramFieldTypeSetting -> {
@@ -96,45 +70,31 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
     }
 
     @Override
-    protected void doExecute(Task task, MetricsRequest request, ActionListener<MetricsResponse> listener) {
+    protected ProcessingContext prepareBulkRequest(OTLPActionRequest request, BulkRequestBuilder bulkRequestBuilder) throws IOException {
         BufferedByteStringAccessor byteStringAccessor = new BufferedByteStringAccessor();
         DataPointGroupingContext context = new DataPointGroupingContext(byteStringAccessor);
-        try {
-            var metricsServiceRequest = ExportMetricsServiceRequest.parseFrom(request.exportMetricsServiceRequest.streamInput());
-            context.groupDataPoints(metricsServiceRequest);
-            if (context.totalDataPoints() == 0) {
-                handleEmptyRequest(listener);
-                return;
-            }
-            BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
-            MetricDocumentBuilder metricDocumentBuilder = new MetricDocumentBuilder(byteStringAccessor, defaultMappingHints);
-            context.consume(dataPointGroup -> addIndexRequest(bulkRequestBuilder, metricDocumentBuilder, dataPointGroup));
-            if (bulkRequestBuilder.numberOfActions() == 0) {
-                // all data points were ignored
-                handlePartialSuccess(listener, context);
-                return;
-            }
-
-            bulkRequestBuilder.execute(new ActionListener<>() {
-                @Override
-                public void onResponse(BulkResponse bulkItemResponses) {
-                    if (bulkItemResponses.hasFailures() || context.getIgnoredDataPoints() > 0) {
-                        handlePartialSuccess(bulkItemResponses, context, listener);
-                    } else {
-                        handleSuccess(listener);
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    handleFailure(listener, e, context);
-                }
-            });
-
-        } catch (Exception e) {
-            logger.error("failed to execute otlp metrics request", e);
-            handleFailure(listener, e, context);
+        var metricsServiceRequest = ExportMetricsServiceRequest.parseFrom(request.getRequest().streamInput());
+        context.groupDataPoints(metricsServiceRequest);
+        if (context.totalDataPoints() == 0) {
+            return context;
         }
+        MetricDocumentBuilder metricDocumentBuilder = new MetricDocumentBuilder(byteStringAccessor, defaultMappingHints);
+        context.consume(dataPointGroup -> addIndexRequest(bulkRequestBuilder, metricDocumentBuilder, dataPointGroup));
+        return context;
+    }
+
+    @Override
+    protected ExportMetricsServiceResponse emptyResponse() {
+        return ExportMetricsServiceResponse.newBuilder().build();
+    }
+
+    @Override
+    protected ExportMetricsServiceResponse responseWithRejectedDataPoints(int rejectedDataPoints, String message) {
+        ExportMetricsPartialSuccess partialSuccess = ExportMetricsPartialSuccess.newBuilder()
+            .setRejectedDataPoints(rejectedDataPoints)
+            .setErrorMessage(message)
+            .build();
+        return ExportMetricsServiceResponse.newBuilder().setPartialSuccess(partialSuccess).build();
     }
 
     private void addIndexRequest(
@@ -163,152 +123,4 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         }
     }
 
-    private static void handleSuccess(ActionListener<MetricsResponse> listener) {
-        listener.onResponse(new MetricsResponse(RestStatus.OK, ExportMetricsServiceResponse.newBuilder().build()));
-    }
-
-    private static void handleEmptyRequest(ActionListener<MetricsResponse> listener) {
-        // If the server receives an empty request
-        // (a request that does not carry any telemetry data)
-        // the server SHOULD respond with success.
-        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
-        handleSuccess(listener);
-    }
-
-    private static void handlePartialSuccess(ActionListener<MetricsResponse> listener, DataPointGroupingContext context) {
-        // If the request is only partially accepted
-        // (i.e. when the server accepts only parts of the data and rejects the rest),
-        // the server MUST respond with HTTP 200 OK.
-        // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-        ExportMetricsServiceResponse response = responseWithRejectedDataPoints(
-            context.getIgnoredDataPoints(),
-            context.getIgnoredDataPointsMessage(IGNORED_DATA_POINTS_MESSAGE_LIMIT)
-        );
-        listener.onResponse(new MetricsResponse(RestStatus.BAD_REQUEST, response));
-    }
-
-    private static void handlePartialSuccess(
-        BulkResponse bulkItemResponses,
-        DataPointGroupingContext context,
-        ActionListener<MetricsResponse> listener
-    ) {
-        // index -> status -> failure group
-        Map<String, Map<RestStatus, FailureGroup>> failureGroups = new HashMap<>();
-        // If the request is only partially accepted
-        // (i.e. when the server accepts only parts of the data and rejects the rest),
-        // the server MUST respond with HTTP 200 OK.
-        // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-        RestStatus status = RestStatus.OK;
-        int failures = 0;
-        for (BulkItemResponse bulkItemResponse : bulkItemResponses.getItems()) {
-            BulkItemResponse.Failure failure = bulkItemResponse.getFailure();
-            if (failure != null) {
-                // we're counting each document as one data point here
-                // which is an approximation since one document can represent multiple data points
-                failures++;
-                if (failure.getStatus() == RestStatus.TOO_MANY_REQUESTS) {
-                    // If the server receives more requests than the client is allowed or the server is overloaded,
-                    // the server SHOULD respond with HTTP 429 Too Many Requests or HTTP 503 Service Unavailable
-                    // and MAY include “Retry-After” header with a recommended time interval in seconds to wait before retrying.
-                    // https://opentelemetry.io/docs/specs/otlp/#otlphttp-throttling
-                    status = RestStatus.TOO_MANY_REQUESTS;
-                }
-                FailureGroup failureGroup = failureGroups.computeIfAbsent(failure.getIndex(), k -> new HashMap<>())
-                    .computeIfAbsent(failure.getStatus(), k -> new FailureGroup(new AtomicInteger(0), failure.getMessage()));
-                failureGroup.failureCount().incrementAndGet();
-            }
-        }
-        if (bulkItemResponses.getItems().length == failures) {
-            // all data points failed, so we report total data points as failures
-            failures = context.totalDataPoints();
-        }
-        StringBuilder failureMessageBuilder = new StringBuilder();
-        for (Map.Entry<String, Map<RestStatus, FailureGroup>> indexEntry : failureGroups.entrySet()) {
-            String indexName = indexEntry.getKey();
-            for (Map.Entry<RestStatus, FailureGroup> statusEntry : indexEntry.getValue().entrySet()) {
-                RestStatus restStatus = statusEntry.getKey();
-                FailureGroup failureGroup = statusEntry.getValue();
-                failureMessageBuilder.append("Index [")
-                    .append(indexName)
-                    .append("] returned status [")
-                    .append(restStatus)
-                    .append("] for ")
-                    .append(failureGroup.failureCount())
-                    .append(" documents. Sample error message: ");
-                failureMessageBuilder.append(failureGroup.failureMessageSample());
-                failureMessageBuilder.append("\n");
-            }
-        }
-        failureMessageBuilder.append(context.getIgnoredDataPointsMessage(10));
-        ExportMetricsServiceResponse response = responseWithRejectedDataPoints(
-            failures + context.getIgnoredDataPoints(),
-            failureMessageBuilder.toString()
-        );
-        listener.onResponse(new MetricsResponse(status, response));
-    }
-
-    record FailureGroup(AtomicInteger failureCount, String failureMessageSample) {}
-
-    private static void handleFailure(ActionListener<MetricsResponse> listener, Exception e, DataPointGroupingContext context) {
-        // https://opentelemetry.io/docs/specs/otlp/#failures-1
-        // If the processing of the request fails,
-        // the server MUST respond with appropriate HTTP 4xx or HTTP 5xx status code.
-        listener.onResponse(
-            new MetricsResponse(ExceptionsHelper.status(e), responseWithRejectedDataPoints(context.totalDataPoints(), e.getMessage()))
-        );
-    }
-
-    private static ExportMetricsServiceResponse responseWithRejectedDataPoints(int rejectedDataPoints, String message) {
-        ExportMetricsPartialSuccess partialSuccess = ExportMetricsPartialSuccess.newBuilder()
-            .setRejectedDataPoints(rejectedDataPoints)
-            .setErrorMessage(message)
-            .build();
-        return ExportMetricsServiceResponse.newBuilder().setPartialSuccess(partialSuccess).build();
-    }
-
-    public static class MetricsRequest extends ActionRequest implements CompositeIndicesRequest {
-        private final BytesReference exportMetricsServiceRequest;
-
-        public MetricsRequest(StreamInput in) throws IOException {
-            super(in);
-            exportMetricsServiceRequest = in.readBytesReference();
-        }
-
-        public MetricsRequest(BytesReference exportMetricsServiceRequest) {
-            this.exportMetricsServiceRequest = exportMetricsServiceRequest;
-        }
-
-        @Override
-        public ActionRequestValidationException validate() {
-            return null;
-        }
-    }
-
-    public static class MetricsResponse extends ActionResponse {
-        private final BytesReference response;
-        private final RestStatus status;
-
-        public MetricsResponse(RestStatus status, ExportMetricsServiceResponse response) {
-            this(status, new BytesArray(response.toByteArray()));
-        }
-
-        public MetricsResponse(RestStatus status, BytesReference response) {
-            this.response = response;
-            this.status = status;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeBytesReference(response);
-            out.writeEnum(status);
-        }
-
-        public BytesReference getResponse() {
-            return response;
-        }
-
-        public RestStatus getStatus() {
-            return status;
-        }
-    }
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.oteldata.otlp.tsid.ResourceTsidFunnel;
 import org.elasticsearch.xpack.oteldata.otlp.tsid.ScopeTsidFunnel;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.oteldata.otlp.datapoint;
 
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.common.v1.KeyValue;
 
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -22,6 +23,7 @@ public final class TargetIndex {
 
     public static final String TYPE_METRICS = "metrics";
 
+    private static final String RECEIVER = "/receiver/";
     private static final String ELASTICSEARCH_INDEX = "elasticsearch.index";
     private static final String DATA_STREAM_DATASET = "data_stream.dataset";
     private static final String DATA_STREAM_NAMESPACE = "data_stream.namespace";
@@ -94,6 +96,20 @@ public final class TargetIndex {
             target.namespace = null;
         }
         return target;
+    }
+
+    public static @Nullable String extractReceiverName(InstrumentationScope scope) {
+        String scopeName = scope.getName();
+        int indexOfReceiver = scopeName.indexOf(RECEIVER);
+        if (indexOfReceiver >= 0) {
+            int beginIndex = indexOfReceiver + RECEIVER.length();
+            int endIndex = scopeName.indexOf('/', beginIndex);
+            if (endIndex < 0) {
+                endIndex = scopeName.length();
+            }
+            return scopeName.substring(beginIndex, endIndex);
+        }
+        return null;
     }
 
     private TargetIndex() {}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -52,7 +52,7 @@ public class MetricDocumentBuilder extends OTelDocumentBuilder {
         buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
         buildDataStream(builder, dataPointGroup.targetIndex());
         buildScope(builder, dataPointGroup.scope(), dataPointGroup.scopeSchemaUrl());
-        buildAttributes(builder, dataPointGroup.dataPointAttributes());
+        buildAttributes(builder, dataPointGroup.dataPointAttributes(), 0);
         if (Strings.hasLength(dataPointGroup.unit())) {
             builder.field("unit", dataPointGroup.unit());
         }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -7,13 +7,6 @@
 
 package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
 
-import io.opentelemetry.proto.common.v1.AnyValue;
-import io.opentelemetry.proto.common.v1.InstrumentationScope;
-import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.resource.v1.Resource;
-
-import com.google.protobuf.ByteString;
-
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.common.Strings;
@@ -22,7 +15,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.ExponentialHistogramConverter;
-import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
@@ -34,15 +26,14 @@ import java.util.concurrent.TimeUnit;
  * This class constructs an Elasticsearch document representation of a metric data point group.
  * It also handles dynamic templates for metrics based on their attributes.
  */
-public class MetricDocumentBuilder {
+public class MetricDocumentBuilder extends OTelDocumentBuilder {
 
-    private final BufferedByteStringAccessor byteStringAccessor;
     private final BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
     private final MappingHints defaultMappingHints;
     private final ExponentialHistogramConverter.BucketBuffer scratch = new ExponentialHistogramConverter.BucketBuffer();
 
     public MetricDocumentBuilder(BufferedByteStringAccessor byteStringAccessor, MappingHints defaultMappingHints) {
-        this.byteStringAccessor = byteStringAccessor;
+        super(byteStringAccessor);
         this.defaultMappingHints = defaultMappingHints;
     }
 
@@ -60,8 +51,11 @@ public class MetricDocumentBuilder {
         }
         buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
         buildDataStream(builder, dataPointGroup.targetIndex());
-        buildScope(builder, dataPointGroup.scopeSchemaUrl(), dataPointGroup.scope());
-        buildDataPointAttributes(builder, dataPointGroup.dataPointAttributes(), dataPointGroup.unit());
+        buildScope(builder, dataPointGroup.scope(), dataPointGroup.scopeSchemaUrl());
+        buildAttributes(builder, dataPointGroup.dataPointAttributes());
+        if (Strings.hasLength(dataPointGroup.unit())) {
+            builder.field("unit", dataPointGroup.unit());
+        }
         String metricNamesHash = dataPointGroup.getMetricNamesHash(hasher);
         builder.field("_metric_names_hash", metricNamesHash);
 
@@ -93,101 +87,6 @@ public class MetricDocumentBuilder {
         TsidBuilder tsidBuilder = dataPointGroup.tsidBuilder();
         tsidBuilder.addStringDimension("_metric_names_hash", metricNamesHash);
         return tsidBuilder.buildTsid();
-    }
-
-    private void buildResource(Resource resource, ByteString schemaUrl, XContentBuilder builder) throws IOException {
-        builder.startObject("resource");
-        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
-        if (resource.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", resource.getDroppedAttributesCount());
-        }
-        builder.startObject("attributes");
-        buildAttributes(builder, resource.getAttributesList());
-        builder.endObject();
-        builder.endObject();
-    }
-
-    private void buildScope(XContentBuilder builder, ByteString schemaUrl, InstrumentationScope scope) throws IOException {
-        builder.startObject("scope");
-        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
-        if (scope.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", scope.getDroppedAttributesCount());
-        }
-        addFieldIfNotEmpty(builder, "name", scope.getNameBytes());
-        addFieldIfNotEmpty(builder, "version", scope.getVersionBytes());
-        builder.startObject("attributes");
-        buildAttributes(builder, scope.getAttributesList());
-        builder.endObject();
-        builder.endObject();
-    }
-
-    private void addFieldIfNotEmpty(XContentBuilder builder, String name, ByteString value) throws IOException {
-        if (value != null && value.isEmpty() == false) {
-            builder.field(name);
-            byteStringAccessor.utf8Value(builder, value);
-        }
-    }
-
-    private void buildDataPointAttributes(XContentBuilder builder, List<KeyValue> attributes, String unit) throws IOException {
-        builder.startObject("attributes");
-        buildAttributes(builder, attributes);
-        builder.endObject();
-        if (Strings.hasLength(unit)) {
-            builder.field("unit", unit);
-        }
-    }
-
-    private void buildDataStream(XContentBuilder builder, TargetIndex targetIndex) throws IOException {
-        if (targetIndex.isDataStream() == false) {
-            return;
-        }
-        builder.startObject("data_stream");
-        builder.field("type", targetIndex.type());
-        builder.field("dataset", targetIndex.dataset());
-        builder.field("namespace", targetIndex.namespace());
-        builder.endObject();
-    }
-
-    private void buildAttributes(XContentBuilder builder, List<KeyValue> attributes) throws IOException {
-        for (int i = 0, size = attributes.size(); i < size; i++) {
-            KeyValue attribute = attributes.get(i);
-            String key = attribute.getKey();
-            if (isIgnoredAttribute(key) == false) {
-                builder.field(key);
-                attributeValue(builder, attribute.getValue());
-            }
-        }
-    }
-
-    /**
-     * Checks if the given attribute key is an ignored attribute.
-     * Ignored attributes are well-known Elastic-specific attributes
-     * that influence how the documents are indexed but are not stored themselves.
-     *
-     * @param attributeKey the attribute key to check
-     * @return true if the attribute is ignored, false otherwise
-     */
-    public static boolean isIgnoredAttribute(String attributeKey) {
-        return TargetIndex.isTargetIndexAttribute(attributeKey) || MappingHints.isMappingHintsAttribute(attributeKey);
-    }
-
-    private void attributeValue(XContentBuilder builder, AnyValue value) throws IOException {
-        switch (value.getValueCase()) {
-            case STRING_VALUE -> byteStringAccessor.utf8Value(builder, value.getStringValueBytes());
-            case BOOL_VALUE -> builder.value(value.getBoolValue());
-            case INT_VALUE -> builder.value(value.getIntValue());
-            case DOUBLE_VALUE -> builder.value(value.getDoubleValue());
-            case ARRAY_VALUE -> {
-                builder.startArray();
-                List<AnyValue> valuesList = value.getArrayValue().getValuesList();
-                for (int i = 0, valuesListSize = valuesList.size(); i < valuesListSize; i++) {
-                    AnyValue arrayValue = valuesList.get(i);
-                    attributeValue(builder, arrayValue);
-                }
-                builder.endArray();
-            }
-            default -> throw new IllegalArgumentException("Unsupported attribute value type: " + value.getValueCase());
-        }
     }
 
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+
+import com.google.protobuf.ByteString;
+
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
+import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
+
+import java.io.IOException;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Base class for constructing Elasticsearch document representations of OTel data (metrics, logs, traces).
+ * Provides shared logic for building resource, scope, attribute, and data stream fields.
+ */
+public abstract class OTelDocumentBuilder {
+
+    private final BufferedByteStringAccessor byteStringAccessor;
+
+    public OTelDocumentBuilder(BufferedByteStringAccessor byteStringAccessor) {
+        this.byteStringAccessor = byteStringAccessor;
+    }
+
+    protected void buildResource(Resource resource, ByteString schemaUrl, XContentBuilder builder) throws IOException {
+        builder.startObject("resource");
+        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
+        if (resource.getDroppedAttributesCount() > 0) {
+            builder.field("dropped_attributes_count", resource.getDroppedAttributesCount());
+        }
+        buildAttributes(builder, resource.getAttributesList());
+        builder.endObject();
+    }
+
+    protected void buildScope(XContentBuilder builder, InstrumentationScope scope, ByteString schemaUrl) throws IOException {
+        builder.startObject("scope");
+        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
+        addFieldIfNotEmpty(builder, "name", scope.getNameBytes());
+        addFieldIfNotEmpty(builder, "version", scope.getVersionBytes());
+        if (scope.getDroppedAttributesCount() > 0) {
+            builder.field("dropped_attributes_count", scope.getDroppedAttributesCount());
+        }
+        buildAttributes(builder, scope.getAttributesList());
+        builder.endObject();
+    }
+
+    protected void addFieldIfNotEmpty(XContentBuilder builder, String name, ByteString value) throws IOException {
+        if (value != null && value.isEmpty() == false) {
+            builder.field(name);
+            byteStringAccessor.utf8Value(builder, value);
+        }
+    }
+
+    protected void buildDataStream(XContentBuilder builder, TargetIndex targetIndex) throws IOException {
+        if (targetIndex.isDataStream() == false) {
+            return;
+        }
+        builder.startObject("data_stream");
+        builder.field("type", targetIndex.type());
+        builder.field("dataset", targetIndex.dataset());
+        builder.field("namespace", targetIndex.namespace());
+        builder.endObject();
+    }
+
+    protected void buildAttributes(XContentBuilder builder, List<KeyValue> attributes) throws IOException {
+        builder.startObject("attributes");
+        for (int i = 0, size = attributes.size(); i < size; i++) {
+            KeyValue attribute = attributes.get(i);
+            String key = attribute.getKey();
+            if (isIgnoredAttribute(key) == false) {
+                builder.field(key);
+                buildAnyValue(builder, attribute.getValue());
+            }
+        }
+        builder.endObject();
+    }
+
+    /**
+     * Checks if the given attribute key is an ignored attribute.
+     * Ignored attributes are well-known Elastic-specific attributes
+     * that influence how the documents are indexed but are not stored themselves.
+     *
+     * @param attributeKey the attribute key to check
+     * @return true if the attribute is ignored, false otherwise
+     */
+    public static boolean isIgnoredAttribute(String attributeKey) {
+        return TargetIndex.isTargetIndexAttribute(attributeKey) || MappingHints.isMappingHintsAttribute(attributeKey);
+    }
+
+    protected void buildAnyValue(XContentBuilder builder, AnyValue value) throws IOException {
+        switch (value.getValueCase()) {
+            case STRING_VALUE -> byteStringAccessor.utf8Value(builder, value.getStringValueBytes());
+            case BOOL_VALUE -> builder.value(value.getBoolValue());
+            case INT_VALUE -> builder.value(value.getIntValue());
+            case DOUBLE_VALUE -> builder.value(value.getDoubleValue());
+            case ARRAY_VALUE -> {
+                builder.startArray();
+                List<AnyValue> valuesList = value.getArrayValue().getValuesList();
+                for (int i = 0, valuesListSize = valuesList.size(); i < valuesListSize; i++) {
+                    AnyValue arrayValue = valuesList.get(i);
+                    buildAnyValue(builder, arrayValue);
+                }
+                builder.endArray();
+            }
+            default -> throw new IllegalArgumentException("Unsupported attribute value type: " + value.getValueCase());
+        }
+    }
+
+    protected void addSpanId(XContentBuilder builder, byte[] spanId) throws IOException {
+        if (spanId.length > 0) {
+            builder.field("span_id", HexFormat.of().formatHex(spanId));
+        }
+    }
+
+    protected void addTraceId(XContentBuilder builder, byte[] traceId) throws IOException {
+        if (traceId.length > 0) {
+            builder.field("trace_id", HexFormat.of().formatHex(traceId));
+        }
+    }
+
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
@@ -37,10 +37,7 @@ public abstract class OTelDocumentBuilder {
     protected void buildResource(Resource resource, ByteString schemaUrl, XContentBuilder builder) throws IOException {
         builder.startObject("resource");
         addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
-        if (resource.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", resource.getDroppedAttributesCount());
-        }
-        buildAttributes(builder, resource.getAttributesList());
+        buildAttributes(builder, resource.getAttributesList(), resource.getDroppedAttributesCount());
         builder.endObject();
     }
 
@@ -49,10 +46,7 @@ public abstract class OTelDocumentBuilder {
         addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
         addFieldIfNotEmpty(builder, "name", scope.getNameBytes());
         addFieldIfNotEmpty(builder, "version", scope.getVersionBytes());
-        if (scope.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", scope.getDroppedAttributesCount());
-        }
-        buildAttributes(builder, scope.getAttributesList());
+        buildAttributes(builder, scope.getAttributesList(), scope.getDroppedAttributesCount());
         builder.endObject();
     }
 
@@ -74,7 +68,10 @@ public abstract class OTelDocumentBuilder {
         builder.endObject();
     }
 
-    protected void buildAttributes(XContentBuilder builder, List<KeyValue> attributes) throws IOException {
+    protected void buildAttributes(XContentBuilder builder, List<KeyValue> attributes, int droppedAttributesCount) throws IOException {
+        if (droppedAttributesCount > 0) {
+            builder.field("dropped_attributes_count", droppedAttributesCount);
+        }
         builder.startObject("attributes");
         for (int i = 0, size = attributes.size(); i < size; i++) {
             KeyValue attribute = attributes.get(i);

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportActionTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Base test class for OTLP transport actions. Tests the common request/response handling
+ * defined in {@link AbstractOTLPTransportAction}, parameterized by signal-specific behavior
+ * (request construction and response parsing).
+ */
+public abstract class AbstractOTLPTransportActionTests extends ESTestCase {
+
+    protected Client client;
+    private AbstractOTLPTransportAction action;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        when(client.prepareBulk()).thenAnswer(invocation -> new BulkRequestBuilder(client));
+        action = createAction();
+    }
+
+    /** Construct the signal-specific transport action under test. */
+    protected abstract AbstractOTLPTransportAction createAction();
+
+    /** Create an {@link OTLPActionRequest} containing at least one data point / log record. */
+    protected abstract OTLPActionRequest createRequestWithData();
+
+    /** Create an {@link OTLPActionRequest} with no data points / log records. */
+    protected abstract OTLPActionRequest createEmptyRequest();
+
+    /** Parse whether the protobuf response has a partial success field set. */
+    protected abstract boolean parseHasPartialSuccess(byte[] responseBytes) throws InvalidProtocolBufferException;
+
+    /** Parse the rejected count from the partial success in the protobuf response. */
+    protected abstract long parseRejectedCount(byte[] responseBytes) throws InvalidProtocolBufferException;
+
+    /** Parse the error message from the partial success in the protobuf response. */
+    protected abstract String parseErrorMessage(byte[] responseBytes) throws InvalidProtocolBufferException;
+
+    /** The data stream type, e.g. {@code "metrics"} or {@code "logs"}. Used to construct index names in bulk responses. */
+    protected abstract String dataStreamType();
+
+    // --- shared tests ---
+
+    public void testSuccess() throws Exception {
+        OTLPActionResponse response = executeRequest(createRequestWithData());
+
+        assertThat(response.getStatus(), equalTo(RestStatus.OK));
+        assertThat(parseHasPartialSuccess(response.getResponse().array()), equalTo(false));
+    }
+
+    public void testSuccessEmptyRequest() throws Exception {
+        OTLPActionResponse response = executeRequest(createEmptyRequest());
+
+        assertThat(response.getStatus(), equalTo(RestStatus.OK));
+        assertThat(parseHasPartialSuccess(response.getResponse().array()), equalTo(false));
+    }
+
+    public void test429() throws Exception {
+        BulkItemResponse[] bulkItemResponses = new BulkItemResponse[] {
+            bulkItemFailure(dataStreamType() + "-generic.otel-default", RestStatus.TOO_MANY_REQUESTS, "too many requests"),
+            successResponse() };
+        OTLPActionResponse response = executeRequest(createRequestWithData(), new BulkResponse(bulkItemResponses, 0));
+
+        assertThat(response.getStatus(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+        assertThat(
+            parseRejectedCount(response.getResponse().array()),
+            equalTo(Arrays.stream(bulkItemResponses).filter(BulkItemResponse::isFailed).count())
+        );
+        assertThat(parseErrorMessage(response.getResponse().array()), containsString("too many requests"));
+    }
+
+    public void testPartialSuccess() throws Exception {
+        OTLPActionResponse response = executeRequest(
+            createRequestWithData(),
+            new BulkResponse(
+                new BulkItemResponse[] {
+                    bulkItemFailure(dataStreamType() + "-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 1"),
+                    bulkItemFailure(dataStreamType() + "-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 2"),
+                    bulkItemFailure(dataStreamType() + "-other.otel-default", RestStatus.BAD_REQUEST, "bad request 3"),
+                    bulkItemFailure(
+                        dataStreamType() + "-generic.otel-default",
+                        RestStatus.INTERNAL_SERVER_ERROR,
+                        "internal server error"
+                    ) },
+                0
+            )
+        );
+
+        assertThat(response.getStatus(), equalTo(RestStatus.OK));
+        byte[] responseBytes = response.getResponse().array();
+        assertThat(parseRejectedCount(responseBytes), equalTo(1L));
+        // the error message contains only one message per unique index and error status
+        String errorMessage = parseErrorMessage(responseBytes);
+        assertThat(errorMessage, containsString("bad request 1"));
+        assertThat(errorMessage, not(containsString("bad request  2")));
+        assertThat(errorMessage, containsString("bad request 3"));
+        assertThat(errorMessage, containsString("internal server error"));
+    }
+
+    public void testBulkError() throws Exception {
+        assertExceptionStatus(new IllegalArgumentException("bazinga"), RestStatus.BAD_REQUEST);
+        assertExceptionStatus(new IllegalStateException("bazinga"), RestStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private void assertExceptionStatus(Exception exception, RestStatus restStatus) throws InvalidProtocolBufferException {
+        if (randomBoolean()) {
+            doThrow(exception).when(client).execute(any(), any(), any());
+        }
+        OTLPActionResponse response = executeRequest(createRequestWithData(), exception);
+
+        assertThat(response.getStatus(), equalTo(restStatus));
+        byte[] responseBytes = response.getResponse().array();
+        assertThat(parseRejectedCount(responseBytes), equalTo(1L));
+        assertThat(parseErrorMessage(responseBytes), equalTo(exception.getMessage()));
+    }
+
+    // --- shared test infrastructure ---
+
+    protected OTLPActionResponse executeRequest(OTLPActionRequest request) {
+        return executeRequest(request, listener -> listener.onResponse(new BulkResponse(new BulkItemResponse[] {}, 0)));
+    }
+
+    protected OTLPActionResponse executeRequest(OTLPActionRequest request, BulkResponse bulkResponse) {
+        return executeRequest(request, listener -> listener.onResponse(bulkResponse));
+    }
+
+    protected OTLPActionResponse executeRequest(OTLPActionRequest request, Exception bulkFailure) {
+        return executeRequest(request, listener -> listener.onFailure(bulkFailure));
+    }
+
+    protected OTLPActionResponse executeRequest(OTLPActionRequest request, Consumer<ActionListener<BulkResponse>> bulkResponseConsumer) {
+        ArgumentCaptor<ActionListener<BulkResponse>> bulkResponseListener = ArgumentCaptor.captor();
+        doNothing().when(client).execute(any(), any(), bulkResponseListener.capture());
+
+        ActionListener<OTLPActionResponse> responseListener = mock();
+        action.doExecute(null, request, responseListener);
+        if (bulkResponseListener.getAllValues().isEmpty() == false) {
+            bulkResponseConsumer.accept(bulkResponseListener.getValue());
+        }
+
+        ArgumentCaptor<OTLPActionResponse> response = ArgumentCaptor.forClass(OTLPActionResponse.class);
+        verify(responseListener).onResponse(response.capture());
+        return response.getValue();
+    }
+
+    protected static BulkItemResponse successResponse() {
+        return BulkItemResponse.success(-1, DocWriteRequest.OpType.CREATE, mock(DocWriteResponse.class));
+    }
+
+    protected static BulkItemResponse bulkItemFailure(String index, RestStatus restStatus, String failureMessage) {
+        return BulkItemResponse.failure(
+            -1,
+            DocWriteRequest.OpType.CREATE,
+            new BulkItemResponse.Failure(index, "id", new RuntimeException(failureMessage), restStatus)
+        );
+    }
+}

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
@@ -7,190 +7,99 @@
 
 package org.elasticsearch.xpack.oteldata.otlp;
 
-import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsPartialSuccess;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.metrics.v1.Metric;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.oteldata.OTelPlugin;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
-import org.mockito.ArgumentCaptor;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class OTLPMetricsTransportActionTests extends ESTestCase {
+public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportActionTests {
 
-    private OTLPMetricsTransportAction action;
-    private Client client;
+    private OTLPMetricsTransportAction metricsAction;
     private ClusterSettings clusterSettings;
 
     @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        client = mock(Client.class);
-        when(client.prepareBulk()).thenAnswer(invocation -> new BulkRequestBuilder(client));
-
+    protected AbstractOTLPTransportAction createAction() {
         ClusterService clusterService = mock(ClusterService.class);
-        // setup clusterService.getClusterSettings() to return an empty ClusterSettings
         clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
-        action = new OTLPMetricsTransportAction(
+        metricsAction = new OTLPMetricsTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
             mock(ThreadPool.class),
             client,
             clusterService
         );
+        return metricsAction;
     }
 
-    public void testSuccess() throws Exception {
-        OTLPActionResponse response = executeRequest(createMetricsRequest(createMetric()));
-
-        assertThat(response.getStatus(), equalTo(RestStatus.OK));
-        ExportMetricsServiceResponse metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array());
-        assertThat(metricsServiceResponse.hasPartialSuccess(), equalTo(false));
+    @Override
+    protected OTLPActionRequest createRequestWithData() {
+        return createMetricsRequest(createMetric());
     }
 
-    public void testSuccessEmptyRequest() throws Exception {
-        OTLPActionResponse response = executeRequest(createMetricsRequest());
-
-        assertThat(response.getStatus(), equalTo(RestStatus.OK));
-        ExportMetricsServiceResponse metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array());
-        assertThat(metricsServiceResponse.hasPartialSuccess(), equalTo(false));
+    @Override
+    protected OTLPActionRequest createEmptyRequest() {
+        return createMetricsRequest();
     }
 
-    public void test429() throws Exception {
-        BulkItemResponse[] bulkItemResponses = new BulkItemResponse[] {
-            failureResponse("metrics-generic.otel-default", RestStatus.TOO_MANY_REQUESTS, "too many requests"),
-            successResponse() };
-        OTLPActionResponse response = executeRequest(createMetricsRequest(createMetric()), new BulkResponse(bulkItemResponses, 0));
-
-        assertThat(response.getStatus(), equalTo(RestStatus.TOO_MANY_REQUESTS));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
-            .getPartialSuccess();
-        assertThat(
-            metricsServiceResponse.getRejectedDataPoints(),
-            equalTo(Arrays.stream(bulkItemResponses).filter(BulkItemResponse::isFailed).count())
-        );
-        assertThat(metricsServiceResponse.getErrorMessage(), containsString("too many requests"));
+    @Override
+    protected boolean parseHasPartialSuccess(byte[] responseBytes) throws InvalidProtocolBufferException {
+        return ExportMetricsServiceResponse.parseFrom(responseBytes).hasPartialSuccess();
     }
 
-    public void testPartialSuccess() throws Exception {
-        OTLPActionResponse response = executeRequest(
-            createMetricsRequest(createMetric()),
-            new BulkResponse(
-                new BulkItemResponse[] {
-                    failureResponse("metrics-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 1"),
-                    failureResponse("metrics-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 2"),
-                    failureResponse("metrics-hostmetricsreceiver.otel-default", RestStatus.BAD_REQUEST, "bad request 3"),
-                    failureResponse("metrics-generic.otel-default", RestStatus.INTERNAL_SERVER_ERROR, "internal server error") },
-                0
-            )
-        );
-
-        assertThat(response.getStatus(), equalTo(RestStatus.OK));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
-            .getPartialSuccess();
-        assertThat(metricsServiceResponse.getRejectedDataPoints(), equalTo(1L));
-        // the error message contains only one message per unique index and error status
-        assertThat(metricsServiceResponse.getErrorMessage(), containsString("bad request 1"));
-        assertThat(metricsServiceResponse.getErrorMessage(), not(containsString("bad request  2")));
-        assertThat(metricsServiceResponse.getErrorMessage(), containsString("bad request 3"));
-        assertThat(metricsServiceResponse.getErrorMessage(), containsString("internal server error"));
+    @Override
+    protected long parseRejectedCount(byte[] responseBytes) throws InvalidProtocolBufferException {
+        return ExportMetricsServiceResponse.parseFrom(responseBytes).getPartialSuccess().getRejectedDataPoints();
     }
 
-    public void testBulkError() throws Exception {
-        assertExceptionStatus(new IllegalArgumentException("bazinga"), RestStatus.BAD_REQUEST);
-        assertExceptionStatus(new IllegalStateException("bazinga"), RestStatus.INTERNAL_SERVER_ERROR);
+    @Override
+    protected String parseErrorMessage(byte[] responseBytes) throws InvalidProtocolBufferException {
+        return ExportMetricsServiceResponse.parseFrom(responseBytes).getPartialSuccess().getErrorMessage();
     }
+
+    @Override
+    protected String dataStreamType() {
+        return "metrics";
+    }
+
+    // --- metrics-specific tests ---
 
     public void testMappingHintsSettingsUpdate() throws Exception {
-        assertThat(action.defaultMappingHints, equalTo(MappingHints.DEFAULT_TDIGEST));
+        assertThat(metricsAction.defaultMappingHints, equalTo(MappingHints.DEFAULT_TDIGEST));
         assertThat(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE.isDynamic(), equalTo(true));
 
         clusterSettings.applySettings(
             Settings.builder().put(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE.getKey(), "exponential_histogram").build()
         );
-        assertThat(action.defaultMappingHints, equalTo(MappingHints.DEFAULT_EXPONENTIAL_HISTOGRAM));
+        assertThat(metricsAction.defaultMappingHints, equalTo(MappingHints.DEFAULT_EXPONENTIAL_HISTOGRAM));
 
         clusterSettings.applySettings(
             Settings.builder().put(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE.getKey(), "histogram").build()
         );
-        assertThat(action.defaultMappingHints, equalTo(MappingHints.DEFAULT_TDIGEST));
+        assertThat(metricsAction.defaultMappingHints, equalTo(MappingHints.DEFAULT_TDIGEST));
     }
 
-    private void assertExceptionStatus(Exception exception, RestStatus restStatus) throws InvalidProtocolBufferException {
-        if (randomBoolean()) {
-            doThrow(exception).when(client).execute(any(), any(), any());
-        }
-        OTLPActionResponse response = executeRequest(createMetricsRequest(createMetric()), exception);
-
-        assertThat(response.getStatus(), equalTo(restStatus));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
-            .getPartialSuccess();
-        assertThat(metricsServiceResponse.getRejectedDataPoints(), equalTo(1L));
-        assertThat(metricsServiceResponse.getErrorMessage(), equalTo(exception.getMessage()));
-    }
-
-    private OTLPActionResponse executeRequest(OTLPActionRequest request) {
-        return executeRequest(request, listener -> listener.onResponse(new BulkResponse(new BulkItemResponse[] {}, 0)));
-    }
-
-    private OTLPActionResponse executeRequest(OTLPActionRequest request, BulkResponse bulkResponse) {
-        return executeRequest(request, listener -> listener.onResponse(bulkResponse));
-    }
-
-    private OTLPActionResponse executeRequest(OTLPActionRequest request, Exception bulkFailure) {
-        return executeRequest(request, listener -> listener.onFailure(bulkFailure));
-    }
-
-    private OTLPActionResponse executeRequest(OTLPActionRequest request, Consumer<ActionListener<BulkResponse>> bulkResponseConsumer) {
-        ArgumentCaptor<ActionListener<BulkResponse>> bulkResponseListener = ArgumentCaptor.captor();
-        doNothing().when(client).execute(any(), any(), bulkResponseListener.capture());
-
-        ActionListener<OTLPActionResponse> metricsResponseListener = mock();
-        action.doExecute(null, request, metricsResponseListener);
-        if (bulkResponseListener.getAllValues().isEmpty() == false) {
-            bulkResponseConsumer.accept(bulkResponseListener.getValue());
-        }
-
-        ArgumentCaptor<OTLPActionResponse> response = ArgumentCaptor.forClass(OTLPActionResponse.class);
-        verify(metricsResponseListener).onResponse(response.capture());
-        return response.getValue();
-    }
+    // --- helpers ---
 
     private static OTLPActionRequest createMetricsRequest(Metric... metrics) {
         return new OTLPActionRequest(
@@ -211,17 +120,4 @@ public class OTLPMetricsTransportActionTests extends ESTestCase {
     private static Metric createMetric() {
         return OtlpUtils.createGaugeMetric("test.metric", "", List.of(OtlpUtils.createDoubleDataPoint(0)));
     }
-
-    private static BulkItemResponse successResponse() {
-        return BulkItemResponse.success(-1, DocWriteRequest.OpType.CREATE, mock(DocWriteResponse.class));
-    }
-
-    private static BulkItemResponse failureResponse(String index, RestStatus restStatus, String failureMessage) {
-        return BulkItemResponse.failure(
-            -1,
-            DocWriteRequest.OpType.CREATE,
-            new BulkItemResponse.Failure(index, "id", new RuntimeException(failureMessage), restStatus)
-        );
-    }
-
 }


### PR DESCRIPTION
Pure refactoring without behavioral changes. Makes it easier to add support for other signals.

 - Extract `AbstractOTLPTransportAction` from `OTLPMetricsTransportAction` to share request lifecycle management (bulk request execution, success/partial-success/failure response handling) across signal types
 - Extract `AbstractOTLPRestAction` from `OTLPMetricsRestAction` to share protobuf content-type validation, request dispatching, and empty-request handling 
 - Extract `OTelDocumentBuilder` from `MetricDocumentBuilder` to share document building logic for resource, scope, attributes, data stream fields, and span/trace IDs
 - Extract `OTLPActionRequest` and `OTLPActionResponse` from inner classes in `OTLPMetricsTransportAction` to be reused across signal types 
 - Extract `AbstractOTLPIndexingRestIT` from `OTLPMetricsIndexingRestIT` to share test cluster setup
 - Move `extractReceiverName` from `DataPointGroupingContext.ScopeGroup` to `TargetIndex` where it better fits conceptually 
 - Have `DataPointGroupingContext` implement the new `ProcessingContext` interface to integrate cleanly with the abstract transport action 


Sub PRs
- https://github.com/elastic/elasticsearch/pull/142109
- https://github.com/elastic/elasticsearch/pull/142110
- https://github.com/elastic/elasticsearch/pull/142111
- https://github.com/elastic/elasticsearch/pull/142118
  - https://github.com/elastic/elasticsearch/pull/142231
    - https://github.com/elastic/elasticsearch/pull/142218