### PR TITLE
Fix CPS linked project histogram

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/PlanTelemetry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/PlanTelemetry.java
@@ -24,7 +24,7 @@ public class PlanTelemetry {
     private final Map<String, Integer> commands = new HashMap<>();
     private final Map<String, Integer> functions = new HashMap<>();
     private final Map<String, Integer> settings = new HashMap<>();
-    private int linkedProjectsCount = 0;
+    private Integer linkedProjectsCount = null;
 
     public PlanTelemetry(EsqlFunctionRegistry functionRegistry) {
         this.functionRegistry = functionRegistry;
@@ -38,7 +38,7 @@ public class PlanTelemetry {
         this.linkedProjectsCount = linkedProjectsCount;
     }
 
-    public int linkedProjectsCount() {
+    public Integer linkedProjectsCount() {
         return linkedProjectsCount;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/PlanTelemetryManager.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/PlanTelemetryManager.java
@@ -109,7 +109,9 @@ public class PlanTelemetryManager {
         metrics.commands().forEach((key, value) -> incCommand(key, value, success));
         metrics.functions().forEach((key, value) -> incFunction(key, value, success));
         metrics.settings().forEach((key, value) -> incSetting(key, value, success));
-        linkedProjectsHistogram.incrementBy(1, Map.of("es_linked_projects_count", metrics.linkedProjectsCount()));
+        if (metrics.linkedProjectsCount() != null) {
+            linkedProjectsHistogram.incrementBy(1, Map.of("es_linked_projects_count", metrics.linkedProjectsCount()));
+        }
     }
 
     private void incCommand(String name, int count, boolean success) {


### PR DESCRIPTION
Prior this change we were incrementing `linkedProjectsCount` only for CPS query, but publishing the count unconditionally. As a result most of the query were actually non CPS and reported `0` linked projects.

This change now only publish count originated from CPS. Non CPS queries remain with null count and are not published.