### PR TITLE
[9.2] [Inference API] Prevent trailing slashes from being included in URLs (#141692)

### DIFF
--- a/docs/changelog/141692.yaml
+++ b/docs/changelog/141692.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 141692
+summary: "[Inference API] Prevent trailing slashes from being included in URLs"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioModel.java
@@ -101,4 +101,15 @@ public abstract class AzureAiStudioModel extends Model {
     }
 
     public abstract ExecutableAction accept(AzureAiStudioActionVisitor creator, Map<String, Object> taskSettings);
+
+    /**
+     * Strips the last trailing slash from a String
+     */
+    public static String stripTrailingSlash(String url) {
+        if (url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        } else {
+            return url;
+        }
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModel.java
@@ -95,7 +95,7 @@ public class AzureAiStudioChatCompletionModel extends AzureAiStudioModel {
             return new URI(this.target);
         }
 
-        return new URI(this.target + COMPLETIONS_URI_PATH);
+        return new URI(stripTrailingSlash(this.target) + COMPLETIONS_URI_PATH);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModel.java
@@ -99,7 +99,7 @@ public class AzureAiStudioEmbeddingsModel extends AzureAiStudioModel {
             return new URI(this.target);
         }
 
-        return new URI(this.target + EMBEDDINGS_URI_PATH);
+        return new URI(stripTrailingSlash(this.target) + EMBEDDINGS_URI_PATH);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankModel.java
@@ -85,7 +85,7 @@ public class AzureAiStudioRerankModel extends AzureAiStudioModel {
 
     @Override
     protected URI getEndpointUri() throws URISyntaxException {
-        return new URI(this.target + RERANK_URI_PATH);
+        return new URI(stripTrailingSlash(this.target) + RERANK_URI_PATH);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceModel.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.inference.services.elastic;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xpack.inference.services.RateLimitGroupingModel;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.net.URISyntaxException;
 import java.util.Objects;
 
 public abstract class ElasticInferenceServiceModel extends RateLimitGroupingModel {
@@ -44,6 +46,10 @@ public abstract class ElasticInferenceServiceModel extends RateLimitGroupingMode
     public int rateLimitGroupingHash() {
         // We only have one model for rerank
         return Objects.hash(this.getServiceSettings().modelId());
+    }
+
+    public URIBuilder getBaseURIBuilder() throws URISyntaxException {
+        return new URIBuilder(elasticInferenceServiceComponents.elasticInferenceServiceUrl());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModel.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 
 public class ElasticInferenceServiceCompletionModel extends ElasticInferenceServiceModel {
 
+    public static final String COMPLETION_PATH = "/api/v1/chat";
+
     public static ElasticInferenceServiceCompletionModel of(
         ElasticInferenceServiceCompletionModel model,
         UnifiedCompletionRequest request
@@ -105,7 +107,7 @@ public class ElasticInferenceServiceCompletionModel extends ElasticInferenceServ
     private URI createUri() throws ElasticsearchStatusException {
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
-            return new URI(elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/chat");
+            return getBaseURIBuilder().setPath(COMPLETION_PATH).build();
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
                 "Failed to create URI for service ["

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModel.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 public class ElasticInferenceServiceDenseTextEmbeddingsModel extends ElasticInferenceServiceExecutableActionModel {
 
+    public static final String TEXT_EMBEDDING_PATH = "/api/v1/embed/text/dense";
     private final URI uri;
 
     public ElasticInferenceServiceDenseTextEmbeddingsModel(
@@ -99,7 +100,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsModel extends ElasticInfe
     private URI createUri() throws ElasticsearchStatusException {
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
-            return new URI(elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/dense");
+            return getBaseURIBuilder().setPath(TEXT_EMBEDDING_PATH).build();
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
                 "Failed to create URI for service ["

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModel.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 public class ElasticInferenceServiceRerankModel extends ElasticInferenceServiceExecutableActionModel {
 
+    public static final String RERANK_PATH = "/api/v1/rerank/text/text-similarity";
     private final URI uri;
 
     public ElasticInferenceServiceRerankModel(
@@ -87,7 +88,7 @@ public class ElasticInferenceServiceRerankModel extends ElasticInferenceServiceE
     private URI createUri() throws ElasticsearchStatusException {
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
-            return new URI(elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/rerank/text/text-similarity");
+            return getBaseURIBuilder().setPath(RERANK_PATH).build();
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
                 "Failed to create URI for service ["

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsModel.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferenceServiceExecutableActionModel {
 
+    public static final String SPARSE_EMBEDDING_PATH = "/api/v1/embed/text/sparse";
     private final URI uri;
 
     public ElasticInferenceServiceSparseEmbeddingsModel(
@@ -99,7 +100,7 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
     private URI createUri() throws ElasticsearchStatusException {
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
-            return new URI(elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/sparse");
+            return getBaseURIBuilder().setPath(SPARSE_EMBEDDING_PATH).build();
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
                 "Failed to create URI for service ["

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModelTests.java
@@ -189,6 +189,22 @@ public class AzureAiStudioChatCompletionModelTests extends ESTestCase {
         assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/v1/chat/completions"));
     }
 
+    public void testSetsProperUrlForNonOpenAiTokenModel_WithTrailingSlash() throws URISyntaxException {
+        var model = createModel("id", "http://testtarget.local/", AzureAiStudioProvider.COHERE, AzureAiStudioEndpointType.TOKEN, "apikey");
+        assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/v1/chat/completions"));
+    }
+
+    public void testSetsProperUrlForCohereModel_WithExistingPath() throws URISyntaxException {
+        var model = createModel(
+            "id",
+            "http://testtarget.local/models",
+            AzureAiStudioProvider.COHERE,
+            AzureAiStudioEndpointType.TOKEN,
+            "apikey"
+        );
+        assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/models/v1/chat/completions"));
+    }
+
     public void testSetsProperUrlForRealtimeEndpointModel() throws URISyntaxException {
         var model = createModel(
             "id",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModelTests.java
@@ -95,6 +95,22 @@ public class AzureAiStudioEmbeddingsModelTests extends ESTestCase {
         assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/v1/embeddings"));
     }
 
+    public void testSetsProperUrlForCohereModel_WithTrailingSlash() throws URISyntaxException {
+        var model = createModel("id", "http://testtarget.local/", AzureAiStudioProvider.COHERE, AzureAiStudioEndpointType.TOKEN, "apikey");
+        assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/v1/embeddings"));
+    }
+
+    public void testSetsProperUrlForCohereModel_WithExistingPath() throws URISyntaxException {
+        var model = createModel(
+            "id",
+            "http://testtarget.local/models",
+            AzureAiStudioProvider.COHERE,
+            AzureAiStudioEndpointType.TOKEN,
+            "apikey"
+        );
+        assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/models/v1/embeddings"));
+    }
+
     public static AzureAiStudioEmbeddingsModel createModel(
         String inferenceId,
         String target,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankModelTests.java
@@ -100,6 +100,22 @@ public class AzureAiStudioRerankModelTests extends ESTestCase {
         assertThat(model.getEndpointUri().toString(), is(TARGET_URI + "/v1/rerank"));
     }
 
+    public void testSetsProperUrlForCohereTokenModel_WithTrailingSlash() throws URISyntaxException {
+        final var model = createModel(MODEL_ID, TARGET_URI + "/", AzureAiStudioProvider.COHERE, AzureAiStudioEndpointType.TOKEN, API_KEY);
+        assertThat(model.getEndpointUri().toString(), is(TARGET_URI + "/v1/rerank"));
+    }
+
+    public void testSetsProperUrlForCohereModel_WithExistingPath() throws URISyntaxException {
+        var model = createModel(
+            "id",
+            "http://testtarget.local/models",
+            AzureAiStudioProvider.COHERE,
+            AzureAiStudioEndpointType.TOKEN,
+            "apikey"
+        );
+        assertThat(model.getEndpointUri().toString(), is("http://testtarget.local/models/v1/rerank"));
+    }
+
     public static AzureAiStudioRerankModel createModel(
         String id,
         String target,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
@@ -260,7 +260,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESSingleNo
                     new ElasticInferenceServiceCompletionServiceSettings("rainbow-sprinkles"),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
-                    ElasticInferenceServiceComponents.EMPTY_INSTANCE
+                    new ElasticInferenceServiceComponents("url")
                 ),
                 MinimalServiceSettings.chatCompletion(ElasticInferenceService.NAME)
             ),
@@ -273,7 +273,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESSingleNo
                     new ElasticInferenceServiceSparseEmbeddingsServiceSettings("elser-2", null, null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
-                    ElasticInferenceServiceComponents.EMPTY_INSTANCE,
+                    new ElasticInferenceServiceComponents("url"),
                     ChunkingSettingsBuilder.DEFAULT_SETTINGS
                 ),
                 MinimalServiceSettings.sparseEmbedding(ElasticInferenceService.NAME)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
@@ -47,4 +47,67 @@ public class ElasticInferenceServiceCompletionModelTests extends ESTestCase {
         assertThat(overriddenModel.getServiceSettings().modelId(), is("new_model_id"));
         assertThat(overriddenModel.getTaskType(), is(TaskType.COMPLETION));
     }
+
+    public void testUriCreation() {
+        var model = createModel("http://eis-gateway.com", "my-model-id", TaskType.COMPLETION);
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/chat"));
+    }
+
+    public void testUriCreation_WithTrailingSlash() {
+        var model = createModel("http://eis-gateway.com/", "my-model-id", TaskType.COMPLETION);
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/chat"));
+    }
+
+    public void testGetServiceSettings() {
+        var modelId = "test-model";
+        var model = createModel("http://eis-gateway.com", modelId, TaskType.COMPLETION);
+
+        var serviceSettings = model.getServiceSettings();
+        assertThat(serviceSettings.modelId(), is(modelId));
+    }
+
+    public void testGetTaskType() {
+        var model = createModel("http://eis-gateway.com", "my-model-id", TaskType.COMPLETION);
+        assertThat(model.getTaskType(), is(TaskType.COMPLETION));
+    }
+
+    public void testGetInferenceEntityId() {
+        var inferenceEntityId = "test-id";
+        var model = new ElasticInferenceServiceCompletionModel(
+            inferenceEntityId,
+            TaskType.COMPLETION,
+            "elastic",
+            new ElasticInferenceServiceCompletionServiceSettings("my-model-id"),
+            EmptyTaskSettings.INSTANCE,
+            EmptySecretSettings.INSTANCE,
+            ElasticInferenceServiceComponents.of("http://eis-gateway.com")
+        );
+
+        assertThat(model.getInferenceEntityId(), is(inferenceEntityId));
+    }
+
+    public void testModelWithOverriddenServiceSettings() {
+        var originalModel = createModel("http://eis-gateway.com", "original-model", TaskType.COMPLETION);
+        var newServiceSettings = new ElasticInferenceServiceCompletionServiceSettings("new-model");
+
+        var overriddenModel = new ElasticInferenceServiceCompletionModel(originalModel, newServiceSettings);
+
+        assertThat(overriddenModel.getServiceSettings().modelId(), is("new-model"));
+        assertThat(overriddenModel.getTaskType(), is(TaskType.COMPLETION));
+        assertThat(overriddenModel.uri().toString(), is(originalModel.uri().toString()));
+    }
+
+    public static ElasticInferenceServiceCompletionModel createModel(String url, String modelId, TaskType taskType) {
+        return new ElasticInferenceServiceCompletionModel(
+            "id",
+            taskType,
+            "elastic",
+            new ElasticInferenceServiceCompletionServiceSettings(modelId),
+            EmptyTaskSettings.INSTANCE,
+            EmptySecretSettings.INSTANCE,
+            ElasticInferenceServiceComponents.of(url)
+        );
+    }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
@@ -14,7 +14,22 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceComponents;
 
+import static org.elasticsearch.test.ESTestCase.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class ElasticInferenceServiceDenseTextEmbeddingsModelTests {
+
+    public void testUriCreation() {
+        var model = createModel("http://eis-gateway.com", "my-model-id");
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/embed/dense"));
+    }
+
+    public void testUriCreation_WithTrailingSlash() {
+        var model = createModel("http://eis-gateway.com/", "my-model-id");
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/embed/text/dense"));
+    }
 
     public static ElasticInferenceServiceDenseTextEmbeddingsModel createModel(String url, String modelId) {
         return new ElasticInferenceServiceDenseTextEmbeddingsModel(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
@@ -11,18 +11,19 @@ import org.elasticsearch.inference.EmptySecretSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceComponents;
 
 import static org.elasticsearch.test.ESTestCase.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ElasticInferenceServiceDenseTextEmbeddingsModelTests {
+public class ElasticInferenceServiceDenseTextEmbeddingsModelTests extends ESTestCase {
 
     public void testUriCreation() {
         var model = createModel("http://eis-gateway.com", "my-model-id");
 
-        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/embed/dense"));
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/embed/text/dense"));
     }
 
     public void testUriCreation_WithTrailingSlash() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModelTests.java
@@ -13,7 +13,21 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceComponents;
 
+import static org.hamcrest.Matchers.is;
+
 public class ElasticInferenceServiceRerankModelTests extends ESTestCase {
+
+    public void testUriCreation() {
+        var model = createModel("http://eis-gateway.com", "my-model-id");
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/rerank/text/text-similarity"));
+    }
+
+    public void testUriCreation_WithTrailingSlash() {
+        var model = createModel("http://eis-gateway.com/", "my-model-id");
+
+        assertThat(model.uri().toString(), is("http://eis-gateway.com/api/v1/rerank/text/text-similarity"));
+    }
 
     public static ElasticInferenceServiceRerankModel createModel(String url, String modelId) {
         return new ElasticInferenceServiceRerankModel(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Inference API] Prevent trailing slashes from being included in URLs (#141692)](https://github.com/elastic/elasticsearch/pull/141692)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)