### PR TITLE
Account for vector similarity function availability

### DIFF
--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.VectorUtil;
+import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.simdvec.internal.Similarities;
 
 import java.lang.foreign.MemorySegment;
@@ -44,6 +45,9 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
 
     static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
 
+    /** Whether native vector distance functions are available (not supported on Windows). */
+    private static final boolean HAS_NATIVE_VECTOR_DISTANCES = NativeAccess.instance().getVectorSimilarityFunctions().isPresent();
+
     private static FloatVector fma(FloatVector a, FloatVector b, FloatVector c) {
         if (Constants.HAS_FAST_VECTOR_FMA) {
             return a.fma(b, c);
@@ -62,14 +66,14 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
 
     @Override
     public float dotProduct(float[] a, float[] b) {
-        return SUPPORTS_HEAP_SEGMENTS
+        return SUPPORTS_HEAP_SEGMENTS && HAS_NATIVE_VECTOR_DISTANCES
             ? Similarities.dotProductF32(MemorySegment.ofArray(a), MemorySegment.ofArray(b), a.length)
             : VectorUtil.dotProduct(a, b);
     }
 
     @Override
     public float squareDistance(float[] a, float[] b) {
-        return SUPPORTS_HEAP_SEGMENTS
+        return SUPPORTS_HEAP_SEGMENTS && HAS_NATIVE_VECTOR_DISTANCES
             ? Similarities.squareDistanceF32(MemorySegment.ofArray(a), MemorySegment.ofArray(b), a.length)
             : VectorUtil.squareDistance(a, b);
     }


### PR DESCRIPTION
This code change stems from the fact that Windows doesn't support these and running `CsvTestsDataLoader.main` (used for testing purposes) without disabling assertions results in 

```
AssertionError
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at org.elasticsearch.simdvec@9.4.0-SNAPSHOT/org.elasticsearch.simdvec.internal.Similarities.<clinit>(Similarities.java:26)
        at org.elasticsearch.simdvec@9.4.0-SNAPSHOT/org.elasticsearch.simdvec.internal.vectorization.PanamaESVectorUtilSupport.dotProduct(PanamaESVectorUtilSupport.java:66)
        at org.elasticsearch.simdvec@9.4.0-SNAPSHOT/org.elasticsearch.simdvec.ESVectorUtil.dotProduct(ESVectorUtil.java:73)
```