### PR TITLE
Terminate S3 get blob retries when node is shutting down

### DIFF
--- a/docs/changelog/142186.yaml
+++ b/docs/changelog/142186.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 142186
+summary: Terminate S3 get blob retries on non-SDK exceptions
+type: bug

--- a/docs/changelog/142186.yaml
+++ b/docs/changelog/142186.yaml
@@ -1,5 +1,5 @@
 area: Snapshot/Restore
 issues: []
 pr: 142186
-summary: Terminate S3 get blob retries on non-SDK exceptions
+summary: Terminate S3 get blob retries when node is shutting down
 type: bug

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -276,7 +276,7 @@ class S3BlobStore implements BlobStore {
         return service.client(projectId, repositoryMetadata);
     }
 
-    final int getMaxRetries() {
+    int getMaxRetries() {
         return service.settings(projectId, repositoryMetadata).maxRetries;
     }
 

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
@@ -133,7 +133,7 @@ class S3RetryingInputStream extends RetryingInputStream<String> {
         @Override
         public boolean isRetryableException(StreamAction action, Exception e) {
             return switch (action) {
-                case OPEN -> e instanceof RuntimeException;
+                case OPEN -> e instanceof SdkException;
                 case READ -> e instanceof IOException;
             };
         }


### PR DESCRIPTION
This was a regression introduced when we factored out the `RetryingInputStream`. The logic changed such that the S3 implementation no longer aborted retries when an `IllegalStateException` was thrown, such as is the case when the repository is closed.