### PR TITLE
[9.3] Terminate get blob retries when GCS blob store is closed (#142193)

### DIFF
--- a/docs/changelog/142193.yaml
+++ b/docs/changelog/142193.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 142193
+summary: Terminate GCS retries when node is shutting down
+type: bug

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
@@ -155,4 +155,9 @@ class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
     public void getRegister(OperationPurpose purpose, String key, ActionListener<OptionalBytesReference> listener) {
         ActionListener.completeWith(listener, () -> blobStore.getRegister(purpose, buildKey(key), path, key));
     }
+
+    // visible for testing
+    public GoogleCloudStorageBlobStore getBlobStore() {
+        return blobStore;
+    }
 }

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRetryingInputStream.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRetryingInputStream.java
@@ -15,6 +15,7 @@ import com.google.cloud.storage.StorageException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.RetryingInputStream;
 import org.elasticsearch.core.Nullable;
@@ -149,6 +150,9 @@ class GoogleCloudStorageRetryingInputStream extends RetryingInputStream<Long> {
 
         @Override
         public boolean isRetryableException(StreamAction action, Exception e) {
+            if (e instanceof AlreadyClosedException) {
+                return false;
+            }
             return switch (action) {
                 case OPEN -> BaseService.EXCEPTION_HANDLER.shouldRetry(e, null);
                 case READ -> e instanceof StorageException;

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -24,6 +24,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.http.HttpStatus;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
@@ -74,6 +75,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -100,6 +102,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -667,6 +670,44 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
                 )
             );
         }
+    }
+
+    public void testRetriesAreTerminatedWhenClientProviderIsClosed() {
+        final GoogleCloudStorageBlobContainer blobContainer = asInstanceOf(
+            GoogleCloudStorageBlobContainer.class,
+            blobContainerBuilder().maxRetries(randomIntBetween(1000, 2000)).build()
+        );
+        final byte[] blobContents = randomByteArrayOfLength(1024);
+        final int incompleteLength = 10;
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_while_store_closes"), exchange -> {
+            try {
+                Streams.readFully(exchange.getRequestBody());
+                if ("GET".equals(exchange.getRequestMethod())) {
+                    final int rangeStart = getRangeStart(exchange);
+                    assertThat(rangeStart, lessThan(blobContents.length));
+                    final OptionalInt rangeEnd = getRangeEnd(exchange);
+                    final int requestedLength = rangeEnd.orElse(blobContents.length) - rangeStart;
+                    if (rangeEnd.isPresent()) {
+                        assertThat(rangeEnd.getAsInt(), greaterThanOrEqualTo(rangeStart));
+                    }
+                    assertThat(requestedLength, lessThanOrEqualTo(blobContents.length - rangeStart));
+                    assertThat(requestedLength, greaterThan(incompleteLength));
+                    addSuccessfulDownloadHeaders(exchange);
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), requestedLength);
+                    exchange.getResponseBody().write(blobContents, rangeStart, incompleteLength);
+                } else {
+                    ExceptionsHelper.maybeDieOnAnotherThread(
+                        new AssertionError("unexpected request method: " + exchange.getRequestMethod())
+                    );
+                }
+            } finally {
+                exchange.close();
+                // Close the blob store once we've sent the first chunk
+                blobContainer.getBlobStore().close();
+            }
+        });
+
+        assertThrows(AlreadyClosedException.class, () -> blobContainer.readBlob(randomRetryingPurpose(), "read_blob_while_store_closes"));
     }
 
     private void restartHttpServer() throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Terminate get blob retries when GCS blob store is closed (#142193)](https://github.com/elastic/elasticsearch/pull/142193)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)