### PR TITLE
[9.3] Make modifications to enable RestBulkPutRolesAction for Serverless (#140247)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRoleRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRoleRequestBuilder.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Builder for requests to bulk add a roles to the security index
@@ -37,7 +37,7 @@ public class BulkPutRoleRequestBuilder extends ActionRequestBuilder<BulkPutRoles
     );
 
     static {
-        PARSER.declareNamedObjects(optionalConstructorArg(), (p, c, n) -> {
+        PARSER.declareNamedObjects(constructorArg(), (p, c, n) -> {
             p.nextToken();
             return ROLE_DESCRIPTOR_PARSER.parse(n, p, false);
         }, new ParseField("roles"));
@@ -48,13 +48,16 @@ public class BulkPutRoleRequestBuilder extends ActionRequestBuilder<BulkPutRoles
     }
 
     public BulkPutRoleRequestBuilder content(BytesReference content, XContentType xContentType) throws IOException {
-        XContentParser parser = XContentHelper.createParserNotCompressed(
-            LoggingDeprecationHandler.XCONTENT_PARSER_CONFIG,
-            content,
-            xContentType
-        );
-        List<RoleDescriptor> roles = PARSER.parse(parser, null);
-        request.setRoles(roles);
+        try (
+            XContentParser parser = XContentHelper.createParserNotCompressed(
+                LoggingDeprecationHandler.XCONTENT_PARSER_CONFIG,
+                content,
+                xContentType
+            )
+        ) {
+            List<RoleDescriptor> roles = PARSER.parse(parser, null);
+            request.setRoles(roles);
+        }
         return this;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRolesRequest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
 public class BulkPutRolesRequest extends LegacyActionRequest {
 
     private List<RoleDescriptor> roles;
@@ -34,8 +36,11 @@ public class BulkPutRolesRequest extends LegacyActionRequest {
 
     @Override
     public ActionRequestValidationException validate() {
-        // Handle validation where put role is handled to produce partial success if validation fails
-        return null;
+        ActionRequestValidationException validationException = null;
+        if (roles.isEmpty()) {
+            validationException = addValidationError("roles cannot be empty", validationException);
+        }
+        return validationException;
     }
 
     public List<RoleDescriptor> getRoles() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -2542,7 +2542,7 @@ public class Security extends Plugin
         securityExtensions.addAll(loader.loadExtensions(SecurityExtension.class));
         loadSingletonExtensionAndSetOnce(loader, operatorOnlyRegistry, OperatorOnlyRegistry.class);
         loadSingletonExtensionAndSetOnce(loader, putRoleRequestBuilderFactory, PutRoleRequestBuilderFactory.class);
-        // TODO add bulkPutRoleRequestBuilderFactory loading here when available
+        loadSingletonExtensionAndSetOnce(loader, bulkPutRoleRequestBuilderFactory, BulkPutRoleRequestBuilderFactory.class);
         loadSingletonExtensionAndSetOnce(loader, getBuiltinPrivilegesResponseTranslator, GetBuiltinPrivilegesResponseTranslator.class);
         loadSingletonExtensionAndSetOnce(loader, updateApiKeyRequestTranslator, UpdateApiKeyRequestTranslator.class);
         loadSingletonExtensionAndSetOnce(loader, bulkUpdateApiKeyRequestTranslator, BulkUpdateApiKeyRequestTranslator.class);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestBulkPutRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestBulkPutRolesAction.java
@@ -11,6 +11,8 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.security.action.role.BulkPutRoleRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.role.BulkPutRoleRequestBuilderFactory;
@@ -23,6 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 /**
  * Rest endpoint to bulk add a Roles to the security index
  */
+@ServerlessScope(Scope.PUBLIC)
 public class RestBulkPutRolesAction extends NativeRoleBaseRestHandler {
 
     private final BulkPutRoleRequestBuilderFactory builderFactory;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Make modifications to enable RestBulkPutRolesAction for Serverless (#140247)