### PR TITLE
rest-api-spec: remove extra space in YAML test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -205,7 +205,7 @@ setup:
   - gte: { aggregations.percentile_ranks_agg.values.5000\.0: 77.9 }
   - lte: { aggregations.percentile_ranks_agg.values.5000\.0: 78.1 }
 
----  
+---
 "Exists query":
   - do:
       search:


### PR DESCRIPTION
Introduced in https://github.com/elastic/elasticsearch/pull/141845

This breaks our custom parser that naively splits on `"\n---\n"`.