### PR TITLE
[9.2] Dynamically grow hash in linear counting in HLL (#142047)

### DIFF
--- a/docs/changelog/142047.yaml
+++ b/docs/changelog/142047.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 41847
+pr: 142047
+summary: Dynamically grow hash in linear counting in HLL
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
@@ -91,5 +91,24 @@ public abstract class AbstractLinearCounting extends AbstractCardinalityAlgorith
          * @return the current value of the counter.
          */
         int value();
+
+        HashesIterator EMPTY = new EmptyIterator();
+    }
+
+    private static class EmptyIterator implements HashesIterator {
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean next() {
+            return false;
+        }
+
+        @Override
+        public int value() {
+            throw new IllegalStateException("empty iterator");
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -44,7 +44,7 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
 
   public static CountDistinctBytesRefAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctBytesRefAggregatorFunction(driverContext, channels, CountDistinctBytesRefAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctBytesRefAggregatorFunction(driverContext, channels, CountDistinctBytesRefAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
 
   public static CountDistinctBytesRefGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, CountDistinctBytesRefAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, CountDistinctBytesRefAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
 
   public static CountDistinctDoubleAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctDoubleAggregatorFunction(driverContext, channels, CountDistinctDoubleAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctDoubleAggregatorFunction(driverContext, channels, CountDistinctDoubleAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
@@ -48,7 +48,7 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
 
   public static CountDistinctDoubleGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctDoubleGroupingAggregatorFunction(channels, CountDistinctDoubleAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctDoubleGroupingAggregatorFunction(channels, CountDistinctDoubleAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctFloatAggregatorFunction implements AggregatorFun
 
   public static CountDistinctFloatAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctFloatAggregatorFunction(driverContext, channels, CountDistinctFloatAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctFloatAggregatorFunction(driverContext, channels, CountDistinctFloatAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatGroupingAggregatorFunction.java
@@ -48,7 +48,7 @@ public final class CountDistinctFloatGroupingAggregatorFunction implements Group
 
   public static CountDistinctFloatGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctFloatGroupingAggregatorFunction(channels, CountDistinctFloatAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctFloatGroupingAggregatorFunction(channels, CountDistinctFloatAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
 
   public static CountDistinctIntAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctIntAggregatorFunction(driverContext, channels, CountDistinctIntAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctIntAggregatorFunction(driverContext, channels, CountDistinctIntAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
@@ -47,7 +47,7 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
 
   public static CountDistinctIntGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctIntGroupingAggregatorFunction(channels, CountDistinctIntAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctIntGroupingAggregatorFunction(channels, CountDistinctIntAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
 
   public static CountDistinctLongAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctLongAggregatorFunction(driverContext, channels, CountDistinctLongAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctLongAggregatorFunction(driverContext, channels, CountDistinctLongAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
@@ -48,7 +48,7 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
 
   public static CountDistinctLongGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctLongGroupingAggregatorFunction(channels, CountDistinctLongAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctLongGroupingAggregatorFunction(channels, CountDistinctLongAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctBytesRefAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, BytesRef v) {
@@ -38,8 +37,8 @@ public class CountDistinctBytesRefAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, BytesRef v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctDoubleAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, double v) {
@@ -38,8 +37,8 @@ public class CountDistinctDoubleAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, double v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctFloatAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, float v) {
@@ -38,8 +37,8 @@ public class CountDistinctFloatAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, float v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctIntAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, int v) {
@@ -38,8 +37,8 @@ public class CountDistinctIntAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, int v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctLongAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, long v) {
@@ -38,8 +37,8 @@ public class CountDistinctLongAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, long v) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.core.Releasables;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HllStatesTests extends ComputeTestCase {
+
+    public void testGroupingStateSerializedMergeRoundTrip() {
+        BlockFactory blockFactory = blockFactory();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+
+        final int precision = 1 << between(4, 14);
+        final boolean sparse = randomBoolean();
+        try (
+            var source = new HllStates.GroupingState(driverContext, precision);
+            var target = new HllStates.GroupingState(driverContext, precision)
+        ) {
+            final int numGroups = sparse ? between(1000, 100_000) : between(1, 100);
+            for (int g = 0; g < numGroups; g++) {
+                int numValues = sparse ? between(1, 64) : between(1, 10_000);
+                for (int v = 0; v < numValues; v++) {
+                    source.collect(g, sparse ? randomIntBetween(1, 1000) : randomIntBetween(1, 100_000));
+                }
+            }
+            Block[] intermediates = new Block[1];
+            try {
+                try (IntVector selected = blockFactory.newIntRangeVector(0, numGroups)) {
+                    source.toIntermediate(intermediates, 0, selected, driverContext);
+                }
+                BytesRef scratch = new BytesRef();
+                BytesRefBlock serializedBlock = (BytesRefBlock) intermediates[0];
+                for (int g = 0; g < numGroups; g++) {
+                    target.merge(g, serializedBlock.getBytesRef(g, scratch), 0);
+                }
+            } finally {
+                Releasables.close(intermediates);
+            }
+
+            for (int g = 0; g < numGroups; g++) {
+                assertThat(target.cardinality(g), equalTo(source.cardinality(g)));
+            }
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
@@ -22,7 +22,7 @@ public class HllStatesTests extends ComputeTestCase {
 
     public void testGroupingStateSerializedMergeRoundTrip() {
         BlockFactory blockFactory = blockFactory();
-        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory);
 
         final int precision = 1 << between(4, 14);
         final boolean sparse = randomBoolean();
@@ -39,7 +39,7 @@ public class HllStatesTests extends ComputeTestCase {
             }
             Block[] intermediates = new Block[1];
             try {
-                try (IntVector selected = blockFactory.newIntRangeVector(0, numGroups)) {
+                try (IntVector selected = IntVector.range(0, numGroups, blockFactory)) {
                     source.toIntermediate(intermediates, 0, selected, driverContext);
                 }
                 BytesRef scratch = new BytesRef();


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Dynamically grow hash in linear counting in HLL (#142047)