### PR TITLE
Pre-allocate full capacity for first few buckets in HLL

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -410,7 +410,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             this.cells = bigArrays.newObjectArray(initialBucketCount);
         }
 
-        private int initialCellSize(long bucket) {
+        private static int initialCellSize(long bucket, int capacity) {
             // Pre-allocate full capacity for the first few buckets to bypass the cost of multiple rehashes.
             // Optimized for ungrouped aggregations or those with few groups but high cardinality.
             if (bucket < 10) {
@@ -439,7 +439,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             LinearCountingCell cell;
             if (bucketOrd >= cells.size()) {
                 cells = bigArrays.grow(cells, bucketOrd + 1);
-                cell = newCell(initialCellSize(bucketOrd));
+                cell = newCell(initialCellSize(bucketOrd, capacity));
                 cells.set(bucketOrd, cell);
             } else {
                 cell = cells.get(bucketOrd);
@@ -452,7 +452,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
                         cell = newCell;
                     }
                 } else {
-                    cell = newCell(initialCellSize(bucketOrd));
+                    cell = newCell(initialCellSize(bucketOrd, capacity));
                     cells.set(bucketOrd, cell);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -160,22 +160,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
     }
 
     void upgradeToHll(long bucketOrd) {
-        // We need to copy values into an arrays as we will override
-        // the values on the buffer
         hll.ensureCapacity(bucketOrd + 1);
-        // It's safe to reuse lc's readSpare because we're single threaded.
-        final AbstractLinearCounting.HashesIterator hashes = lc.values(bucketOrd);
-        try {
-            int size = hashes.size();
-            hll.reset(bucketOrd);
-            for (int i = 0; i < size; i++) {
-                hashes.next();
-                hll.collectEncoded(bucketOrd, hashes.value());
-            }
-            algorithm.set(bucketOrd);
-        } finally {
-            lc.closeBucket(bucketOrd);
-        }
+        hll.reset(bucketOrd);
+        lc.copyToHll(bucketOrd, hll);
+        algorithm.set(bucketOrd);
     }
 
     public void combine(long bucket, BytesRef other) throws IOException {
@@ -487,14 +475,18 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             }
         }
 
-        private void closeBucket(long bucketOrd) {
-            if (bucketOrd < cells.size()) {
-                LinearCountingCell cell = cells.get(bucketOrd);
-                if (cell != null) {
-                    closeCell(cell);
-                    cells.set(bucketOrd, null);
+        void copyToHll(long bucketOrd, HyperLogLog hll) {
+            final LinearCountingCell cell = bucketOrd < cells.size() ? cells.get(bucketOrd) : null;
+            if (cell == null) {
+                return;
+            }
+            for (int v : cell.values) {
+                if (v != 0) {
+                    hll.collectEncoded(bucketOrd, v);
                 }
             }
+            closeCell(cell);
+            cells.set(bucketOrd, null);
         }
 
         long maxOrd() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -411,16 +411,25 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         private long bytesUsed;
         private final int threshold;
         private ObjectArray<LinearCountingCell> cells;
-        private final int initialCellSize;
+        private final int capacity;
 
         LinearCounting(BigArrays bigArrays, CircuitBreaker breaker, long initialBucketCount, int precision) {
             super(precision);
             this.bigArrays = bigArrays;
             this.breaker = breaker;
-            final int capacity = (1 << precision) / 4;
-            this.initialCellSize = Math.min(capacity, 32);
+            this.capacity = (1 << precision) / 4;
             this.threshold = (int) (capacity * MAX_LOAD_FACTOR);
             this.cells = bigArrays.newObjectArray(initialBucketCount);
+        }
+
+        private int initialCellSize(long bucket) {
+            // Pre-allocate full capacity for the first few buckets to bypass the cost of multiple rehashes.
+            // Optimized for ungrouped aggregations or those with few groups but high cardinality.
+            if (bucket < 10) {
+                return capacity;
+            } else {
+                return Math.min(capacity, 32);
+            }
         }
 
         private LinearCountingCell newCell(int capacity) {
@@ -442,7 +451,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             LinearCountingCell cell;
             if (bucketOrd >= cells.size()) {
                 cells = bigArrays.grow(cells, bucketOrd + 1);
-                cell = newCell(initialCellSize);
+                cell = newCell(initialCellSize(bucketOrd));
                 cells.set(bucketOrd, cell);
             } else {
                 cell = cells.get(bucketOrd);
@@ -455,7 +464,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
                         cell = newCell;
                     }
                 } else {
-                    cell = newCell(initialCellSize);
+                    cell = newCell(initialCellSize(bucketOrd));
                     cells.set(bucketOrd, cell);
                 }
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
@@ -195,10 +195,11 @@ public class HyperLogLogPlusPlusTests extends ESTestCase {
 
     public void testDynamicGrowth() {
         int numGroups = between(1000, 10_000);
-        int numValuesPerGroup = between(1, 20);
+        int numValuesPerGroup = between(1, 14);
         long requiredBytesOneGroup = 32L * 4L + 48L + 8L; // 48 bytes overhead each group + 8L bytes for the object reference in the array
         long requiredBytes = requiredBytesOneGroup * numGroups;
         requiredBytes += 2 * PageCacheRecycler.PAGE_SIZE_IN_BYTES; // extra pages for the object array
+        requiredBytes += 10 * PageCacheRecycler.PAGE_SIZE_IN_BYTES; // full allocations for the first few groups
         CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("test", ByteSizeValue.ofBytes(requiredBytes));
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(requiredBytes));
         int precision = 14;


### PR DESCRIPTION
We have a performance regression with ungrouped count_distinct. The issue is that all groups start with a small size (32 entries), and if the number of distinct values is large, we need to rehash several times to reach 4K. Previously, we did not perform any rehashing. The change allocates full capacity for the first 10 buckets. Perhaps we should gradually reduce the initial capacity for cells after the first 10 - for example, 10-20: half capacity, 20-30: quarter capacity, etc. - but I'd prefer to leave this for the new HLL state in ES|QL.

Relates #142047