### PR TITLE
ESQL: Unmute GenerativeIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -270,9 +270,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:spatial.ConvertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/139213
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:string.Url_encode_component tests with table reads}
-  issue: https://github.com/elastic/elasticsearch/issues/140809
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackSubqueryIT
   method: testGiantTextFieldInSubqueryIntermediateResultsWithSort
   issue: https://github.com/elastic/elasticsearch/issues/141034
@@ -368,9 +365,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/50_index_patterns/disjoint_mappings}
   issue: https://github.com/elastic/elasticsearch/issues/141856
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/141894
 - class: org.elasticsearch.compute.lucene.read.ValueSourceReaderTypeConversionTests
   method: testLoadAll
   issue: https://github.com/elastic/elasticsearch/issues/141954


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/141894

Unmute 2 tests:

- `GenerativeForkIT`: This was muted here, and then fixed, but the test wasn't unmuted: https://github.com/elastic/elasticsearch/issues/140809
- `GenerativeIT`: Failures reported in https://github.com/elastic/elasticsearch/issues/141894 looked like just timeouts and unrelated things