### PR TITLE
ES|QL: fix NPE with null field parameter

### DIFF
--- a/docs/changelog/142328.yaml
+++ b/docs/changelog/142328.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 142281
+pr: 142328
+summary: Fix NPE with null field parameter
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -1318,7 +1318,10 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
                 )
             );
         }
-        return new UnresolvedAttribute(source(ctx), param.value().toString());
+        if (param.value() == null) {
+            context.params.addParsingError(new ParsingException(source(ctx), "Query parameter [{}] is null", ctx.getText()));
+        }
+        return new UnresolvedAttribute(source(ctx), String.valueOf(param.value()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ParamsParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ParamsParserTests.java
@@ -823,6 +823,22 @@ public class ParamsParserTests extends AbstractStatementParserTests {
         }
     }
 
+    public void testNullDoubleParamsValue() {
+        assumeTrue("double parameters markers for identifiers", EsqlCapabilities.Cap.DOUBLE_PARAMETER_MARKERS_FOR_IDENTIFIERS.isEnabled());
+        String error = "Query parameter [??f1] is null";
+        List<String> commandWithDoubleParams = List.of(
+            "eval x = ??f1",
+            "stats x = count(??f1)",
+            "sort ??f1",
+            "keep ??f1",
+            "drop ??f1",
+            "mv_expand ??f1"
+        );
+        for (String command : commandWithDoubleParams) {
+            expectError("from test | " + command, List.of(paramAsConstant("f1", null)), error);
+        }
+    }
+
     public void testLikeParam() {
         if (EsqlCapabilities.Cap.LIKE_PARAMETER_SUPPORT.isEnabled()) {
             LogicalPlan anonymous = query(


### PR DESCRIPTION
Fixing a NullPointerException while parsing a query with a field parameter (`??` syntax) with null value

Fixes: https://github.com/elastic/elasticsearch/issues/142281