### PR TITLE
Clarify `expectedSize` behaviour of `ReleasableBytesStreamOutput`

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -291,7 +291,7 @@ public class SearchApplicationIndexService {
     }
 
     private void updateSearchApplication(SearchApplication app, boolean create, ActionListener<DocWriteResponse> listener) {
-        try (ReleasableBytesStreamOutput buffer = new ReleasableBytesStreamOutput(0, bigArrays.withCircuitBreaking())) {
+        try (ReleasableBytesStreamOutput buffer = new ReleasableBytesStreamOutput(bigArrays.withCircuitBreaking())) {
             try (XContentBuilder source = XContentFactory.jsonBuilder(buffer)) {
                 source.startObject()
                     .field(SearchApplication.NAME_FIELD.getPreferredName(), app.name())


### PR DESCRIPTION
This caught me out in #140365: we actually don't use the slow-growth
behaviour by default with a `ReleasableBytesStreamOutput`, you have to
ask for it. But we do ask for it sometimes, so this commit fixes the
docs and one of the places where we do.

Relates #142290, which fixes another case of this.