### PR TITLE
Fix thread assertion in RewriteableTests.testRewriteAndFetchWithExecutorOnFailure for synchronous failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -380,9 +380,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077
-- class: org.elasticsearch.index.query.RewriteableTests
-  method: testRewriteAndFetchWithExecutorOnFailure
-  issue: https://github.com/elastic/elasticsearch/issues/142140
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsKeyword
   issue: https://github.com/elastic/elasticsearch/issues/142282

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -150,7 +150,7 @@ public class RewriteableTests extends ESTestCase {
             assertTrue("Timed out waiting for rewrite to complete", latch.await(10, TimeUnit.SECONDS));
             assertNotNull("Exception should be caught", caughtException.get());
             assertThat(caughtException.get().getMessage(), containsString("Simulated async failure"));
-            assertThat("Should complete on search thread pool", completionThreadName.get(), containsString("search"));
+            assertThat("Should not complete on transport thread", completionThreadName.get(), not(containsString("transport")));
         } finally {
             ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Solves #142140

When (int the test) `FailingTestRewriteable` fails synchronously during the rewrite loop (before any async actions are registered), the `SubscribableListener` created by `newForked` completes immediately on the calling thread. This is the expected behavior, synchronous completion executes on the calling thread to avoid unnecessary thread context switches. 

```
   static <T extends Rewriteable<T>> void rewriteAndFetch(
        T original,
        QueryRewriteContext context,
        Executor responseExecutor,
        ActionListener<T> rewriteResponse
    ) {
        SubscribableListener.<T>newForked(l -> rewriteAndFetch(original, context, l, 0))
            .addListener(rewriteResponse, Objects.requireNonNull(responseExecutor), null);
    }
```
The executor-based forking only applies when async actions are pending, and completion happens later on a potentially unsafe thread (e.g., a transport thread).

The existing test incorrectly asserts that onFailure must always complete on the search thread pool (containsString("search")), which fails for synchronous failures that complete on the test thread.

This PR updates the assertion to verify that the listener does not execute on a transport thread, rather than asserting a specific target thread pool.