### PR TITLE
Extract AbstractOTLPRestAction

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.GeneratedMessage;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestResponseListener;
+
+import java.io.IOException;
+
+public abstract class AbstractOTLPRestAction extends BaseRestHandler {
+
+    private final ActionType<OTLPActionResponse> type;
+    private final BytesArray emptyResponse;
+
+    public AbstractOTLPRestAction(ActionType<OTLPActionResponse> type, GeneratedMessage emptyResponse) {
+        this.type = type;
+        this.emptyResponse = new BytesArray(emptyResponse.toByteArray());
+    }
+
+    @Override
+    public final boolean mediaTypesValid(RestRequest request) {
+        return request.getXContentType() == null
+            && request.getParsedContentType().mediaTypeWithoutParameters().equals("application/x-protobuf");
+    }
+
+    @Override
+    protected final RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (request.hasContent()) {
+            var transportRequest = new OTLPActionRequest(request.content().retain());
+            return channel -> client.execute(
+                type,
+                transportRequest,
+                ActionListener.releaseBefore(request.content(), new RestResponseListener<>(channel) {
+                    @Override
+                    public RestResponse buildResponse(OTLPActionResponse r) {
+                        return new RestResponse(r.getStatus(), "application/x-protobuf", r.getResponse());
+                    }
+                })
+            );
+        }
+
+        // If the server receives an empty request
+        // (a request that does not carry any telemetry data)
+        // the server SHOULD respond with success.
+        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
+        return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "application/x-protobuf", emptyResponse));
+    }
+
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+public class OTLPActionRequest extends ActionRequest implements CompositeIndicesRequest {
+    private final BytesReference request;
+
+    // This constructor is required by the HandledTransportAction API but is never used at runtime.
+    // The REST handler creates the request locally and the transport action processes it on the same node,
+    // so node-to-node serialization does not occur. A matching writeTo is intentionally omitted.
+    public OTLPActionRequest(StreamInput in) throws IOException {
+        super(in);
+        throw new UnsupportedOperationException("OTLPActionRequest should not be deserialized from a stream");
+    }
+
+    public OTLPActionRequest(BytesReference request) {
+        this.request = request;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public BytesReference getRequest() {
+        return request;
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
@@ -18,12 +18,9 @@ import java.io.IOException;
 public class OTLPActionRequest extends ActionRequest implements CompositeIndicesRequest {
     private final BytesReference request;
 
-    // This constructor is required by the HandledTransportAction API but is never used at runtime.
-    // The REST handler creates the request locally and the transport action processes it on the same node,
-    // so node-to-node serialization does not occur. A matching writeTo is intentionally omitted.
     public OTLPActionRequest(StreamInput in) throws IOException {
         super(in);
-        throw new UnsupportedOperationException("OTLPActionRequest should not be deserialized from a stream");
+        request = in.readBytesReference();
     }
 
     public OTLPActionRequest(BytesReference request) {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp;
+
+import com.google.protobuf.MessageLite;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+public class OTLPActionResponse extends ActionResponse {
+    private final BytesReference response;
+    private final RestStatus status;
+
+    public OTLPActionResponse(RestStatus status, MessageLite response) {
+        this(status, new BytesArray(response.toByteArray()));
+    }
+
+    public OTLPActionResponse(RestStatus status, BytesReference response) {
+        this.response = response;
+        this.status = status;
+    }
+
+    // writeTo is required by the ActionResponse contract but is never used at runtime.
+    // The response is created and consumed locally on the same node, so node-to-node serialization does not occur.
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("OTLPActionResponse should not be serialized to a stream");
+    }
+
+    public BytesReference getResponse() {
+        return response;
+    }
+
+    public RestStatus getStatus() {
+        return status;
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionResponse.java
@@ -30,11 +30,10 @@ public class OTLPActionResponse extends ActionResponse {
         this.status = status;
     }
 
-    // writeTo is required by the ActionResponse contract but is never used at runtime.
-    // The response is created and consumed locally on the same node, so node-to-node serialization does not occur.
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("OTLPActionResponse should not be serialized to a stream");
+        out.writeBytesReference(response);
+        out.writeEnum(status);
     }
 
     public BytesReference getResponse() {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsRestAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsRestAction.java
@@ -9,24 +9,19 @@ package org.elasticsearch.xpack.oteldata.otlp;
 
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestResponseListener;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 @ServerlessScope(Scope.PUBLIC)
-public class OTLPMetricsRestAction extends BaseRestHandler {
+public class OTLPMetricsRestAction extends AbstractOTLPRestAction {
+    public OTLPMetricsRestAction() {
+        super(OTLPMetricsTransportAction.TYPE, ExportMetricsServiceResponse.newBuilder().build());
+    }
+
     @Override
     public String getName() {
         return "otlp_metrics_action";
@@ -35,41 +30,6 @@ public class OTLPMetricsRestAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(new Route(POST, "/_otlp/v1/metrics"));
-    }
-
-    @Override
-    public boolean mediaTypesValid(RestRequest request) {
-        return request.getXContentType() == null
-            && request.getParsedContentType().mediaTypeWithoutParameters().equals("application/x-protobuf");
-    }
-
-    @Override
-    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (request.hasContent()) {
-            var transportRequest = new OTLPMetricsTransportAction.MetricsRequest(request.content().retain());
-            return channel -> client.execute(
-                OTLPMetricsTransportAction.TYPE,
-                transportRequest,
-                ActionListener.releaseBefore(request.content(), new RestResponseListener<>(channel) {
-                    @Override
-                    public RestResponse buildResponse(OTLPMetricsTransportAction.MetricsResponse r) {
-                        return new RestResponse(r.getStatus(), "application/x-protobuf", r.getResponse());
-                    }
-                })
-            );
-        }
-
-        // If the server receives an empty request
-        // (a request that does not carry any telemetry data)
-        // the server SHOULD respond with success.
-        // https://opentelemetry.io/docs/specs/otlp/#full-success-1
-        return channel -> channel.sendResponse(
-            new RestResponse(
-                RestStatus.OK,
-                "application/x-protobuf",
-                new BytesArray(ExportMetricsServiceResponse.newBuilder().build().toByteArray())
-            )
-        );
     }
 
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
@@ -16,11 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -30,11 +26,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.injection.guice.Inject;
@@ -64,12 +56,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @see <a href="https://opentelemetry.io/docs/specs/otlp">OTLP Specification</a>
  */
-public class OTLPMetricsTransportAction extends HandledTransportAction<
-    OTLPMetricsTransportAction.MetricsRequest,
-    OTLPMetricsTransportAction.MetricsResponse> {
+public class OTLPMetricsTransportAction extends HandledTransportAction<OTLPActionRequest, OTLPActionResponse> {
 
     public static final String NAME = "indices:data/write/otlp/metrics";
-    public static final ActionType<MetricsResponse> TYPE = new ActionType<>(NAME);
+    public static final ActionType<OTLPActionResponse> TYPE = new ActionType<>(NAME);
 
     private static final Logger logger = LogManager.getLogger(OTLPMetricsTransportAction.class);
     public static final int IGNORED_DATA_POINTS_MESSAGE_LIMIT = 10;
@@ -86,7 +76,7 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         Client client,
         ClusterService clusterService
     ) {
-        super(NAME, transportService, actionFilters, MetricsRequest::new, threadPool.executor(ThreadPool.Names.WRITE));
+        super(NAME, transportService, actionFilters, OTLPActionRequest::new, threadPool.executor(ThreadPool.Names.WRITE));
         this.client = client;
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         defaultMappingHints = MappingHints.fromSettings(clusterSettings.get(OTelPlugin.USE_EXPONENTIAL_HISTOGRAM_FIELD_TYPE));
@@ -96,11 +86,11 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
     }
 
     @Override
-    protected void doExecute(Task task, MetricsRequest request, ActionListener<MetricsResponse> listener) {
+    protected void doExecute(Task task, OTLPActionRequest request, ActionListener<OTLPActionResponse> listener) {
         BufferedByteStringAccessor byteStringAccessor = new BufferedByteStringAccessor();
         DataPointGroupingContext context = new DataPointGroupingContext(byteStringAccessor);
         try {
-            var metricsServiceRequest = ExportMetricsServiceRequest.parseFrom(request.exportMetricsServiceRequest.streamInput());
+            var metricsServiceRequest = ExportMetricsServiceRequest.parseFrom(request.getRequest().streamInput());
             context.groupDataPoints(metricsServiceRequest);
             if (context.totalDataPoints() == 0) {
                 handleEmptyRequest(listener);
@@ -163,11 +153,11 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         }
     }
 
-    private static void handleSuccess(ActionListener<MetricsResponse> listener) {
-        listener.onResponse(new MetricsResponse(RestStatus.OK, ExportMetricsServiceResponse.newBuilder().build()));
+    private static void handleSuccess(ActionListener<OTLPActionResponse> listener) {
+        listener.onResponse(new OTLPActionResponse(RestStatus.OK, ExportMetricsServiceResponse.newBuilder().build()));
     }
 
-    private static void handleEmptyRequest(ActionListener<MetricsResponse> listener) {
+    private static void handleEmptyRequest(ActionListener<OTLPActionResponse> listener) {
         // If the server receives an empty request
         // (a request that does not carry any telemetry data)
         // the server SHOULD respond with success.
@@ -175,7 +165,7 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         handleSuccess(listener);
     }
 
-    private static void handlePartialSuccess(ActionListener<MetricsResponse> listener, DataPointGroupingContext context) {
+    private static void handlePartialSuccess(ActionListener<OTLPActionResponse> listener, DataPointGroupingContext context) {
         // If the request is only partially accepted
         // (i.e. when the server accepts only parts of the data and rejects the rest),
         // the server MUST respond with HTTP 200 OK.
@@ -184,13 +174,13 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
             context.getIgnoredDataPoints(),
             context.getIgnoredDataPointsMessage(IGNORED_DATA_POINTS_MESSAGE_LIMIT)
         );
-        listener.onResponse(new MetricsResponse(RestStatus.BAD_REQUEST, response));
+        listener.onResponse(new OTLPActionResponse(RestStatus.BAD_REQUEST, response));
     }
 
     private static void handlePartialSuccess(
         BulkResponse bulkItemResponses,
         DataPointGroupingContext context,
-        ActionListener<MetricsResponse> listener
+        ActionListener<OTLPActionResponse> listener
     ) {
         // index -> status -> failure group
         Map<String, Map<RestStatus, FailureGroup>> failureGroups = new HashMap<>();
@@ -209,7 +199,7 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
                 if (failure.getStatus() == RestStatus.TOO_MANY_REQUESTS) {
                     // If the server receives more requests than the client is allowed or the server is overloaded,
                     // the server SHOULD respond with HTTP 429 Too Many Requests or HTTP 503 Service Unavailable
-                    // and MAY include “Retry-After” header with a recommended time interval in seconds to wait before retrying.
+                    // and MAY include "Retry-After" header with a recommended time interval in seconds to wait before retrying.
                     // https://opentelemetry.io/docs/specs/otlp/#otlphttp-throttling
                     status = RestStatus.TOO_MANY_REQUESTS;
                 }
@@ -244,17 +234,17 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
             failures + context.getIgnoredDataPoints(),
             failureMessageBuilder.toString()
         );
-        listener.onResponse(new MetricsResponse(status, response));
+        listener.onResponse(new OTLPActionResponse(status, response));
     }
 
     record FailureGroup(AtomicInteger failureCount, String failureMessageSample) {}
 
-    private static void handleFailure(ActionListener<MetricsResponse> listener, Exception e, DataPointGroupingContext context) {
+    private static void handleFailure(ActionListener<OTLPActionResponse> listener, Exception e, DataPointGroupingContext context) {
         // https://opentelemetry.io/docs/specs/otlp/#failures-1
         // If the processing of the request fails,
         // the server MUST respond with appropriate HTTP 4xx or HTTP 5xx status code.
         listener.onResponse(
-            new MetricsResponse(ExceptionsHelper.status(e), responseWithRejectedDataPoints(context.totalDataPoints(), e.getMessage()))
+            new OTLPActionResponse(ExceptionsHelper.status(e), responseWithRejectedDataPoints(context.totalDataPoints(), e.getMessage()))
         );
     }
 
@@ -266,49 +256,4 @@ public class OTLPMetricsTransportAction extends HandledTransportAction<
         return ExportMetricsServiceResponse.newBuilder().setPartialSuccess(partialSuccess).build();
     }
 
-    public static class MetricsRequest extends ActionRequest implements CompositeIndicesRequest {
-        private final BytesReference exportMetricsServiceRequest;
-
-        public MetricsRequest(StreamInput in) throws IOException {
-            super(in);
-            exportMetricsServiceRequest = in.readBytesReference();
-        }
-
-        public MetricsRequest(BytesReference exportMetricsServiceRequest) {
-            this.exportMetricsServiceRequest = exportMetricsServiceRequest;
-        }
-
-        @Override
-        public ActionRequestValidationException validate() {
-            return null;
-        }
-    }
-
-    public static class MetricsResponse extends ActionResponse {
-        private final BytesReference response;
-        private final RestStatus status;
-
-        public MetricsResponse(RestStatus status, ExportMetricsServiceResponse response) {
-            this(status, new BytesArray(response.toByteArray()));
-        }
-
-        public MetricsResponse(RestStatus status, BytesReference response) {
-            this.response = response;
-            this.status = status;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeBytesReference(response);
-            out.writeEnum(status);
-        }
-
-        public BytesReference getResponse() {
-            return response;
-        }
-
-        public RestStatus getStatus() {
-            return status;
-        }
-    }
 }


### PR DESCRIPTION
Extract common REST handler logic into AbstractOTLPRestAction base class and introduce shared OTLPActionRequest/OTLPActionResponse types replacing the inner MetricsRequest/MetricsResponse classes.

Part of https://github.com/elastic/elasticsearch/pull/142041
