### PR TITLE
[9.3] [Inference API] Fix ChunkingSettings field missing from ModelConfigurations equals method (#142238)

### DIFF
--- a/docs/changelog/142238.yaml
+++ b/docs/changelog/142238.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 142238
+summary: "[Inference API] Fix `ChunkingSettings` field missing from `ModelConfigurations` equals method"
+type: bug

--- a/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -104,7 +105,7 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
         String service,
         ServiceSettings serviceSettings,
         TaskSettings taskSettings,
-        ChunkingSettings chunkingSettings
+        @Nullable ChunkingSettings chunkingSettings
     ) {
         this.inferenceEntityId = Objects.requireNonNull(inferenceEntityId);
         this.taskType = Objects.requireNonNull(taskType);
@@ -222,11 +223,12 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
             && taskType == model.taskType
             && Objects.equals(service, model.service)
             && Objects.equals(serviceSettings, model.serviceSettings)
-            && Objects.equals(taskSettings, model.taskSettings);
+            && Objects.equals(taskSettings, model.taskSettings)
+            && Objects.equals(chunkingSettings, model.chunkingSettings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(inferenceEntityId, taskType, service, serviceSettings, taskSettings);
+        return Objects.hash(inferenceEntityId, taskType, service, serviceSettings, taskSettings, chunkingSettings);
     }
 }

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
@@ -65,6 +65,7 @@ import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.Elast
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalModel;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElserInternalModel;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserInternalServiceSettingsTests;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserMlNodeTaskSettingsTests;
 import org.hamcrest.Matchers;
@@ -77,6 +78,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -86,6 +88,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder.OLD_DEFAULT_SETTINGS;
 import static org.elasticsearch.xpack.inference.registry.ModelRegistryTests.assertMinimalServiceSettings;
 import static org.elasticsearch.xpack.inference.registry.ModelRegistryTests.assertStoreModel;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -145,7 +148,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
 
     public void testGetModel() throws Exception {
         String inferenceEntityId = "test-get-model";
-        Model model = buildElserModelConfig(inferenceEntityId, TaskType.SPARSE_EMBEDDING);
+        // This can return chunking settings as null
+        var model = buildElserModelConfig(inferenceEntityId, TaskType.SPARSE_EMBEDDING);
         assertStoreModel(modelRegistry, model);
 
         // now get the model
@@ -166,13 +170,38 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
                 InferenceStatsTests.mockInferenceStats()
             )
         );
+
+        // When we parse the persisted config, if the chunking settings were null they will be defaulted to OLD_DEFAULT_SETTINGS
         ElasticsearchInternalModel roundTripModel = (ElasticsearchInternalModel) elserService.parsePersistedConfigWithSecrets(
             modelHolder.get().inferenceEntityId(),
             modelHolder.get().taskType(),
             modelHolder.get().settings(),
             modelHolder.get().secrets()
         );
-        assertEquals(model, roundTripModel);
+
+        assertElserModelsEqual(roundTripModel, model);
+    }
+
+    /**
+     * Asserts that the parsed ElasticsearchInternalModel is equal to the expected ElserInternalModel, taking into account
+     * when chunking settings is null in the expected model.
+     * @param actualParsedModel the parsed model by the {@link ElasticsearchInternalService}
+     * @param expected the expected model that was randomly generated and stored
+     */
+    private static void assertElserModelsEqual(ElasticsearchInternalModel actualParsedModel, ElserInternalModel expected) {
+        var expectedChunkingSettings = Objects.requireNonNullElse(expected.getConfigurations().getChunkingSettings(), OLD_DEFAULT_SETTINGS);
+
+        // Recreate the expected model with chunking settings set to the default if it was null
+        var expectedModelWithChunkingSettings = new ElserInternalModel(
+            expected.getInferenceEntityId(),
+            expected.getTaskType(),
+            expected.getConfigurations().getService(),
+            expected.getServiceSettings(),
+            expected.getTaskSettings(),
+            expectedChunkingSettings
+        );
+
+        assertThat(actualParsedModel, equalTo(expectedModelWithChunkingSettings));
     }
 
     public void testStoreModelFailsWhenModelExists() {
@@ -1251,9 +1280,9 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         }
     }
 
-    static Model buildElserModelConfig(String inferenceEntityId, TaskType taskType) {
+    static ElserInternalModel buildElserModelConfig(String inferenceEntityId, TaskType taskType) {
         return switch (taskType) {
-            case SPARSE_EMBEDDING -> new org.elasticsearch.xpack.inference.services.elasticsearch.ElserInternalModel(
+            case SPARSE_EMBEDDING -> new ElserInternalModel(
                 inferenceEntityId,
                 taskType,
                 ElasticsearchInternalService.NAME,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/ModelConfigurationsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/ModelConfigurationsTests.java
@@ -7,22 +7,23 @@
 
 package org.elasticsearch.xpack.inference;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserInternalServiceSettingsTests;
-import org.elasticsearch.xpack.inference.services.elasticsearch.ElserMlNodeTaskSettings;
+import org.elasticsearch.xpack.inference.services.jinaai.rerank.JinaAIRerankTaskSettingsTests;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class ModelConfigurationsTests extends AbstractWireSerializingTestCase<ModelConfigurations> {
+public class ModelConfigurationsTests extends AbstractBWCWireSerializationTestCase<ModelConfigurations> {
 
     public static ModelConfigurations createRandomInstance() {
         var taskType = randomFrom(TaskType.values());
@@ -31,45 +32,82 @@ public class ModelConfigurationsTests extends AbstractWireSerializingTestCase<Mo
             taskType,
             randomAlphaOfLength(6),
             randomServiceSettings(),
-            randomTaskSettings(taskType),
+            randomTaskSettings(),
             randomBoolean() ? ChunkingSettingsTests.createRandomChunkingSettings() : null
         );
     }
 
     public static ModelConfigurations mutateTestInstance(ModelConfigurations instance) {
-        switch (randomIntBetween(0, 2)) {
+        return switch (randomIntBetween(0, 5)) {
             case 0 -> new ModelConfigurations(
                 instance.getInferenceEntityId() + "foo",
                 instance.getTaskType(),
                 instance.getService(),
                 instance.getServiceSettings(),
-                instance.getTaskSettings()
+                instance.getTaskSettings(),
+                instance.getChunkingSettings()
             );
             case 1 -> new ModelConfigurations(
                 instance.getInferenceEntityId(),
                 TaskType.values()[(instance.getTaskType().ordinal() + 1) % TaskType.values().length],
                 instance.getService(),
                 instance.getServiceSettings(),
-                instance.getTaskSettings()
+                instance.getTaskSettings(),
+                instance.getChunkingSettings()
             );
             case 2 -> new ModelConfigurations(
                 instance.getInferenceEntityId(),
                 instance.getTaskType(),
                 instance.getService() + "bar",
                 instance.getServiceSettings(),
-                instance.getTaskSettings()
+                instance.getTaskSettings(),
+                instance.getChunkingSettings()
             );
+            case 3 -> new ModelConfigurations(
+                instance.getInferenceEntityId(),
+                instance.getTaskType(),
+                instance.getService(),
+                randomValueOtherThan(instance.getServiceSettings(), ModelConfigurationsTests::randomServiceSettings),
+                instance.getTaskSettings(),
+                instance.getChunkingSettings()
+            );
+            case 4 -> new ModelConfigurations(
+                instance.getInferenceEntityId(),
+                instance.getTaskType(),
+                instance.getService(),
+                instance.getServiceSettings(),
+                randomValueOtherThan(instance.getTaskSettings(), ModelConfigurationsTests::randomTaskSettings),
+                instance.getChunkingSettings()
+            );
+            case 5 -> {
+                var chunkingSettings = instance.getChunkingSettings();
+                // Mutate chunkingSettings: if null, create a random one; if non-null, toggle to null or create a different one
+                if (chunkingSettings == null) {
+                    chunkingSettings = ChunkingSettingsTests.createRandomChunkingSettings();
+                } else {
+                    chunkingSettings = randomBoolean()
+                        ? null
+                        : randomValueOtherThan(chunkingSettings, ChunkingSettingsTests::createRandomChunkingSettings);
+                }
+                yield new ModelConfigurations(
+                    instance.getInferenceEntityId(),
+                    instance.getTaskType(),
+                    instance.getService(),
+                    instance.getServiceSettings(),
+                    instance.getTaskSettings(),
+                    chunkingSettings
+                );
+            }
             default -> throw new IllegalStateException();
-        }
-        return null;
+        };
     }
 
     private static ServiceSettings randomServiceSettings() {
         return ElserInternalServiceSettingsTests.createRandom();
     }
 
-    private static TaskSettings randomTaskSettings(TaskType taskType) {
-        return ElserMlNodeTaskSettings.DEFAULT; // only 1 implementation
+    private static TaskSettings randomTaskSettings() {
+        return JinaAIRerankTaskSettingsTests.createRandom();
     }
 
     @Override
@@ -95,4 +133,8 @@ public class ModelConfigurationsTests extends AbstractWireSerializingTestCase<Mo
         return mutateTestInstance(instance);
     }
 
+    @Override
+    protected ModelConfigurations mutateInstanceForVersion(ModelConfigurations instance, TransportVersion version) {
+        return instance;
+    }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.core.inference.chunking.RerankRequestChunker;
 import org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings;
@@ -836,7 +837,8 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     TaskType.TEXT_EMBEDDING,
                     ElasticsearchInternalService.NAME,
                     elandServiceSettings,
-                    null
+                    // Using the old default because we're parsing a stored config
+                    ChunkingSettingsBuilder.OLD_DEFAULT_SETTINGS
                 ),
                 parsedModel
             );
@@ -875,7 +877,8 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     TaskType.TEXT_EMBEDDING,
                     ElasticsearchInternalService.NAME,
                     e5ServiceSettings,
-                    null
+                    // Using the old default because we're parsing a stored config
+                    ChunkingSettingsBuilder.OLD_DEFAULT_SETTINGS
                 ),
                 parsedModel
             );
@@ -1641,7 +1644,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                 taskType,
                 ElasticsearchInternalService.NAME,
                 serviceSettings,
-                null
+                ChunkingSettingsBuilder.DEFAULT_SETTINGS
             );
         } else if (taskType == TaskType.SPARSE_EMBEDDING) {
             expectedModel = new CustomElandModel(
@@ -1649,7 +1652,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                 taskType,
                 ElasticsearchInternalService.NAME,
                 new CustomElandInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, "custom-model", null, null)),
-                (ChunkingSettings) null
+                ChunkingSettingsBuilder.DEFAULT_SETTINGS
             );
         }
         return expectedModel;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Inference API] Fix ChunkingSettings field missing from ModelConfigurations equals method (#142238)