### PR TITLE
Fix serialization of StreamsMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/StreamsMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/StreamsMetadata.java
@@ -120,8 +120,10 @@ public class StreamsMetadata extends AbstractNamedDiffable<Metadata.ProjectCusto
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(logsEnabled);
-        out.writeBoolean(logsECSEnabled);
-        out.writeBoolean(logsOTelEnabled);
+        if (out.getTransportVersion().supports(STREAM_SPLIT_VERSION)) {
+            out.writeBoolean(logsECSEnabled);
+            out.writeBoolean(logsOTelEnabled);
+        }
     }
 
     @Override


### PR DESCRIPTION
Accidentally introduced in https://github.com/elastic/elasticsearch/pull/141564 during a refactor, this fixes the serialization issue for older versions.
