### PR TITLE
[9.3] Terminate S3 get blob retries when node is shutting down (#142186)

### DIFF
--- a/docs/changelog/142186.yaml
+++ b/docs/changelog/142186.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 142186
+summary: Terminate S3 get blob retries when node is shutting down
+type: bug

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -277,7 +277,7 @@ class S3BlobStore implements BlobStore {
         return service.client(projectId, repositoryMetadata);
     }
 
-    final int getMaxRetries() {
+    int getMaxRetries() {
         return service.settings(projectId, repositoryMetadata).maxRetries;
     }
 

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
@@ -112,7 +112,7 @@ class S3RetryingInputStream extends RetryingInputStream<Void> {
         @Override
         public boolean isRetryableException(StreamAction action, Exception e) {
             return switch (action) {
-                case OPEN -> e instanceof RuntimeException;
+                case OPEN -> e instanceof SdkException;
                 case READ -> e instanceof IOException;
             };
         }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Terminate S3 get blob retries when node is shutting down (#142186)