### PR TITLE
Easier `BlockLoaderTestRunner`

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
@@ -766,45 +766,49 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
     public TsidExtractingIdFieldMapperTests(@Named("testCase") TestCase testCase) {
         this.testCase = testCase;
         this.blockLoaderTestRunner = new BlockLoaderTestRunner(
-            new BlockLoaderTestCase.Params(false, randomFrom(MappedFieldType.FieldExtractPreference.values())),
-            false
+            new BlockLoaderTestCase.Params(false, randomFrom(MappedFieldType.FieldExtractPreference.values()))
         );
     }
 
     public void testExpectedIdWithRoutingPath() throws IOException {
         MapperService mapperService = mapperService(false);
-        ParsedDocument parsed = parse(mapperService, testCase.source);
-        assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
-        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
+        blockLoaderTestRunner.mapperService(mapperService);
+        blockLoaderTestRunner.document(parse(mapperService, testCase.source));
+        assertThat(blockLoaderTestRunner.document().id(), equalTo(testCase.expectedIdWithRoutingPath));
+        verifyIdFromBlockLoader(testCase.expectedIdWithRoutingPath);
     }
 
     public void testExpectedIdWithIndexDimensions() throws IOException {
         MapperService mapperService = mapperService(true);
-        ParsedDocument parsed = parse(mapperService, testCase.source);
-        assertThat(parsed.id(), equalTo(testCase.expectedIdWithIndexDimensions));
-        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithIndexDimensions);
+        blockLoaderTestRunner.mapperService(mapperService);
+        blockLoaderTestRunner.document(parse(mapperService, testCase.source));
+        assertThat(blockLoaderTestRunner.document().id(), equalTo(testCase.expectedIdWithIndexDimensions));
+        verifyIdFromBlockLoader(testCase.expectedIdWithIndexDimensions);
     }
 
     public void testProvideExpectedIdWithRoutingPath() throws IOException {
         MapperService mapperService = mapperService(false);
-        ParsedDocument parsed = parse(testCase.expectedIdWithRoutingPath, mapperService, testCase.source);
-        assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
-        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
+        blockLoaderTestRunner.mapperService(mapperService);
+        blockLoaderTestRunner.document(parse(testCase.expectedIdWithRoutingPath, mapperService, testCase.source));
+        assertThat(blockLoaderTestRunner.document().id(), equalTo(testCase.expectedIdWithRoutingPath));
+        verifyIdFromBlockLoader(testCase.expectedIdWithRoutingPath);
     }
 
     public void testProvideExpectedIdWithIndexDimensions() throws IOException {
         MapperService mapperService = mapperService(true);
-        ParsedDocument parsed = parse(testCase.expectedIdWithIndexDimensions, mapperService, testCase.source);
-        assertThat(parsed.id(), equalTo(testCase.expectedIdWithIndexDimensions));
-        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithIndexDimensions);
+        blockLoaderTestRunner.mapperService(mapperService);
+        blockLoaderTestRunner.document(parse(testCase.expectedIdWithIndexDimensions, mapperService, testCase.source));
+        assertThat(blockLoaderTestRunner.document().id(), equalTo(testCase.expectedIdWithIndexDimensions));
+        verifyIdFromBlockLoader(testCase.expectedIdWithIndexDimensions);
     }
 
     public void testEquivalentSourcesWithRoutingPath() throws IOException {
         MapperService mapperService = mapperService(false);
         for (CheckedConsumer<XContentBuilder, IOException> equivalent : testCase.equivalentSources) {
-            ParsedDocument parsed = parse(mapperService, equivalent);
-            assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
-            verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
+            blockLoaderTestRunner.mapperService(mapperService);
+            blockLoaderTestRunner.document(parse(mapperService, equivalent));
+            assertThat(blockLoaderTestRunner.document().id(), equalTo(testCase.expectedIdWithRoutingPath));
+            verifyIdFromBlockLoader(testCase.expectedIdWithRoutingPath);
         }
     }
 
@@ -991,7 +995,7 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
         );
     }
 
-    private void verifyIdFromBlockLoader(MapperService mapperService, ParsedDocument doc, String expectedId) throws IOException {
-        blockLoaderTestRunner.runTest(mapperService, doc, new BytesRef(expectedId), "_id");
+    private void verifyIdFromBlockLoader(String expectedId) throws IOException {
+        blockLoaderTestRunner.fieldName("_id").run(new BytesRef(expectedId));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
@@ -36,8 +36,8 @@ public class FlattenedFieldRootBlockLoaderTests extends BlockLoaderTestCase {
     }
 
     @Override
-    protected BlockLoaderTestRunner.ResultMatcher getResultMatcher(Settings.Builder settings, Mapping mapping, String fullFieldName) {
-        return (expected, actual) -> {
+    protected BlockLoaderTestRunner configureRunner(BlockLoaderTestRunner runner, Settings.Builder settings, Mapping mapping) {
+        return runner.matcher((expected, actual) -> {
             try {
                 var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
                 var matcher = new FlattenedFieldMatcher(mappingXContent, settings, mappingXContent, settings);
@@ -45,14 +45,14 @@ public class FlattenedFieldRootBlockLoaderTests extends BlockLoaderTestCase {
                 List<Object> expectedList = parseExpected(expected);
                 List<Object> actualList = parseActual(actual);
 
-                var fieldMapping = mapping.lookup().get(fullFieldName);
+                var fieldMapping = mapping.lookup().get(runner.fieldName());
 
                 var result = matcher.match(actualList, expectedList, fieldMapping, fieldMapping);
                 assertTrue(result.getMessage(), result.isMatch());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        };
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
@@ -37,72 +37,135 @@ import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+/**
+ * Test helper for {@link BlockLoader}. Run it like:
+ * <pre>{@code
+ *  BlockLoaderTestRunner runner = new BlockLoaderTestRunner();
+ *  runner.mapperService(createMapperService...);
+ *  runner.fieldName("field").document(Map.of("field", 1));
+ *  runner.run(1);
+ * }</pre>
+ */
 public class BlockLoaderTestRunner {
-    private final BlockLoaderTestCase.Params params;
-    private final boolean allowDummyDocs;
-
     public interface ResultMatcher {
         void match(Object expected, Object actual);
     }
 
-    public BlockLoaderTestRunner(BlockLoaderTestCase.Params params, boolean allowDummyDocs) {
+    private final BlockLoaderTestCase.Params params;
+    private boolean allowDummyDocs;
+    private MapperService mapperService;
+    private String fieldName;
+    private ParsedDocument doc;
+    private Map<String, Object> mapDoc;
+    private ResultMatcher matcher = (expected, actual) -> assertThat(actual, PrettyEqual.prettyEqualTo(expected));
+
+    public BlockLoaderTestRunner(BlockLoaderTestCase.Params params) {
         this.params = params;
-        this.allowDummyDocs = allowDummyDocs;
     }
 
-    public void defaultMatcher(Object expected, Object actual) {
-        assertThat(actual, PrettyEqual.prettyEqualTo(expected));
+    public BlockLoaderTestRunner allowDummyDocs() {
+        this.allowDummyDocs = true;
+        return this;
     }
 
-    public void runTest(MapperService mapperService, Map<String, Object> document, Object expected, String blockLoaderFieldName)
-        throws IOException {
-        runTest(mapperService, document, expected, blockLoaderFieldName, this::defaultMatcher);
+    public BlockLoaderTestRunner mapperService(MapperService mapperService) {
+        this.mapperService = mapperService;
+        return this;
     }
 
-    public void runTest(
-        MapperService mapperService,
-        Map<String, Object> document,
-        Object expected,
-        String blockLoaderFieldName,
-        ResultMatcher matcher
-    ) throws IOException {
-        var documentXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(document);
-        var source = new SourceToParse(
-            "1",
-            BytesReference.bytes(documentXContent),
-            XContentType.JSON,
-            null,
-            Map.of(),
-            Map.of(),
-            true,
-            XContentMeteringParserDecorator.NOOP,
-            null
-        );
-        var parsedDoc = mapperService.documentMapper().parse(source);
-        runTest(mapperService, parsedDoc, expected, blockLoaderFieldName, matcher);
+    public String fieldName() {
+        return fieldName;
     }
 
-    public void runTest(MapperService mapperService, ParsedDocument parsedDoc, Object expected, String blockLoaderFieldName)
-        throws IOException {
-        runTest(mapperService, parsedDoc, expected, blockLoaderFieldName, this::defaultMatcher);
+    public BlockLoaderTestRunner fieldName(String fieldName) {
+        this.fieldName = fieldName;
+        return this;
     }
 
-    public void runTest(
-        MapperService mapperService,
-        ParsedDocument parsedDoc,
-        Object expected,
-        String blockLoaderFieldName,
-        ResultMatcher matcher
-    ) throws IOException {
-        Object blockLoaderResult = setupAndInvokeBlockLoader(mapperService, parsedDoc, blockLoaderFieldName);
-        matcher.match(expected, blockLoaderResult);
+    /**
+     * Configuration a non-standard matcher. The default matcher is usually fine and
+     * you often don't have to call this.
+     */
+    public BlockLoaderTestRunner matcher(ResultMatcher matcher) {
+        this.matcher = matcher;
+        return this;
     }
 
-    private Object setupAndInvokeBlockLoader(MapperService mapperService, ParsedDocument parsedDoc, String fieldName) throws IOException {
+    /**
+     * The document being parsed.
+     */
+    public ParsedDocument document() {
+        if (doc != null) {
+            return doc;
+        }
+        if (mapDoc != null) {
+            if (mapperService == null) {
+                throw new IllegalStateException("need to set mapperService");
+            }
+            try {
+                var documentXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapDoc);
+                var source = new SourceToParse(
+                    "1",
+                    BytesReference.bytes(documentXContent),
+                    XContentType.JSON,
+                    null,
+                    Map.of(),
+                    Map.of(),
+                    true,
+                    XContentMeteringParserDecorator.NOOP,
+                    null
+                );
+                doc = mapperService.documentMapper().parse(source);
+                return doc;
+            } catch (IOException e) {
+                throw new RuntimeException("shouldn't be possible", e);
+            }
+        }
+        throw new IllegalStateException("need to set doc");
+    }
+
+    /**
+     * The document to be parsed as a {@link Map}.
+     */
+    public Map<String, Object> mapDoc() {
+        if (mapDoc == null) {
+            throw new IllegalStateException("need to set doc to a map");
+        }
+        return mapDoc;
+    }
+
+    /**
+     * Set the document to be parsed.
+     */
+    public void document(Map<String, Object> doc) throws IOException {
+        this.mapDoc = doc;
+    }
+
+    /**
+     * Set the document to be parsed.
+     */
+    public void document(ParsedDocument doc) throws IOException {
+        this.doc = doc;
+    }
+
+    /**
+     * Run the test and compare to {@code expected}.
+     */
+    public void run(Object expected) throws IOException {
+        matcher.match(expected, setupAndInvokeBlockLoader());
+    }
+
+    private Object setupAndInvokeBlockLoader() throws IOException {
+        if (mapperService == null) {
+            throw new IllegalStateException("need to set mapperService");
+        }
+        if (fieldName == null) {
+            throw new IllegalStateException("need to set fieldName");
+        }
         try (Directory directory = newDirectory()) {
             RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
 
-            LuceneDocument doc = parsedDoc.rootDoc();
+            LuceneDocument doc = this.document().rootDoc();
 
             /*
              * Add three documents with doc id 0, 1, 2. The real document is 1.
@@ -112,13 +175,13 @@ public class BlockLoaderTestRunner {
             iw.close();
 
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
-                LeafReaderContext context = reader.leaves().get(0);
-                return load(createBlockLoader(mapperService, fieldName), context, mapperService);
+                LeafReaderContext context = reader.leaves().getFirst();
+                return load(createBlockLoader(fieldName), context);
             }
         }
     }
 
-    private Object load(BlockLoader blockLoader, LeafReaderContext context, MapperService mapperService) throws IOException {
+    private Object load(BlockLoader blockLoader, LeafReaderContext context) throws IOException {
         // `columnAtATimeReader` is tried first, we mimic `ValuesSourceReaderOperator`
         var columnAtATimeReader = blockLoader.columnAtATimeReader(context);
         if (columnAtATimeReader != null) {
@@ -174,7 +237,7 @@ public class BlockLoaderTestRunner {
         return block.get(0);
     }
 
-    private BlockLoader createBlockLoader(MapperService mapperService, String fieldName) {
+    private BlockLoader createBlockLoader(String fieldName) {
         return mapperService.fieldType(fieldName).blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapperService) {
             @Override
             public MappedFieldType.FieldExtractPreference fieldExtractPreference() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * Test helper for {@link BlockLoader}. Run it like:
  * <pre>{@code
- *  BlockLoaderTestRunner runner = new BlockLoaderTestRunner();
+ *  BlockLoaderTestRunner runner = new BlockLoaderTestRunner(params);
  *  runner.mapperService(createMapperService...);
  *  runner.fieldName("field").document(Map.of("field", 1));
  *  runner.run(1);
@@ -63,27 +63,42 @@ public class BlockLoaderTestRunner {
         this.params = params;
     }
 
+    /**
+     * Allow dummy documents in test index. This defaults to {@code false} but many callers
+     * are fine with these and call this.
+     */
     public BlockLoaderTestRunner allowDummyDocs() {
         this.allowDummyDocs = true;
         return this;
     }
 
+    /**
+     * Set the {@link MapperService} to use for the test. This must be provided before
+     * calling {@link #run}.
+     */
     public BlockLoaderTestRunner mapperService(MapperService mapperService) {
         this.mapperService = mapperService;
         return this;
     }
 
+    /**
+     * The name of the field to load. The test sends this to {@link MapperService#fieldType}.
+     */
     public String fieldName() {
         return fieldName;
     }
 
+    /**
+     * Set the name of the field to load. The test sends this to {@link MapperService#fieldType}.
+     * This is required before calling {@link #run}
+     */
     public BlockLoaderTestRunner fieldName(String fieldName) {
         this.fieldName = fieldName;
         return this;
     }
 
     /**
-     * Configuration a non-standard matcher. The default matcher is usually fine and
+     * Configuration a non-standard matcher. The default matcher is usually fine, and
      * you often don't have to call this.
      */
     public BlockLoaderTestRunner matcher(ResultMatcher matcher) {
@@ -125,7 +140,8 @@ public class BlockLoaderTestRunner {
     }
 
     /**
-     * The document to be parsed as a {@link Map}.
+     * The document to be parsed as a {@link Map}. This will only work if the document
+     * was set with {@link #document(Map)}.
      */
     public Map<String, Object> mapDoc() {
         if (mapDoc == null) {
@@ -135,14 +151,16 @@ public class BlockLoaderTestRunner {
     }
 
     /**
-     * Set the document to be parsed.
+     * Set the document to be parsed. A method with this name must be called before
+     * calling {@link #run}.
      */
     public void document(Map<String, Object> doc) throws IOException {
         this.mapDoc = doc;
     }
 
     /**
-     * Set the document to be parsed.
+     * Set the document to be parsed. A method with this name must be called before
+     * calling {@link #run}.
      */
     public void document(ParsedDocument doc) throws IOException {
         this.doc = doc;


### PR DESCRIPTION
While working to merge main into #140666 I had a lot of trouble dealing with `BlockLoaderTestRunner` and decided that I'd rewrite it instead. Previously it had run `runTest` methods with different sets of arguments. In #140666 I add another parameter to all four methods. In this PR I swap the whole thing into a builder style. It should be simpler to add that extra parameter in that case.
