### PR TITLE
ESQL: Move time_zone to GA

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/settings/time_zone.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/settings/time_zone.md
@@ -2,8 +2,8 @@
 
 ### `time_zone` [esql-time_zone]
 ```{applies_to}
-serverless: preview
-stack: preview 9.4+
+serverless: ga
+stack: ga 9.4+
 ```
 The default timezone to be used in the query. Defaults to UTC, and overrides the `time_zone` request parameter. See [timezones](/reference/query-languages/esql/esql-rest.md#esql-timezones).
 

--- a/docs/reference/query-languages/esql/esql-rest.md
+++ b/docs/reference/query-languages/esql/esql-rest.md
@@ -231,8 +231,8 @@ Which returns:
 
 ### Setting the query timezone [esql-timezones]
 ```{applies_to}
-stack: preview 9.4
-serverless: preview
+stack: ga 9.4
+serverless: ga
 ```
 
 To set the default timezone for the query, use the `time_zone` parameter in the request body. If not specified, the default timezone is UTC.

--- a/docs/reference/query-languages/esql/kibana/definition/settings/time_zone.json
+++ b/docs/reference/query-languages/esql/kibana/definition/settings/time_zone.json
@@ -5,7 +5,7 @@
     "keyword"
   ],
   "serverlessOnly" : false,
-  "preview" : true,
+  "preview" : false,
   "snapshotOnly" : false,
   "description" : "The default timezone to be used in the query. Defaults to UTC, and overrides the `time_zone` request parameter. See [timezones](https://www.elastic.co/docs/reference/query-languages/esql/esql-rest#esql-timezones)."
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -62,7 +62,7 @@ public class QuerySettings {
         "time_zone",
         DataType.KEYWORD,
         false,
-        true,
+        false,
         false,
         (value) -> {
             String timeZone = Foldables.stringLiteralValueOf(value, "Unexpected value");


### PR DESCRIPTION
Time_zone is currently in preview. This change moves it to GA.

API spec PR: https://github.com/elastic/elasticsearch-specification/pull/6014