### PR TITLE
[8.19] [Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)

### DIFF
--- a/docs/changelog/142181.yaml
+++ b/docs/changelog/142181.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues: []
+pr: 142181
+summary: "[Inference API] Do not write \"task\" field in Jina embedding request if\
+  \ unsupported"
+type: bug

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -928,7 +928,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -950,7 +950,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1016,7 +1016,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1038,7 +1038,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1103,14 +1103,14 @@ public class JinaAIServiceTests extends ESTestCase {
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool))) {
 
             String responseJson = """
-                {"model":"jina-clip-v2","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
+                {"model":"jina-embeddings-v3","object":"list","usage":{"total_tokens":5,"prompt_tokens":5},
                 "data":[{"object":"embedding","index":0,"embedding":[0.123, -0.123]}]}
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1163,7 +1163,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1185,7 +1185,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1579,7 +1579,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1601,7 +1601,7 @@ public class JinaAIServiceTests extends ESTestCase {
 
             String apiKey = "apiKey";
             int dimensions = 1024;
-            String modelName = "jina-clip-v2";
+            String modelName = "jina-embeddings-v3";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
                 apiKey,
@@ -1654,7 +1654,7 @@ public class JinaAIServiceTests extends ESTestCase {
             createRandomChunkingSettings(),
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1669,7 +1669,7 @@ public class JinaAIServiceTests extends ESTestCase {
             null,
             1024,
             1024,
-            "jina-clip-v2",
+            "jina-embeddings-v3",
             JinaAIEmbeddingType.FLOAT
         );
 
@@ -1678,7 +1678,13 @@ public class JinaAIServiceTests extends ESTestCase {
 
     public void test_Embedding_ChunkedInfer_noInputs() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
-        var model = JinaAIEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1024, "jina-clip-v2", JinaAIEmbeddingType.FLOAT);
+        var model = JinaAIEmbeddingsModelTests.createModel(
+            getUrl(webServer),
+            "secret",
+            1024,
+            "jina-embeddings-v3",
+            JinaAIEmbeddingType.FLOAT
+        );
 
         try (var service = new JinaAIService(senderFactory, createWithEmptySettings(threadPool))) {
             PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
@@ -1706,7 +1712,7 @@ public class JinaAIServiceTests extends ESTestCase {
             // Batching will call the service with 2 input
             String responseJson = """
                 {
-                    "model": "jina-clip-v2",
+                    "model": "jina-embeddings-v3",
                     "object": "list",
                     "usage": {
                         "total_tokens": 5,
@@ -1784,7 +1790,7 @@ public class JinaAIServiceTests extends ESTestCase {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             MatcherAssert.assertThat(
                 requestMap,
-                is(Map.of("input", List.of("a", "bb"), "model", "jina-clip-v2", "embedding_type", "float", "dimensions", 1024))
+                is(Map.of("input", List.of("a", "bb"), "model", "jina-embeddings-v3", "embedding_type", "float", "dimensions", 1024))
             );
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
@@ -20,6 +20,7 @@ import org.hamcrest.MatcherAssert;
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.inference.InputType.INGEST;
 import static org.hamcrest.CoreMatchers.is;
 
 public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
@@ -27,7 +28,7 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
         var entity = new JinaAIEmbeddingsRequestEntity(
             List.of("abc"),
             InputType.INTERNAL_INGEST,
-            new JinaAIEmbeddingsTaskSettings(InputType.INGEST),
+            new JinaAIEmbeddingsTaskSettings(INGEST),
             "modelName",
             JinaAIEmbeddingType.FLOAT,
             512,
@@ -136,5 +137,47 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
 
         MatcherAssert.assertThat(xContentResult, is("""
             {"input":["abc"],"model":"modelName"}"""));
+    }
+
+    public void testXContent_DoesNotWriteTaskField_WhenModelDoesNotSupportSpecifiedInputType() throws IOException {
+        String textInput = "text input";
+        String modelName = "jina-clip-v2";
+        var entity = new JinaAIEmbeddingsRequestEntity(
+            List.of(textInput),
+            INGEST,
+            JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
+            modelName,
+            null,
+            512,
+            false
+        );
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        assertThat(xContentResult, is(Strings.format("""
+            {"input":["%s"],"model":"%s"}""", textInput, modelName)));
+    }
+
+    public void testXContent_DoesNotWriteTaskField_WhenModelDoesNotSupportSpecifiedInputType_InputTypeInTaskSettings() throws IOException {
+        String textInput = "text input";
+        String modelName = "jina-clip-v2";
+        var entity = new JinaAIEmbeddingsRequestEntity(
+            List.of(textInput),
+            null,
+            new JinaAIEmbeddingsTaskSettings(INGEST),
+            modelName,
+            null,
+            512,
+            false
+        );
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        assertThat(xContentResult, is(Strings.format("""
+            {"input":["%s"],"model":"%s"}""", textInput, modelName)));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference API] Do not write "task" field in Jina embedding request if unsupported (#142181)](https://github.com/elastic/elasticsearch/pull/142181)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)