### PR TITLE
Ensure each node has at least one shard in testFieldDataStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -389,9 +389,6 @@ tests:
 - class: org.elasticsearch.xpack.gpu.GPUPluginInitializationWithGPUIT
   method: testAutoModeSupportedVectorType
   issue: https://github.com/elastic/elasticsearch/issues/142072
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFieldDataStats
-  issue: https://github.com/elastic/elasticsearch/issues/142078
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/142079


### PR DESCRIPTION
`IndexStatsIT.testFieldDataStats` assumes that the two nodes in the cluster each have at least one shard of a two-shard index and failed due to a NPE.


This PR ensures this assumption:
 - disable rebalancing
 - in the case where there are 0 replicas and both primaries go to one node, update the number of replicas to 1


Closes #142078