### PR TITLE
ES|QL: fix NPE with null field parameter (#142328)

### DIFF
--- a/docs/changelog/142328.yaml
+++ b/docs/changelog/142328.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 142281
+pr: 142328
+summary: Fix NPE with null field parameter
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -1163,7 +1163,10 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
                 )
             );
         }
-        return new UnresolvedAttribute(source(ctx), param.value().toString());
+        if (param.value() == null) {
+            context.params.addParsingError(new ParsingException(source(ctx), "Query parameter [{}] is null", ctx.getText()));
+        }
+        return new UnresolvedAttribute(source(ctx), String.valueOf(param.value()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -5114,7 +5114,6 @@ public class StatementParserTests extends AbstractStatementParserTests {
         }
     }
 
-
     public void testNullDoubleParamsValue() {
         assumeTrue("double parameters markers for identifiers", EsqlCapabilities.Cap.DOUBLE_PARAMETER_MARKERS_FOR_IDENTIFIERS.isEnabled());
         String error = "Query parameter [??f1] is null";
@@ -5130,7 +5129,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
             expectError("from test | " + command, List.of(paramAsConstant("f1", null)), error);
         }
     }
-    
+
     public void testUnclosedParenthesis() {
         String[] queries = {
             "row a = )",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -5114,6 +5114,23 @@ public class StatementParserTests extends AbstractStatementParserTests {
         }
     }
 
+
+    public void testNullDoubleParamsValue() {
+        assumeTrue("double parameters markers for identifiers", EsqlCapabilities.Cap.DOUBLE_PARAMETER_MARKERS_FOR_IDENTIFIERS.isEnabled());
+        String error = "Query parameter [??f1] is null";
+        List<String> commandWithDoubleParams = List.of(
+            "eval x = ??f1",
+            "stats x = count(??f1)",
+            "sort ??f1",
+            "keep ??f1",
+            "drop ??f1",
+            "mv_expand ??f1"
+        );
+        for (String command : commandWithDoubleParams) {
+            expectError("from test | " + command, List.of(paramAsConstant("f1", null)), error);
+        }
+    }
+    
     public void testUnclosedParenthesis() {
         String[] queries = {
             "row a = )",


### PR DESCRIPTION
Manual backport of #142328