### PR TITLE
Suppress success callback when failing master task

### DIFF
--- a/docs/changelog/142042.yaml
+++ b/docs/changelog/142042.yaml
@@ -1,0 +1,5 @@
+area: Cluster Coordination
+issues: []
+pr: 142042
+summary: Suppress success callback when failing master task
+type: bug

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -1037,6 +1037,7 @@ public class MasterService extends AbstractLifecycleComponent {
         void onBatchFailure(Exception failure) {
             // if the whole batch resulted in an exception then this overrides any task-level results whether successful or not
             this.failure = Objects.requireNonNull(failure);
+            this.onPublicationSuccess = null;
             this.publishedStateConsumer = null;
             this.clusterStateAckListener = null;
         }


### PR DESCRIPTION
If the execution of a cluster state update task throws an exception then
all the tasks in the batch must be failed with that exception, even if
some of them have been marked as successfully completed.