### PR TITLE
[9.3] [Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)

### DIFF
--- a/docs/changelog/142181.yaml
+++ b/docs/changelog/142181.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues: []
+pr: 142181
+summary: "[Inference API] Do not write \"task\" field in Jina embedding request if\
+  \ unsupported"
+type: bug

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -927,7 +927,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -949,7 +949,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1015,7 +1015,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1037,7 +1037,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1102,14 +1102,14 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
 
             String responseJson = """
-                {"model":"jina-clip-v2","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
+                {"model":"jina-embeddings-v3","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
                 "data":[{"object":"embedding","index":0,"embedding":[0.123, -0.123]}]}
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1162,7 +1162,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1184,7 +1184,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1578,7 +1578,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1600,7 +1600,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1653,7 +1653,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             createRandomChunkingSettings(),
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1668,7 +1668,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             null,
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1683,7 +1683,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             null,
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1698,7 +1698,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             null,
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1707,7 +1707,13 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
     public void test_Embedding_ChunkedInfer_noInputs() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
-        var model = JinaAIEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1024, "jina-clip-v2", JinaAIEmbeddingType.FLOAT);
+        var model = JinaAIEmbeddingsModelTests.createModel(
+            getUrl(webServer),
+            "secret",
+            1024,
+            "jina-embeddings-v3",
+            JinaAIEmbeddingType.FLOAT
+        );
 
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
@@ -1778,7 +1784,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
         if (Boolean.TRUE.equals(lateChunking)) {
             var responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1799,7 +1805,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
             var responseJson2 = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1821,7 +1827,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
         } else {
             var responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)](https://github.com/elastic/elasticsearch/pull/142181)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)