### PR TITLE
[9.2] [Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)

### DIFF
--- a/docs/changelog/142181.yaml
+++ b/docs/changelog/142181.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues: []
+pr: 142181
+summary: "[Inference API] Do not write \"task\" field in Jina embedding request if\
+  \ unsupported"
+type: bug

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -927,7 +927,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -949,7 +949,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1015,7 +1015,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1037,7 +1037,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1102,14 +1102,14 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
 
             String responseJson = """
-                {"model":"jina-clip-v2","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
+                {"model":"jina-embeddings-v3","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
                 "data":[{"object":"embedding","index":0,"embedding":[0.123, -0.123]}]}
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1162,7 +1162,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1184,7 +1184,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1578,7 +1578,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1600,7 +1600,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1653,7 +1653,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             createRandomChunkingSettings(),
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1668,7 +1668,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             null,
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1677,7 +1677,13 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
 
     public void test_Embedding_ChunkedInfer_noInputs() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
-        var model = JinaAIEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1024, "jina-clip-v2", JinaAIEmbeddingType.FLOAT);
+        var model = JinaAIEmbeddingsModelTests.createModel(
+            getUrl(webServer),
+            "secret",
+            1024,
+            "jina-embeddings-v3",
+            JinaAIEmbeddingType.FLOAT
+        );
 
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
@@ -1705,7 +1711,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             // Batching will call the service with 2 input
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1783,7 +1789,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             MatcherAssert.assertThat(
                 requestMap,
-                is(Map.of("input", List.of("a", "bb"), "model", "jina-clip-v2", "embedding_type", "float", "dimensions", 1024))
+                is(Map.of("input", List.of("a", "bb"), "model", "jina-embeddings-v3", "embedding_type", "float", "dimensions", 1024))
             );
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
@@ -20,6 +20,7 @@ import org.hamcrest.MatcherAssert;
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.inference.InputType.INGEST;
 import static org.hamcrest.CoreMatchers.is;
 
 public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
@@ -27,7 +28,7 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
         var entity = new JinaAIEmbeddingsRequestEntity(
             List.of("abc"),
             InputType.INTERNAL_INGEST,
-            new JinaAIEmbeddingsTaskSettings(InputType.INGEST),
+            new JinaAIEmbeddingsTaskSettings(INGEST),
             "modelName",
             JinaAIEmbeddingType.FLOAT,
             512,
@@ -136,5 +137,47 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
 
         MatcherAssert.assertThat(xContentResult, is("""
             {"input":["abc"],"model":"modelName"}"""));
+    }
+
+    public void testXContent_DoesNotWriteTaskField_WhenModelDoesNotSupportSpecifiedInputType() throws IOException {
+        String textInput = "text input";
+        String modelName = "jina-clip-v2";
+        var entity = new JinaAIEmbeddingsRequestEntity(
+            List.of(textInput),
+            INGEST,
+            JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
+            modelName,
+            null,
+            512,
+            false
+        );
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        assertThat(xContentResult, is(Strings.format("""
+            {"input":["%s"],"model":"%s"}""", textInput, modelName)));
+    }
+
+    public void testXContent_DoesNotWriteTaskField_WhenModelDoesNotSupportSpecifiedInputType_InputTypeInTaskSettings() throws IOException {
+        String textInput = "text input";
+        String modelName = "jina-clip-v2";
+        var entity = new JinaAIEmbeddingsRequestEntity(
+            List.of(textInput),
+            null,
+            new JinaAIEmbeddingsTaskSettings(INGEST),
+            modelName,
+            null,
+            512,
+            false
+        );
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        assertThat(xContentResult, is(Strings.format("""
+            {"input":["%s"],"model":"%s"}""", textInput, modelName)));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)](https://github.com/elastic/elasticsearch/pull/142181)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)