### PR TITLE
Fix visited vs filter_selectivity header vs column placements

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -489,9 +489,9 @@ public class KnnIndexTester {
                     String.format(Locale.ROOT, "%.2f", queryResult.avgCpuCount),
                     String.format(Locale.ROOT, "%.2f", queryResult.qps),
                     String.format(Locale.ROOT, "%.2f", queryResult.avgRecall),
+                    String.format(Locale.ROOT, "%.2f", queryResult.averageVisited),
                     String.format(Locale.ROOT, "%.2f", queryResult.filterSelectivity),
                     Boolean.toString(queryResult.filterCached),
-                    String.format(Locale.ROOT, "%.2f", queryResult.averageVisited),
                     String.format(Locale.ROOT, "%.2f", queryResult.overSamplingFactor),
                     String.format(Locale.ROOT, "%d", queryResult.numCandidates),
                     Boolean.toString(queryResult.earlyTermination) };


### PR DESCRIPTION
The current `visited` header in `KnnIndexTester` is misplaced (on top of the `filter_selectivity` column).

before the fix
```
index_name                                           index_type  visit_percentage(%)  latency(ms)  net_cpu_time(ms)  avg_cpu_count      QPS  recall  visited  filter_selectivity  filter_cached  oversampling_factor  num_candidates  early_termination
---------------------------------------------------  ----------  -------------------  -----------  ----------------  -------------  -------  ------  -------  ------------------  -------------  -------------------  --------------  -----------------  
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf                1.000         0.50              0.74           1.48  2000.00    0.58     1.00                true        7786.58                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf                5.000         0.52              0.90           1.73  1923.08    0.72     1.00                true       20558.60                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               10.000         0.62              1.32           2.13  1612.90    0.76     1.00                true       37271.72                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               30.000         0.92              2.28           2.48  1086.96    0.78     1.00                true      105446.04                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               50.000         1.20              3.10           2.58   833.33    0.78     1.00                true      173189.06                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               70.000         1.52              3.96           2.61   657.89    0.78     1.00                true      241608.10                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf              100.000         1.94              5.14           2.65   515.46    0.78     1.00                true      341984.00                 3.00            1000              false


```

after the fix
```
index_name                                           index_type  visit_percentage(%)  latency(ms)  net_cpu_time(ms)  avg_cpu_count      QPS  recall    visited  filter_selectivity  filter_cached  oversampling_factor  num_candidates  early_termination
---------------------------------------------------  ----------  -------------------  -----------  ----------------  -------------  -------  ------  ---------  ------------------  -------------  -------------------  --------------  -----------------  
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf                1.000         0.52              0.70           1.35  1923.08    0.58    8242.64                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf                5.000         0.56              0.94           1.68  1785.71    0.71   20596.58                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               10.000         0.64              1.28           2.00  1562.50    0.76   37347.84                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               30.000         0.96              2.32           2.42  1041.67    0.78  105698.76                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               50.000         1.24              3.20           2.58   806.45    0.78  174139.04                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf               70.000         1.54              4.06           2.64   649.35    0.78  242307.92                1.00           true                 3.00            1000              false
target/knn_index/trec-covid.docs-ivf-384-16-1.index         ivf              100.000         1.98              5.42           2.74   505.05    0.78  342294.00                1.00           true                 3.00            1000              false
```