### PR TITLE
[9.2] Use BoundedDelimitedStringCollector to Prevent large CancelTasksRequest descriptions by truncating nodes and actions (#141918)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestTests.java
@@ -16,6 +16,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Collections;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class CancelTasksRequestTests extends ESTestCase {
 
     public void testGetDescription_NoTruncation() {
@@ -33,88 +35,24 @@ public class CancelTasksRequestTests extends ESTestCase {
         assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
     }
 
-    public void testGetDescription_TruncatesNodesOnly() {
+    public void testGetDescription_BoundedCollectorTruncation() {
         CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
-
-        String[] nodes = IntStream.rangeClosed(1, 12).mapToObj(i -> "node" + i).toArray(String[]::new);
-        cancelTasksRequest.setNodes(nodes);
         cancelTasksRequest.setActions("action1", "action2");
         cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
         cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
 
-        assertEquals(
-            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
-                + "targetParentTaskId[node1:0], "
-                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (2 more)], "
-                + "actions[action1, action2]",
-            cancelTasksRequest.getDescription()
-        );
-
-        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
-        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
-    }
-
-    public void testGetDescription_TruncatesActionsOnly() {
-        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
-
-        String[] actions = IntStream.rangeClosed(1, 15).mapToObj(i -> "action" + i).toArray(String[]::new);
-        cancelTasksRequest.setActions(actions);
-        cancelTasksRequest.setNodes("node1", "node2");
-        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
-        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
-
-        assertEquals(
-            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
-                + "targetParentTaskId[node1:0], "
-                + "nodes[node1, node2], "
-                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (5 more)]",
-            cancelTasksRequest.getDescription()
-        );
-
-        Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
-        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
-    }
-
-    public void testGetDescription_TruncatesNodesAndActions() {
-        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
-
-        String[] nodes = IntStream.rangeClosed(1, 11).mapToObj(i -> "node" + i).toArray(String[]::new);
-        String[] actions = IntStream.rangeClosed(1, 20).mapToObj(i -> "action" + i).toArray(String[]::new);
-
+        String huge = "n".repeat(800);
+        String[] nodes = IntStream.rangeClosed(1, 5).mapToObj(i -> "node" + i + "-" + huge).toArray(String[]::new);
         cancelTasksRequest.setNodes(nodes);
-        cancelTasksRequest.setActions(actions);
-        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
-        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
 
-        assertEquals(
-            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
-                + "targetParentTaskId[node1:0], "
-                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10, ... (1 more)], "
-                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10, ... (10 more)]",
-            cancelTasksRequest.getDescription()
-        );
+        String description = cancelTasksRequest.getDescription();
+
+        assertThat(description, containsString("], nodes["));
+        assertThat(description, containsString("... (5 in total, "));
+        assertThat(description, containsString(" omitted)]"));
+        assertThat(description, containsString(", actions[action1, action2]"));
 
         Task task = cancelTasksRequest.createTask(1, "type", "action", null, Collections.emptyMap());
-        assertEquals(cancelTasksRequest.getDescription(), task.getDescription());
-    }
-
-    public void testGetDescription_ExactlyMaxDoesNotTruncate() {
-        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
-
-        String[] nodes = IntStream.rangeClosed(1, 10).mapToObj(i -> "node" + i).toArray(String[]::new);
-        String[] actions = IntStream.rangeClosed(1, 10).mapToObj(i -> "action" + i).toArray(String[]::new);
-
-        cancelTasksRequest.setNodes(nodes);
-        cancelTasksRequest.setActions(actions);
-        cancelTasksRequest.setTargetTaskId(new TaskId("node1", 1));
-        cancelTasksRequest.setTargetParentTaskId(new TaskId("node1", 0));
-
-        assertEquals(
-            "reason[by user request], waitForCompletion[false], targetTaskId[node1:1], "
-                + "targetParentTaskId[node1:0], "
-                + "nodes[node1, node2, node3, node4, node5, node6, node7, node8, node9, node10], "
-                + "actions[action1, action2, action3, action4, action5, action6, action7, action8, action9, action10]",
-            cancelTasksRequest.getDescription()
-        );
+        assertEquals(description, task.getDescription());
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Use BoundedDelimitedStringCollector to Prevent large CancelTasksRequest descriptions by truncating nodes and actions (#141918)