### PR TITLE
Correct ordinal check for native vector scorer

### DIFF
--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
@@ -54,7 +54,7 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= maxOrd) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }


### PR DESCRIPTION
Technically, this should be a `>=` as its the inverse of `<`.

Regardless, if code ever got to this place where it would throw here, we likely have another issue :D.