### PR TITLE
Provide a way to access the underlying MemorySegmentAccessInput

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/MemorySegmentAccessInputAccess.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/MemorySegmentAccessInputAccess.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MemorySegmentAccessInput;
+
+public interface MemorySegmentAccessInputAccess {
+    MemorySegmentAccessInput get();
+
+    static IndexInput unwrap(IndexInput input) {
+        return input instanceof MemorySegmentAccessInputAccess msaia ? (IndexInput) msaia.get() : input;
+    }
+}

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
@@ -42,6 +42,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         FloatVectorValues values
     ) {
         input = FilterIndexInput.unwrapOnlyTest(input);
+        input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
             checkInvariants(values.size(), values.dimension(), input);
             return switch (similarityType) {
@@ -66,6 +67,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         float scoreCorrectionConstant
     ) {
         input = FilterIndexInput.unwrapOnlyTest(input);
+        input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
             checkInvariants(values.size(), values.dimension(), input);
             return switch (similarityType) {

--- a/libs/simdvec/src/main22/java/org/elasticsearch/simdvec/internal/FloatVectorScorer.java
+++ b/libs/simdvec/src/main22/java/org/elasticsearch/simdvec/internal/FloatVectorScorer.java
@@ -17,6 +17,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -42,6 +43,7 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
             return Optional.empty();
         }
         input = FilterIndexInput.unwrapOnlyTest(input);
+        input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
             checkInvariants(values.size(), values.dimension(), input);
 

--- a/libs/simdvec/src/main22/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorer.java
+++ b/libs/simdvec/src/main22/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorer.java
@@ -18,6 +18,7 @@ import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
+import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -45,6 +46,7 @@ public abstract sealed class Int7SQVectorScorer extends RandomVectorScorer.Abstr
             return Optional.empty();
         }
         input = FilterIndexInput.unwrapOnlyTest(input);
+        input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput == false) {
             return Optional.empty();
         }

--- a/server/src/main/java/org/elasticsearch/index/store/StoreMetricsIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreMetricsIndexInput.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.store;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.store.RandomAccessInput;
 
 import java.io.IOException;
@@ -25,6 +26,9 @@ public class StoreMetricsIndexInput extends FilterIndexInput {
     public static IndexInput create(String resourceDescription, IndexInput in, PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder) {
         if (in instanceof StoreMetricsIndexInput) {
             // annoyingly, source-only snapshots do this for linked files.
+            return in;
+        } else if (in instanceof MemorySegmentAccessInput) {
+            // currently, we can't delegate a method that returns MemorySegment as that is a preview API in JDK21
             return in;
         } else if (in instanceof RandomAccessInput) {
             return new RandomAccessIndexInput(resourceDescription, in, metricHolder);

--- a/server/src/main/java/org/elasticsearch/index/store/StoreMetricsIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreMetricsIndexInput.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 
 import java.io.IOException;
 import java.util.Map;
@@ -26,9 +27,6 @@ public class StoreMetricsIndexInput extends FilterIndexInput {
     public static IndexInput create(String resourceDescription, IndexInput in, PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder) {
         if (in instanceof StoreMetricsIndexInput) {
             // annoyingly, source-only snapshots do this for linked files.
-            return in;
-        } else if (in instanceof MemorySegmentAccessInput) {
-            // currently, we can't delegate a method that returns MemorySegment as that is a preview API in JDK21
             return in;
         } else if (in instanceof RandomAccessInput) {
             return new RandomAccessIndexInput(resourceDescription, in, metricHolder);
@@ -220,7 +218,10 @@ public class StoreMetricsIndexInput extends FilterIndexInput {
         return result;
     }
 
-    private static class RandomAccessIndexInput extends StoreMetricsIndexInput implements RandomAccessInput {
+    private static class RandomAccessIndexInput extends StoreMetricsIndexInput
+        implements
+            RandomAccessInput,
+            MemorySegmentAccessInputAccess {
         private final RandomAccessInput delegate;
 
         private RandomAccessIndexInput(
@@ -231,6 +232,11 @@ public class StoreMetricsIndexInput extends FilterIndexInput {
             super(resourceDescription, in, metricHolder);
             assert in instanceof RandomAccessInput;
             this.delegate = (RandomAccessInput) in;
+        }
+
+        @Override
+        public MemorySegmentAccessInput get() {
+            return delegate instanceof MemorySegmentAccessInput ms ? ms : null;
         }
 
         @Override


### PR DESCRIPTION
The IndexInput needs to allow access to the underlying `MemorySegmentAccessInput` so that native vector scorers can be used, without actually referencing `MemorySegment`

Fixes #142376