### PR TITLE
Fix corrupted character in sort-search-results.md

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/sort-search-results.md
+++ b/docs/reference/elasticsearch/rest-apis/sort-search-results.md
@@ -7,7 +7,7 @@ applies_to:
 
 # Sort search results
 
-The [sort￼parameter in the search API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search#operation-search-body-application-json-sort) allows you to add one or more sorts on specific fields. Each sort can be reversed as well. The sort is defined on a per field level, with special field name for `_score` to sort by score, and `_doc` to sort by index order.
+The [sort parameter in the search API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search#operation-search-body-application-json-sort) allows you to add one or more sorts on specific fields. Each sort can be reversed as well. The sort is defined on a per field level, with special field name for `_score` to sort by score, and `_doc` to sort by index order.
 
 To optimize sorting performance, avoid sorting by [`text`](/reference/elasticsearch/mapping-reference/text.md)fields; instead, use [`keyword`](/reference/elasticsearch/mapping-reference/keyword.md) or [`numerical`](/reference/elasticsearch/mapping-reference/number.md) fields. Additionally, you can improve performance by enabling pre-sorting at index time using [index sorting](/reference/elasticsearch/index-settings/sorting.md). While this can speed up query-time sorting, it may reduce indexing performance and increase memory usage.
 


### PR DESCRIPTION
Commit 47c49fda7018f776a4440989b3cb3389301a66dc introduced a corrupted [obj] character in the text.