### PR TITLE
Fix version numbers for tech-preview of spatial functions

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/layout/st_geohash.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/layout/st_geohash.md
@@ -2,7 +2,7 @@
 
 ### `ST_GEOHASH` [esql-st_geohash]
 ```{applies_to}
-stack: preview
+stack: preview 9.2.0
 serverless: preview
 ```
 

--- a/docs/reference/query-languages/esql/_snippets/functions/layout/st_geohex.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/layout/st_geohex.md
@@ -2,7 +2,7 @@
 
 ### `ST_GEOHEX` [esql-st_geohex]
 ```{applies_to}
-stack: preview
+stack: preview 9.2.0
 serverless: preview
 ```
 

--- a/docs/reference/query-languages/esql/_snippets/functions/layout/st_geotile.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/layout/st_geotile.md
@@ -2,7 +2,7 @@
 
 ### `ST_GEOTILE` [esql-st_geotile]
 ```{applies_to}
-stack: preview
+stack: preview 9.2.0
 serverless: preview
 ```
 

--- a/docs/reference/query-languages/esql/_snippets/lists/spatial-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/spatial-functions.md
@@ -7,14 +7,14 @@
 * Geometry functions
   * [`ST_X`](../../functions-operators/spatial-functions.md#esql-st_x)
   * [`ST_Y`](../../functions-operators/spatial-functions.md#esql-st_y)
-  * [`ST_NPOINTS`](../../functions-operators/spatial-functions.md#esql-st_npoints) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-  * [`ST_SIMPLIFY`](../../functions-operators/spatial-functions.md#esql-st_simplify) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+  * [`ST_NPOINTS`](../../functions-operators/spatial-functions.md#esql-st_npoints) {applies_to}`stack: preview 9.4.0` {applies_to}`serverless: preview`
+  * [`ST_SIMPLIFY`](../../functions-operators/spatial-functions.md#esql-st_simplify) {applies_to}`stack: preview 9.4.0` {applies_to}`serverless: preview`
 * [`ST_ENVELOPE`](../../functions-operators/spatial-functions.md#esql-st_envelope) {applies_to}`stack: preview` {applies_to}`serverless: preview`
   * [`ST_XMAX`](../../functions-operators/spatial-functions.md#esql-st_xmax) {applies_to}`stack: preview` {applies_to}`serverless: preview`
   * [`ST_XMIN`](../../functions-operators/spatial-functions.md#esql-st_xmin) {applies_to}`stack: preview` {applies_to}`serverless: preview`
   * [`ST_YMAX`](../../functions-operators/spatial-functions.md#esql-st_ymax) {applies_to}`stack: preview` {applies_to}`serverless: preview`
   * [`ST_YMIN`](../../functions-operators/spatial-functions.md#esql-st_ymin) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * Grid encoding functions
-  * [`ST_GEOTILE`](../../functions-operators/spatial-functions.md#esql-st_geotile) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-  * [`ST_GEOHEX`](../../functions-operators/spatial-functions.md#esql-st_geohex) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-  * [`ST_GEOHASH`](../../functions-operators/spatial-functions.md#esql-st_geohash) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+  * [`ST_GEOTILE`](../../functions-operators/spatial-functions.md#esql-st_geotile) {applies_to}`stack: preview 9.2.0` {applies_to}`serverless: preview`
+  * [`ST_GEOHEX`](../../functions-operators/spatial-functions.md#esql-st_geohex) {applies_to}`stack: preview 9.2.0` {applies_to}`serverless: preview`
+  * [`ST_GEOHASH`](../../functions-operators/spatial-functions.md#esql-st_geohash) {applies_to}`stack: preview 9.2.0` {applies_to}`serverless: preview`

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohash.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohash.java
@@ -115,7 +115,7 @@ public class StGeohash extends SpatialGridFunction implements EvaluatorMapper {
     @FunctionInfo(
         returnType = "geohash",
         preview = true,
-        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW) },
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW, version = "9.2.0") },
         description = """
             Calculates the `geohash` of the supplied geo_point at the specified precision.
             The result is long encoded. Use [TO_STRING](#esql-to_string) to convert the result to a string,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohex.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohex.java
@@ -116,7 +116,7 @@ public class StGeohex extends SpatialGridFunction implements EvaluatorMapper {
     @FunctionInfo(
         returnType = "geohex",
         preview = true,
-        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW) },
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW, version = "9.2.0") },
         description = """
             Calculates the `geohex`, the H3 cell-id, of the supplied geo_point at the specified precision.
             The result is long encoded. Use [TO_STRING](#esql-to_string) to convert the result to a string,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotile.java
@@ -112,7 +112,7 @@ public class StGeotile extends SpatialGridFunction implements EvaluatorMapper {
     @FunctionInfo(
         returnType = "geotile",
         preview = true,
-        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW) },
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW, version = "9.2.0") },
         description = """
             Calculates the `geotile` of the supplied geo_point at the specified precision.
             The result is long encoded. Use [TO_STRING](#esql-to_string) to convert the result to a string,


### PR DESCRIPTION
The geo-grid functions all just said `preview`, but should also name the version they were made preview in.