### PR TITLE
Unmute DiskBBQ tests that were re-muted by a stray commit

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -300,12 +300,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/141234
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testSparseVectors
-  issue: https://github.com/elastic/elasticsearch/issues/141270
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQBFloat16VectorsFormatTests
-  method: testSparseVectors
-  issue: https://github.com/elastic/elasticsearch/issues/141271
 - class: org.elasticsearch.snapshots.SnapshotStatusApisIT
   method: testFailedSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/141279


### PR DESCRIPTION
These are already fixed by https://github.com/elastic/elasticsearch/pull/141372, but were re-muted by a stray PR merge