### PR TITLE
Fix prometheus template conflict with Fleet-managed templates

### DIFF
--- a/x-pack/plugin/prometheus/src/main/resources/index-templates/metrics-prometheus@template.yaml
+++ b/x-pack/plugin/prometheus/src/main/resources/index-templates/metrics-prometheus@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.prometheus.template.version}
 index_patterns: ["metrics-*.prometheus-*"]
-priority: 200
+priority: 150
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/prometheus/src/main/resources/resources.yaml
+++ b/x-pack/plugin/prometheus/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates installed by xpack-plugin prometheus.
 # This must be increased whenever an existing template is changed, in order for it
 # to be updated on Elasticsearch upgrade.
-version: 1
+version: 2
 component-templates:
   - metrics-prometheus@mappings
   - metrics-prometheus@settings


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/elastic/elasticsearch/pull/141823. 
The priority for the new `prometheus@template` index template caused a conflict with the Fleet-managed index templates, resulting in the following error:

```
Failure to install package [fleet_server]: [ResponseError: illegal_argument_exception Root causes: illegal_argument_exception: index template [metrics-fleet_server.agent_versions] has index patterns [metrics-fleet_server.agent_versions-*] matching patterns from existing templates [metrics-prometheus@template] with patterns (metrics-prometheus@template => [metrics-*.prometheus-*]) that have the same priority [200], multiple index templates may not match during index creation, please use a different priority]
```

This change lowers the priority for `prometheus@template` from 200 to 150 ~and also adds a check to the `IndexTemplateRegistry` that prevents the installation of logs/metrics/traces/synthetics/profiling templates with the priority 200, to prevent such issues from happening again in the future.~

~I didn't enforce the priority to be lower than 200 as there are some APM templates that intentionally have a priority that's intentionally higher (210).~

edit: I've created a separate PR for this: https://github.com/elastic/elasticsearch/pull/142105