### PR TITLE
[8.19] Dynamically grow hash in linear counting in HLL (#142047)

### DIFF
--- a/docs/changelog/142047.yaml
+++ b/docs/changelog/142047.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 41847
+pr: 142047
+summary: Dynamically grow hash in linear counting in HLL
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
@@ -96,5 +96,24 @@ public abstract class AbstractLinearCounting extends AbstractCardinalityAlgorith
          * @return the current value of the counter.
          */
         int value();
+
+        HashesIterator EMPTY = new EmptyIterator();
+    }
+
+    private static class EmptyIterator implements HashesIterator {
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean next() {
+            return false;
+        }
+
+        @Override
+        public int value() {
+            throw new IllegalStateException("empty iterator");
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -10,17 +10,20 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.ByteUtils;
-import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import java.io.IOException;
 
 /**
  * Hyperloglog++ counter, implemented based on pseudo code from
@@ -45,6 +48,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
     public static final int DEFAULT_PRECISION = 14;
 
     private final BitArray algorithm;
+    private final CircuitBreaker breaker;
     private final HyperLogLog hll;
     private final LinearCounting lc;
 
@@ -67,14 +71,29 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
     }
 
     public HyperLogLogPlusPlus(int precision, BigArrays bigArrays, long initialBucketCount) {
+        this(precision, bigArrays, breaker(bigArrays), initialBucketCount);
+    }
+
+    private static CircuitBreaker breaker(BigArrays bigArrays) {
+        final CircuitBreakerService breakerService = bigArrays.breakerService();
+        final CircuitBreaker breaker = breakerService != null ? breakerService.getBreaker(CircuitBreaker.REQUEST) : null;
+        if (breaker != null) {
+            return breaker;
+        } else {
+            return new NoopCircuitBreaker("hll");
+        }
+    }
+
+    public HyperLogLogPlusPlus(int precision, BigArrays bigArrays, CircuitBreaker breaker, long initialBucketCount) {
         super(precision);
+        this.breaker = breaker;
         HyperLogLog hll = null;
         LinearCounting lc = null;
         BitArray algorithm = null;
         boolean success = false;
         try {
             hll = new HyperLogLog(bigArrays, initialBucketCount, precision);
-            lc = new LinearCounting(bigArrays, initialBucketCount, precision, hll);
+            lc = new LinearCounting(bigArrays, breaker, initialBucketCount, precision);
             algorithm = new BitArray(1, bigArrays);
             success = true;
         } finally {
@@ -89,7 +108,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
 
     @Override
     public long maxOrd() {
-        return hll.maxOrd();
+        return Math.max(hll.maxOrd(), lc.maxOrd());
     }
 
     @Override
@@ -118,13 +137,13 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
 
     @Override
     public void collect(long bucket, long hash) {
-        hll.ensureCapacity(bucket + 1);
         if (algorithm.get(bucket) == LINEAR_COUNTING) {
             final int newSize = lc.collect(bucket, hash);
             if (newSize > lc.threshold) {
                 upgradeToHll(bucket);
             }
         } else {
+            hll.ensureCapacity(bucket + 1);
             hll.collect(bucket, hash);
         }
     }
@@ -146,22 +165,55 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         // the values on the buffer
         hll.ensureCapacity(bucketOrd + 1);
         // It's safe to reuse lc's readSpare because we're single threaded.
-        final AbstractLinearCounting.HashesIterator hashes = new LinearCountingIterator(lc, lc.readSpare, bucketOrd);
-        final IntArray values = lc.bigArrays.newIntArray(hashes.size());
+        final AbstractLinearCounting.HashesIterator hashes = lc.values(bucketOrd);
         try {
-            int i = 0;
-            while (hashes.next()) {
-                values.set(i++, hashes.value());
-            }
-            assert i == hashes.size();
+            int size = hashes.size();
             hll.reset(bucketOrd);
-            for (long j = 0; j < values.size(); ++j) {
-                final int encoded = values.get(j);
-                hll.collectEncoded(bucketOrd, encoded);
+            for (int i = 0; i < size; i++) {
+                hashes.next();
+                hll.collectEncoded(bucketOrd, hashes.value());
             }
             algorithm.set(bucketOrd);
         } finally {
-            Releasables.close(values);
+            lc.closeBucket(bucketOrd);
+        }
+    }
+
+    public void combine(long bucket, BytesRef other) throws IOException {
+        ByteArrayStreamInput in = new ByteArrayStreamInput(other.bytes);
+        in.reset(other.bytes, other.offset, other.length);
+        final int precision = in.readVInt();
+        final boolean algorithm = in.readBoolean();
+        if (algorithm == LINEAR_COUNTING && getAlgorithm(bucket) == LINEAR_COUNTING) {
+            final int length = Math.toIntExact(in.readVLong());
+            final long bytesUsed = (long) length * Integer.BYTES;
+            breaker.addEstimateBytesAndMaybeBreak(bytesUsed, "merge linear counting");
+            try {
+                int[] values = new int[length];
+                for (int i = 0; i < length; i++) {
+                    values[i] = in.readInt();
+                }
+                int i = 0;
+                while (i < length) {
+                    // TODO: bulk
+                    int size = lc.addEncoded(bucket, values[i++]);
+                    if (size > lc.threshold) {
+                        upgradeToHll(bucket);
+                        break;
+                    }
+                }
+                while (i < length) {
+                    hll.collectEncoded(bucket, values[i++]);
+                }
+            } finally {
+                breaker.addWithoutBreaking(-bytesUsed);
+            }
+            return;
+        }
+        // fallback
+        in.reset(other.bytes, other.offset, other.length);
+        try (AbstractHyperLogLogPlusPlus otherHll = readFrom(in, hll.bigArrays)) {
+            merge(bucket, otherHll, 0);
         }
     }
 
@@ -269,129 +321,80 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
     }
 
-    private static class LinearCounting extends AbstractLinearCounting implements Releasable {
-
-        protected final int threshold;
+    private static final class LinearCountingCell {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LinearCountingCell.class);
+        private int size;
+        private final int nextGrowSize;
         private final int mask;
-        private final BytesRef readSpare;
-        private final ByteBuffer writeSpare;
-        private final BigArrays bigArrays;
-        // We are actually using HyperLogLog's runLens array but interpreting it as a hash set for linear counting.
-        private final HyperLogLog hll;
-        private final int capacity;
-        // Number of elements stored.
-        private IntArray sizes;
+        private final int[] values;
 
-        LinearCounting(BigArrays bigArrays, long initialBucketCount, int p, HyperLogLog hll) {
-            super(p);
-            this.bigArrays = bigArrays;
-            this.hll = hll;
-            this.capacity = (1 << p) / 4; // because ints take 4 bytes
-            threshold = (int) (capacity * MAX_LOAD_FACTOR);
-            mask = capacity - 1;
-            sizes = bigArrays.newIntArray(initialBucketCount);
-            readSpare = new BytesRef();
-            writeSpare = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        LinearCountingCell(int capacity) {
+            this.mask = capacity - 1;
+            this.values = new int[capacity];
+            this.nextGrowSize = (int) (capacity * MAX_LOAD_FACTOR);
         }
 
-        @Override
-        protected int addEncoded(long bucketOrd, int encoded) {
-            sizes = bigArrays.grow(sizes, bucketOrd + 1);
-            assert encoded != 0;
-            for (int i = (encoded & mask);; i = (i + 1) & mask) {
-                hll.runLens.get(index(bucketOrd, i), 4, readSpare);
-                final int v = ByteUtils.readIntLE(readSpare.bytes, readSpare.offset);
-                if (v == 0) {
-                    // means unused, take it!
-                    set(bucketOrd, i, encoded);
-                    return sizes.increment(bucketOrd, 1);
-                } else if (v == encoded) {
-                    // k is already in the set
-                    return -1;
-                }
-            }
+        static long bytesUsed(int length) {
+            return BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Integer.BYTES * length
+            );
         }
 
-        @Override
-        protected int size(long bucketOrd) {
-            if (bucketOrd >= sizes.size()) {
-                return 0;
-            }
-            final int size = sizes.get(bucketOrd);
-            assert size == recomputedSize(bucketOrd);
-            return size;
-        }
-
-        @Override
-        protected HashesIterator values(long bucketOrd) {
-            // Make a fresh BytesRef for reading scratch work because this method can be called on many threads
-            return new LinearCountingIterator(this, new BytesRef(), bucketOrd);
-        }
-
-        private long index(long bucketOrd, int index) {
-            return (bucketOrd << p) + (index << 2);
-        }
-
-        private void set(long bucketOrd, int index, int value) {
-            writeSpare.putInt(0, value);
-            hll.runLens.set(index(bucketOrd, index), writeSpare.array(), 0, 4);
-        }
-
-        private int recomputedSize(long bucketOrd) {
-            if (bucketOrd >= hll.maxOrd()) {
-                return 0;
-            }
-            int size = 0;
-            BytesRef spare = new BytesRef();
-            for (int i = 0; i <= mask; ++i) {
-                hll.runLens.get(index(bucketOrd, i), 4, spare);
-                final int v = ByteUtils.readIntLE(spare.bytes, spare.offset);
+        void rehashTo(LinearCountingCell newCell) {
+            final int[] newValues = newCell.values;
+            final int newMask = newCell.mask;
+            for (int v : this.values) {
                 if (v != 0) {
-                    ++size;
+                    int pos = v & newMask;
+                    if (newValues[pos] != 0) {
+                        do {
+                            pos = (pos + 1) & newMask;
+                        } while (newValues[pos] != 0);
+                    }
+                    newValues[pos] = v;
                 }
             }
-            return size;
+            newCell.size = this.size;
         }
 
-        @Override
-        public void close() {
-            Releasables.close(sizes);
+        void add(int encoded) {
+            assert encoded != 0;
+            int pos = encoded & mask;
+            while (values[pos] != 0) {
+                if (values[pos] == encoded) {
+                    return;
+                }
+                pos = (pos + 1) & mask;
+            }
+            values[pos] = encoded;
+            ++size;
+        }
+
+        int capacity() {
+            return values.length;
         }
     }
 
     private static class LinearCountingIterator implements AbstractLinearCounting.HashesIterator {
+        private final LinearCountingCell cell;
+        private int index;
 
-        private final LinearCounting lc;
-        private final BytesRef spare;
-        private final long bucketOrd;
-        private final int size;
-        private int pos;
-        private int value;
-
-        LinearCountingIterator(LinearCounting lc, BytesRef spare, long bucketOrd) {
-            this.lc = lc;
-            this.spare = spare;
-            this.bucketOrd = bucketOrd;
-            this.size = lc.size(bucketOrd);
-            this.pos = size == 0 ? lc.capacity : 0;
+        LinearCountingIterator(LinearCountingCell cell) {
+            this.cell = cell;
+            this.index = 0;
         }
 
         @Override
         public int size() {
-            return size;
+            return cell.size;
         }
 
         @Override
         public boolean next() {
-            if (pos < lc.capacity) {
-                for (; pos < lc.capacity; ++pos) {
-                    lc.hll.runLens.get(lc.index(bucketOrd, pos), 4, spare);
-                    int k = ByteUtils.readIntLE(spare.bytes, spare.offset);
-                    if (k != 0) {
-                        ++pos;
-                        value = k;
-                        return true;
-                    }
+            while (index < cell.values.length) {
+                int v = cell.values[index++];
+                if (v != 0) {
+                    return true;
                 }
             }
             return false;
@@ -399,7 +402,102 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
 
         @Override
         public int value() {
-            return value;
+            return cell.values[index - 1];
+        }
+    }
+
+    private static class LinearCounting extends AbstractLinearCounting implements Releasable {
+        private final BigArrays bigArrays;
+        private final CircuitBreaker breaker;
+        private long bytesUsed;
+        private final int threshold;
+        private ObjectArray<LinearCountingCell> cells;
+        private final int initialCellSize;
+
+        LinearCounting(BigArrays bigArrays, CircuitBreaker breaker, long initialBucketCount, int precision) {
+            super(precision);
+            this.bigArrays = bigArrays;
+            this.breaker = breaker;
+            final int capacity = (1 << precision) / 4;
+            this.initialCellSize = Math.min(capacity, 32);
+            this.threshold = (int) (capacity * MAX_LOAD_FACTOR);
+            this.cells = bigArrays.newObjectArray(initialBucketCount);
+        }
+
+        private LinearCountingCell newCell(int capacity) {
+            long bytes = LinearCountingCell.bytesUsed(capacity);
+            breaker.addEstimateBytesAndMaybeBreak(bytes, "linear counting cell");
+            bytesUsed += bytes;
+            return new LinearCountingCell(capacity);
+        }
+
+        private void closeCell(LinearCountingCell cell) {
+            long bytes = LinearCountingCell.bytesUsed(cell.values.length);
+            breaker.addWithoutBreaking(-bytes);
+            bytesUsed -= bytes;
+        }
+
+        @Override
+        protected int addEncoded(long bucketOrd, int encoded) {
+            assert encoded != 0;
+            LinearCountingCell cell;
+            if (bucketOrd >= cells.size()) {
+                cells = bigArrays.grow(cells, bucketOrd + 1);
+                cell = newCell(initialCellSize);
+                cells.set(bucketOrd, cell);
+            } else {
+                cell = cells.get(bucketOrd);
+                if (cell != null) {
+                    if (cell.size > cell.nextGrowSize) {
+                        var newCell = newCell(cell.capacity() << 1);
+                        cell.rehashTo(newCell);
+                        cells.set(bucketOrd, newCell);
+                        closeCell(cell);
+                        cell = newCell;
+                    }
+                } else {
+                    cell = newCell(initialCellSize);
+                    cells.set(bucketOrd, cell);
+                }
+            }
+            cell.add(encoded);
+            return cell.size;
+        }
+
+        @Override
+        protected int size(long bucketOrd) {
+            final var cell = bucketOrd < cells.size() ? cells.get(bucketOrd) : null;
+            return cell != null ? cell.size : 0;
+        }
+
+        @Override
+        protected HashesIterator values(long bucketOrd) {
+            LinearCountingCell cell = bucketOrd < cells.size() ? cells.get(bucketOrd) : null;
+            if (cell == null) {
+                return AbstractLinearCounting.HashesIterator.EMPTY;
+            } else {
+                return new LinearCountingIterator(cell);
+            }
+        }
+
+        private void closeBucket(long bucketOrd) {
+            if (bucketOrd < cells.size()) {
+                LinearCountingCell cell = cells.get(bucketOrd);
+                if (cell != null) {
+                    closeCell(cell);
+                    cells.set(bucketOrd, null);
+                }
+            }
+        }
+
+        long maxOrd() {
+            return cells.size() - 1;
+        }
+
+        @Override
+        public void close() {
+            breaker.addWithoutBreaking(-bytesUsed);
+            Releasables.close(cells);
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -44,7 +44,7 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
 
   public static CountDistinctBytesRefAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctBytesRefAggregatorFunction(driverContext, channels, CountDistinctBytesRefAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctBytesRefAggregatorFunction(driverContext, channels, CountDistinctBytesRefAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
@@ -45,7 +45,7 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
 
   public static CountDistinctBytesRefGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, CountDistinctBytesRefAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, CountDistinctBytesRefAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
 
   public static CountDistinctDoubleAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctDoubleAggregatorFunction(driverContext, channels, CountDistinctDoubleAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctDoubleAggregatorFunction(driverContext, channels, CountDistinctDoubleAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
@@ -47,7 +47,7 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
 
   public static CountDistinctDoubleGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctDoubleGroupingAggregatorFunction(channels, CountDistinctDoubleAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctDoubleGroupingAggregatorFunction(channels, CountDistinctDoubleAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctFloatAggregatorFunction implements AggregatorFun
 
   public static CountDistinctFloatAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctFloatAggregatorFunction(driverContext, channels, CountDistinctFloatAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctFloatAggregatorFunction(driverContext, channels, CountDistinctFloatAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatGroupingAggregatorFunction.java
@@ -47,7 +47,7 @@ public final class CountDistinctFloatGroupingAggregatorFunction implements Group
 
   public static CountDistinctFloatGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctFloatGroupingAggregatorFunction(channels, CountDistinctFloatAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctFloatGroupingAggregatorFunction(channels, CountDistinctFloatAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
 
   public static CountDistinctIntAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctIntAggregatorFunction(driverContext, channels, CountDistinctIntAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctIntAggregatorFunction(driverContext, channels, CountDistinctIntAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
@@ -45,7 +45,7 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
 
   public static CountDistinctIntGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctIntGroupingAggregatorFunction(channels, CountDistinctIntAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctIntGroupingAggregatorFunction(channels, CountDistinctIntAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -46,7 +46,7 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
 
   public static CountDistinctLongAggregatorFunction create(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    return new CountDistinctLongAggregatorFunction(driverContext, channels, CountDistinctLongAggregator.initSingle(driverContext.bigArrays(), precision), precision);
+    return new CountDistinctLongAggregatorFunction(driverContext, channels, CountDistinctLongAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
@@ -47,7 +47,7 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
 
   public static CountDistinctLongGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, int precision) {
-    return new CountDistinctLongGroupingAggregatorFunction(channels, CountDistinctLongAggregator.initGrouping(driverContext.bigArrays(), precision), driverContext, precision);
+    return new CountDistinctLongGroupingAggregatorFunction(channels, CountDistinctLongAggregator.initGrouping(driverContext, precision), driverContext, precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctBytesRefAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, BytesRef v) {
@@ -38,8 +37,8 @@ public class CountDistinctBytesRefAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, BytesRef v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctDoubleAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, double v) {
@@ -38,8 +37,8 @@ public class CountDistinctDoubleAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, double v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctFloatAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, float v) {
@@ -38,8 +37,8 @@ public class CountDistinctFloatAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, float v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctIntAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, int v) {
@@ -38,8 +37,8 @@ public class CountDistinctIntAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, int v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -21,8 +20,8 @@ import org.elasticsearch.compute.operator.DriverContext;
 @GroupingAggregator
 public class CountDistinctLongAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, long v) {
@@ -38,8 +37,8 @@ public class CountDistinctLongAggregator {
         return driverContext.blockFactory().newConstantLongBlockWith(result, 1);
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, long v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
@@ -10,12 +10,8 @@ package org.elasticsearch.compute.aggregation;
 import com.carrotsearch.hppc.BitMixer;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.hash.MurmurHash3;
-import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.io.stream.BytesRefStreamOutput;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -23,54 +19,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.metrics.AbstractHyperLogLogPlusPlus;
 import org.elasticsearch.search.aggregations.metrics.HyperLogLogPlusPlus;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 final class HllStates {
     private HllStates() {}
-
-    static BytesRef serializeHLL(int groupId, HyperLogLogPlusPlus hll) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        OutputStreamStreamOutput out = new OutputStreamStreamOutput(baos);
-        try {
-            hll.writeTo(groupId, out);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return new BytesRef(baos.toByteArray());
-    }
-
-    static AbstractHyperLogLogPlusPlus deserializeHLL(BytesRef bytesRef) {
-        ByteArrayStreamInput in = new ByteArrayStreamInput(bytesRef.bytes);
-        in.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-        try {
-            return HyperLogLogPlusPlus.readFrom(in, BigArrays.NON_RECYCLING_INSTANCE);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Copies the content of the BytesReference to an array of bytes. The byte[] must
-     * have enough space to fit the bytesReference object, otherwise an
-     * {@link ArrayIndexOutOfBoundsException} will be thrown.
-     *
-     * @return number of bytes copied
-     */
-    static int copyToArray(BytesReference bytesReference, byte[] arr, int offset) {
-        int origOffset = offset;
-        final BytesRefIterator iterator = bytesReference.iterator();
-        try {
-            BytesRef slice;
-            while ((slice = iterator.next()) != null) {
-                System.arraycopy(slice.bytes, slice.offset, arr, offset, slice.length);
-                offset += slice.length;
-            }
-            return offset - origOffset;
-        } catch (IOException e) {
-            throw new AssertionError(e);
-        }
-    }
 
     static class SingleState implements AggregatorState {
 
@@ -78,8 +31,13 @@ final class HllStates {
         final HyperLogLogPlusPlus hll;
         private final MurmurHash3.Hash128 hash = new MurmurHash3.Hash128();
 
-        SingleState(BigArrays bigArrays, int precision) {
-            this.hll = new HyperLogLogPlusPlus(HyperLogLogPlusPlus.precisionFromThreshold(precision), bigArrays, 1);
+        SingleState(DriverContext driverContext, int precision) {
+            this.hll = new HyperLogLogPlusPlus(
+                HyperLogLogPlusPlus.precisionFromThreshold(precision),
+                driverContext.bigArrays(),
+                driverContext.breaker(),
+                1
+            );
         }
 
         void collect(long v) {
@@ -107,19 +65,26 @@ final class HllStates {
             return hll.cardinality(SINGLE_BUCKET_ORD);
         }
 
-        void merge(int groupId, AbstractHyperLogLogPlusPlus other, int otherGroup) {
-            hll.merge(groupId, other, otherGroup);
-        }
-
+        // TODO: bulk and reuse buffer
         void merge(int groupId, BytesRef other, int otherGroup) {
-            hll.merge(groupId, deserializeHLL(other), otherGroup);
+            try {
+                hll.combine(groupId, other);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         /** Extracts an intermediate view of the contents of this state.  */
         @Override
         public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             assert blocks.length >= offset + 1;
-            blocks[offset] = driverContext.blockFactory().newConstantBytesRefBlockWith(serializeHLL(SINGLE_BUCKET_ORD, hll), 1);
+            BytesRefStreamOutput out = new BytesRefStreamOutput();
+            try {
+                hll.writeTo(SINGLE_BUCKET_ORD, out);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            blocks[offset] = driverContext.blockFactory().newConstantBytesRefBlockWith(out.get(), 1);
         }
 
         @Override
@@ -134,8 +99,13 @@ final class HllStates {
 
         final HyperLogLogPlusPlus hll;
 
-        GroupingState(BigArrays bigArrays, int precision) {
-            this.hll = new HyperLogLogPlusPlus(HyperLogLogPlusPlus.precisionFromThreshold(precision), bigArrays, 1);
+        GroupingState(DriverContext driverContext, int precision) {
+            this.hll = new HyperLogLogPlusPlus(
+                HyperLogLogPlusPlus.precisionFromThreshold(precision),
+                driverContext.bigArrays(),
+                driverContext.breaker(),
+                1
+            );
         }
 
         @Override
@@ -173,7 +143,11 @@ final class HllStates {
         }
 
         void merge(int groupId, BytesRef other, int otherGroup) {
-            hll.merge(groupId, deserializeHLL(other), otherGroup);
+            try {
+                hll.combine(groupId, other);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         /** Extracts an intermediate view of the contents of this state.  */
@@ -181,11 +155,16 @@ final class HllStates {
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             assert blocks.length >= offset + 1;
             try (var builder = driverContext.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
+                BytesRefStreamOutput out = new BytesRefStreamOutput();
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int group = selected.getInt(i);
-                    builder.appendBytesRef(serializeHLL(group, hll));
+                    hll.writeTo(group, out);
+                    builder.appendBytesRef(out.get());
+                    out.reset();
                 }
                 blocks[offset] = builder.build();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/HllStatesTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.core.Releasables;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HllStatesTests extends ComputeTestCase {
+
+    public void testGroupingStateSerializedMergeRoundTrip() {
+        BlockFactory blockFactory = blockFactory();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory);
+
+        final int precision = 1 << between(4, 14);
+        final boolean sparse = randomBoolean();
+        try (
+            var source = new HllStates.GroupingState(driverContext, precision);
+            var target = new HllStates.GroupingState(driverContext, precision)
+        ) {
+            final int numGroups = sparse ? between(1000, 100_000) : between(1, 100);
+            for (int g = 0; g < numGroups; g++) {
+                int numValues = sparse ? between(1, 64) : between(1, 10_000);
+                for (int v = 0; v < numValues; v++) {
+                    source.collect(g, sparse ? randomIntBetween(1, 1000) : randomIntBetween(1, 100_000));
+                }
+            }
+            Block[] intermediates = new Block[1];
+            try {
+                try (IntVector selected = IntVector.range(0, numGroups, blockFactory)) {
+                    source.toIntermediate(intermediates, 0, selected, driverContext);
+                }
+                BytesRef scratch = new BytesRef();
+                BytesRefBlock serializedBlock = (BytesRefBlock) intermediates[0];
+                for (int g = 0; g < numGroups; g++) {
+                    target.merge(g, serializedBlock.getBytesRef(g, scratch), 0);
+                }
+            } finally {
+                Releasables.close(intermediates);
+            }
+
+            for (int g = 0; g < numGroups; g++) {
+                assertThat(target.cardinality(g), equalTo(source.cardinality(g)));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Dynamically grow hash in linear counting in HLL (#142047)](https://github.com/elastic/elasticsearch/pull/142047)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)