### PR TITLE
Updating gitignore to ignore cursor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@
 # JetBrainsAI/Junie
 .junie/
 
+# Cursor rules and commands, if we want to implement project level rules and commands we'll want to remove these
+# These are based on the cursor docs here: https://cursor.com/docs/cli/using#rules
+# Prefix slash ensures these are only ignored at the same level as this file
+/.cursor/
+/AGENTS.md
+/CLAUDE.md
+
 # intellij files
 .idea/
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 # These are based on the cursor docs here: https://cursor.com/docs/cli/using#rules
 # Prefix slash ensures these are only ignored at the same level as this file
 /.cursor/
-/AGENTS.md
-/CLAUDE.md
 
 # intellij files
 .idea/


### PR DESCRIPTION
This PR ignores cursor files. I use cursor cli and it seems my rules aren't being applied correctly (I'm getting tired of telling it to use var...)

This may not be totally necessary but I've had trouble getting my rules to run correctly when stored in `~/.cursor`

I don't think cursor cli supports that yet: https://forum.cursor.com/t/how-to-create-global-rules-for-cli/137916

So seems like the rules need to be stored in the project level `.cursor` directory. Once we have project-wide rules we can remove the gitignore changes.
