### PR TITLE
Validate IndexMode in IndexMetadata.Builder.build

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2558,8 +2558,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
             assert eventIngestedRange != null : "eventIngestedRange must be set (non-null) when building IndexMetadata";
             final boolean isSearchableSnapshot = SearchableSnapshotsSettings.isSearchableSnapshotStore(settings);
-            String indexModeString = settings.get(IndexSettings.MODE.getKey());
-            final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
+            final IndexMode indexMode = IndexSettings.MODE.get(settings);
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
             boolean useTimeSeriesSyntheticId = false;
             if (isTsdb
@@ -2614,7 +2613,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 AutoExpandReplicas.SETTING.get(settings),
                 isSearchableSnapshot,
                 isSearchableSnapshot && settings.getAsBoolean(SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY, false),
-                indexMode,
+                settings.get(IndexSettings.MODE.getKey()) == null ? null : indexMode,
                 isTsdb ? IndexSettings.TIME_SERIES_START_TIME.get(settings) : null,
                 isTsdb ? IndexSettings.TIME_SERIES_END_TIME.get(settings) : null,
                 SETTING_INDEX_VERSION_COMPATIBILITY.get(settings),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
@@ -717,6 +717,7 @@ public class IndexRoutingTests extends ESTestCase {
                 .settings(
                     settings(IndexVersion.current()).put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "foo")
                         .put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB)
+                        .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
                         .build()
                 )
                 .numberOfShards(shards)
@@ -744,6 +745,7 @@ public class IndexRoutingTests extends ESTestCase {
             .settings(
                 settings(IndexVersion.current()).put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "foo")
                     .put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB)
+                    .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
                     .build()
             )
             .numberOfShards(shards)

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -43,29 +43,25 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
             .put(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING.getKey(), 2)
             .build();
-        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettingsTests.newIndexMeta("test", s));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.routing_partition_size]"));
     }
 
     public void testSortField() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "a").build();
-        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettingsTests.newIndexMeta("test", s));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.field]"));
     }
 
     public void testSortMode() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey(), "_last").build();
-        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettingsTests.newIndexMeta("test", s));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.missing]"));
     }
 
     public void testSortOrder() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), "desc").build();
-        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettingsTests.newIndexMeta("test", s));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.order]"));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
@@ -999,6 +999,7 @@ public class SubstituteRoundToTests extends AbstractLocalPhysicalPlanOptimizerTe
                     .settings(
                         ESTestCase.indexSettings(IndexVersion.current(), 1, 1)
                             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.name())
+                            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "@timestamp")
                     )
                     .build();
                 return Map.of(new ShardId(new Index("id", "n/a"), 1), indexMetadata);


### PR DESCRIPTION
This catches for example when the mode is lookup but the number of shards is not 1.

Other settings accessed in this method go through validation, but IndexMode does not, probably because it wants to avoid explicitly setting it in metadata if there is no explicit setting.

I think we could probably use more systematic validation here of all provided settings, but that change will have a bigger blast radius so I'm inclined to look at it separately.
