### PR TITLE
Relax PR-based benchmarks target branch

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -47,7 +47,6 @@
       "set_commit_status": false,
       "build_on_commit": false,
       "build_on_comment": true,
-      "target_branch": "main",
       "trigger_comment_regex": "^(buildkite|@elastic(search)?machine) benchmark this with (?<benchmark>\\S+)( please)?$"
     }
   ]

--- a/docs/changelog/142297.yaml
+++ b/docs/changelog/142297.yaml
@@ -1,0 +1,5 @@
+area: Performance
+issues: []
+pr: 142297
+summary: Relax PR-based benchmarks target branch
+type: enhancement


### PR DESCRIPTION
Experimental relaxation to check if PR-based benchmark will fare well against `lucene_snapshot` branch.

To be tested in https://github.com/elastic/elasticsearch/pull/142293.