### PR TITLE
[8.19] Remove non-ansi character in hardening_manifest.yaml (#142142)

### DIFF
--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -50,7 +50,7 @@ maintainers:
   - name: "Rene Groeschke"
     email: "rene.groschke@elastic.co"
     username: "breskeby"
-  - name: "Mariusz Józala"
+  - name: "Mariusz Jozala"
     email: "mariusz.jozala@elastic.co"
     username: "mariusz"
   - email: "klepal_alexander@bah.com"


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove non-ansi character in hardening_manifest.yaml (#142142)