### PR TITLE
[9.3] Implement comprehensive top N parameter handling for text similarity reranker (#142039)

### DIFF
--- a/docs/changelog/142039.yaml
+++ b/docs/changelog/142039.yaml
@@ -1,0 +1,5 @@
+area: Ranking
+issues: []
+pr: 142039
+summary: Implement comprehensive top N parameter handling for text similarity reranker
+type: bug

--- a/server/src/main/java/org/elasticsearch/inference/TopNProvider.java
+++ b/server/src/main/java/org/elasticsearch/inference/TopNProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+public interface TopNProvider {
+    Integer getTopN();
+}

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
@@ -31,6 +31,7 @@ import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
@@ -40,7 +41,6 @@ import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -190,7 +190,14 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
                 for (int i = 0; i < totalResults; i++) {
                     results.add(new RankedDocsResults.RankedDoc(i, Float.parseFloat(input.get(i)), input.get(i)));
                 }
-                return new RankedDocsResults(results.stream().sorted(Comparator.reverseOrder()).toList());
+
+                // RankedDoc's compareTo implementation already sorts by score descending, so we don't need to reverse the sort order
+                var sortedResultsStream = results.stream().sorted();
+                if (taskSettings.topN != null) {
+                    sortedResultsStream = sortedResultsStream.limit(taskSettings.topN);
+                }
+
+                return new RankedDocsResults(sortedResultsStream.toList());
             } catch (NumberFormatException ex) {
                 return makeResultFromTextInput(input, taskSettings);
             }
@@ -212,6 +219,10 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             }
             // Ensure result are sorted by descending score
             results.sort((a, b) -> -Float.compare(a.relevanceScore(), b.relevanceScore()));
+            if (taskSettings.topN != null && taskSettings.topN < results.size()) {
+                results = results.subList(0, taskSettings.topN);
+            }
+
             return new RankedDocsResults(results);
         }
 
@@ -253,7 +264,13 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
         }
     }
 
-    public record TestTaskSettings(boolean useTextLength, float minScore, float resultDiff) implements TaskSettings {
+    public record TestTaskSettings(
+        boolean useTextLength,
+        float minScore,
+        float resultDiff,
+        Integer topN,
+        boolean hideTopN
+    ) implements TaskSettings, TopNProvider {
 
         static final String NAME = "test_reranking_task_settings";
 
@@ -261,6 +278,8 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             boolean useTextLength = false;
             float minScore = random.nextFloat(-1f, 1f);
             float resultDiff = 0.2f;
+            Integer topN = null;
+            boolean hideTopN = false;
 
             if (map.containsKey("use_text_length")) {
                 useTextLength = Boolean.parseBoolean(map.remove("use_text_length").toString());
@@ -274,11 +293,19 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
                 resultDiff = Float.parseFloat(map.remove("result_diff").toString());
             }
 
-            return new TestTaskSettings(useTextLength, minScore, resultDiff);
+            if (map.containsKey("top_n")) {
+                topN = Integer.parseInt(map.remove("top_n").toString());
+            }
+
+            if (map.containsKey("hide_top_n")) {
+                hideTopN = Boolean.parseBoolean(map.remove("hide_top_n").toString());
+            }
+
+            return new TestTaskSettings(useTextLength, minScore, resultDiff, topN, hideTopN);
         }
 
         public TestTaskSettings(StreamInput in) throws IOException {
-            this(in.readBoolean(), in.readFloat(), in.readFloat());
+            this(in.readBoolean(), in.readFloat(), in.readFloat(), in.readOptionalInt(), in.readBoolean());
         }
 
         @Override
@@ -291,6 +318,8 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             out.writeBoolean(useTextLength);
             out.writeFloat(minScore);
             out.writeFloat(resultDiff);
+            out.writeOptionalInt(topN);
+            out.writeBoolean(hideTopN);
         }
 
         @Override
@@ -299,8 +328,17 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             builder.field("use_text_length", useTextLength);
             builder.field("min_score", minScore);
             builder.field("result_diff", resultDiff);
+            if (topN != null) {
+                builder.field("top_n", topN);
+            }
+            builder.field("hide_top_n", hideTopN);
             builder.endObject();
             return builder;
+        }
+
+        @Override
+        public Integer getTopN() {
+            return hideTopN ? null : topN;
         }
 
         @Override
@@ -319,7 +357,9 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             return new TestTaskSettings(
                 newSettingsMap.containsKey("use_text_length") ? newSettingsObject.useTextLength() : useTextLength,
                 newSettingsMap.containsKey("min_score") ? newSettingsObject.minScore() : minScore,
-                newSettingsMap.containsKey("result_diff") ? newSettingsObject.resultDiff() : resultDiff
+                newSettingsMap.containsKey("result_diff") ? newSettingsObject.resultDiff() : resultDiff,
+                newSettingsMap.containsKey("top_n") ? newSettingsObject.topN() : topN,
+                newSettingsMap.containsKey("hide_top_n") ? newSettingsObject.hideTopN() : hideTopN
             );
         }
     }

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
@@ -264,13 +264,10 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
         }
     }
 
-    public record TestTaskSettings(
-        boolean useTextLength,
-        float minScore,
-        float resultDiff,
-        Integer topN,
-        boolean hideTopN
-    ) implements TaskSettings, TopNProvider {
+    public record TestTaskSettings(boolean useTextLength, float minScore, float resultDiff, Integer topN, boolean hideTopN)
+        implements
+            TaskSettings,
+            TopNProvider {
 
         static final String NAME = "test_reranking_task_settings";
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -66,6 +66,9 @@ public class InferenceFeatures implements FeatureSpecification {
     public static final NodeFeature INFERENCE_ENDPOINT_CACHE = new NodeFeature("inference.endpoint.cache");
     public static final NodeFeature INFERENCE_CCM_CACHE = new NodeFeature("inference.ccm.cache");
     public static final NodeFeature SEARCH_USAGE_EXTENDED_DATA = new NodeFeature("search.usage.extended_data");
+    public static final NodeFeature TEXT_SIMILARITY_RERANKER_COMPREHENSIVE_TOP_N_HANDLING = new NodeFeature(
+        "text_similarity_reranker.comprehensive_top_n_handling"
+    );
     public static final NodeFeature INFERENCE_AUTH_POLLER_PERSISTENT_TASK = new NodeFeature("inference.auth_poller.persistent_task");
     public static final NodeFeature INFERENCE_CCM_ENABLEMENT_SERVICE = new NodeFeature("inference.ccm.enablement_service");
 
@@ -129,7 +132,8 @@ public class InferenceFeatures implements FeatureSpecification {
                 ModelStats.SEMANTIC_TEXT_USAGE,
                 SEARCH_USAGE_EXTENDED_DATA,
                 TEXT_SIMILARITY_RANK_DOC_EXPLAIN_CHUNKS,
-                RETRIEVER_RESULT_DIVERSIFICATION_USES_QUERY_VECTOR_BUILDER
+                RETRIEVER_RESULT_DIVERSIFICATION_USES_QUERY_VECTOR_BUILDER,
+                TEXT_SIMILARITY_RERANKER_COMPREHENSIVE_TOP_N_HANDLING
             )
         );
         testFeatures.addAll(getFeatures());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
@@ -196,10 +196,7 @@ public class TextSimilarityRankBuilder extends RankBuilder {
             inferenceId,
             inferenceText,
             minScore,
-            failuresAllowed,
-            chunkScorerConfig != null
-                ? new ChunkScorerConfig(chunkScorerConfig.size, inferenceText, chunkScorerConfig.chunkingSettings())
-                : null
+            failuresAllowed
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/rerank/AzureAiStudioRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -29,7 +30,7 @@ import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiSt
 /**
  * Defines the rerank task settings for the AzureAiStudio service.
  */
-public class AzureAiStudioRerankTaskSettings implements TaskSettings {
+public class AzureAiStudioRerankTaskSettings implements TaskSettings, TopNProvider {
     public static final String NAME = "azure_ai_studio_rerank_task_settings";
     private static final TransportVersion ML_INFERENCE_AZURE_AI_STUDIO_RERANK_ADDED = TransportVersion.fromName(
         "ml_inference_azure_ai_studio_rerank_added"
@@ -87,6 +88,11 @@ public class AzureAiStudioRerankTaskSettings implements TaskSettings {
 
     public Integer topN() {
         return topN;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return topN();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/rerank/CohereRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/rerank/CohereRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
  * <a href="https://docs.cohere.com/reference/rerank-1">See api docs for details.</a>
  * </p>
  */
-public class CohereRerankTaskSettings implements TaskSettings {
+public class CohereRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "cohere_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -170,6 +171,11 @@ public class CohereRerankTaskSettings implements TaskSettings {
 
     public Integer getTopNDocumentsOnly() {
         return topNDocumentsOnly;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return getTopNDocumentsOnly();
     }
 
     public Boolean getReturnDocuments() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/rerank/ContextualAiRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/rerank/ContextualAiRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 
@@ -24,7 +25,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalBoolean;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 
-public class ContextualAiRerankTaskSettings implements TaskSettings {
+public class ContextualAiRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "contextualai_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -88,6 +89,7 @@ public class ContextualAiRerankTaskSettings implements TaskSettings {
         return returnDocuments;
     }
 
+    @Override
     @Nullable
     public Integer getTopN() {
         return topN;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,7 +24,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 
-public class GoogleVertexAiRerankTaskSettings implements TaskSettings {
+public class GoogleVertexAiRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "google_vertex_ai_rerank_task_settings";
 
@@ -65,6 +66,11 @@ public class GoogleVertexAiRerankTaskSettings implements TaskSettings {
 
     public Integer topN() {
         return topN;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return topN();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/rerank/HuggingFaceRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/rerank/HuggingFaceRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,7 +25,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalBoolean;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 
-public class HuggingFaceRerankTaskSettings implements TaskSettings {
+public class HuggingFaceRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "hugging_face_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -151,6 +152,11 @@ public class HuggingFaceRerankTaskSettings implements TaskSettings {
 
     public Integer getTopNDocumentsOnly() {
         return topNDocumentsOnly;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return getTopNDocumentsOnly();
     }
 
     public Boolean getReturnDocuments() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,7 +25,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalBoolean;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 
-public class IbmWatsonxRerankTaskSettings implements TaskSettings {
+public class IbmWatsonxRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "ibm_watsonx_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -167,6 +168,11 @@ public class IbmWatsonxRerankTaskSettings implements TaskSettings {
 
     public Integer getTopNDocumentsOnly() {
         return topNDocumentsOnly;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return getTopNDocumentsOnly();
     }
 
     public Boolean getReturnDocuments() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
  * Defines the task settings for the JinaAI rerank service.
  *
  */
-public class JinaAIRerankTaskSettings implements TaskSettings {
+public class JinaAIRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "jinaai_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -145,6 +146,11 @@ public class JinaAIRerankTaskSettings implements TaskSettings {
 
     public Integer getTopNDocumentsOnly() {
         return topNDocumentsOnly;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return getTopNDocumentsOnly();
     }
 
     public Boolean getReturnDocuments() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/rerank/OpenShiftAiRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/rerank/OpenShiftAiRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.openshiftai.OpenShiftAiUtils;
 
@@ -28,7 +29,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 /**
  * Defines the task settings for the OpenShift AI rerank service.
  */
-public class OpenShiftAiRerankTaskSettings implements TaskSettings {
+public class OpenShiftAiRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "openshift_ai_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -172,6 +173,7 @@ public class OpenShiftAiRerankTaskSettings implements TaskSettings {
         return Objects.hash(returnDocuments, topN);
     }
 
+    @Override
     public Integer getTopN() {
         return topN;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/rerank/VoyageAIRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/rerank/VoyageAIRerankTaskSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
+import org.elasticsearch.inference.TopNProvider;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -29,7 +30,7 @@ import static org.elasticsearch.xpack.inference.services.voyageai.VoyageAIServic
  * Defines the task settings for the VoyageAI rerank service.
  *
  */
-public class VoyageAIRerankTaskSettings implements TaskSettings {
+public class VoyageAIRerankTaskSettings implements TaskSettings, TopNProvider {
 
     public static final String NAME = "voyageai_rerank_task_settings";
     public static final String RETURN_DOCUMENTS = "return_documents";
@@ -169,6 +170,11 @@ public class VoyageAIRerankTaskSettings implements TaskSettings {
 
     public Integer getTopKDocumentsOnly() {
         return topKDocumentsOnly;
+    }
+
+    @Override
+    public Integer getTopN() {
+        return getTopKDocumentsOnly();
     }
 
     public Boolean getDoesReturnDocuments() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
@@ -7,121 +7,90 @@
 
 package org.elasticsearch.xpack.inference.rank.textsimilarity;
 
-import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.search.rank.feature.RankFeatureDoc;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 
 import java.util.List;
 
-import static org.elasticsearch.action.support.ActionTestUtils.assertNoFailureListener;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankFeaturePhaseRankCoordinatorContext.extractScoresFromRankedDocs;
 
 public class TextSimilarityRankFeaturePhaseRankCoordinatorContextTests extends ESTestCase {
 
-    private final Client mockClient = mock(Client.class);
-
-    TextSimilarityRankFeaturePhaseRankCoordinatorContext subject = new TextSimilarityRankFeaturePhaseRankCoordinatorContext(
-        10,
-        0,
-        100,
-        mockClient,
-        "my-inference-id",
-        "some query",
-        0.0f,
-        false,
-        null
-    );
-
-    TextSimilarityRankFeaturePhaseRankCoordinatorContext withChunks = new TextSimilarityRankFeaturePhaseRankCoordinatorContext(
-        10,
-        0,
-        100,
-        mockClient,
-        "my-inference-id",
-        "some query",
-        0.0f,
-        false,
-        new ChunkScorerConfig(2, "some query", null)
-    );
-
-    public void testComputeScores() {
-        RankFeatureDoc featureDoc1 = new RankFeatureDoc(0, 1.0f, 0);
-        featureDoc1.featureData(List.of("text 1"));
-        RankFeatureDoc featureDoc2 = new RankFeatureDoc(1, 3.0f, 1);
-        featureDoc2.featureData(List.of("text 2"));
-        RankFeatureDoc featureDoc3 = new RankFeatureDoc(2, 2.0f, 0);
-        featureDoc3.featureData(List.of("text 3"));
-        RankFeatureDoc[] featureDocs = new RankFeatureDoc[] { featureDoc1, featureDoc2, featureDoc3 };
-
-        subject.computeScores(featureDocs, assertNoFailureListener(f -> assertArrayEquals(new float[] { 1.0f, 3.0f, 2.0f }, f, 0.0f)));
-        verify(mockClient).execute(
-            eq(GetInferenceModelAction.INSTANCE),
-            argThat(actionRequest -> ((GetInferenceModelAction.Request) actionRequest).getTaskType().equals(TaskType.RERANK)),
-            any()
-        );
-    }
-
-    public void testComputeScoresForEmpty() {
-        subject.computeScores(new RankFeatureDoc[0], assertNoFailureListener(f -> assertArrayEquals(new float[0], f, 0.0f)));
-        verify(mockClient).execute(
-            eq(GetInferenceModelAction.INSTANCE),
-            argThat(actionRequest -> ((GetInferenceModelAction.Request) actionRequest).getTaskType().equals(TaskType.RERANK)),
-            any()
-        );
-    }
-
     public void testExtractScoresFromRankedDocs() {
-        List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
-            new RankedDocsResults.RankedDoc(0, 1.0f, "text 1"),
+        final List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
             new RankedDocsResults.RankedDoc(1, 3.0f, "text 2"),
-            new RankedDocsResults.RankedDoc(2, 2.0f, "text 3")
+            new RankedDocsResults.RankedDoc(2, 2.0f, "text 3"),
+            new RankedDocsResults.RankedDoc(0, 1.0f, "text 1")
         );
-        float[] scores = subject.extractScoresFromRankedDocs(rankedDocs);
+        final RankFeatureDoc[] featureDocs = new RankFeatureDoc[] {
+            createRankFeatureDoc(0, 0.25f, 0, List.of("text 1")),
+            createRankFeatureDoc(1, 0.50f, 1, List.of("text 2")),
+            createRankFeatureDoc(2, 0.75f, 2, List.of("text 3")) };
+
+        float[] scores = extractScoresFromRankedDocs(rankedDocs, featureDocs);
         assertArrayEquals(new float[] { 1.0f, 3.0f, 2.0f }, scores, 0.0f);
-    }
 
-    public void testExtractScoresFromSingleChunk() {
-
-        List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
-            new RankedDocsResults.RankedDoc(0, 1.0f, "text 1"),
-            new RankedDocsResults.RankedDoc(1, 2.5f, "text 2"),
-            new RankedDocsResults.RankedDoc(2, 1.5f, "text 3")
+        // Truncate the list of ranked docs. This simulates if the reranker service returns fewer docs than are in featureDocs, which can
+        // happen if the service has an unreported top_n setting in use.
+        IllegalStateException e = assertThrows(
+            IllegalStateException.class,
+            () -> extractScoresFromRankedDocs(rankedDocs.subList(0, 1), featureDocs)
         );
-        RankFeatureDoc[] featureDocs = new RankFeatureDoc[] {
-            createRankFeatureDoc(0, 1.0f, 0, List.of("text 1")),
-            createRankFeatureDoc(1, 3.0f, 1, List.of("text 2")),
-            createRankFeatureDoc(2, 2.0f, 0, List.of("text 3")) };
-
-        float[] scores = withChunks.extractScoresFromRankedChunks(rankedDocs, featureDocs);
-        // Returned cores are from the chunk, not the whole text
-        assertArrayEquals(new float[] { 1.0f, 2.5f, 1.5f }, scores, 0.0f);
+        assertEquals(
+            "Expected ranked doc size to be 3, got 1. Is the reranker service using an unreported top N task setting?",
+            e.getMessage()
+        );
     }
 
     public void testExtractScoresFromMultipleChunks() {
-
-        List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
-            new RankedDocsResults.RankedDoc(0, 1.0f, "this is text 1"),
-            new RankedDocsResults.RankedDoc(1, 2.5f, "some more text"),
+        final List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
+            new RankedDocsResults.RankedDoc(3, 3.5f, "this is text 2"),
+            new RankedDocsResults.RankedDoc(4, 2.5f, "this is text 3"),
+            new RankedDocsResults.RankedDoc(1, 2.0f, "some more text"),
             new RankedDocsResults.RankedDoc(2, 1.5f, "yet more text"),
-            new RankedDocsResults.RankedDoc(3, 3.0f, "this is text 2"),
-            new RankedDocsResults.RankedDoc(4, 2.0f, "this is text 3"),
-            new RankedDocsResults.RankedDoc(5, 1.5f, "oh look, more text")
+            new RankedDocsResults.RankedDoc(5, 1.5f, "oh look, more text"),
+            new RankedDocsResults.RankedDoc(0, 1.0f, "this is text 1")
         );
-        RankFeatureDoc[] featureDocs = new RankFeatureDoc[] {
+        final RankFeatureDoc[] featureDocs = new RankFeatureDoc[] {
             createRankFeatureDoc(0, 1.0f, 0, List.of("this is text 1", "some more text")),
             createRankFeatureDoc(1, 3.0f, 1, List.of("yet more text", "this is text 2")),
             createRankFeatureDoc(2, 2.0f, 0, List.of("this is text 3", "oh look, more text")) };
 
-        float[] scores = withChunks.extractScoresFromRankedChunks(rankedDocs, featureDocs);
         // Returned scores are from the best-ranking chunk, not the whole text
-        assertArrayEquals(new float[] { 2.5f, 3.0f, 2.0f }, scores, 0.0f);
+        float[] scores = extractScoresFromRankedDocs(rankedDocs, featureDocs);
+        assertArrayEquals(new float[] { 2.0f, 3.5f, 2.5f }, scores, 0.0f);
+
+        // Truncate the list of ranked docs. This simulates if the reranker service returns fewer docs than are in featureDocs, which can
+        // happen if the service has an unreported top_n setting in use.
+        IllegalStateException e = assertThrows(
+            IllegalStateException.class,
+            () -> extractScoresFromRankedDocs(rankedDocs.subList(0, 3), featureDocs)
+        );
+        assertEquals(
+            "Expected ranked doc size to be 6, got 3. Is the reranker service using an unreported top N task setting?",
+            e.getMessage()
+        );
+    }
+
+    public void testExtractScoresFromRankedDocWithEmptyFeatureData() {
+        final List<RankedDocsResults.RankedDoc> rankedDocs = List.of(
+            new RankedDocsResults.RankedDoc(0, 3.0f, "text 1"),
+            new RankedDocsResults.RankedDoc(1, 2.0f, "text 3")
+        );
+        final RankFeatureDoc[] featureDocs = new RankFeatureDoc[] {
+            createRankFeatureDoc(0, 0.25f, 0, List.of("text 1")),
+            createRankFeatureDoc(1, 0.50f, 1, List.of()),
+            createRankFeatureDoc(2, 0.75f, 2, List.of("text 3")) };
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> extractScoresFromRankedDocs(rankedDocs, featureDocs));
+        assertEquals("Feature doc at index 1 does not have any features", e.getMessage());
+    }
+
+    public void testExtractScoresFromEmptyRankedDocs() {
+        // Tests the scenario when there are no docs to rerank. In this case, both rankedDocs and featureDocs are empty.
+        float[] scores = extractScoresFromRankedDocs(List.of(), new RankFeatureDoc[0]);
+        assertEquals(0, scores.length);
     }
 
     private RankFeatureDoc createRankFeatureDoc(int doc, float score, int shardIndex, List<String> featureData) {
@@ -129,5 +98,4 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContextTests extends E
         featureDoc.featureData(featureData);
         return featureDoc;
     }
-
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
@@ -90,8 +90,7 @@ public class TextSimilarityRankTests extends ESSingleNodeTestCase {
                 inferenceId,
                 inferenceText,
                 minScore,
-                failuresAllowed(),
-                null
+                failuresAllowed()
             ) {
                 @Override
                 protected InferenceAction.Request generateRequest(List<String> docFeatures) {
@@ -264,7 +263,10 @@ public class TextSimilarityRankTests extends ESSingleNodeTestCase {
                 .setQuery(QueryBuilders.matchAllQuery())
         );
         assertThat(ex.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
-        assertThat(ex.getDetailedMessage(), containsString("Reranker input document count and returned score count mismatch"));
+        assertThat(
+            ex.getDetailedMessage(),
+            containsString("Expected ranked doc size to be 5, got 4. Is the reranker service using an unreported top N task setting?")
+        );
     }
 
     private static Matcher<SearchHit> searchHitWith(int expectedRank, float expectedScore, String expectedText) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
@@ -219,8 +219,7 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
                     inferenceId,
                     inferenceText,
                     minScore,
-                    failuresAllowed(),
-                    null
+                    failuresAllowed()
                 ) {
                     @Override
                     protected InferenceAction.Request generateRequest(List<String> docFeatures) {

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -1034,3 +1034,145 @@ setup:
   - contains: { profile.shards.0.searches.0.query.0.description: "+RankDocsQuery{rank_docs:[TextSimilarityRankDoc" }
   - contains: { profile.shards.0.searches.0.query.0.description: "inferenceId=my-rerank-model, field=semantic_text_field, chunkScorerConfig=ChunkScorerConfig{size=1, inferenceText=[null], chunkingSettings=" }
 
+---
+"Text similarity rank retriever with a rerank service that sets top_n":
+  - requires:
+      cluster_features: "text_similarity_reranker.comprehensive_top_n_handling"
+      reason: Comprehensive top N parameter handling for the text similarity reranker
+
+  - do:
+      inference.put:
+        task_type: rerank
+        inference_id: my-rerank-model-with-top-n
+        body: >
+          {
+            "service": "test_reranking_service",
+            "service_settings": {
+              "model_id": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+              "top_n": 3
+            }
+          }
+
+  - do:
+      catch: bad_request
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    match_all: {}
+              rank_window_size: 10
+              inference_id: my-rerank-model-with-top-n
+              inference_text: "How often does the moon hide the sun?"
+              field: inference_text_field
+          size: 10
+
+  - match: { error.suppressed.0.caused_by.type: illegal_argument_exception }
+  - match: { error.suppressed.0.caused_by.reason: "Inference endpoint [my-rerank-model-with-top-n] is configured to
+      return the top [3] results, but rank_window_size is [10]. Reduce rank_window_size to be less than or equal to the
+      configured top N value." }
+
+  - do:
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    match_all: { }
+              rank_window_size: 3
+              inference_id: my-rerank-model-with-top-n
+              inference_text: "How often does the moon hide the sun?"
+              field: inference_text_field
+          size: 3
+
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
+
+  - match: { hits.hits.0._id: "doc_3" }
+  - match: { hits.hits.1._id: "doc_2" }
+  - match: { hits.hits.2._id: "doc_1" }
+
+---
+"Text similarity rank retriever with a rerank service that truncates via an unreported top_n":
+  - requires:
+      cluster_features: "text_similarity_reranker.comprehensive_top_n_handling"
+      reason: Comprehensive top N parameter handling for the text similarity reranker
+
+  # This test simulates using a rerank service with a top_n setting that is not reported via TopNProvider
+  - do:
+      inference.put:
+        task_type: rerank
+        inference_id: my-rerank-model-with-unreported-top-n
+        body: >
+          {
+            "service": "test_reranking_service",
+            "service_settings": {
+              "model_id": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+              "top_n": 1,
+              "hide_top_n": true
+            }
+          }
+
+  - do:
+      catch: request
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    match:
+                      text: "moon"
+              rank_window_size: 10
+              inference_id: my-rerank-model-with-unreported-top-n
+              inference_text: "How often does the moon hide the sun?"
+              field: inference_text_field
+          size: 10
+
+  - match: { status: 500 }
+  - match: { error.suppressed.0.caused_by.type: illegal_state_exception }
+  - match: { error.suppressed.0.caused_by.reason: "Expected ranked doc size to be 3, got 1. Is the reranker service
+      using an unreported top N task setting?" }
+
+  - do:
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    match:
+                      text: "moon"
+              rank_window_size: 10
+              inference_id: my-rerank-model-with-unreported-top-n
+              inference_text: "How often does the moon hide the sun?"
+              field: inference_text_field
+              allow_rerank_failures: true
+          size: 10
+
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
+
+  - match: { hits.hits.0._id: "doc_2" }
+  - match: { hits.hits.1._id: "doc_3" }
+  - match: { hits.hits.2._id: "doc_1" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Implement comprehensive top N parameter handling for text similarity reranker (#142039)](https://github.com/elastic/elasticsearch/pull/142039)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)