### PR TITLE
[9.3] Fix to properly account min_score when having multiple nested retrievers (#142212)

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -57,6 +57,16 @@ The [`from`](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operati
 [Aggregations](/reference/aggregations/index.md) are globally specified as part of a search request. The query used for an aggregation is the combination of all leaf retrievers as `should` clauses in a [boolean query](/reference/query-languages/query-dsl/query-dsl-bool-query.md).
 
 
+### Using `min_score` with compound retrievers [retriever-min-score-compound]
+
+When using `min_score` with compound retrievers (such as [`rrf`](retrievers/rrf-retriever.md) or [`linear`](retrievers/linear-retriever.md)), documents are filtered **after** the compound scoring has been applied. This is important to understand because:
+
+1. **Document collection**: Each child retriever collects documents up to its `rank_window_size` limit.
+2. **Score computation**: The compound retriever computes final scores (e.g., RRF ranking, linear combination with normalization).
+3. **Threshold filtering**: Documents with a final score below `min_score` are excluded from the results.
+
+Because `min_score` is applied after score normalization or RRF computation, the `total_hits` value reflects only the documents that pass the threshold after the compound scoring, not the total number of documents matched by the child retrievers.
+
 ### Restrictions on search parameters when specifying a retriever [retriever-restrictions]
 
 When a retriever is specified as part of a search, the following elements are not allowed at the top-level:

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -313,5 +313,9 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
         return retrieverName;
     }
 
+    protected boolean hasMinScore() {
+        return this.minScore != null;
+    }
+
     // ---- END FOR TESTING ----
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilder;
 import java.util.Set;
 
 import static org.elasticsearch.search.retriever.CompoundRetrieverBuilder.INNER_RETRIEVERS_FILTER_SUPPORT;
+import static org.elasticsearch.search.retriever.RankDocsRetrieverBuilder.NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX;
 import static org.elasticsearch.xpack.rank.linear.L2ScoreNormalizer.LINEAR_RETRIEVER_L2_NORM;
 import static org.elasticsearch.xpack.rank.linear.LinearRetrieverBuilder.LINEAR_RETRIEVER_MINSCORE_FIX;
 import static org.elasticsearch.xpack.rank.linear.MinMaxScoreNormalizer.LINEAR_RETRIEVER_MINMAX_SINGLE_DOC_FIX;
@@ -42,7 +43,8 @@ public class RankRRFFeatures implements FeatureSpecification {
             RRFRetrieverBuilder.SIMPLIFIED_WEIGHTED_SUPPORT,
             LINEAR_RETRIEVER_TOP_LEVEL_NORMALIZER,
             LinearRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT,
-            RRFRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT
+            RRFRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT,
+            NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX
         );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
@@ -1148,3 +1148,48 @@ setup:
   - match: { hits.hits.1._id: "3" }
 
 
+---
+"nested compound retrievers with min_score correctly compute total_hits":
+  - requires:
+      cluster_features: "nested_retriever_min_score_total_hits_fix"
+      reason: "requires fix for correct total_hits computation with nested min_score"
+
+  - do:
+      search:
+        index: test
+        body:
+          retriever:
+            rrf:
+              retrievers:
+                - rrf:
+                    retrievers:
+                      - linear:
+                          retrievers: [
+                            {
+                              retriever: {
+                                standard: {
+                                  query: {
+                                    query_string: {
+                                      query: "term1 OR term2 OR term3",
+                                      default_field: "text"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                          rank_window_size: 100
+                          min_score: 0.5
+                          normalizer: "minmax"
+                    rank_window_size: 100
+              rank_window_size: 100
+          size: 10
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.total.relation: "eq" }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
+
+


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix to properly account min_score when having multiple nested retrievers (#142212)