### PR TITLE
Extract OTelDocumentBuilder base class from MetricDocumentBuilder

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -7,13 +7,6 @@
 
 package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
 
-import io.opentelemetry.proto.common.v1.AnyValue;
-import io.opentelemetry.proto.common.v1.InstrumentationScope;
-import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.resource.v1.Resource;
-
-import com.google.protobuf.ByteString;
-
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.common.Strings;
@@ -22,7 +15,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.ExponentialHistogramConverter;
-import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
@@ -34,15 +26,14 @@ import java.util.concurrent.TimeUnit;
  * This class constructs an Elasticsearch document representation of a metric data point group.
  * It also handles dynamic templates for metrics based on their attributes.
  */
-public class MetricDocumentBuilder {
+public class MetricDocumentBuilder extends OTelDocumentBuilder {
 
-    private final BufferedByteStringAccessor byteStringAccessor;
     private final BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
     private final MappingHints defaultMappingHints;
     private final ExponentialHistogramConverter.BucketBuffer scratch = new ExponentialHistogramConverter.BucketBuffer();
 
     public MetricDocumentBuilder(BufferedByteStringAccessor byteStringAccessor, MappingHints defaultMappingHints) {
-        this.byteStringAccessor = byteStringAccessor;
+        super(byteStringAccessor);
         this.defaultMappingHints = defaultMappingHints;
     }
 
@@ -60,8 +51,11 @@ public class MetricDocumentBuilder {
         }
         buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
         buildDataStream(builder, dataPointGroup.targetIndex());
-        buildScope(builder, dataPointGroup.scopeSchemaUrl(), dataPointGroup.scope());
-        buildDataPointAttributes(builder, dataPointGroup.dataPointAttributes(), dataPointGroup.unit());
+        buildScope(builder, dataPointGroup.scope(), dataPointGroup.scopeSchemaUrl());
+        buildAttributes(builder, dataPointGroup.dataPointAttributes(), 0);
+        if (Strings.hasLength(dataPointGroup.unit())) {
+            builder.field("unit", dataPointGroup.unit());
+        }
         String metricNamesHash = dataPointGroup.getMetricNamesHash(hasher);
         builder.field("_metric_names_hash", metricNamesHash);
 
@@ -93,101 +87,6 @@ public class MetricDocumentBuilder {
         TsidBuilder tsidBuilder = dataPointGroup.tsidBuilder();
         tsidBuilder.addStringDimension("_metric_names_hash", metricNamesHash);
         return tsidBuilder.buildTsid();
-    }
-
-    private void buildResource(Resource resource, ByteString schemaUrl, XContentBuilder builder) throws IOException {
-        builder.startObject("resource");
-        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
-        if (resource.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", resource.getDroppedAttributesCount());
-        }
-        builder.startObject("attributes");
-        buildAttributes(builder, resource.getAttributesList());
-        builder.endObject();
-        builder.endObject();
-    }
-
-    private void buildScope(XContentBuilder builder, ByteString schemaUrl, InstrumentationScope scope) throws IOException {
-        builder.startObject("scope");
-        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
-        if (scope.getDroppedAttributesCount() > 0) {
-            builder.field("dropped_attributes_count", scope.getDroppedAttributesCount());
-        }
-        addFieldIfNotEmpty(builder, "name", scope.getNameBytes());
-        addFieldIfNotEmpty(builder, "version", scope.getVersionBytes());
-        builder.startObject("attributes");
-        buildAttributes(builder, scope.getAttributesList());
-        builder.endObject();
-        builder.endObject();
-    }
-
-    private void addFieldIfNotEmpty(XContentBuilder builder, String name, ByteString value) throws IOException {
-        if (value != null && value.isEmpty() == false) {
-            builder.field(name);
-            byteStringAccessor.utf8Value(builder, value);
-        }
-    }
-
-    private void buildDataPointAttributes(XContentBuilder builder, List<KeyValue> attributes, String unit) throws IOException {
-        builder.startObject("attributes");
-        buildAttributes(builder, attributes);
-        builder.endObject();
-        if (Strings.hasLength(unit)) {
-            builder.field("unit", unit);
-        }
-    }
-
-    private void buildDataStream(XContentBuilder builder, TargetIndex targetIndex) throws IOException {
-        if (targetIndex.isDataStream() == false) {
-            return;
-        }
-        builder.startObject("data_stream");
-        builder.field("type", targetIndex.type());
-        builder.field("dataset", targetIndex.dataset());
-        builder.field("namespace", targetIndex.namespace());
-        builder.endObject();
-    }
-
-    private void buildAttributes(XContentBuilder builder, List<KeyValue> attributes) throws IOException {
-        for (int i = 0, size = attributes.size(); i < size; i++) {
-            KeyValue attribute = attributes.get(i);
-            String key = attribute.getKey();
-            if (isIgnoredAttribute(key) == false) {
-                builder.field(key);
-                attributeValue(builder, attribute.getValue());
-            }
-        }
-    }
-
-    /**
-     * Checks if the given attribute key is an ignored attribute.
-     * Ignored attributes are well-known Elastic-specific attributes
-     * that influence how the documents are indexed but are not stored themselves.
-     *
-     * @param attributeKey the attribute key to check
-     * @return true if the attribute is ignored, false otherwise
-     */
-    public static boolean isIgnoredAttribute(String attributeKey) {
-        return TargetIndex.isTargetIndexAttribute(attributeKey) || MappingHints.isMappingHintsAttribute(attributeKey);
-    }
-
-    private void attributeValue(XContentBuilder builder, AnyValue value) throws IOException {
-        switch (value.getValueCase()) {
-            case STRING_VALUE -> byteStringAccessor.utf8Value(builder, value.getStringValueBytes());
-            case BOOL_VALUE -> builder.value(value.getBoolValue());
-            case INT_VALUE -> builder.value(value.getIntValue());
-            case DOUBLE_VALUE -> builder.value(value.getDoubleValue());
-            case ARRAY_VALUE -> {
-                builder.startArray();
-                List<AnyValue> valuesList = value.getArrayValue().getValuesList();
-                for (int i = 0, valuesListSize = valuesList.size(); i < valuesListSize; i++) {
-                    AnyValue arrayValue = valuesList.get(i);
-                    attributeValue(builder, arrayValue);
-                }
-                builder.endArray();
-            }
-            default -> throw new IllegalArgumentException("Unsupported attribute value type: " + value.getValueCase());
-        }
     }
 
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+
+import com.google.protobuf.ByteString;
+
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
+import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
+
+import java.io.IOException;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Base class for constructing Elasticsearch document representations of OTel data (metrics, logs, traces).
+ * Provides shared logic for building resource, scope, attribute, and data stream fields.
+ */
+public abstract class OTelDocumentBuilder {
+
+    private final BufferedByteStringAccessor byteStringAccessor;
+
+    public OTelDocumentBuilder(BufferedByteStringAccessor byteStringAccessor) {
+        this.byteStringAccessor = byteStringAccessor;
+    }
+
+    protected void buildResource(Resource resource, ByteString schemaUrl, XContentBuilder builder) throws IOException {
+        builder.startObject("resource");
+        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
+        buildAttributes(builder, resource.getAttributesList(), resource.getDroppedAttributesCount());
+        builder.endObject();
+    }
+
+    protected void buildScope(XContentBuilder builder, InstrumentationScope scope, ByteString schemaUrl) throws IOException {
+        builder.startObject("scope");
+        addFieldIfNotEmpty(builder, "schema_url", schemaUrl);
+        addFieldIfNotEmpty(builder, "name", scope.getNameBytes());
+        addFieldIfNotEmpty(builder, "version", scope.getVersionBytes());
+        buildAttributes(builder, scope.getAttributesList(), scope.getDroppedAttributesCount());
+        builder.endObject();
+    }
+
+    protected void addFieldIfNotEmpty(XContentBuilder builder, String name, ByteString value) throws IOException {
+        if (value != null && value.isEmpty() == false) {
+            builder.field(name);
+            byteStringAccessor.utf8Value(builder, value);
+        }
+    }
+
+    protected void buildDataStream(XContentBuilder builder, TargetIndex targetIndex) throws IOException {
+        if (targetIndex.isDataStream() == false) {
+            return;
+        }
+        builder.startObject("data_stream");
+        builder.field("type", targetIndex.type());
+        builder.field("dataset", targetIndex.dataset());
+        builder.field("namespace", targetIndex.namespace());
+        builder.endObject();
+    }
+
+    protected void buildAttributes(XContentBuilder builder, List<KeyValue> attributes, int droppedAttributesCount) throws IOException {
+        if (droppedAttributesCount > 0) {
+            builder.field("dropped_attributes_count", droppedAttributesCount);
+        }
+        builder.startObject("attributes");
+        for (int i = 0, size = attributes.size(); i < size; i++) {
+            KeyValue attribute = attributes.get(i);
+            String key = attribute.getKey();
+            if (isIgnoredAttribute(key) == false) {
+                builder.field(key);
+                buildAnyValue(builder, attribute.getValue());
+            }
+        }
+        builder.endObject();
+    }
+
+    /**
+     * Checks if the given attribute key is an ignored attribute.
+     * Ignored attributes are well-known Elastic-specific attributes
+     * that influence how the documents are indexed but are not stored themselves.
+     *
+     * @param attributeKey the attribute key to check
+     * @return true if the attribute is ignored, false otherwise
+     */
+    public static boolean isIgnoredAttribute(String attributeKey) {
+        return TargetIndex.isTargetIndexAttribute(attributeKey) || MappingHints.isMappingHintsAttribute(attributeKey);
+    }
+
+    protected void buildAnyValue(XContentBuilder builder, AnyValue value) throws IOException {
+        switch (value.getValueCase()) {
+            case STRING_VALUE -> byteStringAccessor.utf8Value(builder, value.getStringValueBytes());
+            case BOOL_VALUE -> builder.value(value.getBoolValue());
+            case INT_VALUE -> builder.value(value.getIntValue());
+            case DOUBLE_VALUE -> builder.value(value.getDoubleValue());
+            case ARRAY_VALUE -> {
+                builder.startArray();
+                List<AnyValue> valuesList = value.getArrayValue().getValuesList();
+                for (int i = 0, valuesListSize = valuesList.size(); i < valuesListSize; i++) {
+                    AnyValue arrayValue = valuesList.get(i);
+                    buildAnyValue(builder, arrayValue);
+                }
+                builder.endArray();
+            }
+            default -> throw new IllegalArgumentException("Unsupported attribute value type: " + value.getValueCase());
+        }
+    }
+
+    protected void addSpanId(XContentBuilder builder, byte[] spanId) throws IOException {
+        if (spanId.length > 0) {
+            builder.field("span_id", HexFormat.of().formatHex(spanId));
+        }
+    }
+
+    protected void addTraceId(XContentBuilder builder, byte[] traceId) throws IOException {
+        if (traceId.length > 0) {
+            builder.field("trace_id", HexFormat.of().formatHex(traceId));
+        }
+    }
+
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
@@ -114,17 +114,4 @@ public abstract class OTelDocumentBuilder {
             default -> throw new IllegalArgumentException("Unsupported attribute value type: " + value.getValueCase());
         }
     }
-
-    protected void addSpanId(XContentBuilder builder, byte[] spanId) throws IOException {
-        if (spanId.length > 0) {
-            builder.field("span_id", HexFormat.of().formatHex(spanId));
-        }
-    }
-
-    protected void addTraceId(XContentBuilder builder, byte[] traceId) throws IOException {
-        if (traceId.length > 0) {
-            builder.field("trace_id", HexFormat.of().formatHex(traceId));
-        }
-    }
-
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OTelDocumentBuilder.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
-import java.util.HexFormat;
 import java.util.List;
 
 /**


### PR DESCRIPTION
Extract shared document building logic (resource, scope, attributes, data stream, any-value serialization) into a reusable OTelDocumentBuilder base class. This allows logs and traces document builders to reuse the same field-building logic without duplicating code.

Also consolidates the dropped_attributes_count handling into buildAttributes, and adds addSpanId/addTraceId helpers for logs/traces.

part of https://github.com/elastic/elasticsearch/pull/142041