### PR TITLE
ESQL: Be careful with duplicate doc ids

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
@@ -488,7 +488,7 @@ public class ValuesSourceReaderBenchmark {
                                     blockFactory.newConstantIntBlockWith(0, end - begin).asVector(),
                                     blockFactory.newConstantIntBlockWith(ctx.ord, end - begin).asVector(),
                                     docs.build(),
-                                    true
+                                    DocVector.config().singleSegmentNonDecreasing(true)
                                 ).asBlock()
                             )
                         );
@@ -525,7 +525,7 @@ public class ValuesSourceReaderBenchmark {
                                         blockFactory.newConstantIntVector(0, size),
                                         leafs.build(),
                                         docs.build(),
-                                        null
+                                        DocVector.config()
                                     ).asBlock()
                                 )
                             );
@@ -543,7 +543,7 @@ public class ValuesSourceReaderBenchmark {
                                 blockFactory.newConstantIntBlockWith(0, size).asVector(),
                                 leafs.build().asBlock().asVector(),
                                 docs.build(),
-                                null
+                                DocVector.config()
                             ).asBlock()
                         )
                     );
@@ -570,7 +570,7 @@ public class ValuesSourceReaderBenchmark {
                                     blockFactory.newConstantIntVector(0, 1),
                                     blockFactory.newConstantIntVector(next.ord, 1),
                                     blockFactory.newConstantIntVector(next.itr.nextInt(), 1),
-                                    true
+                                    DocVector.config().singleSegmentNonDecreasing(true)
                                 ).asBlock()
                             )
                         );

--- a/test/framework/src/main/java/org/elasticsearch/test/BreakerTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BreakerTestUtil.java
@@ -22,9 +22,8 @@ public class BreakerTestUtil {
      * Performs a binary search between 0 and {@code tooBigToBreak} bytes for the largest memory size
      * that'll cause the closure parameter to throw a {@link CircuitBreakingException}.
      */
-    public static <E extends Exception> ByteSizeValue findBreakerLimit(ByteSizeValue tooBigToBreak, CheckedConsumer<ByteSizeValue, E> c)
-        throws E {
-
+    public static ByteSizeValue findBreakerLimit(ByteSizeValue tooBigToBreak, CheckedConsumer<ByteSizeValue, Exception> c)
+        throws Exception {
         // Validate arguments: we don't throw for tooBigToBreak and we *do* throw for 0.
         try {
             c.accept(tooBigToBreak);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FirstDocIdGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FirstDocIdGroupingAggregatorFunction.java
@@ -224,7 +224,13 @@ public final class FirstDocIdGroupingAggregatorFunction implements GroupingAggre
             try {
                 segmentVector = segmentBuilder.build();
                 docVector = docBuilder.build();
-                blocks[offset] = new DocVector(new MappedShardRefs<>(contextRefs), shardVector, segmentVector, docVector, null).asBlock();
+                blocks[offset] = new DocVector(
+                    new MappedShardRefs<>(contextRefs),
+                    shardVector,
+                    segmentVector,
+                    docVector,
+                    DocVector.config().mayContainDuplicates()
+                ).asBlock();
             } finally {
                 if (blocks[offset] == null) {
                     Releasables.closeExpectNoException(shardVector, segmentVector, docVector);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -273,9 +273,8 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
      * Creates a new block that only exposes the positions provided.
      * @param positions the positions to retain
      * @return a filtered block
-     * TODO: pass BlockFactory
      */
-    Block filter(int... positions);
+    Block filter(int... positions); // TODO mayContainDuplicates
 
     /**
      * Build a {@link Block} with the same values as this {@linkplain Block}, but replacing

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -112,7 +112,7 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
         private final IntVector.Builder shards;
         private final IntVector.Builder segments;
         private final IntVector.Builder docs;
-        private IndexedByShardId<? extends RefCounted> shardRefCounters = null;
+        private IndexedByShardId<? extends RefCounted> shardRefCounters = AlwaysReferencedIndexedByShardId.INSTANCE;
 
         public Builder shardRefCounters(IndexedByShardId<? extends RefCounted> shardRefCounters) {
             this.shardRefCounters = shardRefCounters;
@@ -205,13 +205,7 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
                 shards = this.shards.build();
                 segments = this.segments.build();
                 docs = this.docs.build();
-                result = new DocVector(
-                    shardRefCounters == null ? AlwaysReferencedIndexedByShardId.INSTANCE : shardRefCounters,
-                    shards,
-                    segments,
-                    docs,
-                    null
-                );
+                result = new DocVector(shardRefCounters, shards, segments, docs, DocVector.config());
                 return result.asBlock();
             } finally {
                 if (result == null) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -336,7 +336,8 @@ public class LuceneSourceOperator extends LuceneOperator {
                     docs = buildDocsVector(currentPagePos);
                     docsBuilder = blockFactory.newIntVectorBuilder(Math.min(remainingDocs, maxPageSize));
                     int b = 0;
-                    blocks[b++] = new DocVector(refCounteds, shard, leaf, docs, true).asBlock();
+                    blocks[b++] = new DocVector(refCounteds, shard, leaf, docs, DocVector.config().singleSegmentNonDecreasing(true))
+                        .asBlock();
                     shard = null;
                     leaf = null;
                     docs = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -301,7 +301,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
             shard = blockFactory.newConstantIntBlockWith(shardId, size).asVector();
             segments = currentSegmentBuilder.build();
             docs = currentDocsBuilder.build();
-            docBlock = new DocVector(refCounteds, shard, segments, docs, null).asBlock();
+            docBlock = new DocVector(refCounteds, shard, segments, docs, DocVector.config()).asBlock();
             shard = null;
             segments = null;
             docs = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
@@ -209,7 +209,7 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
             }
             docsVector = docsBuilder.build();
             page = new Page(
-                new DocVector(shardContexts, shardsVector, segmentsVector, docsVector, null).asBlock(),
+                new DocVector(shardContexts, shardsVector, segmentsVector, docsVector, DocVector.config().mayContainDuplicates()).asBlock(),
                 positionsVector.asBlock()
             );
         } finally {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/TimeSeriesFirstDocIdDeduplicationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/TimeSeriesFirstDocIdDeduplicationTests.java
@@ -322,7 +322,13 @@ public class TimeSeriesFirstDocIdDeduplicationTests extends OperatorTestCase {
                 }
 
                 var refs = new FirstDocIdGroupingAggregatorFunction.MappedShardRefs<>(shardRefs);
-                DocVector docVector = new DocVector(refs, shardBuilder.build(), segmentBuilder.build(), docBuilder.build(), null);
+                DocVector docVector = new DocVector(
+                    refs,
+                    shardBuilder.build(),
+                    segmentBuilder.build(),
+                    docBuilder.build(),
+                    DocVector.config()
+                );
 
                 currentPosition += length;
                 return new Page(tsidBuilder.build(), timestampBuilder.build(), docVector.asBlock());

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -1477,7 +1477,7 @@ public class BasicBlockTests extends ESTestCase {
             intVector(positionCount),
             intVector(positionCount),
             intVector(positionCount),
-            true
+            DocVector.config().singleSegmentNonDecreasing(true)
         ).asBlock();
         assertThat(breaker.getUsed(), greaterThan(0L));
         assertRefCountingBehavior(block);
@@ -1519,7 +1519,7 @@ public class BasicBlockTests extends ESTestCase {
             intVector(positionCount),
             intVector(positionCount),
             intVector(positionCount),
-            true
+            DocVector.config().singleSegmentNonDecreasing(true)
         );
         assertThat(breaker.getUsed(), greaterThan(0L));
         assertRefCountingBehavior(vector);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ShuffleDocsOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ShuffleDocsOperator.java
@@ -61,7 +61,13 @@ public class ShuffleDocsOperator extends AbstractPageMappingOperator {
             }
         }
         Block[] blocks = new Block[page.getBlockCount()];
-        blocks[0] = new DocVector(AlwaysReferencedIndexedByShardId.INSTANCE, shards, segments, docs, false).asBlock();
+        blocks[0] = new DocVector(
+            AlwaysReferencedIndexedByShardId.INSTANCE,
+            shards,
+            segments,
+            docs,
+            DocVector.config().singleSegmentNonDecreasing(false)
+        ).asBlock();
         for (int i = 1; i < blocks.length; i++) {
             blocks[i] = page.getBlock(i);
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -131,7 +131,7 @@ public class ExtractorTests extends ESTestCase {
                                     blockFactory.newConstantIntBlockWith(randomIntBetween(0, 255), 1).asVector(),
                                     blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
                                     blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
-                                    randomBoolean() ? null : randomBoolean()
+                                    docVectorConfig()
                                 ).asBlock()
                             ) }
                     );
@@ -276,5 +276,13 @@ public class ExtractorTests extends ESTestCase {
         return haveNulls
             ? new LongRangeBlockBuilder.LongRange(randomBoolean() ? from : null, randomBoolean() ? to : null)
             : new LongRangeBlockBuilder.LongRange(from, to);
+    }
+
+    private static DocVector.Config docVectorConfig() {
+        DocVector.Config config = DocVector.config();
+        if (randomBoolean()) {
+            config.singleSegmentNonDecreasing(randomBoolean());
+        }
+        return config;
     }
 }

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
@@ -99,7 +99,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
      * asserting both that this throws a {@link CircuitBreakingException} and releases
      * all pages.
      */
-    public void testSimpleCircuitBreaking() {
+    public void testSimpleCircuitBreaking() throws Exception {
         /*
          * Build the input before building `simple` to handle the rare
          * cases where `simple` need some state from the input - mostly

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
@@ -420,7 +420,7 @@ public class PushExpressionToLoadIT extends ESRestTestCase {
                         // Pushed down function
                         matchesMap().entry("test:column_at_a_time:Utf8CodePointsFromOrds.Singleton", 1),
                         // Field
-                        matchesMap().entry("test:row_stride:BytesRefsFromOrds.Singleton", 1)
+                        matchesMap().entry("test:column_at_a_time:BytesRefsFromOrds.Singleton", 1)
                     )
                     : List.of(matchesMap().entry("test:row_stride:BytesRefsFromOrds.Singleton", 1))
             ),
@@ -455,7 +455,7 @@ public class PushExpressionToLoadIT extends ESRestTestCase {
                     // Pushed down function
                     matchesMap().entry("test:column_at_a_time:Utf8CodePointsFromOrds.Singleton", 1),
                     // TODO It should not load the field value on the data node, but just on the node_reduce phase
-                    matchesMap().entry("test:row_stride:BytesRefsFromOrds.Singleton", 1)
+                    matchesMap().entry("test:column_at_a_time:BytesRefsFromOrds.Singleton", 1)
                 )
             ),
             sig -> assertMap(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
@@ -489,7 +489,7 @@ public class LookupFromIndexOperatorTests extends AsyncOperatorTestCase {
     }
 
     @Override
-    public void testSimpleCircuitBreaking() {
+    public void testSimpleCircuitBreaking() throws Exception {
         // only test field based join and EQ to prevents timeouts in Ci
         if (operation == null || operation.equals(EsqlBinaryComparison.BinaryComparisonOperation.EQ)) {
             super.testSimpleCircuitBreaking();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -163,7 +163,7 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                 blockFactory.newConstantIntVector(index, page.getPositionCount()),
                 blockFactory.newConstantIntVector(0, page.getPositionCount()),
                 blockFactory.newIntArrayVector(IntStream.range(0, page.getPositionCount()).toArray(), page.getPositionCount()),
-                true
+                DocVector.config().singleSegmentNonDecreasing(true)
             );
             var block = docVector.asBlock();
             index++;


### PR DESCRIPTION
ESQL's `DocVector` is *fine* having duplicate doc ids inside it. Except some consumers aren't! It's much easy to optimize some of the loaders if there aren't any duplicate docs ids.

This adds a flag, `mayContainDuplicates` to `DocVector`. When it's `false` we `assert` that there aren't any duplicate docs. When it's `true` we allow duplicates. Callers that need to optimize can check if before running the no-dups-path.

While building this I consolidated a bunch of the ctor calls for `DocVector` into a pattern like this:
```
new DocVector(refCounteds, shards, segments, docs,
  DocVector.config().mayContainDuplicates()
)
```

`config()` handles all of the optional parameters builder-style.

While doing this I noticed that `ResultBuilderForDoc` didn't track it's memory! It should! So I wrote a `DocVector.FixedBuilder` class and plugged it in. It's easier to use than what we had and it tracks memory.
