### PR TITLE
Reduce level of ESQL results warnings

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementService.java
@@ -295,7 +295,7 @@ public class AsyncTaskManagementService<
                         Throwable cause = ExceptionsHelper.unwrapCause(exc);
                         if (cause instanceof DocumentMissingException == false
                             && cause instanceof VersionConflictEngineException == false) {
-                            logger.error(
+                            logger.warn(
                                 () -> format("failed to store ESQL search results for [%s]", searchTask.getExecutionId().getEncoded()),
                                 exc
                             );
@@ -309,7 +309,7 @@ public class AsyncTaskManagementService<
         } catch (Exception exc) {
             taskManager.unregister(searchTask);
             searchTask.onFailure(exc);
-            logger.error(() -> "failed to store ESQL search results for [" + searchTask.getExecutionId().getEncoded() + "]", exc);
+            logger.warn(() -> "failed to store ESQL search results for [" + searchTask.getExecutionId().getEncoded() + "]", exc);
         }
     }
 


### PR DESCRIPTION
Failing to store the results of an ESQL search does not in itself
indicate that the system is running in a degraded state nor that an
operator needs to be paged, so this commit reduces these log messages to
level `WARN` instead.