### PR TITLE
[8.19] Backporting fix to properly account min_score when having multiple nested retrievers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,303 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Elasticsearch is a distributed search and analytics engine built with Gradle on Java. The codebase consists of a minimal core with functionality delivered through a plugin/module architecture, separating open-source (OSS) and commercial (X-Pack) features under different licenses.
+
+## Build Commands
+
+### Building
+
+```bash
+# Build a distribution for your local OS
+./gradlew localDistro
+
+# Build platform-specific distributions
+./gradlew :distribution:archives:linux-tar:assemble
+./gradlew :distribution:archives:darwin-tar:assemble
+./gradlew :distribution:archives:darwin-aarch64-tar:assemble
+./gradlew :distribution:archives:windows-zip:assemble
+
+# Build Docker images
+./gradlew buildDockerImage
+./gradlew buildAarch64DockerImage
+```
+
+### Running
+
+```bash
+# Run Elasticsearch from source
+./gradlew run
+
+# Run with remote debugging (port 5005)
+./gradlew run --debug-jvm
+
+# Debug the CLI launcher (port 5107+)
+./gradlew run --debug-cli-jvm
+
+# Run with different distribution (default is full, not OSS)
+./gradlew run -Drun.distribution=oss
+```
+
+### Testing
+
+```bash
+# Run all tests for a specific project
+./gradlew :server:test
+
+# Run a single test class
+./gradlew :server:test --tests org.elasticsearch.cluster.SnapshotsInProgressTests
+
+# Run a single test method
+./gradlew :server:test --tests "org.elasticsearch.cluster.SnapshotsInProgressTests.testClone"
+
+# Run with specific seed for reproducibility
+./gradlew :server:test --tests "..." -Dtests.seed=<seed>
+
+# Run integration tests
+./gradlew :server:internalClusterTest
+
+# Run REST API tests
+./gradlew :rest-api-spec:yamlRestTest
+
+# Run all precommit checks (formatting, license headers, etc.)
+./gradlew precommit
+
+# Check for forbidden API usage
+./gradlew forbiddenApis
+
+# Run spotless to format code
+./gradlew spotlessApply
+```
+
+### Dependency Management
+
+```bash
+# Update dependency verification metadata after adding/updating dependencies
+./gradlew --write-verification-metadata sha256 precommit
+
+# Resolve all dependencies (useful for verification)
+./gradlew resolveAllDependencies
+```
+
+## Architecture Overview
+
+### Directory Structure
+
+- **server/** - Core Elasticsearch engine with minimal functionality
+  - Primary packages: `action`, `cluster`, `discovery`, `index`, `search`, `ingest`, `gateway`, `transport`, `http`
+  - Contains base `Plugin` class and core Module classes for dependency injection
+  - Source structure: `src/main/java`, `src/test/java`, `src/internalClusterTest/java`, `src/javaRestTest/java`
+
+- **modules/** - Built-in modules (32+) that ship with all distributions
+  - Examples: `ingest-common`, `reindex`, `lang-painless`, `repository-s3`, `analysis-common`
+  - Always loaded; cannot be disabled
+  - Cannot contain bin/ directories or packaging files
+
+- **plugins/** - Optional plugins (18+) that can be installed separately
+  - Examples: `analysis-icu`, `discovery-ec2`, `repository-hdfs`
+  - Include example plugins for developers
+
+- **x-pack/** - Commercial features under Elastic License
+  - 68+ plugins in `x-pack/plugin/` (security, ml, sql, monitoring, watcher, etc.)
+  - Core x-pack utilities in `x-pack/plugin/core/`
+  - Separate licensing and test infrastructure in `x-pack/qa/`
+
+- **libs/** - Shared libraries (28+) used across the codebase
+  - `core`, `x-content`, `geo`, `grok`, `plugin-api`, `plugin-analysis-api`, etc.
+  - Published to Maven with "elasticsearch-" prefix
+
+- **build-tools/** - Three-tier build system
+  - `build-conventions/` - Checkstyle and basic conventions
+  - `build-tools/` - Public build plugins for third-party plugin authors
+  - `build-tools-internal/` - Internal Elasticsearch build logic
+
+- **distribution/** - Packaging and distributions
+  - `archives/` - TAR/ZIP for Linux, macOS, Windows, ARM64
+  - `docker/` - Docker image variants (standard, Cloud ESS, Ironbank, Wolfi)
+  - `packages/` - DEB and RPM packages
+  - `bwc/` - Backward compatibility testing infrastructure
+
+- **test/** - Shared test infrastructure
+  - `framework/` - Core test utilities, base test classes
+  - `fixtures/` - Test fixtures for external services (AWS, Azure, GCS)
+
+- **qa/** - Cross-cutting integration tests (34+ suites)
+  - Upgrade tests: `rolling-upgrade`, `full-cluster-restart`, `mixed-cluster`
+  - Smoke tests, cross-cluster search tests, packaging tests
+
+### Plugin System Architecture
+
+The plugin system is the primary extensibility mechanism:
+
+1. **Base Plugin Class** - All plugins extend `org.elasticsearch.plugins.Plugin`
+
+2. **Specialized Plugin Interfaces** - Plugins implement one or more:
+   - `ActionPlugin` - Add custom REST/transport actions
+   - `AnalysisPlugin` - Add analyzers, tokenizers, filters
+   - `ClusterPlugin` - Add cluster-level functionality
+   - `DiscoveryPlugin` - Add node discovery mechanisms
+   - `EnginePlugin` - Customize indexing/search engine behavior
+   - `IndexStorePlugin` - Customize index storage
+   - `IngestPlugin` - Add ingest processors
+   - `MapperPlugin` - Add custom field mappers
+   - `NetworkPlugin` - Customize network layer
+   - `RepositoryPlugin` - Add snapshot repository types
+   - `ScriptPlugin` - Add scripting languages
+   - `SearchPlugin` - Add aggregations, queries, scoring functions
+
+3. **Module vs Plugin vs X-Pack Plugin**:
+   - **Modules**: Built-in, always loaded, minimal structure, in `modules/`
+   - **Plugins**: Optional, installable, can have bin/ files, in `plugins/`
+   - **X-Pack Plugins**: Commercial, Elastic License, in `x-pack/plugin/`
+
+4. **Gradle Plugin Declaration** - Use `esplugin` DSL block:
+   ```gradle
+   esplugin {
+     name 'plugin-name'
+     description 'Plugin description'
+     classname 'org.elasticsearch.plugin.PluginClass'
+   }
+   ```
+
+### Dependency Injection Pattern
+
+Elasticsearch uses custom Module classes (not Spring/Guice) for wiring:
+- Server has `*Module.java` classes: `ActionModule`, `ClusterModule`, `SearchModule`, `IndicesModule`, etc.
+- Plugins contribute to modules via specialized interfaces
+- Components registered in registries: `NamedWriteableRegistry`, `NamedXContentRegistry`
+
+### Settings System
+
+- Configuration uses `Setting<T>` classes with validation
+- Settings are strongly typed and declared statically
+- Settings can be static (require restart) or dynamic (updateable via API)
+- Plugin settings must be registered via `Plugin.getSettings()`
+
+### Build System Details
+
+**Gradle Composite Build**:
+- Three included builds: `build-conventions`, `build-tools`, `build-tools-internal`
+- Version catalog in `gradle/build.versions.toml`
+- Custom toolchain resolvers for JDK management
+- Dependency verification in `gradle/verification-metadata.xml` (required)
+
+**Custom Gradle Plugins**:
+- `elasticsearch.esplugin` - Build Elasticsearch plugins
+- `elasticsearch.testclusters` - Set up test clusters
+- `elasticsearch.internal-es-plugin` - Internal plugin development
+- `elasticsearch.yaml-rest-test` - YAML REST test infrastructure
+- `elasticsearch.internal-test-artifact` - Share test fixtures between projects
+
+**Key Build Concepts**:
+- Use task avoidance API: `tasks.register()` not `task`
+- Lazy test cluster creation: `testClusters.register()`
+- Component metadata rules manage transitive dependencies (see `ComponentMetadataRulesPlugin`)
+- All dependency versions managed in `build-tools-internal/version.properties`
+
+### Test Infrastructure
+
+**Test Types**:
+1. **Unit Tests** - `src/test/java` - Standard JUnit tests with randomized testing framework
+2. **Internal Cluster Tests** - `src/internalClusterTest/java` - Multi-node cluster tests in same JVM
+3. **Java REST Tests** - `src/javaRestTest/java` - REST API tests using Java client
+4. **YAML REST Tests** - `src/yamlRestTest/resources` - Declarative REST tests
+
+**Test Framework Features**:
+- Randomized testing with seeds for reproducibility
+- `ESTestCase` base class with utilities
+- `@TestLogging` for verbose logging on failures
+- Test clusters managed by `testclusters` plugin
+- Multiple test types can coexist in same project
+
+**QA Test Organization**:
+- Module/plugin-specific: `<module>/qa/` subdirectories
+- Cross-cutting: `qa/` directory at root
+- X-Pack: `x-pack/qa/` for commercial feature integration tests
+
+### Code Organization Patterns
+
+**Dependency Flow**: `libs/` → `server/` → `modules/` → `plugins/`/`x-pack/`
+
+**Key Server Packages**:
+- `action` - Request/response handling, REST/transport actions
+- `cluster` - Cluster state management, master node logic
+- `index` - Index-level operations, shards, segments
+- `search` - Search request handling, query execution
+- `ingest` - Document preprocessing pipeline
+- `transport` - Inter-node communication
+- `http` - HTTP/REST layer
+- `discovery` - Cluster formation and node discovery
+- `gateway` - Cluster metadata persistence
+- `indices` - Cross-index operations, templates
+
+**Common Patterns**:
+- Immutable cluster state with copy-on-write updates
+- Async operations with `ActionListener` callbacks
+- Streaming serialization with `StreamInput`/`StreamOutput`
+- XContent (JSON/YAML) parsing with `XContentParser`
+- Thread pools for different operation types
+
+### Licensing
+
+- **Server, modules, libs**: Dual-licensed (Server Side Public License v1, Elastic License 2.0, AGPL v3)
+- **X-Pack**: Elastic License 2.0
+- License headers required on all source files
+- Check with `./gradlew precommit`
+
+## Development Workflow
+
+### Code Style
+
+- Use `./gradlew spotlessApply` to auto-format code
+- Follow existing patterns in the codebase
+- Do not reformat unchanged lines
+- Checkstyle enforced via `precommit` task
+
+### Making Changes
+
+1. **Before coding**: Discuss on GitHub issue first
+2. **Add tests**: Unit tests required; integration tests for user-facing changes
+3. **Run precommit**: `./gradlew precommit` before committing
+4. **Run relevant tests**: Test your specific module/plugin
+5. **Check forbidden APIs**: Build enforces forbidden API usage rules
+6. **Update verification metadata**: If dependencies changed, run with `--write-verification-metadata`
+
+### Adding Dependencies
+
+1. Add dependency to appropriate `build.gradle`
+2. Add version to `build-tools-internal/version.properties` or `gradle/build.versions.toml`
+3. Run `./gradlew --write-verification-metadata sha256 precommit`
+4. Manually verify checksums and update `origin` in `gradle/verification-metadata.xml`
+5. Add component metadata rules if transitive dependencies need exclusion (see `ComponentMetadataRulesPlugin`)
+
+### Creating a New Plugin/Module
+
+1. Create directory in `modules/` or `plugins/` or `x-pack/plugin/`
+2. Add `build.gradle` with `esplugin` block
+3. Create plugin class extending `Plugin` and implementing specialized interfaces
+4. Create `src/main/resources/plugin-descriptor.properties` (generated by gradle)
+5. Add tests in `src/test/`, `src/internalClusterTest/`, etc.
+6. Plugin is auto-discovered by `settings.gradle` (uses `addSubProjects()`)
+
+## Common Gotchas
+
+- **Gradle build fails on deprecation warnings** - Build configured to fail on deprecated API usage
+- **Dependency verification failures** - All dependency checksums must be in `gradle/verification-metadata.xml`
+- **Test failures with randomization** - Tests use random seeds; use `-Dtests.seed=<seed>` to reproduce
+- **Module vs Plugin confusion** - Modules are always loaded and simpler; plugins are optional and installable
+- **X-Pack requires special build** - Commercial features in x-pack/ have separate licensing
+- **Task avoidance** - Always use `tasks.register()` not direct task creation for performance
+- **Test source sets** - Different test types require different source sets and gradle plugins
+- **Spotless formatting** - CI enforces code formatting; run `spotlessApply` before committing
+
+## Claude Code Tips
+
+### Reviewing GitHub PRs
+- `gh` CLI may not be authenticated. Use `WebFetch` to fetch PR metadata from `github.com/...` and raw diffs from `patch-diff.githubusercontent.com/raw/...`
+- WebFetch summarizes large files. For complete code, fetch individual files via `raw.githubusercontent.com/{org}/{repo}/{sha}/{path}`
+- Get the PR's head SHA from the commits page (`/pull/N/commits`) to fetch exact file versions
+- Always compare both the old (main) and new (PR head) versions of key files to understand the full diff
+- For large PRs, use parallel `WebFetch` and background `Task` agents to fetch files concurrently

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew spotlessApply:*)",
+      "Bash(./gradlew :qa:vector:checkVec:*)",
+      "Bash(find:*)",
+      "Bash(./gradlew :server:compileJava:*)",
+      "Bash(grep:*)",
+      "Bash(./gradlew :server:test:*)",
+      "Bash(xargs -I {} sh -c 'echo \"\"=== {} ===\"\" && grep -o \"\"java\\\\.[a-zA-Z]*Exception[^<]*\"\" {} | head -3')",
+      "Bash(./gradlew:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git stash:*)",
+      "Bash(git checkout:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:patch-diff.githubusercontent.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(git log:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -1222,6 +1222,18 @@ The query used for an aggregation is the combination of all leaf retrievers as `
 clauses in a <<query-dsl-bool-query, boolean query>>.
 
 [discrete]
+[[retriever-min-score-compound]]
+==== Using `min_score` with compound retrievers
+
+When using `min_score` with compound retrievers (such as [`rrf`](retrievers/rrf-retriever.md) or [`linear`](retrievers/linear-retriever.md)), documents are filtered **after** the compound scoring has been applied. This is important to understand because:
+
+1. **Document collection**: Each child retriever collects documents up to its `rank_window_size` limit.
+2. **Score computation**: The compound retriever computes final scores (e.g., RRF ranking, linear combination with normalization).
+3. **Threshold filtering**: Documents with a final score below `min_score` are excluded from the results.
+
+Because `min_score` is applied after score normalization or RRF computation, the `total_hits` value reflects only the documents that pass the threshold after the compound scoring, not the total number of documents matched by the child retrievers.
+
+[discrete]
 [[retriever-restrictions]]
 ==== Restrictions on search parameters when specifying a retriever
 

--- a/docs/reference/search/search-your-data/retrievers-examples.asciidoc
+++ b/docs/reference/search/search-your-data/retrievers-examples.asciidoc
@@ -1495,8 +1495,7 @@ GET /retrievers_example/_search
                                             }
                                         }
                                     ],
-                                    "rank_window_size": 100,
-                                    "normalizer": "minmax"
+                                    "rank_window_size": 100
                                 }
                             }
                         ],

--- a/docs/reference/search/search-your-data/retrievers-examples.asciidoc
+++ b/docs/reference/search/search-your-data/retrievers-examples.asciidoc
@@ -1450,6 +1450,116 @@ GET retrievers_example/_search
 // TESTRESPONSE[s/"took": 42/"took": $body.took/]
 ==============
 
+
+[discrete]
+[[retrievers-examples-nested-retrievers-min-score]]
+==== Example: Multi-level nested retrievers with min_score
+
+This example demonstrates how `min_score` works with deeply nested compound retrievers. The retriever tree structure is:
+
+- **Outer RRF** (rank_window_size: 20)
+- **Inner RRF** (rank_window_size: 50)
+- **Linear** (rank_window_size: 100, minmax normalizer, min_score: 0.5)
+- **Standard** (query_string query)
+
+Documents are first matched by the innermost `standard` retriever using a query_string query. The `linear` retriever then normalizes these scores using the minmax normalizer and filters based on the specified `min_score`. Then, the inner `rrf` retriever computes the scores for the subset of documents that pass `min_score`, and finally the outer `rrf` retriever produces the final ranking.
+
+The `total_hits` value in this scenario is constrained by the `rank_window_size` parameters, as parent retrievers only have access to the top documents from their children.
+
+**Pagination behavior**: When using `from` and `size` at the top level of the search request, pagination is limited to the documents available at the outermost retriever's `rank_window_size`. In this example, even though the inner retrievers process more documents (100 for `linear`, 50 for inner `rrf`), the outer `rrf` only receives 50 documents and produces a final set of 20 documents. Therefore, `from` and `size` can only paginate through these top 20 documents.
+
+[source,console]
+----
+GET /retrievers_example/_search
+{
+    "retriever": {
+        "rrf": {
+            "retrievers": [
+                {
+                    "rrf": {
+                        "retrievers": [
+                            {
+                                "linear": {
+                                    "min_score": 0.5,
+                                    "retrievers": [
+                                        {
+                                            "retriever": {
+                                                "standard": {
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": "artificial intelligence",
+                                                            "default_field": "text"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "rank_window_size": 100,
+                                    "normalizer": "minmax"
+                                }
+                            }
+                        ],
+                        "rank_window_size": 50
+                    }
+                }
+            ],
+            "rank_window_size": 20
+        }
+    },
+    "size": 10
+}
+----
+// TEST[continued]
+
+In this example:
+1. The `standard` retriever matches documents containing "artificial intelligence" in the text field.
+2. The `linear` retriever normalizes these scores to a 0-1 range using minmax normalization and filters documents with score less than 0.5.
+3. The inner `rrf` computes RRF scores based on document ranks.
+4. The outer `rrf` produces the final RRF scores.
+5. The `total_hits` value reflects only the documents passing the inner `min_score` threshold.
+
+
+.Example response
+[%collapsible]
+==============
+[source, console-result]
+----
+{
+    "took": 42,
+    "timed_out": false,
+    "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+    },
+    "hits": {
+        "total": {
+            "value": 1,
+            "relation": "eq"
+        },
+        "max_score": 0.016393442,
+        "hits": [
+            {
+                "_index": "retrievers_example",
+                "_id": "2",
+                "_score": 0.016393442,
+                "_source": {
+                    "vector": [0.12, 0.56, 0.78],
+                    "text": "Artificial intelligence is transforming medicine, from advancing diagnostics and tailoring treatment plans to empowering predictive patient care for improved health outcomes.",
+                    "year": 2023,
+                    "topic": ["ai", "medicine"],
+                    "timestamp": "2022-01-01T12:10:30"
+                }
+            }
+        ]
+    }
+}
+----
+// TESTRESPONSE[s/"took": 42/"took": $body.took/]
+==============
+
 [discrete]
 [[retrievers-examples-explain-multiple-rrf]]
 ==== Example: Explainability with multiple retrievers

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -308,5 +308,9 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
         return retrieverName;
     }
 
+    protected boolean hasMinScore() {
+        return this.minScore != null;
+    }
+
     // ---- END FOR TESTING ----
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilder;
 import java.util.Set;
 
 import static org.elasticsearch.search.retriever.CompoundRetrieverBuilder.INNER_RETRIEVERS_FILTER_SUPPORT;
+import static org.elasticsearch.search.retriever.RankDocsRetrieverBuilder.NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX;
 import static org.elasticsearch.xpack.rank.linear.L2ScoreNormalizer.LINEAR_RETRIEVER_L2_NORM;
 import static org.elasticsearch.xpack.rank.linear.LinearRetrieverBuilder.LINEAR_RETRIEVER_MINSCORE_FIX;
 import static org.elasticsearch.xpack.rank.linear.MinMaxScoreNormalizer.LINEAR_RETRIEVER_MINMAX_SINGLE_DOC_FIX;
@@ -40,7 +41,8 @@ public class RankRRFFeatures implements FeatureSpecification {
             LINEAR_RETRIEVER_L2_NORM,
             LINEAR_RETRIEVER_MINSCORE_FIX,
             LinearRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
-            RRFRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT
+            RRFRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
+            NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX
         );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
@@ -1144,4 +1144,47 @@ setup:
   - match: { hits.hits.0._id: "5" }
   - match: { hits.hits.1._id: "3" }
 
+---
+"nested compound retrievers with min_score correctly compute total_hits":
+  - requires:
+      cluster_features: "nested_retriever_min_score_total_hits_fix"
+      reason: "requires fix for correct total_hits computation with nested min_score"
+
+  - do:
+      search:
+        index: test
+        body:
+          retriever:
+            rrf:
+              retrievers:
+                - rrf:
+                    retrievers:
+                      - linear:
+                          retrievers: [
+                            {
+                              retriever: {
+                                standard: {
+                                  query: {
+                                    query_string: {
+                                      query: "term1 OR term2 OR term3",
+                                      default_field: "text"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                          rank_window_size: 100
+                          min_score: 0.5
+                          normalizer: "minmax"
+                    rank_window_size: 100
+              rank_window_size: 100
+          size: 10
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.total.relation: "eq" }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
 

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
@@ -1162,7 +1162,7 @@ setup:
                       - linear:
                           retrievers: [
                             {
-                              normalizer: "minmax"
+                              normalizer: "minmax",
                               retriever: {
                                 standard: {
                                   query: {

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
@@ -1162,6 +1162,7 @@ setup:
                       - linear:
                           retrievers: [
                             {
+                              normalizer: "minmax"
                               retriever: {
                                 standard: {
                                   query: {
@@ -1176,7 +1177,6 @@ setup:
                           ]
                           rank_window_size: 100
                           min_score: 0.5
-                          normalizer: "minmax"
                     rank_window_size: 100
               rank_window_size: 100
           size: 10


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/142212 to `8.19`.