### PR TITLE
ESQL: Opt into dupes when filtering

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -115,7 +115,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     }
 
     @Override
-    public BooleanBlock filter(int... positions) {
+    public BooleanBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -89,7 +89,7 @@ final class BooleanArrayVector extends AbstractVector implements BooleanVector {
     }
 
     @Override
-    public BooleanVector filter(int... positions) {
+    public BooleanVector filter(boolean mayContainDuplicates, int... positions) {
         try (BooleanVector.Builder builder = blockFactory().newBooleanVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendBoolean(values[pos]);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -113,7 +113,7 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     }
 
     @Override
-    public BooleanBlock filter(int... positions) {
+    public BooleanBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
@@ -104,7 +104,7 @@ public final class BooleanBigArrayVector extends AbstractVector implements Boole
     }
 
     @Override
-    public BooleanVector filter(int... positions) {
+    public BooleanVector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
         final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -62,7 +62,7 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
     ToMask toMask();
 
     @Override
-    BooleanBlock filter(int... positions);
+    BooleanBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -28,7 +28,7 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     BooleanBlock asBlock();
 
     @Override
-    BooleanVector filter(int... positions);
+    BooleanVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     BooleanBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -55,8 +55,8 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
     }
 
     @Override
-    public BooleanBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public BooleanBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -101,7 +101,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     }
 
     @Override
-    public BytesRefBlock filter(int... positions) {
+    public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
         final BytesRef scratch = new BytesRef();
         try (var builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {
             for (int pos : positions) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -87,7 +87,7 @@ final class BytesRefArrayVector extends AbstractVector implements BytesRefVector
     }
 
     @Override
-    public BytesRefVector filter(int... positions) {
+    public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
         final var scratch = new BytesRef();
         try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(positions.length)) {
             for (int pos : positions) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -67,7 +67,7 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     OrdinalBytesRefBlock asOrdinals();
 
     @Override
-    BytesRefBlock filter(int... positions);
+    BytesRefBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -35,7 +35,7 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     OrdinalBytesRefVector asOrdinals();
 
     @Override
-    BytesRefVector filter(int... positions);
+    BytesRefVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     BytesRefBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -60,8 +60,8 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     }
 
     @Override
-    public BytesRefBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -41,7 +41,7 @@ final class ConstantBooleanVector extends AbstractVector implements BooleanVecto
     }
 
     @Override
-    public BooleanVector filter(int... positions) {
+    public BooleanVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantBooleanVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -50,7 +50,7 @@ final class ConstantBytesRefVector extends AbstractVector implements BytesRefVec
     }
 
     @Override
-    public BytesRefVector filter(int... positions) {
+    public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantBytesRefVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -41,7 +41,7 @@ final class ConstantDoubleVector extends AbstractVector implements DoubleVector 
     }
 
     @Override
-    public DoubleVector filter(int... positions) {
+    public DoubleVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantDoubleVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
@@ -41,7 +41,7 @@ final class ConstantFloatVector extends AbstractVector implements FloatVector {
     }
 
     @Override
-    public FloatVector filter(int... positions) {
+    public FloatVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantFloatVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -41,7 +41,7 @@ final class ConstantIntVector extends AbstractVector implements IntVector {
     }
 
     @Override
-    public IntVector filter(int... positions) {
+    public IntVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantIntVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -41,7 +41,7 @@ final class ConstantLongVector extends AbstractVector implements LongVector {
     }
 
     @Override
-    public LongVector filter(int... positions) {
+    public LongVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantLongVector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -94,7 +94,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     }
 
     @Override
-    public DoubleBlock filter(int... positions) {
+    public DoubleBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -88,7 +88,7 @@ final class DoubleArrayVector extends AbstractVector implements DoubleVector {
     }
 
     @Override
-    public DoubleVector filter(int... positions) {
+    public DoubleVector filter(boolean mayContainDuplicates, int... positions) {
         try (DoubleVector.Builder builder = blockFactory().newDoubleVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendDouble(values[pos]);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -92,7 +92,7 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     }
 
     @Override
-    public DoubleBlock filter(int... positions) {
+    public DoubleBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
@@ -79,7 +79,7 @@ public final class DoubleBigArrayVector extends AbstractVector implements Double
     }
 
     @Override
-    public DoubleVector filter(int... positions) {
+    public DoubleVector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
         final DoubleArray filtered = blockFactory.bigArrays().newDoubleArray(positions.length);
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -84,7 +84,7 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
     DoubleVector asVector();
 
     @Override
-    DoubleBlock filter(int... positions);
+    DoubleBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -28,7 +28,7 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     DoubleBlock asBlock();
 
     @Override
-    DoubleVector filter(int... positions);
+    DoubleVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     DoubleBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -49,8 +49,8 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
     }
 
     @Override
-    public DoubleBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public DoubleBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
@@ -94,7 +94,7 @@ public final class FloatArrayBlock extends AbstractArrayBlock implements FloatBl
     }
 
     @Override
-    public FloatBlock filter(int... positions) {
+    public FloatBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newFloatBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
@@ -88,7 +88,7 @@ final class FloatArrayVector extends AbstractVector implements FloatVector {
     }
 
     @Override
-    public FloatVector filter(int... positions) {
+    public FloatVector filter(boolean mayContainDuplicates, int... positions) {
         try (FloatVector.Builder builder = blockFactory().newFloatVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendFloat(values[pos]);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayBlock.java
@@ -92,7 +92,7 @@ public final class FloatBigArrayBlock extends AbstractArrayBlock implements Floa
     }
 
     @Override
-    public FloatBlock filter(int... positions) {
+    public FloatBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newFloatBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayVector.java
@@ -67,7 +67,7 @@ public final class FloatBigArrayVector extends AbstractVector implements FloatVe
     }
 
     @Override
-    public FloatVector filter(int... positions) {
+    public FloatVector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
         final FloatArray filtered = blockFactory.bigArrays().newFloatArray(positions.length);
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
@@ -84,7 +84,7 @@ public sealed interface FloatBlock extends Block permits FloatArrayBlock, FloatV
     FloatVector asVector();
 
     @Override
-    FloatBlock filter(int... positions);
+    FloatBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
@@ -28,7 +28,7 @@ public sealed interface FloatVector extends Vector permits ConstantFloatVector, 
     FloatBlock asBlock();
 
     @Override
-    FloatVector filter(int... positions);
+    FloatVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     FloatBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
@@ -49,8 +49,8 @@ public final class FloatVectorBlock extends AbstractVectorBlock implements Float
     }
 
     @Override
-    public FloatBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public FloatBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -94,7 +94,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     }
 
     @Override
-    public IntBlock filter(int... positions) {
+    public IntBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -98,7 +98,7 @@ final class IntArrayVector extends AbstractVector implements IntVector {
     }
 
     @Override
-    public IntVector filter(int... positions) {
+    public IntVector filter(boolean mayContainDuplicates, int... positions) {
         try (IntVector.Builder builder = blockFactory().newIntVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendInt(values[pos]);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -92,7 +92,7 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     }
 
     @Override
-    public IntBlock filter(int... positions) {
+    public IntBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -119,7 +119,7 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
     }
 
     @Override
-    public IntVector filter(int... positions) {
+    public IntVector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
         final IntArray filtered = blockFactory.bigArrays().newIntArray(positions.length);
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -84,7 +84,7 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
     IntVector asVector();
 
     @Override
-    IntBlock filter(int... positions);
+    IntBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -28,7 +28,7 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     IntBlock asBlock();
 
     @Override
-    IntVector filter(int... positions);
+    IntVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     IntBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -49,8 +49,8 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
     }
 
     @Override
-    public IntBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public IntBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -94,7 +94,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     }
 
     @Override
-    public LongBlock filter(int... positions) {
+    public LongBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -88,7 +88,7 @@ final class LongArrayVector extends AbstractVector implements LongVector {
     }
 
     @Override
-    public LongVector filter(int... positions) {
+    public LongVector filter(boolean mayContainDuplicates, int... positions) {
         try (LongVector.Builder builder = blockFactory().newLongVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendLong(values[pos]);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -92,7 +92,7 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     }
 
     @Override
-    public LongBlock filter(int... positions) {
+    public LongBlock filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
@@ -79,7 +79,7 @@ public final class LongBigArrayVector extends AbstractVector implements LongVect
     }
 
     @Override
-    public LongVector filter(int... positions) {
+    public LongVector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
         final LongArray filtered = blockFactory.bigArrays().newLongArray(positions.length);
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -84,7 +84,7 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
     LongVector asVector();
 
     @Override
-    LongBlock filter(int... positions);
+    LongBlock filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -28,7 +28,7 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
     LongBlock asBlock();
 
     @Override
-    LongVector filter(int... positions);
+    LongVector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     LongBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -49,8 +49,8 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
     }
 
     @Override
-    public LongBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public LongBlock filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
@@ -80,6 +80,7 @@ record FilteredGroupingAggregatorFunction(GroupingAggregatorFunction next, EvalO
             } else {
                 try (
                     BooleanVector offsetMask = mask.filter(
+                        false,
                         IntStream.range(positionOffset, positionOffset + groupIds.getPositionCount()).toArray()
                     );
                     IntBlock filtered = groupIds.keepMask(offsetMask)

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
@@ -52,8 +52,8 @@ public abstract class AbstractDelegatingCompoundBlock<T extends Block> extends A
     }
 
     @Override
-    public T filter(int... positions) {
-        return applyOperationToSubBlocks(block -> block.filter(positions));
+    public T filter(boolean mayContainDuplicates, int... positions) {
+        return applyOperationToSubBlocks(block -> block.filter(mayContainDuplicates, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlock.java
@@ -18,7 +18,7 @@ import java.util.List;
 public sealed interface AggregateMetricDoubleBlock extends Block permits AggregateMetricDoubleArrayBlock, ConstantNullBlock {
 
     @Override
-    AggregateMetricDoubleBlock filter(int... positions);
+    AggregateMetricDoubleBlock filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     AggregateMetricDoubleBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -271,10 +271,11 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
 
     /**
      * Creates a new block that only exposes the positions provided.
+     * @param mayContainDuplicates may the positions array contain duplicate positions?
      * @param positions the positions to retain
      * @return a filtered block
      */
-    Block filter(int... positions); // TODO mayContainDuplicates
+    Block filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Build a {@link Block} with the same values as this {@linkplain Block}, but replacing

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
@@ -151,12 +151,12 @@ public final class CompositeBlock extends AbstractNonThreadSafeRefCounted implem
     }
 
     @Override
-    public CompositeBlock filter(int... positions) {
+    public CompositeBlock filter(boolean mayContainDuplicates, int... positions) {
         CompositeBlock result = null;
         final Block[] filteredBlocks = new Block[blocks.length];
         try {
             for (int i = 0; i < blocks.length; i++) {
-                filteredBlocks[i] = blocks[i].filter(positions);
+                filteredBlocks[i] = blocks[i].filter(mayContainDuplicates, positions);
             }
             result = new CompositeBlock(filteredBlocks);
             return result;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -87,7 +87,7 @@ public final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
-    public ConstantNullBlock filter(int... positions) {
+    public ConstantNullBlock filter(boolean mayContainDuplicates, int... positions) {
         return (ConstantNullBlock) blockFactory().newConstantNullBlock(positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -49,7 +49,7 @@ public final class ConstantNullVector extends AbstractVector
     }
 
     @Override
-    public ConstantNullVector filter(int... positions) {
+    public ConstantNullVector filter(boolean mayContainDuplicates, int... positions) {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -44,8 +44,8 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
     }
 
     @Override
-    public Block filter(int... positions) {
-        return new DocBlock(vector.filter(positions));
+    public Block filter(boolean mayContainDuplicates, int... positions) {
+        return new DocBlock(vector.filter(mayContainDuplicates, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -324,19 +324,20 @@ public final class DocVector extends AbstractVector implements Vector {
     }
 
     @Override
-    public DocVector filter(int... positions) {
+    public DocVector filter(boolean mayContainDuplicates, int... positions) {
+        mayContainDuplicates |= this.mayContainDuplicates;
         IntVector filteredShards = null;
         IntVector filteredSegments = null;
         IntVector filteredDocs = null;
         DocVector result = null;
         try {
-            filteredShards = shards.filter(positions);
-            filteredSegments = segments.filter(positions);
-            filteredDocs = docs.filter(positions);
+            filteredShards = shards.filter(mayContainDuplicates, positions);
+            filteredSegments = segments.filter(mayContainDuplicates, positions);
+            filteredDocs = docs.filter(mayContainDuplicates, positions);
             Config config = config();
-            // TODO accept another parameter to say "I might be passed duplicate positions"
-            // Without that parameter we *always* may contain duplicates
-            config.mayContainDuplicates();
+            if (mayContainDuplicates) {
+                config.mayContainDuplicates();
+            }
             result = new DocVector(refCounteds, filteredShards, filteredSegments, filteredDocs, config);
             return result;
         } finally {
@@ -400,7 +401,10 @@ public final class DocVector extends AbstractVector implements Vector {
             return false;
         }
         DocVector other = (DocVector) obj;
-        return shards.equals(other.shards) && segments.equals(other.segments) && docs.equals(other.docs);
+        return shards.equals(other.shards)
+            && segments.equals(other.segments)
+            && docs.equals(other.docs)
+            && mayContainDuplicates == other.mayContainDuplicates;
     }
 
     @Override
@@ -409,6 +413,7 @@ public final class DocVector extends AbstractVector implements Vector {
         sb.append("shards=").append(shards);
         sb.append(", segments=").append(segments);
         sb.append(", docs=").append(docs);
+        sb.append(", mayContainDuplicates=").append(mayContainDuplicates);
         sb.append(']');
         return sb.toString();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
@@ -46,7 +46,7 @@ final class IntRangeVector extends AbstractVector implements IntVector {
     }
 
     @Override
-    public IntVector filter(int... positions) {
+    public IntVector filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().newIntVectorFixedBuilder(positions.length)) {
             for (int i = 0; i < positions.length; i++) {
                 int p = positions[i];

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeArrayBlock.java
@@ -106,13 +106,13 @@ public final class LongRangeArrayBlock extends AbstractNonThreadSafeRefCounted i
     }
 
     @Override
-    public LongRangeBlock filter(int... positions) {
+    public LongRangeBlock filter(boolean mayContainDuplicates, int... positions) {
         LongRangeBlock result = null;
         LongBlock newFromBlock = null;
         LongBlock newToBlock = null;
         try {
-            newFromBlock = fromBlock.filter(positions);
-            newToBlock = toBlock.filter(positions);
+            newFromBlock = fromBlock.filter(mayContainDuplicates, positions);
+            newToBlock = toBlock.filter(mayContainDuplicates, positions);
             result = new LongRangeArrayBlock(newFromBlock, newToBlock);
             return result;
         } finally {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlock.java
@@ -15,7 +15,7 @@ import org.elasticsearch.core.ReleasableIterator;
  */
 public sealed interface LongRangeBlock extends Block permits LongRangeArrayBlock, ConstantNullBlock {
     @Override
-    LongRangeBlock filter(int... positions);
+    LongRangeBlock filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     LongRangeBlock keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -90,13 +90,13 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     @Override
-    public BytesRefBlock filter(int... positions) {
+    public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
         // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
         // may reappear when hashing the dictionary in BlockHash.
         // TODO: merge this BytesRefArrayBlock#filter
         final OrdinalBytesRefVector vector = asVector();
         if (vector != null) {
-            return vector.filter(positions).asBlock();
+            return vector.filter(mayContainDuplicates, positions).asBlock();
         }
         BytesRef scratch = new BytesRef();
         try (BytesRefBlock.Builder builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -98,7 +98,7 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
-    public BytesRefVector filter(int... positions) {
+    public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
         // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
         // may reappear when hashing the dictionary in BlockHash.
         final BytesRef scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -300,12 +300,18 @@ public final class Page implements Writeable, Releasable {
         }
     }
 
-    public Page filter(int... positions) {
+    /**
+     * Creates a new page that only exposes the positions provided.
+     * @param mayContainDuplicates may the positions array contain duplicate positions?
+     * @param positions the positions to retain
+     * @return a filtered page
+     */
+    public Page filter(boolean mayContainDuplicates, int... positions) {
         Block[] filteredBlocks = new Block[blocks.length];
         boolean success = false;
         try {
             for (int i = 0; i < blocks.length; i++) {
-                filteredBlocks[i] = getBlock(i).filter(positions);
+                filteredBlocks[i] = getBlock(i).filter(mayContainDuplicates, positions);
             }
             success = true;
         } finally {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -42,10 +42,11 @@ public interface Vector extends Accountable, RefCounted, Releasable {
 
     /**
      * Creates a new vector that only exposes the positions provided. Materialization of the selected positions is avoided.
+     * @param mayContainDuplicates may the positions array contain duplicate positions?
      * @param positions the positions to retain
      * @return a filtered vector
      */
-    Vector filter(int... positions);
+    Vector filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Build a {@link Block} the same values as this {@link Vector}, but replacing

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -134,7 +134,7 @@ $endif$
     }
 
     @Override
-    public $Type$Block filter(int... positions) {
+    public $Type$Block filter(boolean mayContainDuplicates, int... positions) {
 $if(BytesRef)$
         final BytesRef scratch = new BytesRef();
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -147,7 +147,7 @@ $endif$
     }
 
     @Override
-    public $Type$Vector filter(int... positions) {
+    public $Type$Vector filter(boolean mayContainDuplicates, int... positions) {
     $if(BytesRef)$
         final var scratch = new BytesRef();
     $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -115,7 +115,7 @@ $endif$
     }
 
     @Override
-    public $Type$Block filter(int... positions) {
+    public $Type$Block filter(boolean mayContainDuplicates, int... positions) {
         try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -164,7 +164,7 @@ $endif$
     }
 
     @Override
-    public $Type$Vector filter(int... positions) {
+    public $Type$Vector filter(boolean mayContainDuplicates, int... positions) {
         var blockFactory = blockFactory();
     $if(boolean)$
         final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -138,7 +138,7 @@ $elseif(boolean)$
 
 $endif$
     @Override
-    $Type$Block filter(int... positions);
+    $Type$Block filter(boolean mayContainDuplicates, int... positions);
 
     /**
      * Make a deep copy of this {@link Block} using the provided {@link BlockFactory},

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -64,7 +64,7 @@ $if(BytesRef)$
 $endif$
 
     @Override
-    public $Type$Vector filter(int... positions) {
+    public $Type$Vector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstant$Type$Vector(value, positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -58,7 +58,7 @@ $if(BytesRef)$
 
 $endif$
     @Override
-    $Type$Vector filter(int... positions);
+    $Type$Vector filter(boolean mayContainDuplicates, int... positions);
 
     @Override
     $Type$Block keepMask(BooleanVector mask);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -76,8 +76,8 @@ $endif$
     }
 
     @Override
-    public $Type$Block filter(int... positions) {
-        return vector.filter(positions).asBlock();
+    public $Type$Block filter(boolean mayContainDuplicates, int... positions) {
+        return vector.filter(mayContainDuplicates, positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneQueryEvaluator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneQueryEvaluator.java
@@ -163,7 +163,7 @@ public abstract class LuceneQueryEvaluator<T extends Block.Builder> implements R
                 }
             }
             try (Block outOfOrder = scoreBuilder.build()) {
-                return outOfOrder.filter(docs.shardSegmentDocMapBackwards());
+                return outOfOrder.filter(false, docs.shardSegmentDocMapBackwards());
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromManyReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromManyReader.java
@@ -131,7 +131,7 @@ class ValuesFromManyReader extends ValuesReader {
             convertAndAccumulate();
             for (int f = 0; f < target.length; f++) {
                 try (Block targetBlock = finalBuilders[f].build()) {
-                    target[f] = targetBlock.filter(backwards);
+                    target[f] = targetBlock.filter(false, backwards);
                 }
                 operator.sanityCheckBlock(rowStride[f], backwards.length, target[f], f);
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromSingleReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromSingleReader.java
@@ -73,7 +73,7 @@ class ValuesFromSingleReader extends ValuesReader {
             );
             final int[] backwards = docs.shardSegmentDocMapBackwards();
             for (int i = 0; i < unshuffled.length; i++) {
-                target[i] = unshuffled[i].filter(backwards);
+                target[i] = unshuffled[i].filter(false, backwards);
                 unshuffled[i].close();
                 unshuffled[i] = null;
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
@@ -357,7 +357,7 @@ public abstract class AbstractPageMappingToIteratorOperator implements Operator 
                 // TODO a way to filter with a range please.
                 int[] positions = IntStream.range(start, positionOffset).toArray();
                 for (int b = 0; b < page.getBlockCount(); b++) {
-                    newBlocks[b] = page.getBlock(b).filter(positions);
+                    newBlocks[b] = page.getBlock(b).filter(false, positions);
                 }
                 Page result = new Page(newBlocks);
                 Arrays.fill(newBlocks, null);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
@@ -68,7 +68,7 @@ public class FilterOperator extends AbstractPageMappingOperator {
             }
             positions = Arrays.copyOf(positions, rowCount);
 
-            return page.filter(positions);
+            return page.filter(false, positions);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
@@ -116,7 +116,7 @@ public class LimitOperator implements Operator {
         Page result = null;
         try {
             for (int b = 0; b < blocks.length; b++) {
-                blocks[b] = page.getBlock(b).filter(filter);
+                blocks[b] = page.getBlock(b).filter(false, filter);
             }
             result = new Page(blocks);
         } finally {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
@@ -156,7 +156,7 @@ public class MvExpandOperator implements Operator {
             }
             nextItemOnExpanded += expandedMask.length;
             for (int b = 0; b < result.length; b++) {
-                result[b] = b == channel ? expandedBlock.filter(expandedMask) : prev.getBlock(b).filter(duplicateFilter);
+                result[b] = b == channel ? expandedBlock.filter(true, expandedMask) : prev.getBlock(b).filter(true, duplicateFilter);
             }
             success = true;
         } finally {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SampleOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SampleOperator.java
@@ -111,7 +111,7 @@ public class SampleOperator implements Operator {
             sampledPositions[sampledIdx++] = Math.toIntExact(i - rowsReceived);
         }
         if (sampledIdx > 0) {
-            outputPages.add(page.filter(Arrays.copyOf(sampledPositions, sampledIdx)));
+            outputPages.add(page.filter(false, Arrays.copyOf(sampledPositions, sampledIdx)));
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/RightChunkedLeftJoin.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/RightChunkedLeftJoin.java
@@ -180,7 +180,7 @@ public class RightChunkedLeftJoin implements Releasable {
 
             int b = 0;
             while (b < leftHand.getBlockCount()) {
-                blocks[b] = leftHand.getBlock(b).filter(leftFilterArray);
+                blocks[b] = leftHand.getBlock(b).filter(true, leftFilterArray);
                 b++;
             }
             int rb = 1; // Skip the positions column
@@ -220,7 +220,7 @@ public class RightChunkedLeftJoin implements Releasable {
         try {
             int b = 0;
             while (b < leftHand.getBlockCount()) {
-                blocks[b] = leftHand.getBlock(b).filter(filter);
+                blocks[b] = leftHand.getBlock(b).filter(true, filter);
                 b++;
             }
             while (b < blocks.length) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockEqualityTests.java
@@ -39,12 +39,12 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
 
         List<AggregateMetricDoubleBlock> blocks = List.of(
             blockFactory.newAggregateMetricDoubleBlockBuilder(0).build(),
-            blockFactory.newAggregateMetricDoubleBlockBuilder(0).appendNull().build().filter(),
-            partialMetricBuilder.build().filter(),
+            blockFactory.newAggregateMetricDoubleBlockBuilder(0).appendNull().build().filter(false),
+            partialMetricBuilder.build().filter(false),
             blockFactory.newConstantAggregateMetricDoubleBlock(
                 new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, 0),
                 0
-            ).filter(),
+            ).filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
 
@@ -75,8 +75,8 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
 
         List<AggregateMetricDoubleBlock> blocks = List.of(
             builder1.build(),
-            builder2.build().filter(0, 2, 5),
-            builder3.build().filter(2, 3, 4)
+            builder2.build().filter(false, 0, 2, 5),
+            builder3.build().filter(false, 2, 3, 4)
         );
         assertAllEquals(blocks);
     }
@@ -119,13 +119,13 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
 
         List<AggregateMetricDoubleBlock> moreBlocks = List.of(
             builder1.build(),
-            builder2.build().filter(0, 2),
+            builder2.build().filter(false, 0, 2),
             AggregateMetricDoubleArrayBlock.fromCompositeBlock(compositeBlock1),
-            AggregateMetricDoubleArrayBlock.fromCompositeBlock(compositeBlock2).filter(2, 3),
+            AggregateMetricDoubleArrayBlock.fromCompositeBlock(compositeBlock2).filter(false, 2, 3),
             blockFactory.newConstantAggregateMetricDoubleBlock(
                 new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6),
                 4
-            ).filter(1, 3),
+            ).filter(false, 1, 3),
             blockFactory.newConstantAggregateMetricDoubleBlock(
                 new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6),
                 2
@@ -162,7 +162,7 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
         builder2.sum().appendNull();
         builder2.count().appendInt(1000);
 
-        List<AggregateMetricDoubleBlock> evenMoreBlocks = List.of(builder1.build(), builder2.build().filter(2, 3, 5));
+        List<AggregateMetricDoubleBlock> evenMoreBlocks = List.of(builder1.build(), builder2.build().filter(false, 2, 3, 5));
         assertAllEquals(evenMoreBlocks);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -1170,30 +1170,30 @@ public class BasicBlockTests extends ESTestCase {
                 assertThat(s, containsString("positions=2"));
             }
             for (IntBlock block : List.of(intBlock, intVector.asBlock())) {
-                try (var filter = block.filter(0)) {
+                try (var filter = block.filter(false, 0)) {
                     assertThat(filter.toString(), containsString("IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]"));
                 }
-                try (var filter = block.filter(1)) {
+                try (var filter = block.filter(false, 1)) {
                     assertThat(filter.toString(), containsString("IntVectorBlock[vector=ConstantIntVector[positions=1, value=2]]"));
                 }
-                try (var filter = block.filter(0, 1)) {
+                try (var filter = block.filter(false, 0, 1)) {
                     assertThat(filter.toString(), containsString("IntVectorBlock[vector=IntArrayVector[positions=2, values=[1, 2]]]"));
                 }
-                try (var filter = block.filter()) {
+                try (var filter = block.filter(false)) {
                     assertThat(filter.toString(), containsString("IntVectorBlock[vector=IntArrayVector[positions=0, values=[]]]"));
                 }
             }
             for (IntVector vector : List.of(intVector, intBlock.asVector())) {
-                try (var filter = vector.filter(0)) {
+                try (var filter = vector.filter(false, 0)) {
                     assertThat(filter.toString(), containsString("ConstantIntVector[positions=1, value=1]"));
                 }
-                try (IntVector filter = vector.filter(1)) {
+                try (IntVector filter = vector.filter(false, 1)) {
                     assertThat(filter.toString(), containsString("ConstantIntVector[positions=1, value=2]"));
                 }
-                try (IntVector filter = vector.filter(0, 1)) {
+                try (IntVector filter = vector.filter(false, 0, 1)) {
                     assertThat(filter.toString(), containsString("IntArrayVector[positions=2, values=[1, 2]]"));
                 }
-                try (IntVector filter = vector.filter()) {
+                try (IntVector filter = vector.filter(false)) {
                     assertThat(filter.toString(), containsString("IntArrayVector[positions=0, values=[]]"));
                 }
             }
@@ -1555,7 +1555,7 @@ public class BasicBlockTests extends ESTestCase {
                 for (int i = 0; i < masks.length; i++) {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
-                try (var filtered = block.filter(masks)) {
+                try (var filtered = block.filter(true, masks)) {
                     assertThat(filtered, not(instanceOf(OrdinalBytesRefBlock.class)));
                 }
             }
@@ -1580,7 +1580,7 @@ public class BasicBlockTests extends ESTestCase {
                 for (int i = 0; i < masks.length; i++) {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
-                try (var filtered = vector.filter(masks)) {
+                try (var filtered = vector.filter(true, masks)) {
                     assertThat(filtered, not(instanceOf(OrdinalBytesRefVector.class)));
                 }
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -271,7 +271,7 @@ public class BasicPageTests extends SerializationTestCase {
                 ),
                 10
             ),
-            toFilter.filter(5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
+            toFilter.filter(false, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
         );
         toFilter.close();
         try {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -51,7 +51,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
             assertThat(positionCount, is(vector.getPositionCount()));
             IntStream.range(0, positionCount).forEach(i -> assertThat(vector.getBoolean(i), is(values[i])));
             assertThat(vector.isConstant(), is(false));
-            try (BooleanVector filtered = vector.filter(IntStream.range(0, positionCount).toArray())) {
+            try (BooleanVector filtered = vector.filter(false, IntStream.range(0, positionCount).toArray())) {
                 IntStream.range(0, positionCount).forEach(i -> assertThat(filtered.getBoolean(i), is(values[i])));
                 assertThat(filtered.isConstant(), is(false));
             }
@@ -62,7 +62,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.isNull(i), is(false));
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
-                try (BooleanBlock filter = block.filter(i)) {
+                try (BooleanBlock filter = block.filter(false, i)) {
                     assertThat(filter.getBoolean(0), is(values[i]));
                 }
             });
@@ -109,7 +109,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
             assertThat(positionCount, is(vector.getPositionCount()));
             IntStream.range(0, positionCount).forEach(i -> assertThat(vector.getInt(i), is(values[i])));
             assertThat(vector.isConstant(), is(false));
-            try (IntVector filtered = vector.filter(IntStream.range(0, positionCount).toArray())) {
+            try (IntVector filtered = vector.filter(false, IntStream.range(0, positionCount).toArray())) {
                 IntStream.range(0, positionCount).forEach(i -> assertThat(filtered.getInt(i), is(values[i])));
                 assertThat(filtered.isConstant(), is(false));
             }
@@ -120,7 +120,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.isNull(i), is(false));
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
-                try (IntBlock filter = block.filter(i)) {
+                try (IntBlock filter = block.filter(false, i)) {
                     assertThat(filter.getInt(0), is(values[i]));
                 }
             });
@@ -151,7 +151,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
             assertThat(positionCount, is(vector.getPositionCount()));
             IntStream.range(0, positionCount).forEach(i -> assertThat(vector.getLong(i), is(values[i])));
             assertThat(vector.isConstant(), is(false));
-            try (LongVector filtered = vector.filter(IntStream.range(0, positionCount).toArray())) {
+            try (LongVector filtered = vector.filter(false, IntStream.range(0, positionCount).toArray())) {
                 IntStream.range(0, positionCount).forEach(i -> assertThat(filtered.getLong(i), is(values[i])));
                 assertThat(filtered.isConstant(), is(false));
             }
@@ -162,7 +162,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.isNull(i), is(false));
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
-                try (LongBlock filter = block.filter(i)) {
+                try (LongBlock filter = block.filter(false, i)) {
                     assertThat(filter.getLong(0), is(values[i]));
                 }
             });
@@ -191,7 +191,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
             assertThat(positionCount, is(vector.getPositionCount()));
             IntStream.range(0, positionCount).forEach(i -> assertThat(vector.getDouble(i), is(values[i])));
             assertThat(vector.isConstant(), is(false));
-            try (DoubleVector filtered = vector.filter(IntStream.range(0, positionCount).toArray())) {
+            try (DoubleVector filtered = vector.filter(false, IntStream.range(0, positionCount).toArray())) {
                 IntStream.range(0, positionCount).forEach(i -> assertThat(filtered.getDouble(i), is(values[i])));
                 assertThat(filtered.isConstant(), is(false));
             }
@@ -202,7 +202,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.isNull(i), is(false));
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
-                try (DoubleBlock filter = block.filter(i)) {
+                try (DoubleBlock filter = block.filter(false, i)) {
                     assertThat(filter.getDouble(0), is(values[i]));
                 }
             });

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -57,7 +57,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         Vector emptyPlusSome = blockFactory.newBooleanArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + randomData.length)));
 
-        Vector filterVector = emptyPlusSome.filter(1);
+        Vector filterVector = emptyPlusSome.filter(false, 1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
@@ -76,7 +76,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         Vector emptyPlusSome = blockFactory.newIntArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + (long) Integer.BYTES * randomData.length)));
 
-        Vector filterVector = emptyPlusSome.filter(1);
+        Vector filterVector = emptyPlusSome.filter(false, 1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
@@ -95,7 +95,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         Vector emptyPlusSome = blockFactory.newLongArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(empty.ramBytesUsed() + (long) Long.BYTES * randomData.length));
 
-        Vector filterVector = emptyPlusSome.filter(1);
+        Vector filterVector = emptyPlusSome.filter(false, 1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
 
         Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
@@ -116,7 +116,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(empty.ramBytesUsed() + (long) Double.BYTES * randomData.length));
 
         // a filter becomes responsible for it's enclosing data, both in terms of accountancy and releasability
-        Vector filterVector = emptyPlusSome.filter(1);
+        Vector filterVector = emptyPlusSome.filter(false, 1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
 
         Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
@@ -136,7 +136,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         Vector emptyPlusOne = blockFactory.newBytesRefArrayVector(arrayWithOne, 1);
         assertThat(emptyPlusOne.ramBytesUsed(), between(emptyVector.ramBytesUsed() + bytesRef.length, UPPER_BOUND));
 
-        Vector filterVector = emptyPlusOne.filter(0);
+        Vector filterVector = emptyPlusOne.filter(false, 0);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
         Releasables.close(emptyVector, emptyPlusOne, filterVector);
     }
@@ -178,7 +178,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         );
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
-        Block filterBlock = emptyPlusSome.filter(1);
+        Block filterBlock = emptyPlusSome.filter(false, 1);
         assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
@@ -230,7 +230,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         );
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
-        Block filterBlock = emptyPlusSome.filter(1);
+        Block filterBlock = emptyPlusSome.filter(false, 1);
         assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
@@ -279,7 +279,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         );
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
-        Block filterBlock = emptyPlusSome.filter(1);
+        Block filterBlock = emptyPlusSome.filter(false, 1);
         assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
@@ -334,7 +334,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         );
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
-        Block filterBlock = emptyPlusSome.filter(1);
+        Block filterBlock = emptyPlusSome.filter(false, 1);
         assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
         Releasables.close(filterBlock);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderCopyFromTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderCopyFromTests.java
@@ -131,6 +131,6 @@ public class BlockBuilderCopyFromTests extends ESTestCase {
     private Block randomFilteredBlock() {
         int keepers = between(0, 4);
         Block orig = randomBlock();
-        return orig.filter(IntStream.range(0, orig.getPositionCount()).filter(i -> i % 5 == keepers).toArray());
+        return orig.filter(false, IntStream.range(0, orig.getPositionCount()).filter(i -> i % 5 == keepers).toArray());
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -213,7 +213,7 @@ public class BlockMultiValuedTests extends ESTestCase {
         var b = RandomBlock.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 10, 0, 0);
         try {
             int[] positions = randomFilterPositions(b.block(), all, shuffled);
-            Block filtered = b.block().filter(positions);
+            Block filtered = b.block().filter(false, positions);
             try {
                 assertThat(filtered.getPositionCount(), equalTo(positions.length));
 
@@ -282,7 +282,7 @@ public class BlockMultiValuedTests extends ESTestCase {
         var b = RandomBlock.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 10, 0, 0);
         try {
             int[] positions = randomFilterPositions(b.block(), all, shuffled);
-            assertExpanded(b.block().filter(positions));
+            assertExpanded(b.block().filter(false, positions));
         } finally {
             b.block().close();
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -69,62 +69,62 @@ public class BlockSerializationTests extends SerializationTestCase {
     public void testEmptyIntBlock() throws IOException {
         assertEmptyBlock(blockFactory.newIntBlockBuilder(0).build());
         try (IntBlock toFilter = blockFactory.newIntBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
         assertEmptyBlock(blockFactory.newIntVectorBuilder(0).build().asBlock());
         try (IntVector toFilter = blockFactory.newIntVectorBuilder(0).appendInt(randomInt()).build()) {
-            assertEmptyBlock(toFilter.filter().asBlock());
+            assertEmptyBlock(toFilter.filter(false).asBlock());
         }
     }
 
     public void testEmptyLongBlock() throws IOException {
         assertEmptyBlock(blockFactory.newLongBlockBuilder(0).build());
         try (LongBlock toFilter = blockFactory.newLongBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
         assertEmptyBlock(blockFactory.newLongVectorBuilder(0).build().asBlock());
         try (LongVector toFilter = blockFactory.newLongVectorBuilder(0).appendLong(randomLong()).build()) {
-            assertEmptyBlock(toFilter.filter().asBlock());
+            assertEmptyBlock(toFilter.filter(false).asBlock());
         }
     }
 
     public void testEmptyFloatBlock() throws IOException {
         assertEmptyBlock(blockFactory.newFloatBlockBuilder(0).build());
         try (FloatBlock toFilter = blockFactory.newFloatBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
         assertEmptyBlock(blockFactory.newFloatVectorBuilder(0).build().asBlock());
         try (FloatVector toFilter = blockFactory.newFloatVectorBuilder(0).appendFloat(randomFloat()).build()) {
-            assertEmptyBlock(toFilter.filter().asBlock());
+            assertEmptyBlock(toFilter.filter(false).asBlock());
         }
     }
 
     public void testEmptyDoubleBlock() throws IOException {
         assertEmptyBlock(blockFactory.newDoubleBlockBuilder(0).build());
         try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
         assertEmptyBlock(blockFactory.newDoubleVectorBuilder(0).build().asBlock());
         try (DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(0).appendDouble(randomDouble()).build()) {
-            assertEmptyBlock(toFilter.filter().asBlock());
+            assertEmptyBlock(toFilter.filter(false).asBlock());
         }
     }
 
     public void testEmptyBytesRefBlock() throws IOException {
         assertEmptyBlock(blockFactory.newBytesRefBlockBuilder(0).build());
         try (BytesRefBlock toFilter = blockFactory.newBytesRefBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
         assertEmptyBlock(blockFactory.newBytesRefVectorBuilder(0).build().asBlock());
         try (BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0).appendBytesRef(randomBytesRef()).build()) {
-            assertEmptyBlock(toFilter.filter().asBlock());
+            assertEmptyBlock(toFilter.filter(false).asBlock());
         }
     }
 
     public void testEmptyAggregateMetricDoubleBlock() throws IOException {
         assertEmptyBlock(blockFactory.newAggregateMetricDoubleBlockBuilder(0).build());
         try (AggregateMetricDoubleBlock toFilter = blockFactory.newAggregateMetricDoubleBlockBuilder(0).appendNull().build()) {
-            assertEmptyBlock(toFilter.filter());
+            assertEmptyBlock(toFilter.filter(false));
         }
     }
 
@@ -137,65 +137,64 @@ public class BlockSerializationTests extends SerializationTestCase {
 
     public void testFilterIntBlock() throws IOException {
         try (IntBlock toFilter = blockFactory.newIntBlockBuilder(0).appendInt(1).appendInt(2).build()) {
-            assertFilterBlock(toFilter.filter(1));
+            assertFilterBlock(toFilter.filter(false, 1));
         }
         try (IntBlock toFilter = blockFactory.newIntBlockBuilder(1).appendInt(randomInt()).appendNull().build()) {
-            assertFilterBlock(toFilter.filter(0));
+            assertFilterBlock(toFilter.filter(false, 0));
         }
         try (IntVector toFilter = blockFactory.newIntVectorBuilder(1).appendInt(randomInt()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
         try (IntVector toFilter = blockFactory.newIntVectorBuilder(1).appendInt(randomInt()).appendInt(randomInt()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
     }
 
     public void testFilterLongBlock() throws IOException {
         try (LongBlock toFilter = blockFactory.newLongBlockBuilder(0).appendLong(1).appendLong(2).build()) {
-            assertFilterBlock(toFilter.filter(1));
+            assertFilterBlock(toFilter.filter(false, 1));
         }
         try (LongBlock toFilter = blockFactory.newLongBlockBuilder(1).appendLong(randomLong()).appendNull().build()) {
-            assertFilterBlock(toFilter.filter(0));
+            assertFilterBlock(toFilter.filter(false, 0));
         }
         try (LongVector toFilter = blockFactory.newLongVectorBuilder(1).appendLong(randomLong()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
         try (LongVector toFilter = blockFactory.newLongVectorBuilder(1).appendLong(randomLong()).appendLong(randomLong()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
     }
 
     public void testFilterFloatBlock() throws IOException {
         try (FloatBlock toFilter = blockFactory.newFloatBlockBuilder(0).appendFloat(1).appendFloat(2).build()) {
-            assertFilterBlock(toFilter.filter(1));
+            assertFilterBlock(toFilter.filter(false, 1));
         }
         try (FloatBlock toFilter = blockFactory.newFloatBlockBuilder(1).appendFloat(randomFloat()).appendNull().build()) {
-            assertFilterBlock(toFilter.filter(0));
+            assertFilterBlock(toFilter.filter(false, 0));
         }
         try (FloatVector toFilter = blockFactory.newFloatVectorBuilder(1).appendFloat(randomFloat()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
 
         }
         try (FloatVector toFilter = blockFactory.newFloatVectorBuilder(1).appendFloat(randomFloat()).appendFloat(randomFloat()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
     }
 
     public void testFilterDoubleBlock() throws IOException {
         try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(0).appendDouble(1).appendDouble(2).build()) {
-            assertFilterBlock(toFilter.filter(1));
+            assertFilterBlock(toFilter.filter(false, 1));
         }
         try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(1).appendDouble(randomDouble()).appendNull().build()) {
-            assertFilterBlock(toFilter.filter(0));
+            assertFilterBlock(toFilter.filter(false, 0));
         }
         try (DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(1).appendDouble(randomDouble()).build()) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
-
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
         try (
             DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(1).appendDouble(randomDouble()).appendDouble(randomDouble()).build()
         ) {
-            assertFilterBlock(toFilter.filter(0).asBlock());
+            assertFilterBlock(toFilter.filter(false, 0).asBlock());
         }
     }
 
@@ -206,15 +205,15 @@ public class BlockSerializationTests extends SerializationTestCase {
                 .appendBytesRef(randomBytesRef())
                 .build()
         ) {
-            assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+            assertFilterBlock(toFilter.filter(false, randomIntBetween(0, 1)));
         }
 
         try (BytesRefBlock toFilter = blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(randomBytesRef()).appendNull().build()) {
-            assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+            assertFilterBlock(toFilter.filter(false, randomIntBetween(0, 1)));
         }
 
         try (BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0).appendBytesRef(randomBytesRef()).build()) {
-            assertFilterBlock(toFilter.asBlock().filter(0));
+            assertFilterBlock(toFilter.asBlock().filter(false, 0));
         }
         try (
             BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0)
@@ -222,7 +221,7 @@ public class BlockSerializationTests extends SerializationTestCase {
                 .appendBytesRef(randomBytesRef())
                 .build()
         ) {
-            assertFilterBlock(toFilter.asBlock().filter(randomIntBetween(0, 1)));
+            assertFilterBlock(toFilter.asBlock().filter(false, randomIntBetween(0, 1)));
         }
     }
 
@@ -238,7 +237,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             builder.sum().appendDouble(randomDouble());
             builder.count().appendInt(randomInt());
             try (AggregateMetricDoubleBlock toFilter = builder.build()) {
-                assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+                assertFilterBlock(toFilter.filter(false, randomIntBetween(0, 1)));
             }
         }
 
@@ -250,7 +249,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             builder.count().appendInt(randomInt());
             builder.appendNull();
             try (AggregateMetricDoubleBlock toFilter = builder.build()) {
-                assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+                assertFilterBlock(toFilter.filter(false, randomIntBetween(0, 1)));
             }
         }
     }
@@ -332,7 +331,7 @@ public class BlockSerializationTests extends SerializationTestCase {
                     }
                 }
                 for (int p = 0; p < v1.getPositionCount(); p++) {
-                    try (BytesRefVector f1 = v1.filter(p); BytesRefVector f2 = v2.filter(p)) {
+                    try (BytesRefVector f1 = v1.filter(false, p); BytesRefVector f2 = v2.filter(false, p)) {
                         BytesRefVector.equals(f1, f2);
                         for (BytesRefVector vector : List.of(f1, f2)) {
                             try (BytesRefBlock deserBlock = serializeDeserializeBlock(vector.asBlock())) {
@@ -386,7 +385,7 @@ public class BlockSerializationTests extends SerializationTestCase {
                     }
                 }
                 for (int p = 0; p < b1.getPositionCount(); p++) {
-                    try (BytesRefBlock f1 = b1.filter(p); BytesRefBlock f2 = b2.filter(p)) {
+                    try (BytesRefBlock f1 = b1.filter(false, p); BytesRefBlock f2 = b2.filter(false, p)) {
                         BytesRefBlock.equals(f1, f2);
                         for (BytesRefBlock block : List.of(f1, f2)) {
                             try (BytesRefBlock deserBlock = serializeDeserializeBlock(block)) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
@@ -23,9 +23,9 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] {}, 0),
             blockFactory.newBooleanArrayVector(new boolean[] { randomBoolean() }, 0),
             blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).asVector(),
-            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).filter().asVector(),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).filter(false).asVector(),
             blockFactory.newBooleanBlockBuilder(0).build().asVector(),
-            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().asVector().filter()
+            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().asVector().filter(false)
         );
         assertAllEquals(vectors);
     }
@@ -51,8 +51,8 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             ),
             blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0),
             blockFactory.newBooleanBlockBuilder(0).build(),
-            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().filter(),
-            blockFactory.newBooleanBlockBuilder(0).appendNull().build().filter(),
+            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().filter(false),
+            blockFactory.newBooleanBlockBuilder(0).appendNull().build().filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
         assertAllEquals(blocks);
@@ -64,19 +64,24 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock().asVector(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2),
-            blockFactory.newBooleanArrayVector(new boolean[] { false, true, false, true }, 4).filter(1, 2, 3),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false, true }, 4).filter(0, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(false, 0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(false, 0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, false, true }, 4).filter(false, 1, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false, true }, 4).filter(false, 0, 2, 3),
             blockFactory.newBooleanVectorBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
-            blockFactory.newBooleanVectorBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
+            blockFactory.newBooleanVectorBuilder(3)
+                .appendBoolean(true)
+                .appendBoolean(false)
+                .appendBoolean(true)
+                .build()
+                .filter(false, 0, 1, 2),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
@@ -85,7 +90,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .appendBoolean(true)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -94,10 +99,10 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3),
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3).asBlock().asVector(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, true }, 3),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3).filter(0, 1, 2),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, false }, 4).filter(0, 1, 2),
-            blockFactory.newBooleanArrayVector(new boolean[] { false, true, true, true }, 4).filter(1, 2, 3),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, true }, 4).filter(0, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3).filter(false, 0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, false }, 4).filter(false, 0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, true, true }, 4).filter(false, 1, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, true }, 4).filter(false, 0, 2, 3),
             blockFactory.newConstantBooleanBlockWith(true, 3).asVector(),
             blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector(),
             blockFactory.newBooleanBlockBuilder(3)
@@ -106,14 +111,14 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .appendBoolean(true)
                 .build()
                 .asVector()
-                .filter(0, 1, 2),
+                .filter(false, 0, 1, 2),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
@@ -122,7 +127,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .appendBoolean(true)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -147,26 +152,31 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, false, true }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, false, true }, 4).filter(false, 0, 1, 3).asBlock(),
             blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
-            blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
+            blockFactory.newBooleanBlockBuilder(3)
+                .appendBoolean(true)
+                .appendBoolean(false)
+                .appendBoolean(true)
+                .build()
+                .filter(false, 0, 1, 2),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .build()
-                .filter(0, 2, 3),
+                .filter(false, 0, 2, 3),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendNull()
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -189,15 +199,15 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true }, 2).filter(0, 1).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 2).filter(0, 1).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 3).filter(0, 1).asBlock(),
-            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 3).filter(false, 0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(false, 0, 2).asBlock(),
             blockFactory.newConstantBooleanBlockWith(true, 2),
             blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).build(),
-            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).build().filter(0, 1),
-            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().filter(0, 2),
-            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendNull().appendBoolean(true).build().filter(0, 2)
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).build().filter(false, 0, 1),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().filter(false, 0, 2),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendNull().appendBoolean(true).build().filter(false, 0, 2)
         );
         assertAllEquals(moreBlocks);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
@@ -32,9 +32,9 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 0, blockFactory),
                 new BytesRefArrayVector(bytesRefArray2, 0, blockFactory),
                 blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).asVector(),
-                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).filter().asVector(),
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).filter(false).asVector(),
                 blockFactory.newBytesRefBlockBuilder(0).build().asVector(),
-                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().asVector().filter()
+                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().asVector().filter(false)
             );
             assertAllEquals(vectors);
         }
@@ -62,8 +62,8 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 ),
                 blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0),
                 blockFactory.newBytesRefBlockBuilder(0).build(),
-                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().filter(),
-                blockFactory.newBytesRefBlockBuilder(0).appendNull().build().filter(),
+                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().filter(false),
+                blockFactory.newBytesRefBlockBuilder(0).appendNull().build().filter(false),
                 (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
             );
             assertAllEquals(blocks);
@@ -77,8 +77,8 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory),
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).asBlock().asVector(),
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
-                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
-                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(false, 0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(false, 0, 1, 2),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
@@ -91,14 +91,14 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .asVector()
-                    .filter(0, 1, 2),
+                    .filter(false, 0, 1, 2),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
-                    .filter(0, 2, 3)
+                    .filter(false, 0, 2, 3)
                     .asVector(),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
@@ -107,7 +107,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .asVector()
-                    .filter(0, 2, 3)
+                    .filter(false, 0, 2, 3)
             );
             assertAllEquals(vectors);
         }
@@ -118,8 +118,8 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory),
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).asBlock().asVector(),
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
-                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
-                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(false, 0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(false, 0, 1, 2),
                 blockFactory.newConstantBytesRefBlockWith(new BytesRef("1"), 3).asVector(),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
@@ -133,14 +133,14 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("1"))
                     .build()
                     .asVector()
-                    .filter(0, 1, 2),
+                    .filter(false, 0, 1, 2),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("1"))
                     .build()
-                    .filter(0, 2, 3)
+                    .filter(false, 0, 2, 3)
                     .asVector(),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
@@ -149,7 +149,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("1"))
                     .build()
                     .asVector()
-                    .filter(0, 2, 3)
+                    .filter(false, 0, 2, 3)
             );
             assertAllEquals(moreVectors);
         }
@@ -176,9 +176,9 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     randomFrom(Block.MvOrdering.values()),
                     blockFactory
                 ),
-                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1, 2).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(false, 0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(false, 0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(false, 0, 1, 2).asBlock(),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
@@ -189,21 +189,21 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
-                    .filter(0, 1, 2),
+                    .filter(false, 0, 1, 2),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
-                    .filter(0, 2, 3),
+                    .filter(false, 0, 2, 3),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendNull()
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
-                    .filter(0, 2, 3)
+                    .filter(false, 0, 2, 3)
             );
             assertAllEquals(blocks);
         }
@@ -228,28 +228,28 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     randomFrom(Block.MvOrdering.values()),
                     blockFactory
                 ),
-                new BytesRefArrayVector(bytesRefArray1, 2, blockFactory).filter(0, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 2, blockFactory).filter(0, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 2, blockFactory).filter(false, 0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 2, blockFactory).filter(false, 0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(false, 0, 1).asBlock(),
                 blockFactory.newConstantBytesRefBlockWith(new BytesRef("9"), 2),
                 blockFactory.newBytesRefBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build(),
                 blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("9"))
                     .appendBytesRef(new BytesRef("9"))
                     .build()
-                    .filter(0, 1),
+                    .filter(false, 0, 1),
                 blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("9"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("9"))
                     .build()
-                    .filter(0, 2),
+                    .filter(false, 0, 2),
                 blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("9"))
                     .appendNull()
                     .appendBytesRef(new BytesRef("9"))
                     .build()
-                    .filter(0, 2)
+                    .filter(false, 0, 2)
             );
             assertAllEquals(moreBlocks);
         }
@@ -276,7 +276,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("2"))
                     .build()
                     .asVector()
-                    .filter(1),
+                    .filter(false, 1),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
@@ -315,7 +315,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .build()
-                    .filter(1),
+                    .filter(false, 1),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/CompositeBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/CompositeBlockTests.java
@@ -78,11 +78,11 @@ public class CompositeBlockTests extends ComputeTestCase {
             for (int i = 0; i < selected.length; i++) {
                 selected[i] = randomIntBetween(0, positionCount - 1);
             }
-            try (CompositeBlock filteredComposite = origComposite.filter(selected)) {
+            try (CompositeBlock filteredComposite = origComposite.filter(true, selected)) {
                 assertThat(filteredComposite.getBlockCount(), equalTo(numBlocks));
                 assertThat(filteredComposite.getPositionCount(), equalTo(selected.length));
                 for (int b = 0; b < numBlocks; b++) {
-                    try (Block filteredSub = origComposite.getBlock(b).filter(selected)) {
+                    try (Block filteredSub = origComposite.getBlock(b).filter(true, selected)) {
                         assertThat(filteredComposite.getBlock(b), equalTo(filteredSub));
                     }
                 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
@@ -24,9 +24,9 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] {}, 0),
             blockFactory.newDoubleArrayVector(new double[] { 0 }, 0),
             blockFactory.newConstantDoubleVector(0, 0),
-            blockFactory.newConstantDoubleBlockWith(0, 0).filter().asVector(),
+            blockFactory.newConstantDoubleBlockWith(0, 0).filter(false).asVector(),
             blockFactory.newDoubleBlockBuilder(0).build().asVector(),
-            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().asVector().filter()
+            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().asVector().filter(false)
         );
         assertAllEquals(vectors);
     }
@@ -50,8 +50,8 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             ),
             blockFactory.newConstantDoubleBlockWith(0, 0),
             blockFactory.newDoubleBlockBuilder(0).build(),
-            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().filter(),
-            blockFactory.newDoubleBlockBuilder(0).appendNull().build().filter(),
+            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().filter(false),
+            blockFactory.newDoubleBlockBuilder(0).appendNull().build().filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
         assertAllEquals(blocks);
@@ -64,19 +64,19 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock().asVector(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newDoubleArrayVector(new double[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 0, 1, 2, 3 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 2, 3 }, 4).filter(false, 0, 2, 3),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector(),
-            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector().filter(0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector().filter(false, 0, 1, 2),
             blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(2)
                 .appendDouble(3)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
@@ -85,7 +85,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 .appendDouble(3)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -94,20 +94,20 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3).asBlock().asVector(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 1 }, 3),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newDoubleArrayVector(new double[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 3, 1, 1, 1 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 1, 1 }, 4).filter(false, 0, 2, 3),
             blockFactory.newConstantDoubleBlockWith(1, 3).asVector(),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector(),
-            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(false, 0, 1, 2),
             blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(1)
                 .appendDouble(1)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
@@ -116,7 +116,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 .appendDouble(1)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -141,14 +141,26 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4, 3 }, 4).filter(false, 0, 1, 3).asBlock(),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build(),
-            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().filter(0, 1, 2),
-            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(4).appendDouble(2).appendDouble(3).build().filter(0, 2, 3),
-            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendNull().appendDouble(2).appendDouble(3).build().filter(0, 2, 3)
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().filter(false, 0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3)
+                .appendDouble(1)
+                .appendDouble(4)
+                .appendDouble(2)
+                .appendDouble(3)
+                .build()
+                .filter(false, 0, 2, 3),
+            blockFactory.newDoubleBlockBuilder(3)
+                .appendDouble(1)
+                .appendNull()
+                .appendDouble(2)
+                .appendDouble(3)
+                .build()
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -171,15 +183,15 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newDoubleArrayVector(new double[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            blockFactory.newDoubleArrayVector(new double[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 3).filter(false, 0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 4, 9 }, 3).filter(false, 0, 2).asBlock(),
             blockFactory.newConstantDoubleBlockWith(9, 2),
             blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(9).build(),
-            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(9).build().filter(0, 1),
-            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(4).appendDouble(9).build().filter(0, 2),
-            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendNull().appendDouble(9).build().filter(0, 2)
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(9).build().filter(false, 0, 1),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(4).appendDouble(9).build().filter(false, 0, 2),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendNull().appendDouble(9).build().filter(false, 0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -193,7 +205,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3),
             blockFactory.newConstantDoubleBlockWith(9, 2).asVector(),
-            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().asVector().filter(1),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().asVector().filter(false, 1),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build().asVector(),
             blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build().asVector()
         );
@@ -209,7 +221,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3).asBlock(),
             blockFactory.newConstantDoubleBlockWith(9, 2),
-            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().filter(1),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().filter(false, 1),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build(),
             blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build(),
             blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendNull().build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
@@ -163,8 +163,8 @@ public class ExponentialHistogramBlockTests extends ComputeTestCase {
 
         Block block2 = blockFactory().newExponentialHistogramBlockBuilder(0).append(histo1).append(histo2).append(histo2).build();
 
-        Block block1Filtered = block1.filter(1, 2);
-        Block block2Filtered = block2.filter(0, 1);
+        Block block1Filtered = block1.filter(false, 1, 2);
+        Block block2Filtered = block2.filter(false, 0, 1);
 
         assertThat(block1, not(equalTo(block2)));
         assertThat(block1, not(equalTo(block1Filtered)));
@@ -192,7 +192,7 @@ public class ExponentialHistogramBlockTests extends ComputeTestCase {
     }
 
     private static Block filterAndRelease(Block toFilterAndRelease) {
-        Block filtered = toFilterAndRelease.filter();
+        Block filtered = toFilterAndRelease.filter(false);
         toFilterAndRelease.close();
         return filtered;
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -49,13 +49,13 @@ public class FilteredBlockTests extends ESTestCase {
     public void testFilterAllPositions() {
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
-        var filteredVector = vector.filter();
+        var filteredVector = vector.filter(false);
 
         assertEquals(0, filteredVector.getPositionCount());
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredVector.getInt(0));
         filteredVector.close();
 
-        var filteredBlock = vector.asBlock().filter();
+        var filteredBlock = vector.asBlock().filter(false);
         assertEquals(0, filteredBlock.getPositionCount());
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredBlock.getInt(0));
         vector.close();
@@ -67,13 +67,13 @@ public class FilteredBlockTests extends ESTestCase {
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
         var positions = IntStream.range(0, positionCount).toArray();
 
-        var filteredVector = vector.filter(positions);
+        var filteredVector = vector.filter(false, positions);
         assertEquals(positionCount, filteredVector.getPositionCount());
         var anyPosition = randomPosition(positionCount);
         assertEquals(anyPosition, filteredVector.getInt(anyPosition));
         filteredVector.close();
 
-        var filteredBlock = vector.filter(positions).asBlock();
+        var filteredBlock = vector.filter(false, positions).asBlock();
         assertEquals(positionCount, filteredBlock.getPositionCount());
         assertEquals(anyPosition, filteredBlock.getInt(anyPosition));
         Releasables.close(vector);
@@ -85,14 +85,14 @@ public class FilteredBlockTests extends ESTestCase {
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
         var positions = IntStream.range(0, positionCount).filter(i -> i % 2 == 0).toArray();
 
-        var filteredVector = vector.filter(positions);
+        var filteredVector = vector.filter(false, positions);
         assertEquals(positionCount / 2, filteredVector.getPositionCount());
         var anyPosition = randomIntBetween(0, (positionCount / 2) - 1);
         assertEquals(anyPosition * 2, filteredVector.getInt(anyPosition));
         assertEquals(anyPosition * 2, filteredVector.asBlock().getInt(anyPosition));
         filteredVector.close();
 
-        var filteredBlock = vector.asBlock().filter(positions);
+        var filteredBlock = vector.asBlock().filter(false, positions);
         assertEquals(positionCount / 2, filteredBlock.getPositionCount());
         assertEquals(anyPosition * 2, filteredBlock.getInt(anyPosition));
         vector.close();
@@ -103,8 +103,8 @@ public class FilteredBlockTests extends ESTestCase {
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
 
-        var filteredVector = vector.filter(IntStream.range(0, positionCount).filter(i1 -> i1 % 2 == 0).toArray());
-        var filteredTwice = filteredVector.filter(IntStream.range(0, positionCount / 2).filter(i -> i % 2 == 0).toArray());
+        var filteredVector = vector.filter(false, IntStream.range(0, positionCount).filter(i1 -> i1 % 2 == 0).toArray());
+        var filteredTwice = filteredVector.filter(false, IntStream.range(0, positionCount / 2).filter(i -> i % 2 == 0).toArray());
 
         assertEquals(positionCount / 4, filteredTwice.getPositionCount());
         var anyPosition = randomIntBetween(0, positionCount / 4 - 1);
@@ -128,7 +128,7 @@ public class FilteredBlockTests extends ESTestCase {
             block = blockBuilder.build();
         }
 
-        var filtered = block.filter(1, 2, 3);
+        var filtered = block.filter(false, 1, 2, 3);
 
         assertTrue(filtered.isNull(0));
         assertTrue(filtered.mayHaveNulls());
@@ -155,7 +155,7 @@ public class FilteredBlockTests extends ESTestCase {
             block = blockBuilder.build();
         }
 
-        var filtered = block.filter(1, 2, 3);
+        var filtered = block.filter(false, 1, 2, 3);
 
         assertTrue(filtered.isNull(0));
         assertTrue(filtered.mayHaveNulls());
@@ -177,7 +177,7 @@ public class FilteredBlockTests extends ESTestCase {
             blockBuilder.appendInt(40);
             block = blockBuilder.build();
         }
-        var filtered = block.filter(1, 2, 3);
+        var filtered = block.filter(false, 1, 2, 3);
 
         assertFalse(filtered.isNull(0));
         assertFalse(filtered.mayHaveNulls());
@@ -202,7 +202,11 @@ public class FilteredBlockTests extends ESTestCase {
             nulls,
             randomFrom(Block.MvOrdering.values())
         );
-        for (Releasable obj : List.of(boolVector.filter(0, 2), boolVector.asBlock().filter(0, 2), boolBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(
+            boolVector.filter(false, 0, 2),
+            boolVector.asBlock().filter(false, 0, 2),
+            boolBlock.filter(false, 0, 2)
+        )) {
             String s = obj.toString();
             assertThat(s, containsString("[true, false]"));
             assertThat(s, containsString("positions=2"));
@@ -212,7 +216,11 @@ public class FilteredBlockTests extends ESTestCase {
 
         var intVector = blockFactory.newIntArrayVector(new int[] { 10, 20, 30, 40 }, 4);
         var intBlock = blockFactory.newIntArrayBlock(new int[] { 10, 20, 30, 40 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
-        for (Releasable obj : List.of(intVector.filter(0, 2), intVector.asBlock().filter(0, 2), intBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(
+            intVector.filter(false, 0, 2),
+            intVector.asBlock().filter(false, 0, 2),
+            intBlock.filter(false, 0, 2)
+        )) {
             String s = obj.toString();
             assertThat(s, containsString("[10, 30]"));
             assertThat(s, containsString("positions=2"));
@@ -228,7 +236,11 @@ public class FilteredBlockTests extends ESTestCase {
             nulls,
             randomFrom(Block.MvOrdering.values())
         );
-        for (Releasable obj : List.of(longVector.filter(0, 2), longVector.asBlock().filter(0, 2), longBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(
+            longVector.filter(false, 0, 2),
+            longVector.asBlock().filter(false, 0, 2),
+            longBlock.filter(false, 0, 2)
+        )) {
             String s = obj.toString();
             assertThat(s, containsString("[100, 300]"));
             assertThat(s, containsString("positions=2"));
@@ -245,7 +257,11 @@ public class FilteredBlockTests extends ESTestCase {
             nulls,
             randomFrom(Block.MvOrdering.values())
         );
-        for (Releasable obj : List.of(doubleVector.filter(0, 2), doubleVector.asBlock().filter(0, 2), doubleBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(
+            doubleVector.filter(false, 0, 2),
+            doubleVector.asBlock().filter(false, 0, 2),
+            doubleBlock.filter(false, 0, 2)
+        )) {
             String s = obj.toString();
             assertThat(s, containsString("[1.1, 3.3]"));
             assertThat(s, containsString("positions=2"));
@@ -263,7 +279,11 @@ public class FilteredBlockTests extends ESTestCase {
             nulls,
             randomFrom(Block.MvOrdering.values())
         );
-        for (Releasable obj : List.of(bytesRefVector.filter(0, 2), bytesRefVector.asBlock().filter(0, 2), bytesRefBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(
+            bytesRefVector.filter(false, 0, 2),
+            bytesRefVector.asBlock().filter(false, 0, 2),
+            bytesRefBlock.filter(false, 0, 2)
+        )) {
             assertThat(
                 obj.toString(),
                 either(equalTo("BytesRefArrayVector[positions=2]")).or(
@@ -281,7 +301,7 @@ public class FilteredBlockTests extends ESTestCase {
             new int[] { 10, 20, 30, 40 },
             4
         );
-        for (Releasable obj : List.of(aggregateMetricDoubleBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(aggregateMetricDoubleBlock.filter(false, 0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[1.1, 3.3]"));
             assertThat(s, containsString("[5.5, 7.7]"));
@@ -300,7 +320,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendBoolean(false).appendBoolean(false).endPositionEntry();
             builder.beginPositionEntry().appendBoolean(false).appendBoolean(false).endPositionEntry();
             BooleanBlock block = builder.build();
-            var filter = block.filter(0, 1);
+            var filter = block.filter(false, 0, 1);
             assertThat(
                 filter.toString(),
                 containsString(
@@ -317,7 +337,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendInt(20).appendInt(50).endPositionEntry();
             builder.beginPositionEntry().appendInt(90).appendInt(1000).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(0, 1);
+            var filter = block.filter(false, 0, 1);
             assertThat(
                 filter.toString(),
                 containsString(
@@ -333,7 +353,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendLong(20).appendLong(50).endPositionEntry();
             builder.beginPositionEntry().appendLong(90).appendLong(1000).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(0, 1);
+            var filter = block.filter(false, 0, 1);
             assertThat(
                 filter.toString(),
                 containsString(
@@ -349,7 +369,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendDouble(0.002).appendDouble(10e8).endPositionEntry();
             builder.beginPositionEntry().appendDouble(90).appendDouble(1000).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(0, 1);
+            var filter = block.filter(false, 0, 1);
             assertThat(
                 filter.toString(),
                 containsString(
@@ -368,7 +388,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendBytesRef(new BytesRef("cat")).appendBytesRef(new BytesRef("dog")).endPositionEntry();
             builder.beginPositionEntry().appendBytesRef(new BytesRef("pig")).appendBytesRef(new BytesRef("chicken")).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(0, 1);
+            var filter = block.filter(false, 0, 1);
             assertThat(
                 filter.toString(),
                 containsString("BytesRefArrayBlock[positions=2, mvOrdering=UNORDERED, vector=BytesRefArrayVector[positions=4]]")
@@ -386,7 +406,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendBoolean(true).appendBoolean(false).endPositionEntry();
             builder.beginPositionEntry().appendBoolean(false).appendBoolean(true).endPositionEntry();
             BooleanBlock block = builder.build();
-            var filter = block.filter(1);
+            var filter = block.filter(false, 1);
             assertThat(filter.getPositionCount(), is(1));
             assertThat(filter.getValueCount(0), is(2));
             assertThat(filter.getBoolean(filter.getFirstValueIndex(0)), is(false));
@@ -399,7 +419,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendInt(0).appendInt(10).endPositionEntry();
             builder.beginPositionEntry().appendInt(20).appendInt(50).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(1);
+            var filter = block.filter(false, 1);
             assertThat(filter.getPositionCount(), is(1));
             assertThat(filter.getInt(filter.getFirstValueIndex(0)), is(20));
             assertThat(filter.getInt(filter.getFirstValueIndex(0) + 1), is(50));
@@ -412,7 +432,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendLong(0).appendLong(10).endPositionEntry();
             builder.beginPositionEntry().appendLong(20).appendLong(50).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(1);
+            var filter = block.filter(false, 1);
             assertThat(filter.getPositionCount(), is(1));
             assertThat(filter.getValueCount(0), is(2));
             assertThat(filter.getLong(filter.getFirstValueIndex(0)), is(20L));
@@ -425,7 +445,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendDouble(0).appendDouble(10).endPositionEntry();
             builder.beginPositionEntry().appendDouble(0.002).appendDouble(10e8).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(1);
+            var filter = block.filter(false, 1);
             assertThat(filter.getPositionCount(), is(1));
             assertThat(filter.getValueCount(0), is(2));
             assertThat(filter.getDouble(filter.getFirstValueIndex(0)), is(0.002));
@@ -438,7 +458,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendBytesRef(new BytesRef("cat")).appendBytesRef(new BytesRef("dog")).endPositionEntry();
             builder.beginPositionEntry().appendBytesRef(new BytesRef("pig")).appendBytesRef(new BytesRef("chicken")).endPositionEntry();
             var block = builder.build();
-            var filter = block.filter(1);
+            var filter = block.filter(false, 1);
             assertThat(filter.getPositionCount(), is(1));
             assertThat(filter.getValueCount(0), is(2));
             assertThat(filter.getBytesRef(filter.getFirstValueIndex(0), new BytesRef()), equalTo(new BytesRef("pig")));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FloatBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FloatBlockEqualityTests.java
@@ -24,9 +24,9 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             blockFactory.newFloatArrayVector(new float[] {}, 0),
             blockFactory.newFloatArrayVector(new float[] { 0 }, 0),
             blockFactory.newConstantFloatVector(0, 0),
-            blockFactory.newConstantFloatBlockWith(0, 0).filter().asVector(),
+            blockFactory.newConstantFloatBlockWith(0, 0).filter(false).asVector(),
             blockFactory.newFloatBlockBuilder(0).build().asVector(),
-            blockFactory.newFloatBlockBuilder(0).appendFloat(1).build().asVector().filter()
+            blockFactory.newFloatBlockBuilder(0).appendFloat(1).build().asVector().filter(false)
         );
         assertAllEquals(vectors);
     }
@@ -50,8 +50,8 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             ),
             blockFactory.newConstantFloatBlockWith(0, 0),
             blockFactory.newFloatBlockBuilder(0).build(),
-            blockFactory.newFloatBlockBuilder(0).appendFloat(1).build().filter(),
-            blockFactory.newFloatBlockBuilder(0).appendNull().build().filter(),
+            blockFactory.newFloatBlockBuilder(0).appendFloat(1).build().filter(false),
+            blockFactory.newFloatBlockBuilder(0).appendNull().build().filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
         assertAllEquals(blocks);
@@ -64,19 +64,19 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3),
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).asBlock().asVector(),
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 3),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newFloatArrayVector(new float[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            blockFactory.newFloatArrayVector(new float[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newFloatArrayVector(new float[] { 0, 1, 2, 3 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newFloatArrayVector(new float[] { 1, 4, 2, 3 }, 4).filter(false, 0, 2, 3),
             blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build().asVector(),
-            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build().asVector().filter(0, 1, 2),
+            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build().asVector().filter(false, 0, 1, 2),
             blockFactory.newFloatBlockBuilder(3)
                 .appendFloat(1)
                 .appendFloat(4)
                 .appendFloat(2)
                 .appendFloat(3)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newFloatBlockBuilder(3)
                 .appendFloat(1)
@@ -85,7 +85,7 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
                 .appendFloat(3)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -94,20 +94,20 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             blockFactory.newFloatArrayVector(new float[] { 1, 1, 1 }, 3),
             blockFactory.newFloatArrayVector(new float[] { 1, 1, 1 }, 3).asBlock().asVector(),
             blockFactory.newFloatArrayVector(new float[] { 1, 1, 1, 1 }, 3),
-            blockFactory.newFloatArrayVector(new float[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            blockFactory.newFloatArrayVector(new float[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newFloatArrayVector(new float[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            blockFactory.newFloatArrayVector(new float[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newFloatArrayVector(new float[] { 1, 1, 1 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newFloatArrayVector(new float[] { 1, 1, 1, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newFloatArrayVector(new float[] { 3, 1, 1, 1 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newFloatArrayVector(new float[] { 1, 4, 1, 1 }, 4).filter(false, 0, 2, 3),
             blockFactory.newConstantFloatBlockWith(1, 3).asVector(),
             blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(1).appendFloat(1).build().asVector(),
-            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(1).appendFloat(1).build().asVector().filter(0, 1, 2),
+            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(1).appendFloat(1).build().asVector().filter(false, 0, 1, 2),
             blockFactory.newFloatBlockBuilder(3)
                 .appendFloat(1)
                 .appendFloat(4)
                 .appendFloat(1)
                 .appendFloat(1)
                 .build()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
                 .asVector(),
             blockFactory.newFloatBlockBuilder(3)
                 .appendFloat(1)
@@ -116,7 +116,7 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
                 .appendFloat(1)
                 .build()
                 .asVector()
-                .filter(0, 2, 3)
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -141,14 +141,14 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 1, 2, 4, 3 }, 4).filter(false, 0, 1, 3).asBlock(),
             blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build(),
-            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build().filter(0, 1, 2),
-            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(4).appendFloat(2).appendFloat(3).build().filter(0, 2, 3),
-            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendNull().appendFloat(2).appendFloat(3).build().filter(0, 2, 3)
+            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(3).build().filter(false, 0, 1, 2),
+            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(4).appendFloat(2).appendFloat(3).build().filter(false, 0, 2, 3),
+            blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendNull().appendFloat(2).appendFloat(3).build().filter(false, 0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -171,15 +171,15 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            blockFactory.newFloatArrayVector(new float[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            blockFactory.newFloatArrayVector(new float[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 9, 9 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 9, 9, 4 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 9, 9, 4 }, 3).filter(false, 0, 1).asBlock(),
+            blockFactory.newFloatArrayVector(new float[] { 9, 4, 9 }, 3).filter(false, 0, 2).asBlock(),
             blockFactory.newConstantFloatBlockWith(9, 2),
             blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendFloat(9).build(),
-            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendFloat(9).build().filter(0, 1),
-            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendFloat(4).appendFloat(9).build().filter(0, 2),
-            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendNull().appendFloat(9).build().filter(0, 2)
+            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendFloat(9).build().filter(false, 0, 1),
+            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendFloat(4).appendFloat(9).build().filter(false, 0, 2),
+            blockFactory.newFloatBlockBuilder(2).appendFloat(9).appendNull().appendFloat(9).build().filter(false, 0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -193,7 +193,7 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3),
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 4 }, 3),
             blockFactory.newConstantFloatBlockWith(9, 2).asVector(),
-            blockFactory.newFloatBlockBuilder(2).appendFloat(1).appendFloat(2).build().asVector().filter(1),
+            blockFactory.newFloatBlockBuilder(2).appendFloat(1).appendFloat(2).build().asVector().filter(false, 1),
             blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(5).build().asVector(),
             blockFactory.newFloatBlockBuilder(1).appendFloat(1).appendFloat(2).appendFloat(3).appendFloat(4).build().asVector()
         );
@@ -209,7 +209,7 @@ public class FloatBlockEqualityTests extends ComputeTestCase {
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newFloatArrayVector(new float[] { 1, 2, 4 }, 3).asBlock(),
             blockFactory.newConstantFloatBlockWith(9, 2),
-            blockFactory.newFloatBlockBuilder(2).appendFloat(1).appendFloat(2).build().filter(1),
+            blockFactory.newFloatBlockBuilder(2).appendFloat(1).appendFloat(2).build().filter(false, 1),
             blockFactory.newFloatBlockBuilder(3).appendFloat(1).appendFloat(2).appendFloat(5).build(),
             blockFactory.newFloatBlockBuilder(1).appendFloat(1).appendFloat(2).appendFloat(3).appendFloat(4).build(),
             blockFactory.newFloatBlockBuilder(1).appendFloat(1).appendNull().build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
@@ -23,9 +23,9 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] {}, 0),
             blockFactory.newIntArrayVector(new int[] { 0 }, 0),
             blockFactory.newConstantIntVector(0, 0),
-            blockFactory.newConstantIntVector(0, 0).filter(),
+            blockFactory.newConstantIntVector(0, 0).filter(false),
             blockFactory.newIntBlockBuilder(0).build().asVector(),
-            blockFactory.newIntBlockBuilder(0).appendInt(1).build().asVector().filter()
+            blockFactory.newIntBlockBuilder(0).appendInt(1).build().asVector().filter(false)
         );
         assertAllEquals(vectors);
     }
@@ -49,8 +49,8 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             ),
             blockFactory.newConstantIntBlockWith(0, 0),
             blockFactory.newIntBlockBuilder(0).build(),
-            blockFactory.newIntBlockBuilder(0).appendInt(1).build().filter(),
-            blockFactory.newIntBlockBuilder(0).appendNull().build().filter(),
+            blockFactory.newIntBlockBuilder(0).appendInt(1).build().filter(false),
+            blockFactory.newIntBlockBuilder(0).appendNull().build().filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
         assertAllEquals(blocks);
@@ -62,14 +62,21 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock().asVector(),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 3),
-            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newIntArrayVector(new int[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            blockFactory.newIntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 0, 1, 2, 3 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(false, 0, 2, 3),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector(),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(0, 1, 2),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3).asVector(),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().asVector().filter(0, 2, 3)
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(false, 0, 1, 2),
+            blockFactory.newIntBlockBuilder(3)
+                .appendInt(1)
+                .appendInt(4)
+                .appendInt(2)
+                .appendInt(3)
+                .build()
+                .filter(false, 0, 2, 3)
+                .asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().asVector().filter(false, 0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -78,15 +85,22 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock().asVector(),
             blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 1 }, 3),
-            blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newIntArrayVector(new int[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            blockFactory.newIntArrayVector(new int[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 3, 1, 1, 1 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 4, 1, 1 }, 4).filter(false, 0, 2, 3),
             blockFactory.newConstantIntBlockWith(1, 3).asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector(),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(0, 1, 2),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().filter(0, 2, 3).asVector(),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().asVector().filter(0, 2, 3)
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(false, 0, 1, 2),
+            blockFactory.newIntBlockBuilder(3)
+                .appendInt(1)
+                .appendInt(4)
+                .appendInt(1)
+                .appendInt(1)
+                .build()
+                .filter(false, 0, 2, 3)
+                .asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().asVector().filter(false, 0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -111,14 +125,14 @@ public class IntBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3, blockFactory).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3, blockFactory).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4, blockFactory).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 4, 3 }, 4, blockFactory).filter(0, 1, 3).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3 }, 3, blockFactory).filter(false, 0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3, blockFactory).filter(false, 0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4, blockFactory).filter(false, 0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 4, 3 }, 4, blockFactory).filter(false, 0, 1, 3).asBlock(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build(),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().filter(0, 1, 2),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendNull().appendInt(2).appendInt(3).build().filter(0, 2, 3)
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().filter(false, 0, 1, 2),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(false, 0, 2, 3),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendNull().appendInt(2).appendInt(3).build().filter(false, 0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -139,15 +153,15 @@ public class IntBlockEqualityTests extends ComputeTestCase {
                 BitSet.valueOf(new byte[] { 0b100 }),
                 randomFrom(Block.MvOrdering.values())
             ),
-            blockFactory.newIntArrayVector(new int[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            blockFactory.newIntArrayVector(new int[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 3).filter(false, 0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 4, 9 }, 3).filter(false, 0, 2).asBlock(),
             blockFactory.newConstantIntBlockWith(9, 2),
             blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(9).build(),
-            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(9).build().filter(0, 1),
-            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(4).appendInt(9).build().filter(0, 2),
-            blockFactory.newIntBlockBuilder(2).appendInt(9).appendNull().appendInt(9).build().filter(0, 2)
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(9).build().filter(false, 0, 1),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(4).appendInt(9).build().filter(false, 0, 2),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendNull().appendInt(9).build().filter(false, 0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -161,7 +175,7 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3),
             blockFactory.newConstantIntBlockWith(9, 2).asVector(),
-            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().asVector().filter(1),
+            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().asVector().filter(false, 1),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build().asVector(),
             blockFactory.newIntBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build().asVector()
         );
@@ -177,7 +191,7 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3).asBlock(),
             blockFactory.newConstantIntBlockWith(9, 2),
-            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().filter(1),
+            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().filter(false, 1),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build(),
             blockFactory.newIntBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build(),
             blockFactory.newIntBlockBuilder(1).appendInt(1).appendNull().build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
@@ -23,9 +23,9 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] {}, 0),
             blockFactory.newLongArrayVector(new long[] { 0 }, 0),
             blockFactory.newConstantLongBlockWith(0, 0).asVector(),
-            blockFactory.newConstantLongBlockWith(0, 0).filter().asVector(),
+            blockFactory.newConstantLongBlockWith(0, 0).filter(false).asVector(),
             blockFactory.newLongBlockBuilder(0).build().asVector(),
-            blockFactory.newLongBlockBuilder(0).appendLong(1).build().asVector().filter()
+            blockFactory.newLongBlockBuilder(0).appendLong(1).build().asVector().filter(false)
         );
         assertAllEquals(vectors);
     }
@@ -49,8 +49,8 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             ),
             blockFactory.newConstantLongBlockWith(0, 0),
             blockFactory.newLongBlockBuilder(0).build(),
-            blockFactory.newLongBlockBuilder(0).appendLong(1).build().filter(),
-            blockFactory.newLongBlockBuilder(0).appendNull().build().filter(),
+            blockFactory.newLongBlockBuilder(0).appendLong(1).build().filter(false),
+            blockFactory.newLongBlockBuilder(0).appendNull().build().filter(false),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
         assertAllEquals(blocks);
@@ -62,14 +62,28 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock().asVector(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newLongArrayVector(new long[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            blockFactory.newLongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 0, 1, 2, 3 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(false, 0, 2, 3),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector(),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(0, 1, 2),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3).asVector(),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().asVector().filter(0, 2, 3)
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(false, 0, 1, 2),
+            blockFactory.newLongBlockBuilder(3)
+                .appendLong(1)
+                .appendLong(4)
+                .appendLong(2)
+                .appendLong(3)
+                .build()
+                .filter(false, 0, 2, 3)
+                .asVector(),
+            blockFactory.newLongBlockBuilder(3)
+                .appendLong(1)
+                .appendLong(4)
+                .appendLong(2)
+                .appendLong(3)
+                .build()
+                .asVector()
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -78,15 +92,29 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3).asBlock().asVector(),
             blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 1 }, 3),
-            blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            blockFactory.newLongArrayVector(new long[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            blockFactory.newLongArrayVector(new long[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3).filter(false, 0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 4 }, 4).filter(false, 0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 3, 1, 1, 1 }, 4).filter(false, 1, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 4, 1, 1 }, 4).filter(false, 0, 2, 3),
             blockFactory.newConstantLongBlockWith(1, 3).asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector(),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(0, 1, 2),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().filter(0, 2, 3).asVector(),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().asVector().filter(0, 2, 3)
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(false, 0, 1, 2),
+            blockFactory.newLongBlockBuilder(3)
+                .appendLong(1)
+                .appendLong(4)
+                .appendLong(1)
+                .appendLong(1)
+                .build()
+                .filter(false, 0, 2, 3)
+                .asVector(),
+            blockFactory.newLongBlockBuilder(3)
+                .appendLong(1)
+                .appendLong(4)
+                .appendLong(1)
+                .appendLong(1)
+                .build()
+                .asVector()
+                .filter(false, 0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -109,14 +137,14 @@ public class LongBlockEqualityTests extends ComputeTestCase {
                 BitSet.valueOf(new byte[] { 0b1000 }),
                 randomFrom(Block.MvOrdering.values())
             ),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(false, 0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 4, 3 }, 4).filter(false, 0, 1, 3).asBlock(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build(),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().filter(0, 1, 2),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendNull().appendLong(2).appendLong(3).build().filter(0, 2, 3)
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().filter(false, 0, 1, 2),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(false, 0, 2, 3),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendNull().appendLong(2).appendLong(3).build().filter(false, 0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -137,15 +165,15 @@ public class LongBlockEqualityTests extends ComputeTestCase {
                 BitSet.valueOf(new byte[] { 0b100 }),
                 randomFrom(Block.MvOrdering.values())
             ),
-            blockFactory.newLongArrayVector(new long[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            blockFactory.newLongArrayVector(new long[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 2).filter(false, 0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 3).filter(false, 0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 4, 9 }, 3).filter(false, 0, 2).asBlock(),
             blockFactory.newConstantLongBlockWith(9, 2),
             blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(9).build(),
-            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(9).build().filter(0, 1),
-            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(4).appendLong(9).build().filter(0, 2),
-            blockFactory.newLongBlockBuilder(2).appendLong(9).appendNull().appendLong(9).build().filter(0, 2)
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(9).build().filter(false, 0, 1),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(4).appendLong(9).build().filter(false, 0, 2),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendNull().appendLong(9).build().filter(false, 0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -159,7 +187,7 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3),
             blockFactory.newConstantLongBlockWith(9, 2).asVector(),
-            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().asVector().filter(1),
+            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().asVector().filter(false, 1),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build().asVector(),
             blockFactory.newLongBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build().asVector()
         );
@@ -175,7 +203,7 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3).asBlock(),
             blockFactory.newConstantLongBlockWith(9, 2),
-            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().filter(1),
+            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().filter(false, 1),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build(),
             blockFactory.newLongBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build(),
             blockFactory.newLongBlockBuilder(1).appendLong(1).appendNull().build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
@@ -518,7 +518,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         int[] shuffleArray = shuffleList.stream().mapToInt(Integer::intValue).toArray();
         Block[] shuffledBlocks = new Block[source.getBlockCount()];
         for (int b = 0; b < shuffledBlocks.length; b++) {
-            shuffledBlocks[b] = source.getBlock(b).filter(shuffleArray);
+            shuffledBlocks[b] = source.getBlock(b).filter(false, shuffleArray);
         }
         source = new Page(shuffledBlocks);
         loadSimpleAndAssert(driverContext, List.of(source), Block.MvOrdering.UNORDERED, Block.MvOrdering.UNORDERED);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -577,7 +577,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             int[] shuffleArray = shuffleList.stream().mapToInt(Integer::intValue).toArray();
             Block[] shuffledBlocks = new Block[source.getBlockCount()];
             for (int b = 0; b < shuffledBlocks.length; b++) {
-                shuffledBlocks[b] = source.getBlock(b).filter(shuffleArray);
+                shuffledBlocks[b] = source.getBlock(b).filter(false, shuffleArray);
             }
             return new Page(shuffledBlocks);
         } finally {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999;
@@ -56,6 +57,7 @@ public class ExtractorTests extends ESTestCase {
                             "regular aggregate_metric_double",
                             e,
                             TopNEncoder.DEFAULT_UNSORTABLE,
+                            false,
                             () -> randomAggregateMetricDouble(true)
                         )
                     );
@@ -64,30 +66,46 @@ public class ExtractorTests extends ESTestCase {
                             "aggregate_metric_double with nulls",
                             e,
                             TopNEncoder.DEFAULT_UNSORTABLE,
+                            false,
                             () -> randomAggregateMetricDouble(false)
                         )
                     );
                 }
                 case LONG_RANGE -> {
-                    cases.add(valueTestCase("date_range with nulls", e, TopNEncoder.DEFAULT_UNSORTABLE, () -> randomDateRange(true)));
-                    cases.add(valueTestCase("date_range with nulls", e, TopNEncoder.DEFAULT_UNSORTABLE, () -> randomDateRange(false)));
+                    cases.add(
+                        valueTestCase("date_range with nulls", e, TopNEncoder.DEFAULT_UNSORTABLE, false, () -> randomDateRange(true))
+                    );
+                    cases.add(
+                        valueTestCase("date_range with nulls", e, TopNEncoder.DEFAULT_UNSORTABLE, false, () -> randomDateRange(false))
+                    );
                 }
                 case FLOAT -> {
                     supportsNull = false;
                 }
                 case BYTES_REF -> {
-                    cases.add(valueTestCase("single alpha", e, TopNEncoder.UTF8, () -> randomAlphaOfLength(5)));
-                    cases.add(valueTestCase("many alpha", e, TopNEncoder.UTF8, () -> randomList(2, 10, () -> randomAlphaOfLength(5))));
-                    cases.add(valueTestCase("single utf8", e, TopNEncoder.UTF8, () -> randomRealisticUnicodeOfLength(10)));
+                    cases.add(valueTestCase("single alpha", e, TopNEncoder.UTF8, true, () -> randomAlphaOfLength(5)));
                     cases.add(
-                        valueTestCase("many utf8", e, TopNEncoder.UTF8, () -> randomList(2, 10, () -> randomRealisticUnicodeOfLength(10)))
+                        valueTestCase("many alpha", e, TopNEncoder.UTF8, true, () -> randomList(2, 10, () -> randomAlphaOfLength(5)))
                     );
-                    cases.add(valueTestCase("single version", e, TopNEncoder.VERSION, () -> TopNEncoderTests.randomVersion().toBytesRef()));
+                    cases.add(valueTestCase("single utf8", e, TopNEncoder.UTF8, true, () -> randomRealisticUnicodeOfLength(10)));
+                    cases.add(
+                        valueTestCase(
+                            "many utf8",
+                            e,
+                            TopNEncoder.UTF8,
+                            true,
+                            () -> randomList(2, 10, () -> randomRealisticUnicodeOfLength(10))
+                        )
+                    );
+                    cases.add(
+                        valueTestCase("single version", e, TopNEncoder.VERSION, true, () -> TopNEncoderTests.randomVersion().toBytesRef())
+                    );
                     cases.add(
                         valueTestCase(
                             "many version",
                             e,
                             TopNEncoder.VERSION,
+                            true,
                             () -> randomList(2, 10, () -> TopNEncoderTests.randomVersion().toBytesRef())
                         )
                     );
@@ -96,6 +114,7 @@ public class ExtractorTests extends ESTestCase {
                             "single IP",
                             e,
                             TopNEncoder.IP,
+                            true,
                             () -> new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean())))
                         )
                     );
@@ -104,15 +123,17 @@ public class ExtractorTests extends ESTestCase {
                             "many IP",
                             e,
                             TopNEncoder.IP,
+                            true,
                             () -> randomList(2, 10, () -> new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean()))))
                         )
                     );
-                    cases.add(valueTestCase("single point", e, TopNEncoder.DEFAULT_UNSORTABLE, TopNEncoderTests::randomPointAsWKB));
+                    cases.add(valueTestCase("single point", e, TopNEncoder.DEFAULT_UNSORTABLE, false, TopNEncoderTests::randomPointAsWKB));
                     cases.add(
                         valueTestCase(
                             "many points",
                             e,
                             TopNEncoder.DEFAULT_UNSORTABLE,
+                            false,
                             () -> randomList(2, 10, TopNEncoderTests::randomPointAsWKB)
                         )
                     );
@@ -125,6 +146,7 @@ public class ExtractorTests extends ESTestCase {
                                 "doc",
                                 e,
                                 new DocVectorEncoder(AlwaysReferencedIndexedByShardId.INSTANCE),
+                                false,
                                 () -> new DocVector(
                                     AlwaysReferencedIndexedByShardId.INSTANCE,
                                     // Shard ID should be small and non-negative.
@@ -132,41 +154,54 @@ public class ExtractorTests extends ESTestCase {
                                     blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
                                     blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
                                     docVectorConfig()
-                                ).asBlock()
+                                ).asBlock(),
+                                b -> {
+                                    DocVector v = (DocVector) b.asVector();
+                                    return new DocVector(
+                                        AlwaysReferencedIndexedByShardId.INSTANCE,
+                                        v.shards(),
+                                        v.segments(),
+                                        v.docs(),
+                                        DocVector.config().mayContainDuplicates()
+                                    ).asBlock();
+                                }
                             ) }
                     );
                 }
                 case TDIGEST, EXPONENTIAL_HISTOGRAM ->
                     // multi values are not supported
-                    cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, () -> BlockTestUtils.randomValue(e)));
+                    cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, false, () -> BlockTestUtils.randomValue(e)));
                 case NULL -> {
                 }
                 default -> {
-                    cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, () -> BlockTestUtils.randomValue(e)));
+                    cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, false, () -> BlockTestUtils.randomValue(e)));
                     cases.add(
                         valueTestCase(
                             "many " + e,
                             e,
                             TopNEncoder.DEFAULT_UNSORTABLE,
+                            false,
                             () -> randomList(2, 10, () -> BlockTestUtils.randomValue(e))
                         )
                     );
                 }
             }
             if (supportsNull) {
-                cases.add(valueTestCase("null " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, () -> null));
+                cases.add(valueTestCase("null " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, false, () -> null));
             }
         }
         return cases;
     }
 
-    static Object[] valueTestCase(String name, ElementType type, TopNEncoder encoder, Supplier<Object> value) {
+    static Object[] valueTestCase(String name, ElementType type, TopNEncoder encoder, boolean sortable, Supplier<Object> value) {
         return new Object[] {
             new TestCase(
                 name,
                 type,
                 encoder,
-                () -> BlockUtils.fromListRow(TestBlockFactory.getNonBreakingInstance(), Arrays.asList(value.get()))[0]
+                sortable,
+                () -> BlockUtils.fromListRow(TestBlockFactory.getNonBreakingInstance(), Arrays.asList(value.get()))[0],
+                Function.identity()
             ) };
     }
 
@@ -174,13 +209,24 @@ public class ExtractorTests extends ESTestCase {
         private final String name;
         private final ElementType type;
         private final TopNEncoder encoder;
+        private final boolean sortable;
         private final Supplier<Block> value;
+        private final Function<Block, Block> expected;
 
-        TestCase(String name, ElementType type, TopNEncoder encoder, Supplier<Block> value) {
+        TestCase(
+            String name,
+            ElementType type,
+            TopNEncoder encoder,
+            boolean sortable,
+            Supplier<Block> value,
+            Function<Block, Block> expected
+        ) {
             this.name = name;
             this.type = type;
             this.encoder = encoder;
+            this.sortable = sortable;
             this.value = value;
+            this.expected = expected;
         }
 
         @Override
@@ -218,11 +264,13 @@ public class ExtractorTests extends ESTestCase {
         assertThat(values.length, equalTo(0));
 
         Block resultBlock = result.build();
-        assertThat(resultBlock, equalTo(value));
+        assertThat(resultBlock, equalTo(testCase.expected.apply(value)));
     }
 
     public void testInKey() {
-        assumeFalse("can't sort with un-sortable encoder", testCase.encoder instanceof DefaultUnsortableTopNEncoder);
+        if (testCase.sortable == false) {
+            return;
+        }
         Block value = testCase.value.get();
 
         BreakingBytesRefBuilder keysBuilder = nonBreakingBytesRefBuilder();
@@ -255,7 +303,7 @@ public class ExtractorTests extends ESTestCase {
         result.decodeValue(values);
         assertThat(values.length, equalTo(0));
 
-        assertThat(result.build(), equalTo(value));
+        assertThat(result.build(), equalTo(testCase.expected.apply(value)));
     }
 
     public static AggregateMetricDoubleLiteral randomAggregateMetricDouble(boolean allMetrics) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceBooleanEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceBooleanEvaluator implements EvalOperator.Expressio
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceBytesRefEvaluator.java
@@ -233,7 +233,9 @@ abstract sealed class CoalesceBytesRefEvaluator implements EvalOperator.Expressi
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceDoubleEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceDoubleEvaluator implements EvalOperator.Expression
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceExponentialHistogramEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceExponentialHistogramEvaluator implements EvalOpera
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceIntEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceIntEvaluator implements EvalOperator.ExpressionEva
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceLongEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceLongEvaluator implements EvalOperator.ExpressionEv
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTDigestEvaluator.java
@@ -230,7 +230,9 @@ abstract sealed class CoalesceTDigestEvaluator implements EvalOperator.Expressio
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -476,7 +476,9 @@ public final class Case extends EsqlScalarFunction {
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (ConditionEvaluator condition : conditions) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/X-CoalesceEvaluator.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/X-CoalesceEvaluator.java.st
@@ -239,7 +239,8 @@ $endif$
                     int[] positions = new int[] { p };
                     Page limited = new Page(
                         1,
-                        IntStream.range(0, page.getBlockCount()).mapToObj(b -> page.getBlock(b).filter(positions)).toArray(Block[]::new)
+                        IntStream.range(0, page.getBlockCount())
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions)).toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/X-CoalesceEvaluator.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/X-CoalesceEvaluator.java.st
@@ -240,7 +240,8 @@ $endif$
                     Page limited = new Page(
                         1,
                         IntStream.range(0, page.getBlockCount())
-                            .mapToObj(b -> page.getBlock(b).filter(false, positions)).toArray(Block[]::new)
+                            .mapToObj(b -> page.getBlock(b).filter(false, positions))
+                            .toArray(Block[]::new)
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -366,7 +366,7 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
 
     private static void consumeIndexDoc(Consumer<DocBlock> indexDocConsumer, DocVector vector, @Nullable List<Integer> currentList) {
         if (currentList != null) {
-            try (DocVector indexDocVector = vector.filter(currentList.stream().mapToInt(Integer::intValue).toArray())) {
+            try (DocVector indexDocVector = vector.filter(false, currentList.stream().mapToInt(Integer::intValue).toArray())) {
                 indexDocConsumer.accept(indexDocVector.asBlock());
             }
         }


### PR DESCRIPTION
As of #142055 we track when `DocVector` contains duplicates. In that PR we said "if you call `filter`, then the result may contain duplicates." This PR adds a flag to `filter` saying "the result of this `filter` may contain duplicates." It's quite common for `filter` calls not to create duplicates and most callers can pass `false`. That'll allow block loaders that follow these `filter` calls to use faster paths.
