### PR TITLE
Cleanup Project.Builder usage in distributed tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -137,6 +137,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
     }
 
     public void testJoinClusterWithReadOnlyCompatibleIndices() {
+        final ProjectId projectId = randomProjectIdOrDefault();
         var randomBlock = randomFrom(IndexMetadata.SETTING_BLOCKS_WRITE, IndexMetadata.SETTING_READ_ONLY);
         {
             var indexMetadata = IndexMetadata.builder("searchable-snapshot")
@@ -154,7 +155,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
-                Metadata.builder().put(indexMetadata, false).build()
+                Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
             );
         }
         {
@@ -174,7 +175,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     IndexVersions.MINIMUM_COMPATIBLE,
                     IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
-                    Metadata.builder().put(indexMetadata, false).build()
+                    Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
                 )
             );
         }
@@ -194,7 +195,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
-                Metadata.builder().put(indexMetadata, false).build()
+                Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
             );
         }
         {
@@ -214,7 +215,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     IndexVersions.MINIMUM_COMPATIBLE,
                     IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
-                    Metadata.builder().put(indexMetadata, false).build()
+                    Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
                 )
             );
         }
@@ -231,7 +232,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     IndexVersions.MINIMUM_COMPATIBLE,
                     IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
-                    Metadata.builder().put(indexMetadata, false).build()
+                    Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
                 )
             );
         }
@@ -256,7 +257,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
-                Metadata.builder().put(indexMetadata, false).build()
+                Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
             );
         }
         {
@@ -275,7 +276,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     IndexVersions.MINIMUM_COMPATIBLE,
                     IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
-                    Metadata.builder().put(indexMetadata, false).build()
+                    Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
                 )
             );
         }
@@ -300,7 +301,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     IndexVersions.MINIMUM_COMPATIBLE,
                     IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
-                    Metadata.builder().put(indexMetadata, false).build()
+                    Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata, false)).build()
                 )
             );
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -378,7 +379,9 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         false,
                         new UpdatedShardGenerations(shardGenerations, ShardGenerations.EMPTY),
                         ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository).getGenId(),
-                        Metadata.builder().put(shard.indexSettings().getIndexMetadata(), false).build(),
+                        Metadata.builder()
+                            .put(ProjectMetadata.builder(projectId).put(shard.indexSettings().getIndexMetadata(), false))
+                            .build(),
                         new SnapshotInfo(
                             new Snapshot(repository.getMetadata().name(), snapshotId),
                             shardGenerations.indices().stream().map(IndexId::getName).collect(Collectors.toList()),


### PR DESCRIPTION
This commit cleans up a number of distributed tests to use methods from ProjectMetadata.Builder in place of Metadata.Builder (and GlobalRoutingTable related methods where necessary)
