### PR TITLE
ESQL: Fix INLINE STATS right side key column pruning on project

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -5313,3 +5313,19 @@ c:long	| n:null	| emp_no:integer
 1     	| null  	| 10002         
 1     	| null  	| 10003          
 ;
+
+inlineStatsPruneColumnsRightSideFix
+required_capability: fix_inline_stats_incorrectly_pruned_columns
+
+FROM employees
+| INLINE STATS x = MAX(salary) WHERE false, c = COUNT(*) BY emp_no
+| KEEP x, c
+| SORT x, c
+| LIMIT 3
+;
+
+x:integer | c:long
+null      | 1
+null      | 1
+null      | 1
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2017,7 +2017,7 @@ public class EsqlCapabilities {
         FIX_INLINE_STATS_GROUP_BY_NULL(INLINE_STATS.enabled),
 
         /**
-         * INLINE STATS fix where columnes were being incorrectly pruned by PruneColumns.
+         * INLINE STATS fix where right side key columns were being incorrectly pruned by PruneColumns.
          */
         FIX_INLINE_STATS_INCORRECTLY_PRUNED_COLUMNS(INLINE_STATS.enabled),
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2017,6 +2017,11 @@ public class EsqlCapabilities {
         FIX_INLINE_STATS_GROUP_BY_NULL(INLINE_STATS.enabled),
 
         /**
+         * INLINE STATS fix where columnes were being incorrectly pruned by PruneColumns.
+         */
+        FIX_INLINE_STATS_INCORRECTLY_PRUNED_COLUMNS(INLINE_STATS.enabled),
+
+        /**
          * Adds a conditional block loader for text fields that prefers using the sub-keyword field whenever possible.
          */
         CONDITIONAL_BLOCK_LOADER_FOR_TEXT_FIELDS,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -142,6 +142,11 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
     private static LogicalPlan pruneColumnsInInlineJoinRight(InlineJoin ij, AttributeSet.Builder used, Holder<Boolean> recheck) {
         LogicalPlan p = ij;
 
+        // Ensure the right-side join keys are never pruned from the right child's output.
+        // ReplaceStatsFilteredOrNullAggWithEval may insert a Project on the right side that PruneColumns would otherwise trim,
+        // removing the join key even though InlineJoin still needs it.
+        used.addAll(ij.config().rightFields());
+
         var right = pruneColumns(ij.right(), used, true);
         if (right.output().isEmpty() || isLocalEmptyRelation(right)) {
             p = pruneRightSideAndProject(ij);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6100,6 +6100,65 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         var source = as(eval.child(), EsRelation.class);
     }
 
+    /**
+     * Verifies that PruneColumns does not prune the InlineJoin's right-side join key when ReplaceStatsFilteredOrNullAggWithEval
+     * inserts a Project on the right side (by replacing some but not all aggregates with evals).
+     * The join key (emp_no{r}) must remain in the right child's output, even when it's not referenced after the INLINE STATS.
+     * <p>
+     *   Before the {@link EsqlCapabilities.Cap#FIX_INLINE_STATS_INCORRECTLY_PRUNED_COLUMNS} fix:
+     * </p>
+     * <pre>{@code
+     * Project[[x{r}#5, c{r}#7]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[emp_no{f}#11],[emp_no{r}#11]]
+     *     |_EsRelation[employees][_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, ..]
+     *     \_Project[[x{r}#5, c{r}#7]]
+     *       \_Eval[[null[INTEGER] AS x#5]]
+     *         \_Aggregate[[emp_no{f}#11],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#7, emp_no{f}#11]]
+     *           \_StubRelation[[_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, gender{f}#13, hire_date{f}#18, job{f}#19, job.raw{f}#20, l
+     * anguages{f}#14, last_name{f}#15, long_noidx{f}#21, salary{f}#16]]
+     * }</pre>
+     *
+     * <p>
+     *     After the fix:
+     * </p>
+     * <pre>{@code
+     * Project[[x{r}#5, c{r}#7]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[emp_no{f}#11],[emp_no{r}#11]]
+     *     |_EsRelation[employees][_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, ..]
+     *     \_Project[[x{r}#5, c{r}#7, emp_no{f}#11]]
+     *       \_Eval[[null[INTEGER] AS x#5]]
+     *         \_Aggregate[[emp_no{f}#11],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#7, emp_no{f}#11]]
+     *           \_StubRelation[[_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, gender{f}#13, hire_date{f}#18, job{f}#19, job.raw{f}#20,
+     *             languages{f}#14, last_name{f}#15, long_noidx{f}#21, salary{f}#16]]
+     * }</pre>
+     */
+    public void testInlineStatsRightJoinKeyPreservedInPlanStructure() {
+        var query = """
+            FROM employees
+            | INLINE STATS x = MAX(salary) WHERE false, c = COUNT(*) BY emp_no
+            | KEEP x, c
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        // Top-level Project keeps only c
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("x", "c")));
+        var limit = asLimit(project.child(), 1000, false);
+        var inlineJoin = as(limit.child(), InlineJoin.class);
+
+        // The join key must be emp_no
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("emp_no")));
+        assertThat(Expressions.names(inlineJoin.config().rightFields()), is(List.of("emp_no")));
+
+        // The right side must include emp_no in its output (this is the core of the bug fix)
+        assertThat(Expressions.names(inlineJoin.right().output()), hasItem("emp_no"));
+    }
+
     /*
      * Project[[avg{r}#1053, decades{r}#1049, avgavg{r}#1063]]
      * \_Limit[1000[INTEGER],true]


### PR DESCRIPTION
Found some GenerativeIT tests that failed with errors like:
```
Plan [InlineJoin[LEFT,[job_positions{f}#121068],[job_positions{r}#121068]]] optimized incorrectly due to missing references from right hand side [job_positions{r}#121068]
```

Which led to this PR's finding. The CI failing queries apparently didn't have this case, and they were actually failing with a timeout, so probably unrelated.