### PR TITLE
Read streams in blob store retries tests

### DIFF
--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -653,7 +653,10 @@ public class AzureBlobContainerRetriesTests extends AbstractBlobContainerRetries
             }
         });
 
-        assertThrows(AlreadyClosedException.class, () -> blobContainer.readBlob(randomRetryingPurpose(), "read_blob_while_store_closes"));
+        assertThrows(
+            AlreadyClosedException.class,
+            () -> Streams.readFully(blobContainer.readBlob(randomRetryingPurpose(), "read_blob_while_store_closes"))
+        );
     }
 
     private BlobContainer createBlobContainer(int maxRetries, String secondaryHost, LocationMode locationMode) {

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -706,7 +706,10 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
             }
         });
 
-        assertThrows(AlreadyClosedException.class, () -> blobContainer.readBlob(randomRetryingPurpose(), "read_blob_while_store_closes"));
+        assertThrows(
+            AlreadyClosedException.class,
+            () -> Streams.readFully(blobContainer.readBlob(randomRetryingPurpose(), "read_blob_while_store_closes"))
+        );
     }
 
     private HttpHandler safeHandler(HttpHandler handler) {


### PR DESCRIPTION
On JDK21 it turns out we need to read from these streams or else we
won't trigger any retries.

Closes #142315
Closes #142318