### PR TITLE
Disable HNSW early termination in testFilteredQueryStrategy

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -312,9 +312,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:spatial_shapes.CartesianPolygonEnvelopeXYMinMax}
   issue: https://github.com/elastic/elasticsearch/issues/141425
-- class: org.elasticsearch.search.query.VectorIT
-  method: testFilteredQueryStrategy
-  issue: https://github.com/elastic/elasticsearch/issues/141469
 - class: org.elasticsearch.xpack.security.authc.TokenServiceTests
   method: testAttachAndGetToken
   issue: https://github.com/elastic/elasticsearch/issues/141470

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/VectorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/VectorIT.java
@@ -74,6 +74,13 @@ public class VectorIT extends ESIntegTestCase {
     }
 
     public void testFilteredQueryStrategy() {
+        // Disable early termination to isolate the filter heuristic behavior
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX_NAME)
+            .setSettings(Settings.builder().put(DenseVectorFieldMapper.HNSW_EARLY_TERMINATION.getKey(), false))
+            .get();
+
         float[] vector = new float[16];
         randomVector(vector, 25);
         int upperLimit = 35;


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/141469