### PR TITLE
Better randomization in StreamsMetadataTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/StreamsMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/StreamsMetadataTests.java
@@ -33,6 +33,11 @@ public class StreamsMetadataTests extends AbstractChunkedSerializingTestCase<Str
 
     @Override
     protected StreamsMetadata mutateInstance(StreamsMetadata instance) throws IOException {
-        return new StreamsMetadata(instance.logsEnabled == false, instance.logsECSEnabled == false, instance.logsOTelEnabled == false);
+        return switch (between(0, 2)) {
+            case 0 -> new StreamsMetadata(instance.logsEnabled == false, instance.logsECSEnabled, instance.logsOTelEnabled);
+            case 1 -> new StreamsMetadata(instance.logsEnabled, instance.logsECSEnabled == false, instance.logsOTelEnabled);
+            case 2 -> new StreamsMetadata(instance.logsEnabled, instance.logsECSEnabled, instance.logsOTelEnabled == false);
+            default -> throw new IllegalArgumentException("Illegal randomisation branch");
+        };
     }
 }


### PR DESCRIPTION
This beefs up the randomization to follow the common pattern in the codebase.

Relates to #141564 and #142171
