### PR TITLE
[9.2] Ensure Rewriteable.rewriteAndFetch listeners are not executed on transport threads (#141904)

### DIFF
--- a/docs/changelog/141904.yaml
+++ b/docs/changelog/141904.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues: []
+pr: 141904
+summary: Ensure Rewriteable.rewriteAndFetch listeners are not executed on transport
+  threads
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -140,6 +140,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
                     null,
                     null
                 ),
+                transportService.getThreadPool().executor(ThreadPool.Names.SEARCH),
                 rewriteListener
             );
         }

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -117,6 +117,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
                 null,
                 false
             ),
+            threadPool.executor(ThreadPool.Names.GET),
             rewriteListener
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -599,6 +599,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 isExplain,
                 allowPartialSearchResults
             ),
+            threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
             rewriteListener
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -138,6 +138,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                 null,
                 null
             ),
+            threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
             listener.delegateFailureAndWrap((delegate, searchRequest) -> {
                 Index[] concreteIndices = resolvedIndices.getConcreteLocalIndices();
                 final Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -2127,6 +2127,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Rewriteable.rewriteAndFetch(
             request.getRewriteable(),
             indicesService.getDataRewriteContext(request::nowInMillis),
+            threadPool.executor(Names.SEARCH),
             request.readerId() == null
                 ? listener.delegateFailureAndWrap((l, r) -> shard.ensureShardSearchActive(b -> l.onResponse(request)))
                 : listener.safeMap(r -> request)

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -9,15 +9,25 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 public class RewriteableTests extends ESTestCase {
 
@@ -28,17 +38,17 @@ public class RewriteableTests extends ESTestCase {
             context,
             randomBoolean()
         );
-        assertEquals(rewrite.numRewrites, 0);
+        assertEquals(0, rewrite.numRewrites);
         IllegalStateException ise = expectThrows(
             IllegalStateException.class,
             () -> Rewriteable.rewrite(new TestRewriteable(Rewriteable.MAX_REWRITE_ROUNDS + 1), context)
         );
-        assertEquals(ise.getMessage(), "too many rewrite rounds, rewriteable might return new objects even if they are not rewritten");
+        assertEquals("too many rewrite rounds, rewriteable might return new objects even if they are not rewritten", ise.getMessage());
         ise = expectThrows(
             IllegalStateException.class,
             () -> Rewriteable.rewrite(new TestRewriteable(Rewriteable.MAX_REWRITE_ROUNDS + 1, true), context, true)
         );
-        assertEquals(ise.getMessage(), "async actions are left after rewrite");
+        assertEquals("async actions are left after rewrite", ise.getMessage());
     }
 
     public void testRewriteAndFetch() throws ExecutionException, InterruptedException {
@@ -46,7 +56,7 @@ public class RewriteableTests extends ESTestCase {
         PlainActionFuture<TestRewriteable> future = new PlainActionFuture<>();
         Rewriteable.rewriteAndFetch(new TestRewriteable(randomIntBetween(0, Rewriteable.MAX_REWRITE_ROUNDS), true), context, future);
         TestRewriteable rewrite = future.get();
-        assertEquals(rewrite.numRewrites, 0);
+        assertEquals(0, rewrite.numRewrites);
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> {
             PlainActionFuture<TestRewriteable> f = new PlainActionFuture<>();
             Rewriteable.rewriteAndFetch(new TestRewriteable(Rewriteable.MAX_REWRITE_ROUNDS + 1, true), context, f);
@@ -56,7 +66,7 @@ public class RewriteableTests extends ESTestCase {
                 throw e.getCause(); // we expect the underlying exception here
             }
         });
-        assertEquals(ise.getMessage(), "too many rewrite rounds, rewriteable might return new objects even if they are not rewritten");
+        assertEquals("too many rewrite rounds, rewriteable might return new objects even if they are not rewritten", ise.getMessage());
     }
 
     public void testRewriteList() throws IOException {
@@ -84,7 +94,136 @@ public class RewriteableTests extends ESTestCase {
         assertSame(rewriteableList, Rewriteable.rewrite(rewriteableList, context));
     }
 
-    private static final class TestRewriteable implements Rewriteable<TestRewriteable> {
+    public void testRewriteAndFetchWithExecutor() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("test");
+        try {
+            Executor searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+            AtomicReference<String> completionThreadName = new AtomicReference<>();
+            CountDownLatch completionLatch = new CountDownLatch(1);
+            CountDownLatch asyncStartLatch = new CountDownLatch(1);
+            TestRewriteable rewrite = new TestRewriteableWithLatchAndCapture(1, asyncStartLatch, completionThreadName);
+            Rewriteable.rewriteAndFetch(rewrite, new QueryRewriteContext(null, null, null), searchExecutor, new ActionListener<>() {
+                @Override
+                public void onResponse(TestRewriteable result) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    completionLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    completionLatch.countDown();
+                }
+            });
+            asyncStartLatch.countDown();
+
+            assertTrue("Timed out waiting for rewrite to complete", completionLatch.await(10, TimeUnit.SECONDS));
+            assertThat("Should complete on search thread pool", completionThreadName.get(), containsString("search"));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testRewriteAndFetchWithExecutorOnFailure() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("test");
+        try {
+            Executor searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+            AtomicReference<String> completionThreadName = new AtomicReference<>();
+            AtomicReference<Exception> caughtException = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            TestRewriteable rewrite = new FailingTestRewriteable(randomIntBetween(1, 3));
+            Rewriteable.rewriteAndFetch(rewrite, new QueryRewriteContext(null, null, null), searchExecutor, new ActionListener<>() {
+                @Override
+                public void onResponse(TestRewriteable result) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    caughtException.set(e);
+                    latch.countDown();
+                }
+            });
+
+            assertTrue("Timed out waiting for rewrite to complete", latch.await(10, TimeUnit.SECONDS));
+            assertNotNull("Exception should be caught", caughtException.get());
+            assertThat(caughtException.get().getMessage(), containsString("Simulated async failure"));
+            assertThat("Should complete on search thread pool", completionThreadName.get(), containsString("search"));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testRewriteAndFetchWithExecutorNoAsyncActions() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("test");
+        try {
+            Executor searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+            Thread callingThread = Thread.currentThread();
+            AtomicReference<Thread> completionThread = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            TestRewriteable rewrite = new TestRewriteable(randomIntBetween(0, 5), false);
+            Rewriteable.rewriteAndFetch(rewrite, new QueryRewriteContext(null, null, null), searchExecutor, new ActionListener<>() {
+                @Override
+                public void onResponse(TestRewriteable result) {
+                    completionThread.set(Thread.currentThread());
+                    assertEquals(0, result.numRewrites);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("Should not fail: " + e.getMessage());
+                    latch.countDown();
+                }
+            });
+
+            assertTrue("Timed out waiting for rewrite to complete", latch.await(10, TimeUnit.SECONDS));
+            assertSame("Should complete on calling thread when no async actions", callingThread, completionThread.get());
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testRewriteAndFetchWithExecutorAsyncOnDifferentThread() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("test");
+        try {
+            Executor searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+            AtomicReference<String> asyncThreadName = new AtomicReference<>();
+            AtomicReference<String> completionThreadName = new AtomicReference<>();
+            CountDownLatch completionLatch = new CountDownLatch(1);
+            CountDownLatch asyncStartLatch = new CountDownLatch(1);
+            TestRewriteable rewrite = new TestRewriteableWithLatchAndCapture(1, asyncStartLatch, asyncThreadName);
+            Rewriteable.rewriteAndFetch(rewrite, new QueryRewriteContext(null, null, null), searchExecutor, new ActionListener<>() {
+                @Override
+                public void onResponse(TestRewriteable result) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    completionLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    completionThreadName.set(Thread.currentThread().getName());
+                    completionLatch.countDown();
+                }
+            });
+            asyncStartLatch.countDown();
+
+            assertTrue("Timed out waiting for rewrite to complete", completionLatch.await(10, TimeUnit.SECONDS));
+            String asyncThread = asyncThreadName.get();
+            assertNotNull("Async thread name should be captured", asyncThread);
+
+            String completionThread = completionThreadName.get();
+            assertNotNull("Completion thread name should be captured", completionThread);
+            assertThat("Should complete on search thread pool", completionThread, containsString("search"));
+            assertThat("Async and completion threads should differ", completionThread, not(asyncThread));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class TestRewriteable implements Rewriteable<TestRewriteable> {
 
         final int numRewrites;
         final boolean fetch;
@@ -131,6 +270,59 @@ public class RewriteableTests extends ESTestCase {
                 return new TestRewriteable(numRewrites - 1, fetch, setOnce::get);
             }
             return new TestRewriteable(numRewrites - 1, fetch, null);
+        }
+    }
+
+    private static class FailingTestRewriteable extends TestRewriteable {
+
+        FailingTestRewriteable(int numRewrites) {
+            super(numRewrites, true, null);
+        }
+
+        @Override
+        public TestRewriteable rewrite(QueryRewriteContext ctx) throws IOException {
+            if (numRewrites == 0) {
+                return this;
+            }
+            SetOnce<Boolean> setOnce = new SetOnce<>();
+            ctx.registerAsyncAction((c, l) -> {
+                // Simulate failure on a separate thread (like transport thread)
+                new Thread(() -> { l.onFailure(new RuntimeException("Simulated async failure")); }).start();
+            });
+            return new FailingTestRewriteable(numRewrites - 1);
+        }
+    }
+
+    private static class TestRewriteableWithLatchAndCapture extends TestRewriteable {
+
+        private final CountDownLatch asyncStartLatch;
+        private final AtomicReference<String> asyncThreadCapture;
+
+        TestRewriteableWithLatchAndCapture(int numRewrites, CountDownLatch asyncStartLatch, AtomicReference<String> asyncThreadCapture) {
+            super(numRewrites, true, null);
+            this.asyncStartLatch = asyncStartLatch;
+            this.asyncThreadCapture = asyncThreadCapture;
+        }
+
+        @Override
+        public TestRewriteable rewrite(QueryRewriteContext ctx) throws IOException {
+            if (numRewrites == 0) {
+                return this;
+            }
+            SetOnce<Boolean> setOnce = new SetOnce<>();
+            ctx.registerAsyncAction((c, l) -> {
+                new Thread(() -> {
+                    try {
+                        asyncStartLatch.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    asyncThreadCapture.set(Thread.currentThread().getName());
+                    setOnce.set(Boolean.TRUE);
+                    l.onResponse(null);
+                }, "simulated-transport-thread").start();
+            });
+            return new TestRewriteable(numRewrites - 1, false, setOnce::get);
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.capabilities.RewriteableAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -52,6 +53,7 @@ public final class QueryBuilderResolver {
             Rewriteable.rewriteAndFetch(
                 new FunctionsRewriteable(plan),
                 queryRewriteContext(services, indexNames(plan)),
+                services.transportService().getThreadPool().executor(ThreadPool.Names.SEARCH_COORDINATION),
                 listener.delegateFailureAndWrap((l, r) -> l.onResponse(r.plan))
             );
         } else {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Ensure Rewriteable.rewriteAndFetch listeners are not executed on transport threads (#141904)