### PR TITLE
Fix another priority conflict with prometheus templates

### DIFF
--- a/x-pack/plugin/prometheus/src/main/resources/index-templates/metrics-prometheus@template.yaml
+++ b/x-pack/plugin/prometheus/src/main/resources/index-templates/metrics-prometheus@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.prometheus.template.version}
 index_patterns: ["metrics-*.prometheus-*"]
-priority: 150
+priority: 140
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/prometheus/src/main/resources/resources.yaml
+++ b/x-pack/plugin/prometheus/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates installed by xpack-plugin prometheus.
 # This must be increased whenever an existing template is changed, in order for it
 # to be updated on Elasticsearch upgrade.
-version: 2
+version: 3
 component-templates:
   - metrics-prometheus@mappings
   - metrics-prometheus@settings


### PR DESCRIPTION
Fleet uses the priority 150 for packages where `dataset_is_prefix=true`: https://github.com/elastic/kibana/blob/946f799ef524289259079fae6e9503464a4c9331/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts#L861-L878.

This PR lowers the priority to 140 to avoid the conflict.


Overview of the priorities for managed templates:

| Priority | Template                                            | Managed by       |
|----------|-----------------------------------------------------|------------------|
| 100      | `metrics-*-*`                                       | ES built-in      |
| 120      | `metrics-*.otel-*`                                  | ES (OTel plugin) |
| 130      | `metrics-transaction.1m.otel-*`, etc.               | ES (OTel plugin) |
| 131      | `metrics-service_destination.1m.otel-*`, etc.       | ES (OTel plugin) |
| 150      | `metrics-apm.app.*-*` (Fleet `dataset_is_prefix`)     | Kibana (Fleet)   |
| 200      | `metrics-apm.internal-*`, etc. (Fleet standard)     | Kibana (Fleet)   |
| 210      | `metrics-apm.app.*-*`, `metrics-apm.internal-*`, etc. | ES (APM plugin)  |

I'll also add a check for priority 150 in https://github.com/elastic/elasticsearch/pull/142105
