### PR TITLE
[Inference] Correctly preserve class information for internal endpoints on update

### DIFF
--- a/docs/changelog/142380.yaml
+++ b/docs/changelog/142380.yaml
@@ -1,5 +1,5 @@
 area: Inference
 issues: []
 pr: 142380
-summary: "[Inference] Correctly preserve class information for internal endpoin…"
+summary: "[Inference] Correctly preserve class information for internal endpoints on update"
 type: bug

--- a/docs/changelog/142380.yaml
+++ b/docs/changelog/142380.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 142380
+summary: "[Inference] Correctly preserve class information for internal endpoin…"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
@@ -8,8 +8,11 @@
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.inference.ServiceSettings;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class CustomElandInternalServiceSettings extends ElasticsearchInternalServiceSettings {
 
@@ -26,5 +29,16 @@ public class CustomElandInternalServiceSettings extends ElasticsearchInternalSer
     @Override
     public String getWriteableName() {
         return CustomElandInternalServiceSettings.NAME;
+    }
+
+    @Override
+    public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
+        serviceSettings = new HashMap<>(serviceSettings);
+        ServiceSettings updated = super.updateServiceSettings(serviceSettings);
+        if (updated instanceof ElasticsearchInternalServiceSettings esSettings) {
+            return new CustomElandInternalServiceSettings(esSettings);
+        } else {
+            throw new IllegalStateException("Unexpected service settings type [" + updated.getClass().getName() + "]");
+        }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettings.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -21,6 +22,7 @@ import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -128,6 +130,18 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
         elementType = in.readEnum(DenseVectorFieldMapper.ElementType.class);
     }
 
+    CustomElandInternalTextEmbeddingServiceSettings(
+        ElasticsearchInternalServiceSettings internalServiceSettings,
+        @Nullable Integer dimensions,
+        SimilarityMeasure similarityMeasure,
+        DenseVectorFieldMapper.ElementType elementType
+    ) {
+        super(internalServiceSettings);
+        this.dimensions = dimensions;
+        this.similarityMeasure = Objects.requireNonNull(similarityMeasure);
+        this.elementType = Objects.requireNonNull(elementType);
+    }
+
     private CustomElandInternalTextEmbeddingServiceSettings(CommonFields commonFields) {
         this(commonFields, null);
     }
@@ -216,4 +230,14 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
         return Objects.hash(super.hashCode(), dimensions, similarityMeasure, elementType);
     }
 
+    @Override
+    public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
+        serviceSettings = new HashMap<>(serviceSettings);
+        ServiceSettings updated = super.updateServiceSettings(serviceSettings);
+        if (updated instanceof ElasticsearchInternalServiceSettings esSettings) {
+            return new CustomElandInternalTextEmbeddingServiceSettings(esSettings, dimensions, similarityMeasure, elementType);
+        } else {
+            throw new IllegalStateException("Unexpected service settings type [" + updated.getClass().getName() + "]");
+        }
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
@@ -12,11 +12,13 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -178,6 +180,17 @@ public class ElasticRerankerServiceSettings extends ElasticsearchInternalService
 
         public static LongDocumentStrategy fromString(String name) {
             return valueOf(name.trim().toUpperCase(Locale.ROOT));
+        }
+    }
+
+    @Override
+    public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
+        serviceSettings = new HashMap<>(serviceSettings);
+        ServiceSettings updated = super.updateServiceSettings(serviceSettings);
+        if (updated instanceof ElasticsearchInternalServiceSettings esSettings) {
+            return new ElasticRerankerServiceSettings(esSettings, longDocumentStrategy, maxChunksPerDoc);
+        } else {
+            throw new IllegalStateException("Unexpected service settings type [" + updated.getClass().getName() + "]");
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettings.java
@@ -10,9 +10,12 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.inference.MinimalServiceSettings;
+import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL_LINUX_X86;
@@ -59,5 +62,16 @@ public class ElserInternalServiceSettings extends ElasticsearchInternalServiceSe
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersion.minimumCompatible();
+    }
+
+    @Override
+    public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
+        serviceSettings = new HashMap<>(serviceSettings);
+        ServiceSettings updated = super.updateServiceSettings(serviceSettings);
+        if (updated instanceof ElasticsearchInternalServiceSettings esSettings) {
+            return new ElserInternalServiceSettings(esSettings);
+        } else {
+            throw new IllegalStateException("Unexpected service settings type [" + updated.getClass().getName() + "]");
+        }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
@@ -11,11 +11,13 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.MinimalServiceSettings;
+import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID;
@@ -113,5 +115,16 @@ public class MultilingualE5SmallInternalServiceSettings extends ElasticsearchInt
     @Override
     public DenseVectorFieldMapper.ElementType elementType() {
         return DenseVectorFieldMapper.ElementType.FLOAT;
+    }
+
+    @Override
+    public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
+        serviceSettings = new HashMap<>(serviceSettings);
+        ServiceSettings updated = super.updateServiceSettings(serviceSettings);
+        if (updated instanceof ElasticsearchInternalServiceSettings esSettings) {
+            return new MultilingualE5SmallInternalServiceSettings(esSettings);
+        } else {
+            throw new IllegalStateException("Unexpected service settings type [" + updated.getClass().getName() + "]");
+        }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/AbstractElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/AbstractElasticsearchInternalServiceSettingsTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.elasticsearch;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+abstract class AbstractElasticsearchInternalServiceSettingsTests<T extends ElasticsearchInternalServiceSettings> extends
+    AbstractWireSerializingTestCase<T> {
+
+    protected abstract void assertUpdated(T original, T updated);
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateNumAllocations() {
+        var testInstance = createTestInstance();
+        var expectedNumAllocations = testInstance.getNumAllocations() != null ? testInstance.getNumAllocations() + 1 : 1;
+        var updatedInstance = testInstance.updateServiceSettings(
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, expectedNumAllocations)
+        );
+
+        assertThat("update should create a new instance", updatedInstance, not(equalTo(testInstance)));
+        assertThat(updatedInstance.getClass(), equalTo(testInstance.getClass()));
+        assertThat(updatedInstance, instanceOf(ElasticsearchInternalServiceSettings.class));
+        var updatedElasticSearchInternalServiceSettings = (ElasticsearchInternalServiceSettings) updatedInstance;
+        assertThat(updatedElasticSearchInternalServiceSettings.getNumAllocations(), equalTo(expectedNumAllocations));
+        assertThat(updatedElasticSearchInternalServiceSettings.getAdaptiveAllocationsSettings(), nullValue());
+        assertThat(updatedElasticSearchInternalServiceSettings.getNumThreads(), equalTo(testInstance.getNumThreads()));
+        assertThat(updatedElasticSearchInternalServiceSettings.getDeploymentId(), equalTo(testInstance.getDeploymentId()));
+        assertThat(updatedElasticSearchInternalServiceSettings.modelId(), equalTo(testInstance.modelId()));
+        assertUpdated(testInstance, (T) updatedInstance);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateAdaptiveAllocations() throws IOException {
+        var testInstance = createTestInstance();
+        var expectedAdaptiveAllocations = adaptiveAllocationSettings(testInstance.getAdaptiveAllocationsSettings());
+        var updatedInstance = testInstance.updateServiceSettings(
+            Map.of(ElasticsearchInternalServiceSettings.ADAPTIVE_ALLOCATIONS, toMap(expectedAdaptiveAllocations))
+        );
+
+        assertThat("update should create a new instance", updatedInstance, not(equalTo(testInstance)));
+        assertThat(updatedInstance.getClass(), equalTo(testInstance.getClass()));
+        assertThat(updatedInstance, instanceOf(ElasticsearchInternalServiceSettings.class));
+        var updatedElasticSearchInternalServiceSettings = (ElasticsearchInternalServiceSettings) updatedInstance;
+        assertThat(updatedElasticSearchInternalServiceSettings.getNumAllocations(), nullValue());
+        assertThat(updatedElasticSearchInternalServiceSettings.getAdaptiveAllocationsSettings(), equalTo(expectedAdaptiveAllocations));
+        assertThat(updatedElasticSearchInternalServiceSettings.getNumThreads(), equalTo(testInstance.getNumThreads()));
+        assertThat(updatedElasticSearchInternalServiceSettings.getDeploymentId(), equalTo(testInstance.getDeploymentId()));
+        assertThat(updatedElasticSearchInternalServiceSettings.modelId(), equalTo(testInstance.modelId()));
+        assertUpdated(testInstance, (T) updatedInstance);
+    }
+
+    public void testUpdateNumAllocationsAndAdaptiveAllocations() {
+        var validationException = assertThrows(ValidationException.class, () -> {
+            createTestInstance().updateServiceSettings(
+                Map.ofEntries(
+                    Map.entry(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1),
+                    Map.entry(ElasticsearchInternalServiceSettings.ADAPTIVE_ALLOCATIONS, toMap(adaptiveAllocationSettings(null)))
+                )
+            );
+        });
+        assertThat(
+            validationException.getMessage(),
+            equalTo("Validation Failed: 1: [num_allocations] cannot be set if [adaptive_allocations] is set;")
+        );
+    }
+
+    public void testUpdateWithNoNumAllocationsAndAdaptiveAllocations() {
+        var validationException = assertThrows(ValidationException.class, () -> createTestInstance().updateServiceSettings(Map.of()));
+        assertThat(
+            validationException.getMessage(),
+            equalTo(
+                "Validation Failed: 1: [service_settings] does not contain one of the required settings "
+                    + "[num_allocations, adaptive_allocations];"
+            )
+        );
+    }
+
+    private static AdaptiveAllocationsSettings adaptiveAllocationSettings(AdaptiveAllocationsSettings base) {
+        if (base == null) {
+            base = new AdaptiveAllocationsSettings(true, 0, 1);
+        } else {
+            base = new AdaptiveAllocationsSettings(true, base.getMinNumberOfAllocations() + 1, base.getMaxNumberOfAllocations() + 1);
+        }
+        return base;
+    }
+
+    private static Map<String, ?> toMap(AdaptiveAllocationsSettings adaptiveAllocationsSettings) throws IOException {
+        try (var builder = JsonXContent.contentBuilder()) {
+            adaptiveAllocationsSettings.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            var bytes = Strings.toString(builder).getBytes(StandardCharsets.UTF_8);
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, bytes)) {
+                return parser.map();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/AbstractElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/AbstractElasticsearchInternalServiceSettingsTests.java
@@ -86,13 +86,9 @@ abstract class AbstractElasticsearchInternalServiceSettingsTests<T extends Elast
 
     public void testUpdateWithNoNumAllocationsAndAdaptiveAllocations() {
         var validationException = assertThrows(ValidationException.class, () -> createTestInstance().updateServiceSettings(Map.of()));
-        assertThat(
-            validationException.getMessage(),
-            equalTo(
-                "Validation Failed: 1: [service_settings] does not contain one of the required settings "
-                    + "[num_allocations, adaptive_allocations];"
-            )
-        );
+        assertThat(validationException.getMessage(), equalTo("""
+            Validation Failed: 1: [service_settings] does not contain one of the required settings \
+            [num_allocations, adaptive_allocations];"""));
     }
 
     private static AdaptiveAllocationsSettings adaptiveAllocationSettings(AdaptiveAllocationsSettings base) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettingsTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.elasticsearch;
+
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+public class CustomElandInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<
+    CustomElandInternalServiceSettings> {
+
+    public static CustomElandInternalServiceSettings createRandom() {
+        return new CustomElandInternalServiceSettings(ElasticsearchInternalServiceSettingsTests.validInstance(randomAlphaOfLength(10)));
+    }
+
+    @Override
+    protected Writeable.Reader<CustomElandInternalServiceSettings> instanceReader() {
+        return CustomElandInternalServiceSettings::new;
+    }
+
+    @Override
+    protected CustomElandInternalServiceSettings createTestInstance() {
+        return createRandom();
+    }
+
+    @Override
+    protected CustomElandInternalServiceSettings mutateInstance(CustomElandInternalServiceSettings instance) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected void assertUpdated(CustomElandInternalServiceSettings original, CustomElandInternalServiceSettings updated) {
+        // Nothing to do as there are no additional properties
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettingsTests.java
@@ -30,7 +30,7 @@ public class CustomElandInternalServiceSettingsTests extends AbstractElasticsear
 
     @Override
     protected CustomElandInternalServiceSettings mutateInstance(CustomElandInternalServiceSettings instance) throws IOException {
-        return null;
+        return new CustomElandInternalServiceSettings(ElasticsearchInternalServiceSettingsTests.doMutateInstance(instance));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.ELEMENT_TYPE;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class CustomElandInternalTextEmbeddingServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<
@@ -281,6 +282,8 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         CustomElandInternalTextEmbeddingServiceSettings original,
         CustomElandInternalTextEmbeddingServiceSettings updated
     ) {
-        // Nothing to do as there are no additional properties
+        assertThat(updated.dimensions(), equalTo(original.dimensions()));
+        assertThat(updated.similarity(), equalTo(original.similarity()));
+        assertThat(updated.elementType(), equalTo(original.elementType()));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.SimilarityMeasure;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -31,7 +30,7 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
 import static org.hamcrest.Matchers.is;
 
-public class CustomElandInternalTextEmbeddingServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class CustomElandInternalTextEmbeddingServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<
     CustomElandInternalTextEmbeddingServiceSettings> {
 
     public static CustomElandInternalTextEmbeddingServiceSettings createRandom() {
@@ -275,5 +274,13 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
             similarity,
             elementType
         );
+    }
+
+    @Override
+    protected void assertUpdated(
+        CustomElandInternalTextEmbeddingServiceSettings original,
+        CustomElandInternalTextEmbeddingServiceSettings updated
+    ) {
+        // Nothing to do as there are no additional properties
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettingsTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 import org.junit.Assert;
 
@@ -24,8 +23,9 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
+import static org.hamcrest.Matchers.equalTo;
 
-public class ElasticRerankerServiceSettingsTests extends AbstractWireSerializingTestCase<ElasticRerankerServiceSettings> {
+public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<ElasticRerankerServiceSettings> {
     public static ElasticRerankerServiceSettings createRandomWithoutChunkingConfiguration(String modelId) {
         return createRandom(null, null, modelId);
     }
@@ -321,5 +321,11 @@ public class ElasticRerankerServiceSettingsTests extends AbstractWireSerializing
     @Override
     protected ElasticRerankerServiceSettings mutateInstance(ElasticRerankerServiceSettings instance) throws IOException {
         return randomValueOtherThan(instance, ElasticRerankerServiceSettingsTests::createRandom);
+    }
+
+    @Override
+    protected void assertUpdated(ElasticRerankerServiceSettings original, ElasticRerankerServiceSettings updated) {
+        assertThat(updated.getLongDocumentStrategy(), equalTo(original.getLongDocumentStrategy()));
+        assertThat(updated.getMaxChunksPerDoc(), equalTo(original.getMaxChunksPerDoc()));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
@@ -49,6 +49,10 @@ public class ElasticsearchInternalServiceSettingsTests extends AbstractElasticse
 
     @Override
     protected ElasticsearchInternalServiceSettings mutateInstance(ElasticsearchInternalServiceSettings instance) throws IOException {
+        return doMutateInstance(instance);
+    }
+
+    public static ElasticsearchInternalServiceSettings doMutateInstance(ElasticsearchInternalServiceSettings instance) {
         return switch (randomIntBetween(0, 2)) {
             case 0 -> new ElserInternalServiceSettings(
                 new ElasticsearchInternalServiceSettings(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
@@ -7,27 +7,18 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 
-public class ElasticsearchInternalServiceSettingsTests extends AbstractWireSerializingTestCase<ElasticsearchInternalServiceSettings> {
+public class ElasticsearchInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<
+    ElasticsearchInternalServiceSettings> {
 
     public static ElasticsearchInternalServiceSettings validInstance(String modelId) {
         boolean useAdaptive = randomBoolean();
@@ -148,83 +139,8 @@ public class ElasticsearchInternalServiceSettingsTests extends AbstractWireSeria
         assertThat(e.getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
     }
 
-    public void testUpdateNumAllocations() {
-        var testInstance = createTestInstance();
-        var expectedNumAllocations = testInstance.getNumAllocations() != null ? testInstance.getNumAllocations() + 1 : 1;
-        var updatedInstance = testInstance.updateServiceSettings(
-            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, expectedNumAllocations)
-        );
-
-        assertThat("update should create a new instance", updatedInstance, not(equalTo(testInstance)));
-        assertThat(updatedInstance, instanceOf(ElasticsearchInternalServiceSettings.class));
-        var updatedElasticSearchInternalServiceSettings = (ElasticsearchInternalServiceSettings) updatedInstance;
-        assertThat(updatedElasticSearchInternalServiceSettings.getNumAllocations(), equalTo(expectedNumAllocations));
-        assertThat(updatedElasticSearchInternalServiceSettings.getAdaptiveAllocationsSettings(), nullValue());
-        assertThat(updatedElasticSearchInternalServiceSettings.getNumThreads(), equalTo(testInstance.getNumThreads()));
-        assertThat(updatedElasticSearchInternalServiceSettings.getDeploymentId(), equalTo(testInstance.getDeploymentId()));
-        assertThat(updatedElasticSearchInternalServiceSettings.modelId(), equalTo(testInstance.modelId()));
-
-    }
-
-    public void testUpdateAdaptiveAllocations() throws IOException {
-        var testInstance = createTestInstance();
-        var expectedAdaptiveAllocations = adaptiveAllocationSettings(testInstance.getAdaptiveAllocationsSettings());
-        var updatedInstance = testInstance.updateServiceSettings(
-            Map.of(ElasticsearchInternalServiceSettings.ADAPTIVE_ALLOCATIONS, toMap(expectedAdaptiveAllocations))
-        );
-
-        assertThat("update should create a new instance", updatedInstance, not(equalTo(testInstance)));
-        assertThat(updatedInstance, instanceOf(ElasticsearchInternalServiceSettings.class));
-        var updatedElasticSearchInternalServiceSettings = (ElasticsearchInternalServiceSettings) updatedInstance;
-        assertThat(updatedElasticSearchInternalServiceSettings.getNumAllocations(), nullValue());
-        assertThat(updatedElasticSearchInternalServiceSettings.getAdaptiveAllocationsSettings(), equalTo(expectedAdaptiveAllocations));
-        assertThat(updatedElasticSearchInternalServiceSettings.getNumThreads(), equalTo(testInstance.getNumThreads()));
-        assertThat(updatedElasticSearchInternalServiceSettings.getDeploymentId(), equalTo(testInstance.getDeploymentId()));
-        assertThat(updatedElasticSearchInternalServiceSettings.modelId(), equalTo(testInstance.modelId()));
-    }
-
-    private static AdaptiveAllocationsSettings adaptiveAllocationSettings(AdaptiveAllocationsSettings base) {
-        if (base == null) {
-            base = new AdaptiveAllocationsSettings(true, 0, 1);
-        } else {
-            base = new AdaptiveAllocationsSettings(true, base.getMinNumberOfAllocations() + 1, base.getMaxNumberOfAllocations() + 1);
-        }
-        return base;
-    }
-
-    private static Map<String, ?> toMap(AdaptiveAllocationsSettings adaptiveAllocationsSettings) throws IOException {
-        try (var builder = JsonXContent.contentBuilder()) {
-            adaptiveAllocationsSettings.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            var bytes = Strings.toString(builder).getBytes(StandardCharsets.UTF_8);
-            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, bytes)) {
-                return parser.map();
-            }
-        }
-    }
-
-    public void testUpdateNumAllocationsAndAdaptiveAllocations() {
-        var validationException = assertThrows(ValidationException.class, () -> {
-            createTestInstance().updateServiceSettings(
-                Map.ofEntries(
-                    Map.entry(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1),
-                    Map.entry(ElasticsearchInternalServiceSettings.ADAPTIVE_ALLOCATIONS, toMap(adaptiveAllocationSettings(null)))
-                )
-            );
-        });
-        assertThat(
-            validationException.getMessage(),
-            equalTo("Validation Failed: 1: [num_allocations] cannot be set if [adaptive_allocations] is set;")
-        );
-    }
-
-    public void testUpdateWithNoNumAllocationsAndAdaptiveAllocations() {
-        var validationException = assertThrows(ValidationException.class, () -> createTestInstance().updateServiceSettings(Map.of()));
-        assertThat(
-            validationException.getMessage(),
-            equalTo(
-                "Validation Failed: 1: [service_settings] does not contain one of the required settings "
-                    + "[num_allocations, adaptive_allocations];"
-            )
-        );
+    @Override
+    protected void assertUpdated(ElasticsearchInternalServiceSettings original, ElasticsearchInternalServiceSettings updated) {
+        // Nothing to do as there are no additional properties
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
@@ -8,13 +8,12 @@
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.HashSet;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModelsTests.randomElserModel;
 
-public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTestCase<ElserInternalServiceSettings> {
+public class ElserInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<ElserInternalServiceSettings> {
 
     public static ElserInternalServiceSettings createRandom() {
         return new ElserInternalServiceSettings(ElasticsearchInternalServiceSettingsTests.validInstance(randomElserModel()));
@@ -66,5 +65,10 @@ public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTe
             }
             default -> throw new IllegalStateException();
         };
+    }
+
+    @Override
+    protected void assertUpdated(ElserInternalServiceSettings original, ElserInternalServiceSettings updated) {
+        // Nothing to do as there are no additional properties
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,7 +16,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 
-public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<
     MultilingualE5SmallInternalServiceSettings> {
 
     public static MultilingualE5SmallInternalServiceSettings createRandom() {
@@ -125,4 +124,8 @@ public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractWir
         };
     }
 
+    @Override
+    protected void assertUpdated(MultilingualE5SmallInternalServiceSettings original, MultilingualE5SmallInternalServiceSettings updated) {
+        // Nothing to do as there are no additional properties
+    }
 }


### PR DESCRIPTION
This addresses a bug introduced in #140003 which causes service settings for elasticsearch internal inference endpoints to lose their subclass information and remain only as the `ElasticsearchInternalServiceSettings` parent class.
