### PR TITLE
[ES|QL] Support DATE/DATE_NANOS in the first parameter of First/Last

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/types/first.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/first.md
@@ -7,6 +7,12 @@
 | boolean | date | boolean |
 | boolean | date_nanos | boolean |
 | boolean | long | boolean |
+| date | date | date |
+| date | date_nanos | date |
+| date | long | date |
+| date_nanos | date | date_nanos |
+| date_nanos | date_nanos | date_nanos |
+| date_nanos | long | date_nanos |
 | double | date | double |
 | double | date_nanos | double |
 | double | long | double |

--- a/docs/reference/query-languages/esql/_snippets/functions/types/last.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/last.md
@@ -7,6 +7,12 @@
 | boolean | date | boolean |
 | boolean | date_nanos | boolean |
 | boolean | long | boolean |
+| date | date | date |
+| date | date_nanos | date |
+| date | long | date |
+| date_nanos | date | date_nanos |
+| date_nanos | date_nanos | date_nanos |
+| date_nanos | long | date_nanos |
 | double | date | double |
 | double | date_nanos | double |
 | double | long | double |

--- a/docs/reference/query-languages/esql/kibana/definition/functions/first.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/first.json
@@ -62,6 +62,114 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "double",
           "optional" : false,
           "description" : "The search field"

--- a/docs/reference/query-languages/esql/kibana/definition/functions/last.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/last.json
@@ -62,6 +62,114 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "The search field"
+        },
+        {
+          "name" : "sortField",
+          "type" : "long",
+          "optional" : false,
+          "description" : "The sort field"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "double",
           "optional" : false,
           "description" : "The search field"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_first_last.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_first_last.csv-spec
@@ -242,3 +242,20 @@ d1:long | d2:long | status:keyword
 ;
 
 # ----------------------------------------------------------------------------------------------------------------------
+
+Test date types in the search field
+
+required_capability: first_last_agg_with_dates
+
+FROM voyager
+| STATS 
+    f_date = FIRST(@timestamp, distance_to_earth),
+    l_date = LAST(@timestamp, distance_to_earth),
+    f_date_nanos = FIRST(@timestamp::date_nanos, distance_to_earth),
+    l_date_nanos = LAST(@timestamp::date_nanos, distance_to_earth)
+;
+
+f_date:datetime                                                                | l_date:datetime          | f_date_nanos:date_nanos                                                        | l_date_nanos:date_nanos
+[2025-12-25T00:00:10.000Z, 2025-12-25T00:00:20.000Z, 2025-12-25T00:00:30.000Z] | 2025-12-25T00:00:20.000Z | [2025-12-25T00:00:10.000Z, 2025-12-25T00:00:20.000Z, 2025-12-25T00:00:30.000Z] | 2025-12-25T00:00:20.000Z
+;
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1853,6 +1853,12 @@ public class EsqlCapabilities {
         LAST_AGG_WITH_NULL_AND_MV_SUPPORT,
 
         /**
+         * Allow FIRST/LAST aggs to accept DATE/DATE_NANOS in the search field
+         * https://github.com/elastic/elasticsearch/issues/142137
+         */
+        FIRST_LAST_AGG_WITH_DATES,
+
+        /**
          * Allow ST_EXTENT_AGG to gracefully handle missing spatial shapes
          */
         ST_EXTENT_AGG_NULL_SUPPORT,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
@@ -46,7 +46,7 @@ public class First extends AggregateFunction implements ToAggregator {
     @FunctionInfo(
         type = FunctionType.AGGREGATE,
         preview = true,
-        returnType = { "long", "integer", "double", "keyword", "ip", "boolean" },
+        returnType = { "long", "integer", "double", "keyword", "ip", "boolean", "date", "date_nanos" },
         description = """
             This function calculates the earliest occurrence of the search field
             (the first parameter), where sorting order is determined by the sort
@@ -73,7 +73,7 @@ public class First extends AggregateFunction implements ToAggregator {
         Source source,
         @Param(
             name = "field",
-            type = { "long", "integer", "double", "keyword", "text", "ip", "boolean" },
+            type = { "long", "integer", "double", "keyword", "text", "ip", "boolean", "date", "date_nanos" },
             description = "The search field"
         ) Expression field,
         @Param(name = "sortField", type = { "long", "date", "date_nanos" }, description = "The sort field") Expression sort
@@ -135,6 +135,7 @@ public class First extends AggregateFunction implements ToAggregator {
             field(),
             dt -> dt == DataType.BOOLEAN
                 || dt == DataType.DATETIME
+                || dt == DataType.DATE_NANOS
                 || DataType.isString(dt)
                 || dt == DataType.IP
                 || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG),
@@ -160,7 +161,7 @@ public class First extends AggregateFunction implements ToAggregator {
     public AggregatorFunctionSupplier supplier() {
         final DataType type = field().dataType();
         return switch (type) {
-            case LONG -> new AllFirstLongByTimestampAggregatorFunctionSupplier();
+            case LONG, DATETIME, DATE_NANOS -> new AllFirstLongByTimestampAggregatorFunctionSupplier();
             case INTEGER -> new AllFirstIntByTimestampAggregatorFunctionSupplier();
             case DOUBLE -> new AllFirstDoubleByTimestampAggregatorFunctionSupplier();
             case FLOAT -> new AllFirstFloatByTimestampAggregatorFunctionSupplier();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
@@ -46,7 +46,7 @@ public class Last extends AggregateFunction implements ToAggregator {
     @FunctionInfo(
         type = FunctionType.AGGREGATE,
         preview = true,
-        returnType = { "long", "integer", "double", "keyword", "ip", "boolean" },
+        returnType = { "long", "integer", "double", "keyword", "ip", "boolean", "date", "date_nanos" },
         description = """
             This function calculates the latest occurrence of the search field
             (the first parameter), where sorting order is determined by the sort
@@ -73,7 +73,7 @@ public class Last extends AggregateFunction implements ToAggregator {
         Source source,
         @Param(
             name = "field",
-            type = { "long", "integer", "double", "keyword", "text", "ip", "boolean" },
+            type = { "long", "integer", "double", "keyword", "text", "ip", "boolean", "date", "date_nanos" },
             description = "The search field"
         ) Expression field,
         @Param(name = "sortField", type = { "long", "date", "date_nanos" }, description = "The sort field") Expression sort
@@ -135,6 +135,7 @@ public class Last extends AggregateFunction implements ToAggregator {
             field(),
             dt -> dt == DataType.BOOLEAN
                 || dt == DataType.DATETIME
+                || dt == DataType.DATE_NANOS
                 || DataType.isString(dt)
                 || dt == DataType.IP
                 || (dt.isNumeric() && dt != DataType.UNSIGNED_LONG),
@@ -160,7 +161,7 @@ public class Last extends AggregateFunction implements ToAggregator {
     public AggregatorFunctionSupplier supplier() {
         final DataType type = field().dataType();
         return switch (type) {
-            case LONG -> new AllLastLongByTimestampAggregatorFunctionSupplier();
+            case LONG, DATETIME, DATE_NANOS -> new AllLastLongByTimestampAggregatorFunctionSupplier();
             case INTEGER -> new AllLastIntByTimestampAggregatorFunctionSupplier();
             case DOUBLE -> new AllLastDoubleByTimestampAggregatorFunctionSupplier();
             case FLOAT -> new AllLastFloatByTimestampAggregatorFunctionSupplier();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractFirstLastTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractFirstLastTestCase.java
@@ -23,22 +23,27 @@ import static org.hamcrest.Matchers.anyOf;
 
 public abstract class AbstractFirstLastTestCase extends AbstractAggregationTestCase {
 
-    public static Iterable<Object[]> parameters(boolean isFirst, boolean isNullable) {
+    public static Iterable<Object[]> parameters(boolean isFirst) {
         int rows = 1000;
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
-        List<DataType> types = new ArrayList<>(List.of(DataType.INTEGER, DataType.LONG, DataType.DOUBLE, DataType.KEYWORD, DataType.TEXT));
-
-        if (isNullable) {
-            types.add(DataType.IP);
-            types.add(DataType.BOOLEAN);
-        }
+        List<DataType> types = List.of(
+            DataType.INTEGER,
+            DataType.LONG,
+            DataType.DOUBLE,
+            DataType.KEYWORD,
+            DataType.TEXT,
+            DataType.IP,
+            DataType.BOOLEAN,
+            DataType.DATETIME,
+            DataType.DATE_NANOS
+        );
 
         for (DataType valueType : types) {
             for (TestCaseSupplier.TypedDataSupplier valueSupplier : unlimitedSuppliers(valueType, rows, rows)) {
                 for (DataType sortType : List.of(DataType.LONG, DataType.DATETIME, DataType.DATE_NANOS)) {
                     for (TestCaseSupplier.TypedDataSupplier sortSupplier : unlimitedSuppliers(sortType, rows, rows)) {
-                        suppliers.add(makeSupplier(valueSupplier, sortSupplier, isFirst, isNullable));
+                        suppliers.add(makeSupplier(valueSupplier, sortSupplier, isFirst));
                     }
                 }
             }
@@ -50,8 +55,7 @@ public abstract class AbstractFirstLastTestCase extends AbstractAggregationTestC
     private static TestCaseSupplier makeSupplier(
         TestCaseSupplier.TypedDataSupplier valueSupplier,
         TestCaseSupplier.TypedDataSupplier sortSupplier,
-        boolean first,
-        boolean isNullable
+        boolean first
     ) {
         return new TestCaseSupplier(
             valueSupplier.name() + ", " + sortSupplier.name(),
@@ -77,9 +81,7 @@ public abstract class AbstractFirstLastTestCase extends AbstractAggregationTestC
 
                 return new TestCaseSupplier.TestCase(
                     List.of(values, sorts),
-                    (isNullable ? "All" : "")
-                        + standardAggregatorNameAllBytesTheSame(first ? "First" : "Last", values.type())
-                        + "ByTimestamp",
+                    "All" + standardAggregatorNameAllBytesTheSame(first ? "First" : "Last", values.type()) + "ByTimestamp",
                     values.type(),
                     anyOf(() -> Iterators.map(expected.iterator(), Matchers::equalTo))
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstTests.java
@@ -24,7 +24,7 @@ public class FirstTests extends AbstractFirstLastTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameters(true, true);
+        return parameters(true);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastTests.java
@@ -24,7 +24,7 @@ public class LastTests extends AbstractFirstLastTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameters(false, true);
+        return parameters(false);
     }
 
     @Override


### PR DESCRIPTION
- Add support for DATE and DATE_NANOS types in the search field.
- (Unrelated) Removed obsolete boolean param passed in unit tests.
