### PR TITLE
Reduce batch size in logsdb randomized reindexing tests

### DIFF
--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/ReindexChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/ReindexChallengeRestIT.java
@@ -45,7 +45,8 @@ public abstract class ReindexChallengeRestIT extends StandardVersusLogsIndexMode
         reindexRequest.setJsonEntity(String.format(Locale.ROOT, """
             {
                 "source": {
-                    "index": "%s"
+                    "index": "%s",
+                    "size": 50
                 },
                 "dest": {
                   "index": "%s",


### PR DESCRIPTION
This PR reduces the reindexing batch size for the logsdb ReindexChallengeRestIT tests to 50 documents. These tests run with a constrained memory budget, and the default value of 1000 documents was causing occasional 429 errors.