### PR TITLE
[9.2] SPI based TemplateDecorator to modify xpack templates for stateless (#141426)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProviderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProviderIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.core.TimeValue.timeValueDays;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class TemplateDecoratorProviderIT extends ESIntegTestCase {
+
+    private static final String TEMPLATE = """
+        {
+            "settings": {
+                "index.number_of_shards": 1,
+                "index.number_of_replicas": 1
+            },
+            "lifecycle": {
+                "data_retention": "7d",
+                "downsampling": {
+                    "after": "1d",
+                    "fixed_interval": "1h"
+                }
+            }
+        }
+        """;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(PluginWithDecorator.class);
+    }
+
+    public void testTemplateDecoratorProvider() throws Exception {
+        internalCluster().startNode();
+
+        Template.TemplateDecorator decorator = TemplateDecoratorProvider.getInstance();
+        assertThat(decorator, instanceOf(TestTemplateDecorator.class));
+
+        // everything but index.number_of_shards dropped
+        Settings expectedSettings = Settings.builder().put("index.number_of_shards", 1).build();
+        // data_retention overwritten to 3d
+        DataStreamLifecycle.Template expectedLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
+            .dataRetention(timeValueDays(3))
+            .downsamplingRounds(List.of(new DataStreamLifecycle.DownsamplingRound(timeValueDays(1), DateHistogramInterval.HOUR)))
+            .buildTemplate();
+
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, TEMPLATE.getBytes(UTF_8))) {
+            var template = Template.parse(parser, "template", decorator);
+            assertThat(template.settings(), equalTo(expectedSettings));
+            assertThat(template.lifecycle(), equalTo(expectedLifecycle));
+        }
+    }
+
+    // decorator that keeps only index.number_of_shards and sets data_retention to 3 days
+    private static class TestTemplateDecorator implements Template.TemplateDecorator {
+        @Override
+        public Settings decorate(String template, Settings settings) {
+            return settings.filter("index.number_of_shards"::equals);
+        }
+
+        @Override
+        public DataStreamLifecycle.Template decorate(String template, DataStreamLifecycle.Template lifecycle) {
+            return DataStreamLifecycle.builder(lifecycle).dataRetention(timeValueDays(3)).buildTemplate();
+        }
+    }
+
+    public static class PluginWithDecorator extends Plugin {}
+
+    public static class TestTemplateDecoratorProvider implements TemplateDecoratorProvider {
+
+        // making sure the provider is exclusive to this test / plugin
+        public TestTemplateDecoratorProvider(PluginWithDecorator plugin) {}
+
+        @Override
+        public Template.TemplateDecorator get() {
+            return new TestTemplateDecorator();
+        }
+    }
+}

--- a/server/src/internalClusterTest/resources/META-INF/services/org.elasticsearch.cluster.metadata.TemplateDecoratorProvider
+++ b/server/src/internalClusterTest/resources/META-INF/services/org.elasticsearch.cluster.metadata.TemplateDecoratorProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.cluster.metadata.TemplateDecoratorProviderIT$TestTemplateDecoratorProvider

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
@@ -14,6 +14,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
+import org.elasticsearch.cluster.metadata.Template.NamedTemplateDecorator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -46,7 +47,7 @@ public class ComponentTemplate implements SimpleDiffable<ComponentTemplate>, ToX
     private static final ParseField MODIFIED_DATE_MILLIS = new ParseField("modified_date_millis");
 
     @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<ComponentTemplate, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<ComponentTemplate, NamedTemplateDecorator> PARSER = new ConstructingObjectParser<>(
         "component_template",
         false,
         a -> new ComponentTemplate((Template) a[0], (Long) a[1], (Map<String, Object>) a[2], (Boolean) a[3], (Long) a[4], (Long) a[5])
@@ -80,7 +81,11 @@ public class ComponentTemplate implements SimpleDiffable<ComponentTemplate>, ToX
     }
 
     public static ComponentTemplate parse(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return PARSER.apply(parser, NamedTemplateDecorator.DEFAULT);
+    }
+
+    public static ComponentTemplate parse(XContentParser parser, String templateName, Template.TemplateDecorator decorator) {
+        return PARSER.apply(parser, new NamedTemplateDecorator(templateName, decorator));
     }
 
     public ComponentTemplate(Template template, @Nullable Long version, @Nullable Map<String, Object> metadata) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -14,6 +14,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
+import org.elasticsearch.cluster.metadata.Template.NamedTemplateDecorator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -74,7 +75,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
     }
 
     @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<ComposableIndexTemplate, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<ComposableIndexTemplate, NamedTemplateDecorator> PARSER = new ConstructingObjectParser<>(
         "index_template",
         false,
         a -> ComposableIndexTemplate.builder()
@@ -139,7 +140,11 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
     }
 
     public static ComposableIndexTemplate parse(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
+        return PARSER.parse(parser, NamedTemplateDecorator.DEFAULT);
+    }
+
+    public static ComposableIndexTemplate parse(XContentParser parser, String templateName, Template.TemplateDecorator decorator) {
+        return PARSER.apply(parser, new NamedTemplateDecorator(templateName, decorator));
     }
 
     public static Builder builder() {
@@ -520,7 +525,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
         private static final ParseField ALLOW_CUSTOM_ROUTING = new ParseField("allow_custom_routing");
         private static final ParseField FAILURE_STORE = new ParseField("failure_store");
 
-        public static final ConstructingObjectParser<DataStreamTemplate, Void> PARSER = new ConstructingObjectParser<>(
+        static final ConstructingObjectParser<DataStreamTemplate, NamedTemplateDecorator> PARSER = new ConstructingObjectParser<>(
             "data_stream_template",
             false,
             args -> new DataStreamTemplate(args[0] != null && (boolean) args[0], args[1] != null && (boolean) args[1])

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -699,7 +699,7 @@ public class MetadataIndexTemplateService {
             // We may need to normalize index settings, so do that also
             Settings finalSettings = innerTemplate.settings();
             if (finalSettings != null) {
-                finalSettings = Settings.builder().put(finalSettings).normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX).build();
+                finalSettings = finalSettings.maybeNormalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX);
             }
             // If an inner template was specified, its mappings may need to be
             // adjusted (to add _doc) and it should be validated

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -43,6 +43,33 @@ import java.util.Objects;
  */
 public class Template implements SimpleDiffable<Template>, ToXContentObject {
 
+    /**
+     * A template decorator allows modification of template during parsing.
+     */
+    public interface TemplateDecorator {
+        TemplateDecorator DEFAULT = new TemplateDecorator() {};
+
+        default Settings decorate(String template, @Nullable Settings settings) {
+            return settings;
+        };
+
+        default DataStreamLifecycle.Template decorate(String template, @Nullable DataStreamLifecycle.Template lifecycle) {
+            return lifecycle;
+        };
+    }
+
+    record NamedTemplateDecorator(String name, TemplateDecorator decorator) {
+        static NamedTemplateDecorator DEFAULT = new NamedTemplateDecorator(null, TemplateDecorator.DEFAULT);
+
+        public Settings decorate(Settings settings) {
+            return decorator.decorate(name, settings);
+        }
+
+        public DataStreamLifecycle.Template decorate(DataStreamLifecycle.Template lifecycle) {
+            return decorator.decorate(name, lifecycle);
+        }
+    }
+
     private static final ParseField SETTINGS = new ParseField("settings");
     private static final ParseField MAPPINGS = new ParseField("mappings");
     private static final ParseField ALIASES = new ParseField("aliases");
@@ -50,14 +77,14 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
     private static final ParseField DATA_STREAM_OPTIONS = new ParseField("data_stream_options");
 
     @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<Template, Void> PARSER = new ConstructingObjectParser<>(
+    static final ConstructingObjectParser<Template, NamedTemplateDecorator> PARSER = new ConstructingObjectParser<>(
         "template",
         false,
-        a -> new Template(
-            (Settings) a[0],
+        (a, d) -> new Template(
+            d.decorate((Settings) a[0]),
             (CompressedXContent) a[1],
             (Map<String, AliasMetadata>) a[2],
-            (DataStreamLifecycle.Template) a[3],
+            d.decorate((DataStreamLifecycle.Template) a[3]),
             a[4] == null ? ResettableValue.undefined() : (ResettableValue<DataStreamOptions.Template>) a[4]
         )
     );
@@ -96,6 +123,10 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             ResettableValue.reset(),
             DATA_STREAM_OPTIONS
         );
+    }
+
+    public static Template parse(XContentParser parser, String templateName, TemplateDecorator decorator) {
+        return PARSER.apply(parser, new NamedTemplateDecorator(templateName, decorator));
     }
 
     public static CompressedXContent parseMappings(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProvider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logging.LogManager;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * SPI service interface to modify templates in Stateless mode.
+ *
+ * Note: currently decorators are not applied in any particular order.
+ */
+public interface TemplateDecoratorProvider extends Supplier<Template.TemplateDecorator> {
+    InstanceHolder TEMPLATE_DECORATOR = new InstanceHolder();
+
+    /**
+     * Get the singleton {@link Template.TemplateDecorator} instance.
+     *
+     * Initialization is done during node construction and must have happened before.
+     */
+    static Template.TemplateDecorator getInstance() {
+        Template.TemplateDecorator decorator = TEMPLATE_DECORATOR.instance.get();
+        if (decorator == null) {
+            var illegalStateException = new IllegalStateException("TemplateDecoratorProvider not initialized");
+            LogManager.getLogger(TemplateDecoratorProvider.class)
+                .warn("Attempted to access TemplateDecorator instance before initialization", illegalStateException);
+            throw illegalStateException;
+        }
+        return decorator;
+    }
+
+    /**
+     * Initialize the singleton {@link Template.TemplateDecorator} instance from the given list of providers.
+     *
+     * This method must be called only once during node construction loading available providers via SPI.
+     */
+    static void initOnce(List<? extends TemplateDecoratorProvider> providers) {
+        Template.TemplateDecorator decorator = switch (providers.size()) {
+            case 0 -> Template.TemplateDecorator.DEFAULT;
+            case 1 -> requireNonNull(providers.get(0).get());
+            default -> new Template.TemplateDecorator() {
+                final Template.TemplateDecorator[] decorators = providers.stream()
+                    .map(p -> requireNonNull(p.get()))
+                    .toArray(Template.TemplateDecorator[]::new);
+
+                @Override
+                public Settings decorate(String template, Settings settings) {
+                    for (Template.TemplateDecorator decorator : decorators) {
+                        settings = decorator.decorate(template, settings);
+                    }
+                    return settings;
+                }
+
+                @Override
+                public DataStreamLifecycle.Template decorate(String template, DataStreamLifecycle.Template lifecycle) {
+                    for (Template.TemplateDecorator decorator : decorators) {
+                        lifecycle = decorator.decorate(template, lifecycle);
+                    }
+                    return lifecycle;
+                }
+            };
+        };
+        if (TEMPLATE_DECORATOR.instance.compareAndSet(null, decorator) == false) {
+            LogManager.getLogger(TemplateDecoratorProvider.class).warn("TemplateDecoratorProvider already initialized");
+        }
+    }
+
+    class InstanceHolder {
+        private final AtomicReference<Template.TemplateDecorator> instance = new AtomicReference<>();
+
+        Template.TemplateDecorator getAndSet(Template.TemplateDecorator decorator) {
+            return instance.getAndSet(decorator);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -899,6 +899,19 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
     }
 
     /**
+     * Checks if all settings start with the specified prefix and renames any that do not. Returns the current instance if nothing needs
+     * to be done. See {@link Builder#normalizePrefix(String)} for more info.
+     */
+    public Settings maybeNormalizePrefix(String prefix) {
+        for (String key : settings.keySet()) {
+            if (key.startsWith(prefix) == false && key.endsWith("*") == false) {
+                return builder().put(this).normalizePrefix(prefix).build();
+            }
+        }
+        return this;
+    }
+
+    /**
      * A builder allowing to put different settings and then {@link #build()} an immutable
      * settings implementation. Use {@link Settings#builder()} in order to
      * construct it.

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.metadata.SystemIndexMetadataUpgradeService;
+import org.elasticsearch.cluster.metadata.TemplateDecoratorProvider;
 import org.elasticsearch.cluster.metadata.TemplateUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -701,6 +702,8 @@ class NodeConstruction {
         Settings settings = settingsModule.getSettings();
 
         modules.bindToInstance(Tracer.class, telemetryProvider.getTracer());
+
+        TemplateDecoratorProvider.initOnce(pluginsService.loadServiceProviders(TemplateDecoratorProvider.class));
 
         RootObjectMapperNamespaceValidator namespaceValidator = pluginsService.loadSingletonServiceProvider(
             RootObjectMapperNamespaceValidator.class,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/TemplateDecoratorProviderTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class TemplateDecoratorProviderTests extends ESTestCase {
+
+    @Rule
+    public final TestRule templateDecoratorRule = TemplateDecoratorRule.reset();
+
+    public void testGetInstanceThrowsWhenNotInitialized() {
+        IllegalStateException e = expectThrows(IllegalStateException.class, TemplateDecoratorProvider::getInstance);
+        assertThat(e.getMessage(), equalTo("TemplateDecoratorProvider not initialized"));
+    }
+
+    public void testInitOnceWithZeroProviders() {
+        TemplateDecoratorProvider.initOnce(List.of());
+        var decorator = TemplateDecoratorProvider.getInstance();
+        assertThat(decorator, is(Template.TemplateDecorator.DEFAULT));
+        assertThat(decorator.decorate("t", Settings.EMPTY), is(Settings.EMPTY));
+        assertThat(decorator.decorate("t", DataStreamLifecycle.Template.DATA_DEFAULT), is(DataStreamLifecycle.Template.DATA_DEFAULT));
+    }
+
+    public void testInitOnceWithOneProvider() {
+        Settings expectedSettings = Settings.builder().put("custom.key", "value").build();
+
+        TemplateDecoratorProvider.initOnce(List.of(() -> new Template.TemplateDecorator() {
+            @Override
+            public Settings decorate(String template, Settings settings) {
+                return Settings.builder().put(settings).put(expectedSettings).build();
+            }
+        }));
+        var decorator = TemplateDecoratorProvider.getInstance();
+        assertThat(decorator.decorate("t", Settings.EMPTY), equalTo(expectedSettings));
+    }
+
+    public void testInitOnceWithMultipleProvidersChainsSettingsAndLifecycle() {
+        var keep7days = DataStreamLifecycle.dataLifecycleBuilder().dataRetention(TimeValue.timeValueDays(7)).buildTemplate();
+
+        var decorator1 = new Template.TemplateDecorator() {
+            @Override
+            public Settings decorate(String template, Settings settings) {
+                return Settings.builder().put(settings).put("first", "1").build();
+            }
+        };
+        var decorator2 = new Template.TemplateDecorator() {
+            @Override
+            public Settings decorate(String template, Settings settings) {
+                return Settings.builder().put(settings).put("second", "2").build();
+            }
+
+            @Override
+            public DataStreamLifecycle.Template decorate(String template, DataStreamLifecycle.Template lifecycle) {
+                return keep7days;
+            }
+        };
+        TemplateDecoratorProvider.initOnce(List.of(() -> decorator1, () -> decorator2));
+        var decorator = TemplateDecoratorProvider.getInstance();
+
+        var result = decorator.decorate("t", Settings.EMPTY);
+        assertThat(result.get("first"), equalTo("1"));
+        assertThat(result.get("second"), equalTo("2"));
+
+        var lifecycle = decorator.decorate("t", DataStreamLifecycle.Template.DATA_DEFAULT);
+        assertThat(lifecycle, equalTo(keep7days));
+    }
+
+    public void testInitOnceOnly() {
+        var decorator1 = Mockito.mock(Template.TemplateDecorator.class);
+        var decorator2 = Mockito.mock(Template.TemplateDecorator.class);
+
+        TemplateDecoratorProvider.initOnce(List.of(() -> decorator1));
+        assertThat(TemplateDecoratorProvider.getInstance(), is(decorator1));
+
+        // lenient for tests, but won't init again
+        TemplateDecoratorProvider.initOnce(List.of(() -> decorator2));
+        assertThat(TemplateDecoratorProvider.getInstance(), is(decorator1));
+    }
+
+    public void testInitOnceWithProviderReturningNullThrows() {
+        TemplateDecoratorProvider nullProvider = () -> null;
+        expectThrows(NullPointerException.class, () -> TemplateDecoratorProvider.initOnce(List.of(nullProvider)));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/TemplateDecoratorRule.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/TemplateDecoratorRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * {@link TestRule} to manage initialization of {@link TemplateDecoratorProvider#TEMPLATE_DECORATOR}.
+ */
+public class TemplateDecoratorRule implements TestRule {
+
+    private final Template.TemplateDecorator decorator;
+
+    /**
+     * Test rule that resets {@link TemplateDecoratorProvider#TEMPLATE_DECORATOR} without re-initializing it.
+     */
+    public static TemplateDecoratorRule reset() {
+        return new TemplateDecoratorRule(null);
+    }
+
+    /**
+     * Test rule that initializes {@link TemplateDecoratorProvider#TEMPLATE_DECORATOR} with the default provider.
+     */
+    public static TemplateDecoratorRule initDefault() {
+        return new TemplateDecoratorRule(Template.TemplateDecorator.DEFAULT);
+    }
+
+    private TemplateDecoratorRule(Template.TemplateDecorator decorator) {
+        this.decorator = decorator;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                var previous = TemplateDecoratorProvider.TEMPLATE_DECORATOR.getAndSet(decorator);
+                try {
+                    base.evaluate();
+                } finally {
+                    TemplateDecoratorProvider.TEMPLATE_DECORATOR.getAndSet(previous);
+                }
+            }
+        };
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -87,6 +87,7 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.TemplateDecoratorRule;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -181,6 +182,8 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -370,6 +373,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     private static ESIntegTestCase INSTANCE = null; // see @SuiteScope
     private static Long SUITE_SEED = null;
+
+    @Rule
+    public final TestRule templateDecoratorRule = TemplateDecoratorRule.reset();
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -64,6 +64,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.TemplateDecoratorRule;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -163,6 +164,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -527,6 +529,9 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @ClassRule
     public static final TestEntitlementsRule TEST_ENTITLEMENTS = new TestEntitlementsRule();
+
+    @ClassRule
+    public static final TestRule TEMPLATE_DECORATOR_RULE = TemplateDecoratorRule.initDefault();
 
     // setup mock filesystems for this test run. we change PathUtils
     // so that all accesses are plumbed thru any mock wrappers

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -34,8 +34,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.indices.SystemIndexDescriptor;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 
 import java.io.IOException;
@@ -383,9 +381,9 @@ public final class MlIndexAndAlias {
         }
 
         TransportPutComposableIndexTemplateAction.Request request;
-        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())) {
+        try {
             request = new TransportPutComposableIndexTemplateAction.Request(templateConfig.getTemplateName()).indexTemplate(
-                ComposableIndexTemplate.parse(parser)
+                templateConfig.load(ComposableIndexTemplate::parse)
             ).masterNodeTimeout(masterTimeout);
         } catch (IOException e) {
             throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateConfig.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.core.template;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Describes an index template to be loaded from a resource file for use with an {@link IndexTemplateRegistry}.
@@ -88,10 +88,15 @@ public class IndexTemplateConfig {
      * @return The template as a UTF-8 byte array.
      */
     public byte[] loadBytes() {
-        String template = TemplateUtils.loadTemplate(fileName, Integer.toString(version), versionProperty, variables);
-        assert template != null && template.length() > 0;
-        assert Pattern.compile("\"version\"\\s*:\\s*" + version).matcher(template).find()
-            : "index template must have a version property set to the given version property";
+        String template = TemplateUtils.loadTemplate(fileName, Integer.toString(version), versionProperty, variables, true);
         return template.getBytes(StandardCharsets.UTF_8);
     }
+
+    /**
+     * Loads and parses the template from disk using the provided template parser.
+     */
+    public <T> T load(TemplateUtils.TemplateParser<T> parser) throws IOException {
+        return TemplateUtils.loadTemplate(fileName, Integer.toString(version), versionProperty, variables, true, parser);
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
@@ -9,13 +9,19 @@ package org.elasticsearch.xpack.core.template;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.cluster.metadata.TemplateDecoratorProvider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.template.resources.TemplateResources;
 
-import java.util.Collections;
+import java.io.IOException;
 import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Handling versioned templates for time-based indices in x-pack
@@ -25,45 +31,105 @@ public class TemplateUtils {
     private TemplateUtils() {}
 
     /**
-     * Loads a built-in template and returns its source.
+     * Loads a built-in template and returns its source after replacing given variables.
      */
-    public static String loadTemplate(String resource, String version, String versionProperty) {
-        return loadTemplate(resource, version, versionProperty, Collections.emptyMap());
+    public static String loadTemplate(String resource, String version, String versionProperty, Map<String, String> variables) {
+        return loadTemplate(resource, version, versionProperty, variables, false);
     }
 
     /**
      * Loads a built-in template and returns its source after replacing given variables.
+     *
+     * If {@code validateVersion} is true and assertions are enabled, a root version field with the provided version
+     * is expected to exist after applying substitutions.
      */
-    public static String loadTemplate(String resource, String version, String versionProperty, Map<String, String> variables) {
+    public static String loadTemplate(
+        String resource,
+        String version,
+        String versionProperty,
+        Map<String, String> variables,
+        boolean validateVersion
+    ) {
         try {
             String source = TemplateResources.load(resource);
             source = replaceVariables(source, version, versionProperty, variables);
-            validate(source);
+            validate(source, version, validateVersion);
             return source;
-        } catch (Exception e) {
+        } catch (Exception | AssertionError e) {
             throw new IllegalArgumentException("Unable to load template [" + resource + "]", e);
         }
     }
 
     /**
-     * Parses and validates that the source is not empty.
+     * A template parser leveraging a {@link Template.TemplateDecorator} to modify templates during parsing.
      */
-    public static void validate(String source) {
+    public interface TemplateParser<T> {
+        T apply(XContentParser parser, String resource, Template.TemplateDecorator decorator) throws IOException;
+    }
+
+    /**
+     * Loads a built-in template, replaces given variables and parses it using the provided {@link TemplateParser}.
+     *
+     * If {@code validateVersion} is true and assertions are enabled, a root version field with the provided version
+     * is expected to exist after applying substitutions.
+     */
+    public static <T> T loadTemplate(
+        String resource,
+        String version,
+        String versionProperty,
+        Map<String, String> variables,
+        boolean validateVersion,
+        TemplateParser<T> templateParser
+    ) throws IOException {
+        Template.TemplateDecorator decorator = TemplateDecoratorProvider.getInstance();
+        return loadTemplate(resource, version, versionProperty, variables, validateVersion, templateParser, decorator);
+    }
+
+    static <T> T loadTemplate(
+        String resource,
+        String version,
+        String versionProperty,
+        Map<String, String> variables,
+        boolean validateVersion,
+        TemplateParser<T> templateParser,
+        Template.TemplateDecorator decorator
+    ) throws IOException {
+        String source = loadTemplate(resource, version, versionProperty, variables, validateVersion);
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, source.getBytes(UTF_8))) {
+            return templateParser.apply(parser, resource, decorator);
+        }
+    }
+
+    /**
+     * Validates that the source is not empty and parses it to check its correctness if assertions are enabled.
+     *
+     * If {@code validateVersion} is true and assertions are enabled, a root version field with the provided version
+     * is expected to exist in the substituted {@source}.
+     */
+    static void validate(String source, String version, boolean validateVersion) {
         if (source == null) {
             throw new ElasticsearchParseException("Template must not be null");
         }
         if (Strings.isEmpty(source)) {
             throw new ElasticsearchParseException("Template must not be empty");
         }
+        assert validateJson(source, version, validateVersion);
+    }
 
+    private static boolean validateJson(String source, String version, boolean validateVersion) {
+        Map<String, Object> map;
         try {
-            XContentHelper.convertToMap(JsonXContent.jsonXContent, source, false);
+            map = XContentHelper.convertToMap(JsonXContent.jsonXContent, source, false);
         } catch (Exception e) {
             throw new ElasticsearchParseException("Invalid template", e);
         }
+        if (validateVersion && Integer.valueOf(version).equals(map.get("version")) == false) {
+            throw new IllegalArgumentException("Template must have a version property set to the given version property");
+        }
+        return true;
     }
 
-    public static String replaceVariables(String input, String version, String versionProperty, Map<String, String> variables) {
+    static String replaceVariables(String input, String version, String versionProperty, Map<String, String> variables) {
         String template = replaceVariable(input, versionProperty, version);
         for (Map.Entry<String, String> variable : variables.entrySet()) {
             template = replaceVariable(template, variable.getKey(), variable.getValue());
@@ -74,7 +140,7 @@ public class TemplateUtils {
     /**
      * Replaces all occurrences of given variable with the value
      */
-    public static String replaceVariable(String input, String variable, String value) {
+    static String replaceVariable(String input, String variable, String value) {
         return input.replace("${" + variable + "}", value);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
@@ -47,9 +47,7 @@ import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.junit.After;
@@ -413,9 +411,9 @@ public class AbstractAuditorTests extends ESTestCase {
                     NotificationsIndex.mapping()
                 )
             );
-            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())) {
+            try {
                 return new TransportPutComposableIndexTemplateAction.Request(templateConfig.getTemplateName()).indexTemplate(
-                    ComposableIndexTemplate.parse(parser)
+                    templateConfig.load(ComposableIndexTemplate::parse)
                 ).masterNodeTimeout(MASTER_TIMEOUT);
             } catch (IOException e) {
                 throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/TestRegistryWithCustomPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/TestRegistryWithCustomPlugin.java
@@ -16,8 +16,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 
 import java.io.IOException;
@@ -64,9 +62,7 @@ class TestRegistryWithCustomPlugin extends IndexTemplateRegistry {
         );
         ComponentTemplate componentTemplate = null;
         try {
-            componentTemplate = ComponentTemplate.parse(
-                JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())
-            );
+            componentTemplate = config.load(ComponentTemplate::parse);
         } catch (IOException e) {
             throw new AssertionError(e);
         }

--- a/x-pack/plugin/core/src/test/resources/settings-only.json
+++ b/x-pack/plugin/core/src/test/resources/settings-only.json
@@ -1,0 +1,9 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "refresh_interval": "1s"
+    }
+  }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -14,15 +14,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
 import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.JsonIngestPipelineConfig;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,32 +44,20 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
 
     static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
 
-    static final Map<String, ComponentTemplate> COMPONENT_TEMPLATES;
-
-    static {
-        final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
-        for (IndexTemplateConfig config : List.of(
-            new IndexTemplateConfig(
-                EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME,
-                ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME + ".json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            ),
-            new IndexTemplateConfig(
-                EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME,
-                ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME + ".json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            )
-        )) {
-            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
-                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }
-        COMPONENT_TEMPLATES = Map.copyOf(componentTemplates);
-    }
+    final Map<String, ComponentTemplate> componentTemplates = parseComponentTemplates(
+        new IndexTemplateConfig(
+            EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME,
+            ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME,
+            ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        )
+    );
 
     @Override
     protected List<IngestPipelineConfig> getIngestPipelines() {
@@ -91,7 +75,7 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
     static final String EVENT_DATA_STREAM_TEMPLATE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "default";
     static final String EVENT_DATA_STREAM_TEMPLATE_FILENAME = EVENT_DATA_STREAM_INDEX_PREFIX + "template";
 
-    static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATES = parseComposableTemplates(
+    final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(
         new IndexTemplateConfig(
             EVENT_DATA_STREAM_TEMPLATE_NAME,
             ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_TEMPLATE_FILENAME + ".json",
@@ -117,12 +101,12 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
-        return COMPONENT_TEMPLATES;
+        return componentTemplates;
     }
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        return COMPOSABLE_INDEX_TEMPLATES;
+        return composableIndexTemplates;
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
@@ -14,15 +14,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
 import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.JsonIngestPipelineConfig;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -64,45 +60,32 @@ public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
 
     private static final String JSON_EXTENSION = ".json";
 
-    static final Map<String, ComponentTemplate> COMPONENT_TEMPLATES;
-
-    static {
-        final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
-        for (IndexTemplateConfig config : List.of(
-            new IndexTemplateConfig(
-                CONNECTOR_TEMPLATE_NAME + MAPPINGS_SUFFIX,
-                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + MAPPINGS_SUFFIX + JSON_EXTENSION,
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            ),
-            new IndexTemplateConfig(
-                CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX,
-                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX + JSON_EXTENSION,
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            ),
-            new IndexTemplateConfig(
-                CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + MAPPINGS_SUFFIX,
-                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + MAPPINGS_SUFFIX + JSON_EXTENSION,
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            ),
-            new IndexTemplateConfig(
-                CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + SETTINGS_SUFFIX,
-                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX + JSON_EXTENSION,
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE
-            )
-        )) {
-
-            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
-                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }
-        COMPONENT_TEMPLATES = Map.copyOf(componentTemplates);
-    }
+    final Map<String, ComponentTemplate> componentTemplates = parseComponentTemplates(
+        new IndexTemplateConfig(
+            CONNECTOR_TEMPLATE_NAME + MAPPINGS_SUFFIX,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + MAPPINGS_SUFFIX + JSON_EXTENSION,
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX + JSON_EXTENSION,
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + MAPPINGS_SUFFIX,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + MAPPINGS_SUFFIX + JSON_EXTENSION,
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + SETTINGS_SUFFIX,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + SETTINGS_SUFFIX + JSON_EXTENSION,
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        )
+    );
 
     @Override
     protected List<IngestPipelineConfig> getIngestPipelines() {
@@ -156,7 +139,7 @@ public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
-        return COMPONENT_TEMPLATES;
+        return componentTemplates;
     }
 
     @Override

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSecretsSystemIndexIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSecretsSystemIndexIT.java
@@ -48,6 +48,8 @@ public class FleetSecretsSystemIndexIT extends AbstractFleetIT {
         assertTrue(responseMap.containsKey("id"));
         final String id = responseMap.get("id").toString();
 
+        ensureHealth(req -> req.addParameter("wait_for_status", "green"));
+
         // get secret
         Request getRequest = new Request("GET", "/_fleet/secret/" + id);
         Response getResponse = client().performRequest(getRequest);

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -7,18 +7,19 @@
 
 package org.elasticsearch.xpack.fleet;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse.ResetFeatureStateStatus;
-import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.datastreams.DeleteDataStreamAction;
 import org.elasticsearch.action.datastreams.DeleteDataStreamAction.Request;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -37,9 +38,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
 import org.elasticsearch.xpack.fleet.action.DeleteSecretAction;
 import org.elasticsearch.xpack.fleet.action.GetGlobalCheckpointsAction;
@@ -133,15 +131,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetActionsSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-actions.json", FLEET_ACTIONS_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-actions.json", FLEET_ACTIONS_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-actions-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-actions~(-results*)")
             .setAliasName(".fleet-actions")
@@ -150,15 +142,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetAgentsSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-agents.json", FLEET_AGENTS_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-agents.json", FLEET_AGENTS_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-agents-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-agents*")
             .setAliasName(".fleet-agents")
@@ -167,18 +153,11 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetEnrollmentApiKeysSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(
-            loadTemplateSource("/fleet-enrollment-api-keys.json", FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION),
-            XContentType.JSON
-        );
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-enrollment-api-keys.json", FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION).setType(
+            Type.EXTERNAL_MANAGED
+        )
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-enrollment-api-keys-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-enrollment-api-keys*")
             .setAliasName(".fleet-enrollment-api-keys")
@@ -187,13 +166,8 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetSecretsSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-secrets.json", FLEET_SECRETS_MAPPINGS_VERSION), XContentType.JSON);
-        return SystemIndexDescriptor.builder()
-            .setType(Type.INTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-secrets.json", FLEET_SECRETS_MAPPINGS_VERSION).setType(Type.INTERNAL_MANAGED)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(FLEET_SECRETS_INDEX_NAME + "-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(FLEET_SECRETS_INDEX_NAME + "*")
             .setAliasName(FLEET_SECRETS_INDEX_NAME)
@@ -202,15 +176,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetPoliciesSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-policies.json", FLEET_POLICIES_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-policies.json", FLEET_POLICIES_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-policies-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-policies-[0-9]+*")
             .setAliasName(".fleet-policies")
@@ -219,15 +187,11 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetPoliciesLeaderSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-policies-leader.json", FLEET_POLICIES_LEADER_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-policies-leader.json", FLEET_POLICIES_LEADER_MAPPINGS_VERSION).setType(
+            Type.EXTERNAL_MANAGED
+        )
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-policies-leader-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-policies-leader*")
             .setAliasName(".fleet-policies-leader")
@@ -236,15 +200,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetServersSystemIndexDescriptors() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-servers.json", FLEET_SERVERS_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-servers.json", FLEET_SERVERS_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-servers-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-servers*")
             .setAliasName(".fleet-servers")
@@ -253,15 +211,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetArtifactsSystemIndexDescriptors() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(loadTemplateSource("/fleet-artifacts.json", FLEET_ARTIFACTS_MAPPINGS_VERSION), XContentType.JSON);
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-artifacts.json", FLEET_ARTIFACTS_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".fleet-artifacts-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-artifacts*")
             .setAliasName(".fleet-artifacts")
@@ -270,21 +222,14 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor fleetIntegrationKnowledgeSystemIndexDescriptor() {
-        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
-        request.source(
-            loadTemplateSource("/fleet-integration-knowledge.json", FLEET_INTEGRATION_KNOWLEDGE_MAPPINGS_VERSION),
-            XContentType.JSON
-        );
-
-        return SystemIndexDescriptor.builder()
-            .setType(Type.EXTERNAL_MANAGED)
+        return systemIndexDescriptorBuilderFrom("/fleet-integration-knowledge.json", FLEET_INTEGRATION_KNOWLEDGE_MAPPINGS_VERSION).setType(
+            Type.EXTERNAL_MANAGED
+        )
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
             // This is a regular search index so it uses the shared thread pools.
             // The only difference is that its mappings and settings are managed internally by Elasticsearch.
             .setThreadPools(ExecutorNames.DEFAULT_INDEX_THREAD_POOLS)
-            .setMappings(request.mappings())
-            .setSettings(request.settings())
             .setPrimaryIndex(".integration_knowledge-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".integration_knowledge*")
             .setAliasName(".integration_knowledge")
@@ -293,9 +238,15 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemDataStreamDescriptor fleetActionsResultsDescriptor() {
-        final String source = loadTemplateSource("/fleet-actions-results.json", FLEET_ACTIONS_RESULTS_MAPPINGS_VERSION);
-        try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, source)) {
-            ComposableIndexTemplate composableIndexTemplate = ComposableIndexTemplate.parse(parser);
+        try {
+            ComposableIndexTemplate composableIndexTemplate = TemplateUtils.loadTemplate(
+                "/fleet-actions-results.json",
+                Version.CURRENT.toString(),
+                MAPPING_VERSION_VARIABLE,
+                Map.of("fleet.managed.index.version", Integer.toString(FLEET_ACTIONS_RESULTS_MAPPINGS_VERSION)),
+                false,
+                ComposableIndexTemplate::parse
+            );
             return new SystemDataStreamDescriptor(
                 ".fleet-actions-results",
                 "Result history of fleet actions",
@@ -359,13 +310,20 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
         }
     }
 
-    private static String loadTemplateSource(String resource, int mappingsVersion) {
-        return TemplateUtils.loadTemplate(
-            resource,
-            Version.CURRENT.toString(),
-            MAPPING_VERSION_VARIABLE,
-            Map.of("fleet.managed.index.version", Integer.toString(mappingsVersion))
-        );
+    private static SystemIndexDescriptor.Builder systemIndexDescriptorBuilderFrom(String resource, int mappingsVersion) {
+        try {
+            Template template = TemplateUtils.loadTemplate(
+                resource,
+                Version.CURRENT.toString(),
+                MAPPING_VERSION_VARIABLE,
+                Map.of("fleet.managed.index.version", Integer.toString(mappingsVersion)),
+                false,
+                Template::parse
+            );
+            return SystemIndexDescriptor.builder().setMappings(template.mappings().string()).setSettings(template.settings());
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("invalid template [{}]", resource);
+        }
     }
 
     @Override

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -35,7 +35,7 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
         new LifecyclePolicyConfig(".fleet-file-fromhost-meta-ilm-policy", "/fleet-file-fromhost-meta-ilm-policy.json")
     );
 
-    public static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
+    final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(
         new IndexTemplateConfig(
             ".fleet-fileds-fromhost-meta",
             "/fleet-file-fromhost-meta.json",
@@ -84,6 +84,6 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        return COMPOSABLE_INDEX_TEMPLATE_CONFIGS;
+        return composableIndexTemplates;
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
@@ -61,14 +61,14 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
         this.ilmHistoryEnabled = LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 
-    private static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
+    private final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(
         new IndexTemplateConfig(ILM_TEMPLATE_NAME, "/ilm-history.json", INDEX_TEMPLATE_VERSION, ILM_TEMPLATE_VERSION_VARIABLE)
     );
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
         if (this.ilmHistoryEnabled) {
-            return COMPOSABLE_INDEX_TEMPLATE_CONFIGS;
+            return composableIndexTemplates;
         } else {
             return Map.of();
         }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.cluster.metadata.TemplateDecoratorRule;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -108,6 +109,8 @@ import org.elasticsearch.xpack.slm.SnapshotLifecycle;
 import org.elasticsearch.xpack.slm.history.SnapshotLifecycleTemplateRegistry;
 import org.elasticsearch.xpack.transform.Transform;
 import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -139,6 +142,9 @@ import static org.hamcrest.Matchers.is;
  * Base class of ML integration tests that use a native autodetect process
  */
 abstract class MlNativeIntegTestCase extends ESIntegTestCase {
+
+    @Rule
+    public final TestRule templateDecoratorRule = TemplateDecoratorRule.initDefault();
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
@@ -16,8 +16,6 @@ import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessageFactory;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditor;
@@ -52,14 +50,9 @@ abstract class AbstractMlAuditor<T extends AbstractAuditMessage> extends Abstrac
     @Override
     protected TransportPutComposableIndexTemplateAction.Request putTemplateRequest() {
         var templateConfig = MlIndexTemplateRegistry.NOTIFICATIONS_TEMPLATE;
-        try (
-            var parser = JsonXContent.jsonXContent.createParser(
-                XContentParserConfiguration.EMPTY,
-                MlIndexTemplateRegistry.NOTIFICATIONS_TEMPLATE.loadBytes()
-            )
-        ) {
+        try {
             return new TransportPutComposableIndexTemplateAction.Request(templateConfig.getTemplateName()).indexTemplate(
-                ComposableIndexTemplate.parse(parser)
+                templateConfig.load(ComposableIndexTemplate::parse)
             ).masterNodeTimeout(MASTER_TIMEOUT);
         } catch (IOException e) {
             throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -304,7 +304,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
-    private static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
+    private final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(
         BEATS_STACK_INDEX_TEMPLATE,
         ES_STACK_INDEX_TEMPLATE,
         KIBANA_STACK_INDEX_TEMPLATE,
@@ -314,7 +314,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        return monitoringTemplatesEnabled ? COMPOSABLE_INDEX_TEMPLATE_CONFIGS : Map.of();
+        return monitoringTemplatesEnabled ? composableIndexTemplates : Map.of();
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -101,8 +101,8 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         indexStateResolver.set(new IndexStateResolver(PROFILING_CHECK_OUTDATED_INDICES.get(settings)));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_CHECK_OUTDATED_INDICES, this::updateCheckOutdatedIndices);
 
-        indexManager.set(new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver.get()));
-        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get()));
+        indexManager.set(new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get()));
+        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get()));
         // set initial value
         updateTemplatesEnabled(PROFILING_TEMPLATES_ENABLED.get(settings));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_TEMPLATES_ENABLED, this::updateTemplatesEnabled);
@@ -111,7 +111,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
             indexManager.get().initialize();
             dataStreamManager.get().initialize();
         }
-        return List.of(createLicenseChecker());
+        return List.of(createLicenseChecker(), registry.get());
     }
 
     protected ProfilingLicenseChecker createLicenseChecker() {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/AbstractProfilingPersistenceManager.java
@@ -44,18 +44,21 @@ abstract class AbstractProfilingPersistenceManager<T extends ProfilingIndexAbstr
     protected final ThreadPool threadPool;
     protected final Client client;
     private final IndexStateResolver indexStateResolver;
+    private final ProfilingIndexTemplateRegistry templateRegistry;
     private volatile boolean templatesEnabled;
 
     AbstractProfilingPersistenceManager(
         ThreadPool threadPool,
         Client client,
         ClusterService clusterService,
-        IndexStateResolver indexStateResolver
+        IndexStateResolver indexStateResolver,
+        ProfilingIndexTemplateRegistry templateRegistry
     ) {
         this.threadPool = threadPool;
         this.client = client;
         this.clusterService = clusterService;
         this.indexStateResolver = indexStateResolver;
+        this.templateRegistry = templateRegistry;
     }
 
     public void initialize() {
@@ -117,7 +120,7 @@ abstract class AbstractProfilingPersistenceManager<T extends ProfilingIndexAbstr
     }
 
     protected boolean areAllIndexTemplatesCreated(ClusterChangedEvent event, Settings settings) {
-        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state(), settings);
+        return templateRegistry.isAllResourcesCreated(event.state(), settings);
     }
 
     /**

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
@@ -55,9 +55,10 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         ThreadPool threadPool,
         Client client,
         ClusterService clusterService,
-        IndexStateResolver indexStateResolver
+        IndexStateResolver indexStateResolver,
+        ProfilingIndexTemplateRegistry templateRegistry
     ) {
-        super(threadPool, client, clusterService, indexStateResolver);
+        super(threadPool, client, clusterService, indexStateResolver, templateRegistry);
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManager.java
@@ -72,9 +72,10 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         ThreadPool threadPool,
         Client client,
         ClusterService clusterService,
-        IndexStateResolver indexStateResolver
+        IndexStateResolver indexStateResolver,
+        ProfilingIndexTemplateRegistry templateRegistry
     ) {
-        super(threadPool, client, clusterService, indexStateResolver);
+        super(threadPool, client, clusterService, indexStateResolver, templateRegistry);
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManagerTests.java
@@ -93,7 +93,7 @@ public class ProfilingDataStreamManagerTests extends ESTestCase {
                 return indexTemplateVersion;
             }
         };
-        datastreamManager = new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver) {
+        datastreamManager = new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver, null) {
             @Override
             protected boolean areAllIndexTemplatesCreated(ClusterChangedEvent event, Settings settings) {
                 return templatesCreated.get();

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManagerTests.java
@@ -93,7 +93,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
                 return indexTemplateVersion;
             }
         };
-        indexManager = new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver) {
+        indexManager = new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver, null) {
             @Override
             protected boolean areAllIndexTemplatesCreated(ClusterChangedEvent event, Settings settings) {
                 return templatesCreated.get();

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistryTests.java
@@ -342,7 +342,7 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
         }
         ClusterState clusterState = createClusterState(Settings.EMPTY, componentTemplates, composableTemplates, policies, nodes);
 
-        assertFalse(ProfilingIndexTemplateRegistry.isAllResourcesCreated(clusterState, Settings.EMPTY));
+        assertFalse(registry.isAllResourcesCreated(clusterState, Settings.EMPTY));
     }
 
     public void testAllResourcesPresentAndCurrent() {
@@ -362,7 +362,7 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
         }
         ClusterState clusterState = createClusterState(Settings.EMPTY, componentTemplates, composableTemplates, policies, nodes);
 
-        assertTrue(ProfilingIndexTemplateRegistry.isAllResourcesCreated(clusterState, Settings.EMPTY));
+        assertTrue(registry.isAllResourcesCreated(clusterState, Settings.EMPTY));
     }
 
     public void testSomeResourcesMissing() {
@@ -388,7 +388,7 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
         }
         ClusterState clusterState = createClusterState(Settings.EMPTY, componentTemplates, composableTemplates, policies, nodes);
 
-        assertFalse(ProfilingIndexTemplateRegistry.isAllResourcesCreated(clusterState, Settings.EMPTY));
+        assertFalse(registry.isAllResourcesCreated(clusterState, Settings.EMPTY));
     }
 
     private ActionResponse verifyComposableTemplateInstalled(

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
@@ -42,6 +42,12 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
 
     public static final String SLM_TEMPLATE_VERSION_VARIABLE = "xpack.slm.template.version";
     public static final String SLM_TEMPLATE_NAME = ".slm-history-" + INDEX_TEMPLATE_VERSION;
+    public static final IndexTemplateConfig SLM_TEMPLATE_CONFIG = new IndexTemplateConfig(
+        SLM_TEMPLATE_NAME,
+        "/slm-history.json",
+        INDEX_TEMPLATE_VERSION,
+        SLM_TEMPLATE_VERSION_VARIABLE
+    );
 
     public static final String SLM_POLICY_NAME = "slm-history-ilm-policy";
 
@@ -63,16 +69,14 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
         slmHistoryEnabled = SLM_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 
-    public static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
-        new IndexTemplateConfig(SLM_TEMPLATE_NAME, "/slm-history.json", INDEX_TEMPLATE_VERSION, SLM_TEMPLATE_VERSION_VARIABLE)
-    );
+    private final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(SLM_TEMPLATE_CONFIG);
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
         if (slmHistoryEnabled == false) {
             return Map.of();
         }
-        return COMPOSABLE_INDEX_TEMPLATE_CONFIGS;
+        return composableIndexTemplates;
     }
 
     private static final List<LifecyclePolicyConfig> LIFECYCLE_POLICY_CONFIGS = List.of(

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
@@ -16,8 +16,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -26,9 +24,7 @@ import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.JsonIngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
 
-import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -142,91 +138,76 @@ public class LegacyStackTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
-    private static final Map<String, ComponentTemplate> COMPONENT_TEMPLATE_CONFIGS;
-
-    static {
-        final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
-        for (IndexTemplateConfig config : List.of(
-            new IndexTemplateConfig(
-                DATA_STREAMS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
-                "/data-streams@mappings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                LOGS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
-                "/logs@mappings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                ECS_DYNAMIC_MAPPINGS_COMPONENT_TEMPLATE_NAME,
-                "/ecs@mappings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                LOGS_SETTINGS_COMPONENT_TEMPLATE_NAME,
-                "/logs@settings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                METRICS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
-                "/metrics@mappings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                METRICS_SETTINGS_COMPONENT_TEMPLATE_NAME,
-                "/metrics@settings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                METRICS_TSDB_SETTINGS_COMPONENT_TEMPLATE_NAME,
-                "/metrics@tsdb-settings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                SYNTHETICS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
-                "/synthetics@mappings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            ),
-            new IndexTemplateConfig(
-                SYNTHETICS_SETTINGS_COMPONENT_TEMPLATE_NAME,
-                "/synthetics@settings.json",
-                REGISTRY_VERSION,
-                TEMPLATE_VERSION_VARIABLE,
-                ADDITIONAL_TEMPLATE_VARIABLES
-            )
-        )) {
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }
-        COMPONENT_TEMPLATE_CONFIGS = Map.copyOf(componentTemplates);
-    }
+    private final Map<String, ComponentTemplate> componentTemplates = parseComponentTemplates(
+        new IndexTemplateConfig(
+            DATA_STREAMS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
+            "/data-streams@mappings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            LOGS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
+            "/logs@mappings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            ECS_DYNAMIC_MAPPINGS_COMPONENT_TEMPLATE_NAME,
+            "/ecs@mappings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            LOGS_SETTINGS_COMPONENT_TEMPLATE_NAME,
+            "/logs@settings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            METRICS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
+            "/metrics@mappings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            METRICS_SETTINGS_COMPONENT_TEMPLATE_NAME,
+            "/metrics@settings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            METRICS_TSDB_SETTINGS_COMPONENT_TEMPLATE_NAME,
+            "/metrics@tsdb-settings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            SYNTHETICS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
+            "/synthetics@mappings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        ),
+        new IndexTemplateConfig(
+            SYNTHETICS_SETTINGS_COMPONENT_TEMPLATE_NAME,
+            "/synthetics@settings.json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            ADDITIONAL_TEMPLATE_VARIABLES
+        )
+    );
 
     @Override
     protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
         if (stackTemplateEnabled) {
-            return COMPONENT_TEMPLATE_CONFIGS;
+            return componentTemplates;
         } else {
             return Map.of();
         }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -17,8 +17,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -27,8 +25,6 @@ import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.JsonIngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -123,12 +119,11 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
         this.clusterService = clusterService;
         this.stackTemplateEnabled = STACK_TEMPLATES_ENABLED.get(nodeSettings);
-        this.componentTemplateConfigs = loadComponentTemplateConfigs();
+        this.componentTemplateConfigs = parseComponentTemplates(getComponentTemplateConfigsAsConfigs());
     }
 
-    private Map<String, ComponentTemplate> loadComponentTemplateConfigs() {
-        final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
-        for (IndexTemplateConfig config : List.of(
+    static IndexTemplateConfig[] getComponentTemplateConfigsAsConfigs() {
+        return new IndexTemplateConfig[] {
             new IndexTemplateConfig(
                 DATA_STREAMS_MAPPINGS_COMPONENT_TEMPLATE_NAME,
                 "/data-streams@mappings.json",
@@ -226,18 +221,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
                 REGISTRY_VERSION,
                 TEMPLATE_VERSION_VARIABLE,
                 ADDITIONAL_TEMPLATE_VARIABLES
-            )
-        )) {
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }
-        return Map.copyOf(componentTemplates);
+            ) };
     }
 
     @Override
@@ -286,48 +270,53 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
         return componentTemplateConfigs;
     }
 
-    private static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
-        new IndexTemplateConfig(
-            LOGS_INDEX_TEMPLATE_NAME,
-            "/logs@template.json",
-            REGISTRY_VERSION,
-            TEMPLATE_VERSION_VARIABLE,
-            ADDITIONAL_TEMPLATE_VARIABLES
-        ),
-        new IndexTemplateConfig(
-            METRICS_INDEX_TEMPLATE_NAME,
-            "/metrics@template.json",
-            REGISTRY_VERSION,
-            TEMPLATE_VERSION_VARIABLE,
-            ADDITIONAL_TEMPLATE_VARIABLES
-        ),
-        new IndexTemplateConfig(
-            SYNTHETICS_INDEX_TEMPLATE_NAME,
-            "/synthetics@template.json",
-            REGISTRY_VERSION,
-            TEMPLATE_VERSION_VARIABLE,
-            ADDITIONAL_TEMPLATE_VARIABLES
-        ),
-        new IndexTemplateConfig(
-            AGENTLESS_INDEX_TEMPLATE_NAME,
-            "/agentless@template.json",
-            REGISTRY_VERSION,
-            TEMPLATE_VERSION_VARIABLE,
-            ADDITIONAL_TEMPLATE_VARIABLES
-        ),
-        new IndexTemplateConfig(
-            KIBANA_REPORTING_INDEX_TEMPLATE_NAME,
-            "/kibana-reporting@template.json",
-            REGISTRY_VERSION,
-            TEMPLATE_VERSION_VARIABLE,
-            ADDITIONAL_TEMPLATE_VARIABLES
-        )
+    private final Map<String, ComposableIndexTemplate> composableIndexTemplateConfigs = parseComposableTemplates(
+        getComposableTemplateConfigsAsConfigs()
     );
+
+    static IndexTemplateConfig[] getComposableTemplateConfigsAsConfigs() {
+        return new IndexTemplateConfig[] {
+            new IndexTemplateConfig(
+                LOGS_INDEX_TEMPLATE_NAME,
+                "/logs@template.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                ADDITIONAL_TEMPLATE_VARIABLES
+            ),
+            new IndexTemplateConfig(
+                METRICS_INDEX_TEMPLATE_NAME,
+                "/metrics@template.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                ADDITIONAL_TEMPLATE_VARIABLES
+            ),
+            new IndexTemplateConfig(
+                SYNTHETICS_INDEX_TEMPLATE_NAME,
+                "/synthetics@template.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                ADDITIONAL_TEMPLATE_VARIABLES
+            ),
+            new IndexTemplateConfig(
+                AGENTLESS_INDEX_TEMPLATE_NAME,
+                "/agentless@template.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                ADDITIONAL_TEMPLATE_VARIABLES
+            ),
+            new IndexTemplateConfig(
+                KIBANA_REPORTING_INDEX_TEMPLATE_NAME,
+                "/kibana-reporting@template.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                ADDITIONAL_TEMPLATE_VARIABLES
+            ) };
+    }
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
         if (stackTemplateEnabled) {
-            return COMPOSABLE_INDEX_TEMPLATE_CONFIGS;
+            return composableIndexTemplateConfigs;
         } else {
             return Map.of();
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -32,7 +32,22 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
 
     public static final String WATCHER_TEMPLATE_VERSION_VARIABLE = "xpack.watcher.template.version";
 
+    public static final IndexTemplateConfig WATCH_HISTORY_NO_ILM = new IndexTemplateConfig(
+        WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME_NO_ILM,
+        "/watch-history-no-ilm.json",
+        WatcherIndexTemplateRegistryField.INDEX_TEMPLATE_VERSION,
+        WATCHER_TEMPLATE_VERSION_VARIABLE
+    );
+
+    public static final IndexTemplateConfig WATCH_HISTORY_CONFIG = new IndexTemplateConfig(
+        WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME,
+        "/watch-history.json",
+        WatcherIndexTemplateRegistryField.INDEX_TEMPLATE_VERSION,
+        WATCHER_TEMPLATE_VERSION_VARIABLE
+    );
+
     private final boolean ilmManagementEnabled;
+    private final Map<String, ComposableIndexTemplate> composableTemplates;
 
     public WatcherIndexTemplateRegistry(
         Settings nodeSettings,
@@ -43,29 +58,14 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
     ) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
         ilmManagementEnabled = Watcher.USE_ILM_INDEX_MANAGEMENT.get(nodeSettings);
+        composableTemplates = ilmManagementEnabled
+            ? parseComposableTemplates(WATCH_HISTORY_CONFIG)
+            : parseComposableTemplates(WATCH_HISTORY_NO_ILM);
     }
-
-    private static final Map<String, ComposableIndexTemplate> TEMPLATES_WATCH_HISTORY = parseComposableTemplates(
-        new IndexTemplateConfig(
-            WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME,
-            "/watch-history.json",
-            WatcherIndexTemplateRegistryField.INDEX_TEMPLATE_VERSION,
-            WATCHER_TEMPLATE_VERSION_VARIABLE
-        )
-    );
-
-    private static final Map<String, ComposableIndexTemplate> TEMPLATES_WATCH_HISTORY_NO_ILM = parseComposableTemplates(
-        new IndexTemplateConfig(
-            WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME_NO_ILM,
-            "/watch-history-no-ilm.json",
-            WatcherIndexTemplateRegistryField.INDEX_TEMPLATE_VERSION,
-            WATCHER_TEMPLATE_VERSION_VARIABLE
-        )
-    );
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        return ilmManagementEnabled ? TEMPLATES_WATCH_HISTORY : TEMPLATES_WATCH_HISTORY_NO_ILM;
+        return composableTemplates;
     }
 
     private static final LifecyclePolicyConfig LIFECYCLE_POLICIES = new LifecyclePolicyConfig(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [SPI based TemplateDecorator to modify xpack templates for stateless (#141426)](https://github.com/elastic/elasticsearch/pull/141426)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)