### PR TITLE
Document GC effects of `*Once` wrappers

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -155,6 +155,9 @@ public enum Releasables {
 
     /**
      * Wraps a {@link Releasable} such that its {@link Releasable#close()} method can be called multiple times without double-releasing.
+     * <p>
+     * Crucially, this drops the reference to the provided resource as soon as it is complete, allowing it and its dependencies to be GCd
+     * even thought the small {@code releaseOnce()} wrapper might remain reachable in a collection of pending-release resources somewhere.
      */
     public static Releasable releaseOnce(final Releasable releasable) {
         return new ReleaseOnce(releasable);

--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -157,7 +157,7 @@ public enum Releasables {
      * Wraps a {@link Releasable} such that its {@link Releasable#close()} method can be called multiple times without double-releasing.
      * <p>
      * Crucially, this drops the reference to the provided resource as soon as it is complete, allowing it and its dependencies to be GCd
-     * even thought the small {@code releaseOnce()} wrapper might remain reachable in a collection of pending-release resources somewhere.
+     * even though the small {@code releaseOnce()} wrapper might remain reachable in a collection of pending-release resources somewhere.
      */
     public static Releasable releaseOnce(final Releasable releasable) {
         return new ReleaseOnce(releasable);

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -351,7 +351,7 @@ public interface ActionListener<Response> {
      * the provided listener will be called at most once.
      * <p>
      * Crucially, this drops the reference to the provided listener as soon as it is complete, allowing it and its dependencies to be GCd
-     * even thought the small {@code notifyOnce()} wrapper might remain reachable in a collection of pending listeners somewhere.
+     * even though the small {@code notifyOnce()} wrapper might remain reachable in a collection of pending listeners somewhere.
      */
     static <Response> ActionListener<Response> notifyOnce(ActionListener<Response> delegate) {
         return new ActionListenerImplementations.NotifyOnceActionListener<>(delegate);

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -347,8 +347,11 @@ public interface ActionListener<Response> {
     }
 
     /**
-     * Wraps a given listener and returns a new listener which makes sure {@link #onResponse(Object)}
-     * and {@link #onFailure(Exception)} of the provided listener will be called at most once.
+     * Wraps a given listener and returns a new listener which makes sure {@link #onResponse(Object)} and {@link #onFailure(Exception)} of
+     * the provided listener will be called at most once.
+     * <p>
+     * Crucially, this drops the reference to the provided listener as soon as it is complete, allowing it and its dependencies to be GCd
+     * even thought the small {@code notifyOnce()} wrapper might remain reachable in a collection of pending listeners somewhere.
      */
     static <Response> ActionListener<Response> notifyOnce(ActionListener<Response> delegate) {
         return new ActionListenerImplementations.NotifyOnceActionListener<>(delegate);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
@@ -14,6 +14,9 @@ import java.util.Objects;
 
 /**
  * Runnable that prevents running its delegate more than once.
+ * <p>
+ * Crucially, this drops the reference to the provided delegate as soon as it executes, allowing it and its dependencies to be GCd even
+ * thought the small {@code RunOnce} wrapper might remain reachable in a collection of pending-execution callbacks somewhere.
  */
 public class RunOnce implements Runnable {
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  * Runnable that prevents running its delegate more than once.
  * <p>
  * Crucially, this drops the reference to the provided delegate as soon as it executes, allowing it and its dependencies to be GCd even
- * thought the small {@code RunOnce} wrapper might remain reachable in a collection of pending-execution callbacks somewhere.
+ * though the small {@code RunOnce} wrapper might remain reachable in a collection of pending-execution callbacks somewhere.
  */
 public class RunOnce implements Runnable {
 


### PR DESCRIPTION
It's certainly useful that these wrapper utilities only call the wrapped
thing once, but it's also important to know that these things allow the
wrapped thing to become eligible for GC even while something else might
retain a reference to the wrapper.