### PR TITLE
[9.2] ESQL: Fix IP_PREFIX function leaking data in scratch

### DIFF
--- a/docs/changelog/141940.yaml
+++ b/docs/changelog/141940.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 141628
+pr: 141940
+summary: Fix IP_PREFIX function leaking data in scratch
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -746,3 +746,29 @@ row ip4 = to_ip("1.2.3.4")
 ip4:ip  | a:ip | b:ip | c:ip
 1.2.3.4 | null | null | null
 ;
+
+ipPrefixV6MultipleRowsDifferentLengthsRow
+required_capability: fn_ip_prefix_fix_dirty_scratch_leak
+ROW ip = ["::1", "::ffff:ffff:ffff:ffff", "::1"]::ip
+| MV_EXPAND ip
+| EVAL v6_prefix = CASE(ip == "::1", 72, 80)
+| EVAL prefix = IP_PREFIX(ip, 32, v6_prefix);
+
+ip:ip                 | v6_prefix:integer | prefix:ip
+::1                   | 72                | ::
+::ffff:ffff:ffff:ffff | 80                | ::ffff:0:0:0
+::1                   | 72                | ::
+;
+
+ipPrefixV4MultipleRowsDifferentLengthsRow
+required_capability: fn_ip_prefix_fix_dirty_scratch_leak
+ROW ip = ["0.0.0.0", "123.123.123.123", "0.0.0.0"]::ip
+| MV_EXPAND ip
+| EVAL v4_prefix = CASE(ip == "0.0.0.0", 16, 24)
+| EVAL prefix = IP_PREFIX(ip, v4_prefix, 128);
+
+ip:ip           | v4_prefix:integer | prefix:ip
+0.0.0.0         | 16                | 0.0.0.0
+123.123.123.123 | 24                | 123.123.123.0
+0.0.0.0         | 16                | 0.0.0.0
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -227,6 +227,11 @@ public class EsqlCapabilities {
         FN_IP_PREFIX,
 
         /**
+         * Fix a bug leading to the scratch leaking data to other rows.
+         */
+        FN_IP_PREFIX_FIX_DIRTY_SCRATCH_LEAK,
+
+        /**
          * Fix on function {@code SUBSTRING} that makes it not return null on empty strings.
          */
         FN_SUBSTRING_EMPTY_NULL,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
@@ -167,6 +167,8 @@ public class IpPrefix extends EsqlScalarFunction implements OptionalArgument {
     }
 
     private static void makePrefix(BytesRef ip, BytesRef scratch, int fullBytes, int remainingBits) {
+        int filledBytes = fullBytes;
+
         // Copy the first full bytes
         System.arraycopy(ip.bytes, ip.offset, scratch.bytes, 0, fullBytes);
 
@@ -174,11 +176,12 @@ public class IpPrefix extends EsqlScalarFunction implements OptionalArgument {
         if (remainingBits > 0) {
             byte lastByteMask = (byte) (0xFF << (8 - remainingBits));
             scratch.bytes[fullBytes] = (byte) (ip.bytes[ip.offset + fullBytes] & lastByteMask);
+            filledBytes++;
         }
 
-        // Copy the last empty bytes
-        if (fullBytes < 16) {
-            Arrays.fill(scratch.bytes, fullBytes + 1, 16, (byte) 0);
+        // Fill the last untouched bytes with zeroes
+        if (filledBytes < 16) {
+            Arrays.fill(scratch.bytes, filledBytes, 16, (byte) 0);
         }
     }
 


### PR DESCRIPTION
Manual 9.2 backport of https://github.com/elastic/elasticsearch/pull/141940