### PR TITLE
Fix up Project usage in more distributed tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -432,7 +432,11 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             .build();
 
         MetaStateWriterUtils.writeIndex(nodeEnv, "test index being created", indexMetadata);
-        final Metadata metadata = Metadata.builder(clusterService.state().metadata()).put(indexMetadata, true).build();
+        final Metadata current = clusterService.state().metadata();
+        final ProjectMetadata updatedProject = ProjectMetadata.builder(current.getProject(ProjectId.DEFAULT))
+            .put(indexMetadata, true)
+            .build();
+        final Metadata metadata = Metadata.builder(current).put(updatedProject).build();
         final ClusterState csWithIndex = new ClusterState.Builder(clusterService.state()).metadata(metadata).build();
         try {
             indicesService.verifyIndexIsDeleted(index, csWithIndex);

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -13,6 +13,8 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -52,6 +54,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
     private void testOverShardLimit(LimitGroup group, int nodesInCluster) {
         final ShardCounts counts = computeShardCounts(group, nodesInCluster);
         ClusterState state = createClusterForShardLimitTest(
+            randomProjectIdOrDefault(),
             nodesInCluster,
             counts.getFirstIndexShards(),
             counts.getFirstIndexReplicas(),
@@ -103,6 +106,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         // Calculate the counts for a cluster with maximum of 60% of occupancy
         ShardCounts counts = computeShardCounts(group, (int) (nodesInCluster * 0.6));
         ClusterState state = createClusterForShardLimitTest(
+            randomProjectIdOrDefault(),
             nodesInCluster,
             counts.getFirstIndexShards(),
             counts.getFirstIndexReplicas(),
@@ -284,7 +288,8 @@ public class ShardLimitValidatorTests extends ESTestCase {
         return state;
     }
 
-    public static ClusterState createClusterForShardLimitTest(
+    private static ClusterState createClusterForShardLimitTest(
+        final ProjectId projectId,
         int nodesInCluster,
         int shardsInIndex,
         int replicas,
@@ -302,7 +307,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
             .creationDate(randomLong())
             .numberOfShards(shardsInIndex)
             .numberOfReplicas(replicas);
-        Metadata.Builder metadata = Metadata.builder().put(indexMetadata);
+        Metadata.Builder metadata = Metadata.builder().put(ProjectMetadata.builder(projectId).put(indexMetadata));
         Settings.Builder clusterSettings = Settings.builder()
             .put(ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.getKey(), maxShardsPerNode)
             .put(ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), maxShardsPerNode);


### PR DESCRIPTION
Replace deprecated `Metadata.Builder` calls with calls to `ProjectMetadata.Builder` methods instead.
