### PR TITLE
[9.1] [Gradle] Avoid adoptium jdk download in build-tool tests (#142174)

### DIFF
--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -34,6 +34,17 @@ java {
   sourceCompatibility = versions.get("minimumRuntimeJava")
 }
 
+sourceSets {
+  integTest {
+    compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
+    runtimeClasspath += output + compileClasspath
+  }
+}
+
+tasks.named("pluginUnderTestMetadata").configure {
+  getPluginClasspath().from(sourceSets.testFixtures.runtimeClasspath)
+}
+
 gradlePlugin {
     // We already configure publication and we don't need or want the one that comes
     // with the java-gradle-plugin
@@ -94,13 +105,6 @@ tasks.named("processResources").configure {
     }
 }
 
-sourceSets {
-    integTest {
-        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
-        runtimeClasspath += output + compileClasspath
-    }
-}
-
 // we do not publish the test fixtures of build-tools
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
 components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }
@@ -140,6 +144,7 @@ dependencies {
     implementation buildLibs.jackson.core
     implementation buildLibs.jackson.databind
 
+    testFixturesApi buildLibs.commmons.io
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
     testFixturesApi buildLibs.junit
@@ -176,6 +181,7 @@ tasks.withType(JavaCompile).configureEach {
 tasks.named('test').configure {
     useJUnitPlatform()
 }
+
 tasks.register("integTest", Test) {
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/JdkToolchainTestFixtureFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/JdkToolchainTestFixtureFuncTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import spock.lang.IgnoreIf
+
+import static org.elasticsearch.gradle.fixtures.JdkToolchainTestFixture.withMockedJdkDownload
+
+/**
+ * Integration tests for {@link org.elasticsearch.gradle.fixtures.JdkToolchainTestFixture}.
+ * Verifies that the fixture runs a Gradle build with a pre-installed fake JDK path and that
+ * the build succeeds. Full toolchain resolution and ES_JAVA_HOME override are covered by
+ * {@link TestClustersPluginFuncTest#override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities}.
+ */
+@IgnoreIf({ os.isWindows() })
+class JdkToolchainTestFixtureFuncTest extends AbstractGradleFuncTest {
+
+    def "build with mocked JDK path succeeds"() {
+        when:
+        def runner = gradleRunner('tasks', '-i', '-Dorg.gradle.java.installations.auto-detect=false')
+        def result = withMockedJdkDownload(runner, 17, 'eclipse_adoptium')
+
+        then:
+        result.output.contains('BUILD SUCCESSFUL')
+    }
+}

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.fixtures
 
 import spock.lang.Specification
 import spock.lang.TempDir
+import com.github.tomakehurst.wiremock.WireMockServer
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
@@ -20,6 +21,7 @@ import org.elasticsearch.gradle.internal.test.NormalizeOutputGradleRunner
 import org.elasticsearch.gradle.internal.test.TestResultExtension
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.After
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
@@ -30,6 +32,7 @@ import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*
 import static org.elasticsearch.gradle.internal.test.TestUtils.normalizeString
 
 abstract class AbstractGradleFuncTest extends Specification {
@@ -105,6 +108,7 @@ abstract class AbstractGradleFuncTest extends Specification {
         subProjectBuild
     }
 
+
     GradleRunner gradleRunner(Object... arguments) {
         return gradleRunner(testProjectDir.root, arguments)
     }
@@ -170,13 +174,13 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     File internalBuild(
-            List<String> extraPlugins = [],
-            String maintenance = "7.16.10",
-            String major4 = "8.1.3",
-            String major3 = "8.2.1",
-            String major2 = "8.3.0",
-            String major1 = "8.4.0",
-            String current = "9.0.0"
+        List<String> extraPlugins = [],
+        String maintenance = "7.16.10",
+        String major4 = "8.1.3",
+        String major3 = "8.2.1",
+        String major2 = "8.3.0",
+        String major1 = "8.4.0",
+        String current = "9.0.0"
     ) {
         buildFile << """plugins {
           id 'elasticsearch.global-build-info'
@@ -249,7 +253,8 @@ checkstyle = "com.puppycrawl.tools:checkstyle:10.3"
         specificationContext.currentSpec.listeners
             .findAll { it instanceof TestResultExtension.ErrorListener }
             .any {
-                (it as TestResultExtension.ErrorListener).errorInfo != null }
+                (it as TestResultExtension.ErrorListener).errorInfo != null
+            }
     }
 
     ZipAssertion zip(String relativePath) {
@@ -301,7 +306,7 @@ checkstyle = "com.puppycrawl.tools:checkstyle:10.3"
         }
 
         String read() {
-            try(ZipFile zipFile1 = new ZipFile(zipFile)) {
+            try (ZipFile zipFile1 = new ZipFile(zipFile)) {
                 def inputStream = zipFile1.getInputStream(entry)
                 return IOUtils.toString(inputStream, StandardCharsets.UTF_8.name())
             } catch (IOException e) {

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/JdkToolchainTestFixture.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/JdkToolchainTestFixture.groovy
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.fixtures
+
+import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Test fixture for mocking JDK toolchain provisioning in Gradle tests.
+ *
+ * Since Gradle 9.x enforces HTTPS for toolchain downloads and there's no way to bypass this,
+ * we instead pre-install a fake JDK in a temp directory and configure Gradle to detect it
+ * via the org.gradle.java.installations.paths property. This avoids the need for any network
+ * operations during the test.
+ */
+class JdkToolchainTestFixture {
+
+    /**
+     * Runs a Gradle build with a pre-installed fake JDK that Gradle will detect as a valid toolchain.
+     *
+     * @param gradleRunner The GradleRunner to configure
+     * @param buildRunClosure Closure that executes the build
+     * @param javaVersion The Java version to simulate (e.g., 17)
+     * @param vendor The vendor name (e.g., "eclipse_adoptium")
+     * @return The BuildResult from running the build
+     */
+    static BuildResult withMockedJdkDownload(GradleRunner gradleRunner,
+                                             Closure<BuildResult> buildRunClosure,
+                                             int javaVersion,
+                                             String vendor) {
+        // Create a temp directory to hold the fake JDK installation
+        Path tempDir = Files.createTempDirectory("fake-jdk-")
+        try {
+            // Create a fake JDK installation structure that Gradle can detect
+            Path jdkInstallDir = createFakeJdkInstallation(tempDir, javaVersion, vendor)
+
+            // Configure Gradle to find our fake JDK via installations.paths
+            // Disable auto-detect completely to force Gradle to use only our fake JDK
+            List<String> givenArguments = gradleRunner.getArguments()
+
+            // Remove any auto-detect or installations.paths settings - we'll set our own
+            List<String> filteredArguments = givenArguments.findAll { arg ->
+                String argStr = arg.toString()
+                !argStr.contains('org.gradle.java.installations.auto-detect') &&
+                    !argStr.contains('org.gradle.java.installations.paths')
+            }
+
+            // Use toRealPath() to get the canonical path (with /private prefix on macOS)
+            // This ensures consistency between the path we pass and the path Gradle resolves
+            List<String> addedArguments = [
+                "-Dorg.gradle.java.installations.paths=${jdkInstallDir.toRealPath()}".toString(),
+                "-Dorg.gradle.java.installations.auto-detect=false",
+                "-Dorg.gradle.java.installations.auto-download=false"
+            ]
+
+            List<String> effectiveArguments = (filteredArguments + addedArguments).collect { it.toString() }
+
+            GradleRunner effectiveRunner = gradleRunner.withArguments(effectiveArguments)
+            buildRunClosure.delegate = effectiveRunner
+            return buildRunClosure.call(effectiveRunner)
+        } finally {
+            // Clean up temp directory
+            FileUtils.deleteDirectory(tempDir.toFile())
+        }
+    }
+
+    static BuildResult withMockedJdkDownload(GradleRunner gradleRunner, int javaVersion, String vendor) {
+        return withMockedJdkDownload(gradleRunner, { it.build() }, javaVersion, vendor)
+    }
+
+    /**
+     * Creates a fake JDK installation structure that Gradle's toolchain detection will recognize.
+     *
+     * The directory structure follows the convention that Gradle expects:
+     * - For macOS: jdk-<version>/Contents/Home/bin/java and jdk-<version>/Contents/Home/release
+     * - For Linux/Windows: jdk-<version>/bin/java and jdk-<version>/release
+     *
+     * The directory is named to include the vendor so that the path contains "eclipse_adoptium-17"
+     * which the test expects to see in ES_JAVA_HOME output.
+     */
+    private static Path createFakeJdkInstallation(Path baseDir, int javaVersion, String vendor) {
+        // Create a directory name that includes vendor-version for test assertions
+        // e.g., "eclipse_adoptium-17.0.0"
+        String dirName = "${vendor}-${javaVersion}.0.0"
+        Path jdkDir = baseDir.resolve(dirName)
+        Files.createDirectories(jdkDir)
+
+        // Determine if we're on macOS (different JDK structure)
+        boolean isMacOS = System.getProperty("os.name").toLowerCase().contains("mac")
+
+        Path homeDir
+        if (isMacOS) {
+            // macOS structure: jdk/Contents/Home/
+            homeDir = jdkDir.resolve("Contents").resolve("Home")
+        } else {
+            // Linux/Windows structure: jdk/
+            homeDir = jdkDir
+        }
+        Files.createDirectories(homeDir)
+
+        // Create bin directory with java executable
+        Path binDir = homeDir.resolve("bin")
+        Files.createDirectories(binDir)
+
+        Path javaExecutable = binDir.resolve("java")
+        // Create a shell script that handles Gradle's JVM probing
+        // Gradle runs: java -Xmx32m -Xms32m -cp . JavaProbe
+        // Gradle's MetadataProbe generates a JavaProbe.class that outputs lines in format:
+        //   GRADLE_PROBE_VALUE:<property_value>
+        // The order of values matches ProbedSystemProperty enum:
+        //   java.home, java.version, java.vendor, java.runtime.name, java.runtime.version,
+        //   java.vm.name, java.vm.version, java.vm.vendor, os.arch
+        String vendorName = vendorToDisplayName(vendor)
+        String osArch = System.getProperty("os.arch")
+        // Use toRealPath() to get the canonical path with /private prefix on macOS
+        // This is critical because Gradle resolves paths to their canonical form
+        // and expects JAVA_HOME output to match exactly
+        String homePath = homeDir.toRealPath().toString()
+
+        // Gradle's JavaProbe outputs GRADLE_PROBE_VALUE:<value> lines, one per property in enum order
+        String script = """\
+#!/bin/bash
+# Fake Java ${javaVersion} executable for Gradle toolchain testing
+
+# Gradle runs: java -cp . JavaProbe
+# We detect this by checking if the last argument is "JavaProbe"
+LAST_ARG="\${@: -1}"
+
+if [ "\$LAST_ARG" = "JavaProbe" ]; then
+    # Output JVM metadata in the format Gradle expects (GRADLE_PROBE_VALUE:<value>)
+    # Order MUST match ProbedSystemProperty enum:
+    # java.home, java.version, java.vendor, java.runtime.name, java.runtime.version,
+    # java.vm.name, java.vm.version, java.vm.vendor, os.arch
+    echo "GRADLE_PROBE_VALUE:${homePath}"
+    echo "GRADLE_PROBE_VALUE:${javaVersion}.0.0"
+    echo "GRADLE_PROBE_VALUE:${vendorName}"
+    echo "GRADLE_PROBE_VALUE:OpenJDK Runtime Environment"
+    echo "GRADLE_PROBE_VALUE:${javaVersion}.0.0+0"
+    echo "GRADLE_PROBE_VALUE:OpenJDK 64-Bit Server VM"
+    echo "GRADLE_PROBE_VALUE:${javaVersion}.0.0+0"
+    echo "GRADLE_PROBE_VALUE:${vendorName}"
+    echo "GRADLE_PROBE_VALUE:${osArch}"
+    exit 0
+fi
+
+# Handle standard -version calls
+if [ "\$1" = "-version" ] || [ "\$1" = "--version" ]; then
+    echo 'openjdk version "${javaVersion}.0.0" 2024-01-01' >&2
+    echo 'OpenJDK Runtime Environment Temurin-${javaVersion}.0.0+0 (build ${javaVersion}.0.0+0)' >&2
+    echo 'OpenJDK 64-Bit Server VM Temurin-${javaVersion}.0.0+0 (build ${javaVersion}.0.0+0, mixed mode)' >&2
+    exit 0
+fi
+
+# For any other invocation, just exit successfully
+exit 0
+"""
+        Files.write(javaExecutable, script.getBytes())
+        // Make it executable
+        javaExecutable.toFile().setExecutable(true, false)
+
+        // Create release file with proper metadata that Gradle uses to identify the JDK
+        Path releaseFile = homeDir.resolve("release")
+        String releaseContent = """\
+IMPLEMENTOR="${vendorName}"
+IMPLEMENTOR_VERSION="Temurin-${javaVersion}.0.0+0"
+JAVA_RUNTIME_VERSION="${javaVersion}.0.0+0"
+JAVA_VERSION="${javaVersion}.0.0"
+JAVA_VERSION_DATE="2024-01-01"
+OS_ARCH="${osArch}"
+OS_NAME="${isMacOS ? 'Darwin' : 'Linux'}"
+FULL_VERSION="${javaVersion}.0.0+0"
+BUILD_INFO="Fake JDK for testing"
+JVM_VARIANT="Hotspot"
+JVM_VERSION="${javaVersion}.0.0+0"
+IMAGE_TYPE="JDK"
+"""
+        Files.write(releaseFile, releaseContent.getBytes())
+
+        // Return the JDK home path (where bin/java and release live) for org.gradle.java.installations.paths
+        return homeDir
+    }
+
+    /**
+     * Converts vendor identifier to display name used in release file.
+     */
+    private static String vendorToDisplayName(String vendor) {
+        switch (vendor) {
+            case "eclipse_adoptium":
+                return "Eclipse Adoptium"
+            case "adoptopenjdk":
+                return "AdoptOpenJDK"
+            case "azul":
+                return "Azul Systems, Inc."
+            case "amazon":
+                return "Amazon.com Inc."
+            case "bellsoft":
+                return "BellSoft"
+            case "oracle":
+                return "Oracle Corporation"
+            default:
+                return vendor
+        }
+    }
+
+}


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [Gradle] Avoid adoptium jdk download in build-tool tests (#142174)