### PR TITLE
Add a es819 codec test to verify tryRead returns null if may contain duplicates

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -247,7 +247,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         boolean binaryMultiValuedFormat
                     ) throws IOException {
                         if (docs.mayContainDuplicates()) {
-                            // isCompressed assumes there aren't duplicates
+                            // isDense assumes there aren't duplicates
                             return null;
                         }
 
@@ -316,6 +316,11 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         boolean toInt,
                         boolean binaryMultiValuedFormat
                     ) throws IOException {
+                        if (docs.mayContainDuplicates()) {
+                            // isDense assumes there aren't duplicates
+                            return null;
+                        }
+
                         int count = docs.count() - offset;
                         int firstDocId = docs.get(offset);
                         int lastDocId = docs.get(docs.count() - 1);
@@ -458,7 +463,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                     boolean binaryMultiValuedFormat
                 ) throws IOException {
                     if (docs.mayContainDuplicates()) {
-                        // isCompressed assumes there aren't duplicates
+                        // isDense assumes there aren't duplicates
                         return null;
                     }
 
@@ -2116,7 +2121,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                 @Override
                 BlockLoader.Block tryRead(BlockLoader.SingletonLongBuilder builder, BlockLoader.Docs docs, int offset) throws IOException {
                     if (docs.mayContainDuplicates()) {
-                        // isCompressed assumes there aren't duplicates
+                        // isDense assumes there aren't duplicates
                         return null;
                     }
                     final int docsCount = docs.count();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -77,7 +77,6 @@ import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
-import static org.elasticsearch.test.ESTestCase.randomInt;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -2259,9 +2258,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
                 d.add(new SortedNumericDocValuesField(denseNumericField, random().nextLong()));
                 d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
-                d.add(
-                    new BinaryDocValuesField(binaryVariableField, new BytesRef(randomAlphaOfLengthBetween(0, binaryVariableMaxLength)))
-                );
+                d.add(new BinaryDocValuesField(binaryVariableField, new BytesRef(randomAlphaOfLengthBetween(0, binaryVariableMaxLength))));
                 d.add(new SortedDocValuesField(sortedField, new BytesRef(randomAlphaOfLengthBetween(1, 10))));
                 iw.addDocument(d);
                 currentTimestamp += 1000L;
@@ -2275,8 +2272,9 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 var leafReader = reader.leaves().get(0).reader();
                 int maxDoc = leafReader.maxDoc();
                 var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
-                var docsWithDups =
-                    TestBlock.docs(IntStream.concat(IntStream.range(0, maxDoc), IntStream.of(between(0, maxDoc-1))).sorted().toArray());
+                var docsWithDups = TestBlock.docs(
+                    IntStream.concat(IntStream.range(0, maxDoc), IntStream.of(between(0, maxDoc - 1))).sorted().toArray()
+                );
 
                 {
                     // Dense numeric

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -77,6 +77,7 @@ import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomInt;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -2234,6 +2235,76 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         "unexpected timestamp [" + timestamp + "], expected between [" + lowerBound + "] and [" + upperBound + "]",
                         timestamp >= lowerBound && timestamp < upperBound
                     );
+                }
+            }
+        }
+    }
+
+    public void testTryReadReturnsNullWithMayContainDuplicates() throws Exception {
+        final String timestampField = "@timestamp";
+        final String denseNumericField = "dense_numeric";
+        final String binaryFixedField = "binary_fixed";
+        final String binaryVariableField = "binary_variable";
+        final String sortedField = "sorted_field";
+        final int binaryFixedLength = randomIntBetween(1, 20);
+        final int binaryVariableMaxLength = randomIntBetween(1, 20);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int numDocs = 256 + random().nextInt(256);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
+                d.add(new SortedNumericDocValuesField(denseNumericField, random().nextLong()));
+                d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                d.add(
+                    new BinaryDocValuesField(binaryVariableField, new BytesRef(randomAlphaOfLengthBetween(0, binaryVariableMaxLength)))
+                );
+                d.add(new SortedDocValuesField(sortedField, new BytesRef(randomAlphaOfLengthBetween(1, 10))));
+                iw.addDocument(d);
+                currentTimestamp += 1000L;
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                var leafReader = reader.leaves().get(0).reader();
+                int maxDoc = leafReader.maxDoc();
+                var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
+                var docsWithDups =
+                    TestBlock.docs(IntStream.concat(IntStream.range(0, maxDoc), IntStream.of(between(0, maxDoc-1))).sorted().toArray());
+
+                {
+                    // Dense numeric
+                    var dv = getBaseDenseNumericValues(leafReader, denseNumericField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getBaseDenseNumericValues(leafReader, denseNumericField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    // Dense binary fixed-length
+                    var dv = getES819BinaryValues(leafReader, binaryFixedField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getES819BinaryValues(leafReader, binaryFixedField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    // Dense binary variable-length
+                    var dv = getES819BinaryValues(leafReader, binaryVariableField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getES819BinaryValues(leafReader, binaryVariableField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    // Sorted doc values
+                    var dv = getBaseSortedDocValues(leafReader, sortedField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getBaseSortedDocValues(leafReader, sortedField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
                 }
             }
         }


### PR DESCRIPTION
Add a test to es819 codec test to verify changes from https://github.com/elastic/elasticsearch/pull/141926 . Just checks that situations which require incoming docs to not contain duplicates, return null on `tryRead` if passed docs with duplicates. Also, update `DenseBinaryDocValues` to return null if `mayContainDuplicates`