### PR TITLE
[9.2] [Transform] Fix transform validation to reject PUT and _start when user lacks remote index permissions (#142403)

### DIFF
--- a/docs/changelog/142403.yaml
+++ b/docs/changelog/142403.yaml
@@ -1,0 +1,6 @@
+area: "Transform"
+issues:
+ - 95367
+pr: 142403
+summary: Fix transform validation to reject PUT and `_start` when user lacks remote index permissions
+type: bug

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -151,7 +151,7 @@ teardown:
         transform_id: "simple-remote-transform"
 
   - do:
-      catch: /Source indices have been deleted or closed./
+      catch: /lacks the required permissions/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         transform_id: "simple-remote-transform"
@@ -306,6 +306,7 @@ teardown:
 ---
 "Batch transform from remote cluster when the user is not authorized":
   - do:
+      catch: /lacks the required permissions/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.put_transform:
         transform_id: "simple-remote-transform-3"
@@ -318,6 +319,30 @@ teardown:
               "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
             }
           }
+
+---
+"Batch transform _start from remote cluster when the user is not authorized":
+  - do:
+      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
+      transform.put_transform:
+        transform_id: "simple-remote-transform-unauthorized-start"
+        defer_validation: true
+        body: >
+          {
+            "source": { "index": "my_remote_cluster:remote_test_index" },
+            "dest": { "index": "simple-remote-transform-unauthorized-start" },
+            "pivot": {
+              "group_by": { "user": {"terms": {"field": "user"}}},
+              "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
+            }
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /lacks the required permissions/
+      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
+      transform.start_transform:
+        transform_id: "simple-remote-transform-unauthorized-start"
 
 ---
 "Batch transform update from remote cluster when the user is not authorized":
@@ -348,7 +373,7 @@ teardown:
 ---
 "Batch transform preview from remote cluster when the user is not authorized":
   - do:
-      catch: /Source indices have been deleted or closed./
+      catch: /lacks the required permissions/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         body: >
@@ -361,7 +386,7 @@ teardown:
             }
           }
   - do:
-      catch: /Source indices have been deleted or closed./
+      catch: /lacks the required permissions/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         body: >

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -87,7 +87,7 @@ public abstract class AbstractCompositeAggFunction implements Function {
                     final InternalAggregations aggregations = r.getAggregations();
                     if (aggregations == null) {
                         listener.onFailure(
-                            new ElasticsearchStatusException("Source indices have been deleted or closed.", RestStatus.BAD_REQUEST)
+                            new ElasticsearchStatusException(SourceAccessDiagnostics.diagnoseSourceAccessFailure(r), RestStatus.BAD_REQUEST)
                         );
                         return;
                     }
@@ -138,6 +138,19 @@ public abstract class AbstractCompositeAggFunction implements Function {
                         )
                     );
                     return;
+                }
+                // Null aggregations may indicate permission issues when accessing remote indices.
+                // We only fail validation when a security failure is positively identified (e.g.,
+                // ElasticsearchSecurityException in cluster or shard failures). We deliberately do NOT
+                // fail when no security failure is found, because null aggregations can also occur when
+                // a local wildcard index pattern resolves to zero indices -- a legitimate scenario for
+                // integrations that start transforms before source data exists (see #95562).
+                if (response.getAggregations() == null) {
+                    String diagnosis = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+                    if (diagnosis.equals(SourceAccessDiagnostics.SOURCE_INDICES_MISSING) == false) {
+                        listener.onFailure(new ValidationException().addValidationError(diagnosis));
+                        return;
+                    }
                 }
                 listener.onResponse(true);
             }, e -> {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnostics.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnostics.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.transforms.common;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ * Diagnoses the cause of an empty or failed search response against transform source indices.
+ * Inspects CCS cluster-level and shard-level failures to distinguish permission errors
+ * from genuinely missing or closed indices.
+ */
+final class SourceAccessDiagnostics {
+
+    static final String SOURCE_INDICES_MISSING = "Source indices have been deleted or closed.";
+
+    private SourceAccessDiagnostics() {}
+
+    /**
+     * Inspects a {@link SearchResponse} that returned null aggregations and produces
+     * a human-readable error message identifying the likely cause.
+     *
+     * <p>The method checks, in order:
+     * <ol>
+     *   <li>CCS cluster-level failures for security exceptions (SKIPPED or FAILED clusters)</li>
+     *   <li>Top-level shard failures for security exceptions</li>
+     *   <li>Falls back to a generic "deleted or closed" message</li>
+     * </ol>
+     */
+    static String diagnoseSourceAccessFailure(SearchResponse response) {
+        String clusterSecurityError = findClusterSecurityFailure(response);
+        if (clusterSecurityError != null) {
+            return clusterSecurityError;
+        }
+
+        String shardSecurityError = findShardSecurityFailure(response);
+        if (shardSecurityError != null) {
+            return shardSecurityError;
+        }
+
+        return SOURCE_INDICES_MISSING;
+    }
+
+    /**
+     * Checks CCS cluster-level information for clusters that were SKIPPED or FAILED
+     * due to a security exception (e.g., user lacks permissions on the remote cluster).
+     */
+    private static String findClusterSecurityFailure(SearchResponse response) {
+        SearchResponse.Clusters clusters = response.getClusters();
+        if (clusters == null || clusters.getTotal() == 0) {
+            return null;
+        }
+
+        for (String alias : clusters.getClusterAliases()) {
+            SearchResponse.Cluster cluster = clusters.getCluster(alias);
+            if (cluster == null) {
+                continue;
+            }
+            if (cluster.getStatus() != SearchResponse.Cluster.Status.SKIPPED
+                && cluster.getStatus() != SearchResponse.Cluster.Status.FAILED) {
+                continue;
+            }
+            for (ShardSearchFailure failure : cluster.getFailures()) {
+                if (isSecurityFailure(failure)) {
+                    return "User lacks the required permissions to read source indices on cluster [" + alias + "].";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks top-level shard failures for security exceptions (e.g., user lacks
+     * permissions on a specific index).
+     */
+    private static String findShardSecurityFailure(SearchResponse response) {
+        for (ShardSearchFailure failure : response.getShardFailures()) {
+            if (isSecurityFailure(failure)) {
+                String index = failure.index();
+                if (index != null) {
+                    return "User lacks the required permissions to read source index [" + index + "].";
+                }
+                return "User lacks the required permissions to read from the source indices.";
+            }
+        }
+        return null;
+    }
+
+    private static boolean isSecurityFailure(ShardSearchFailure failure) {
+        if (failure.getCause() instanceof ElasticsearchSecurityException) {
+            return true;
+        }
+        return failure.status() == RestStatus.FORBIDDEN || failure.status() == RestStatus.UNAUTHORIZED;
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.transforms.common;
+
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SourceAccessDiagnosticsTests extends ESTestCase {
+
+    public void testNoFailures_returnsFallbackMessage() {
+        SearchResponse response = createResponseWithNoFailures();
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, equalTo(SourceAccessDiagnostics.SOURCE_INDICES_MISSING));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testEmptyClusters_returnsFallbackMessage() {
+        SearchResponse response = createResponseWithClustersAndShardFailures(SearchResponse.Clusters.EMPTY, ShardSearchFailure.EMPTY_ARRAY);
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, equalTo(SourceAccessDiagnostics.SOURCE_INDICES_MISSING));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testClusterSkippedDueToSecurityException_returnsClusterMessage() {
+        ShardSearchFailure securityFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("action [indices:data/read/search] is unauthorized", RestStatus.FORBIDDEN)
+        );
+        SearchResponse.Cluster skippedCluster = new SearchResponse.Cluster(
+            "my_remote_cluster",
+            "remote_test_index",
+            true,
+            SearchResponse.Cluster.Status.SKIPPED,
+            0,
+            0,
+            0,
+            0,
+            List.of(securityFailure),
+            null,
+            false,
+            null
+        );
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", skippedCluster));
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(clusters, ShardSearchFailure.EMPTY_ARRAY);
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, containsString("lacks the required permissions"));
+            assertThat(message, containsString("my_remote_cluster"));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testClusterFailedDueToSecurityException_returnsClusterMessage() {
+        ShardSearchFailure securityFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("action [indices:data/read/search] is unauthorized", RestStatus.FORBIDDEN)
+        );
+        SearchResponse.Cluster failedCluster = new SearchResponse.Cluster(
+            "my_remote_cluster",
+            "remote_test_index",
+            false,
+            SearchResponse.Cluster.Status.FAILED,
+            1,
+            0,
+            0,
+            1,
+            List.of(securityFailure),
+            null,
+            false,
+            null
+        );
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", failedCluster));
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(clusters, ShardSearchFailure.EMPTY_ARRAY);
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, containsString("lacks the required permissions"));
+            assertThat(message, containsString("my_remote_cluster"));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testShardFailureWithSecurityException_returnsIndexMessage() {
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            "nodeId",
+            new org.elasticsearch.index.shard.ShardId("my_index", "_na_", 0),
+            null
+        );
+        ShardSearchFailure securityFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("action [indices:data/read/search] is unauthorized", RestStatus.FORBIDDEN),
+            shardTarget
+        );
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(
+            SearchResponse.Clusters.EMPTY,
+            new ShardSearchFailure[] { securityFailure }
+        );
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, containsString("lacks the required permissions"));
+            assertThat(message, containsString("my_index"));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testShardFailureWithForbiddenStatus_returnsIndexMessage() {
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            "nodeId",
+            new org.elasticsearch.index.shard.ShardId("my_index", "_na_", 0),
+            null
+        );
+        ShardSearchFailure forbiddenFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("not authorized", RestStatus.FORBIDDEN),
+            shardTarget
+        );
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(
+            SearchResponse.Clusters.EMPTY,
+            new ShardSearchFailure[] { forbiddenFailure }
+        );
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, containsString("lacks the required permissions"));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testShardFailureWithUnauthorizedStatus_returnsIndexMessage() {
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            "nodeId",
+            new org.elasticsearch.index.shard.ShardId("my_index", "_na_", 0),
+            null
+        );
+        ShardSearchFailure unauthorizedFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("not authenticated", RestStatus.UNAUTHORIZED),
+            shardTarget
+        );
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(
+            SearchResponse.Clusters.EMPTY,
+            new ShardSearchFailure[] { unauthorizedFailure }
+        );
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, containsString("lacks the required permissions"));
+            assertThat(message, containsString("my_index"));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testShardFailureWithSecurityExceptionNoIndex_returnsGenericPermissionMessage() {
+        ShardSearchFailure securityFailure = new ShardSearchFailure(
+            new ElasticsearchSecurityException("unauthorized", RestStatus.FORBIDDEN)
+        );
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(
+            SearchResponse.Clusters.EMPTY,
+            new ShardSearchFailure[] { securityFailure }
+        );
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, equalTo("User lacks the required permissions to read from the source indices."));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testNonSecurityShardFailure_returnsFallbackMessage() {
+        ShardSearchFailure nonSecurityFailure = new ShardSearchFailure(new IndexNotFoundException("missing_index"));
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(
+            SearchResponse.Clusters.EMPTY,
+            new ShardSearchFailure[] { nonSecurityFailure }
+        );
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, equalTo(SourceAccessDiagnostics.SOURCE_INDICES_MISSING));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testClusterSuccessfulWithNonSecurityShardFailures_returnsFallbackMessage() {
+        ShardSearchFailure nonSecurityFailure = new ShardSearchFailure(new IndexNotFoundException("missing_index"));
+
+        SearchResponse.Cluster successfulCluster = new SearchResponse.Cluster(
+            "my_remote_cluster",
+            "remote_test_index",
+            true,
+            SearchResponse.Cluster.Status.SUCCESSFUL,
+            1,
+            1,
+            0,
+            0,
+            List.of(nonSecurityFailure),
+            null,
+            false,
+            null
+        );
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", successfulCluster));
+
+        SearchResponse response = createResponseWithClustersAndShardFailures(clusters, ShardSearchFailure.EMPTY_ARRAY);
+        try {
+            String message = SourceAccessDiagnostics.diagnoseSourceAccessFailure(response);
+            assertThat(message, equalTo(SourceAccessDiagnostics.SOURCE_INDICES_MISSING));
+        } finally {
+            response.decRef();
+        }
+    }
+
+    private static SearchResponse createResponseWithNoFailures() {
+        return createResponseWithClustersAndShardFailures(SearchResponse.Clusters.EMPTY, ShardSearchFailure.EMPTY_ARRAY);
+    }
+
+    private static SearchResponse createResponseWithClustersAndShardFailures(
+        SearchResponse.Clusters clusters,
+        ShardSearchFailure[] shardFailures
+    ) {
+        return new SearchResponse(
+            SearchHits.unpooled(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f),
+            null, // null aggregations -- simulates the scenario we are diagnosing
+            new Suggest(Collections.emptyList()),
+            false,
+            null,
+            null,
+            0,
+            null,
+            1,
+            1,
+            0,
+            0,
+            shardFailures,
+            clusters
+        );
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
@@ -62,7 +62,7 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             0,
             List.of(securityFailure),
             null,
-            false,
+            false
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", skippedCluster));
 
@@ -91,7 +91,7 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             1,
             List.of(securityFailure),
             null,
-            false,
+            false
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", failedCluster));
 
@@ -222,7 +222,7 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             0,
             List.of(nonSecurityFailure),
             null,
-            false,
+            false
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", successfulCluster));
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/common/SourceAccessDiagnosticsTests.java
@@ -63,7 +63,6 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             List.of(securityFailure),
             null,
             false,
-            null
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", skippedCluster));
 
@@ -93,7 +92,6 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             List.of(securityFailure),
             null,
             false,
-            null
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", failedCluster));
 
@@ -225,7 +223,6 @@ public class SourceAccessDiagnosticsTests extends ESTestCase {
             List.of(nonSecurityFailure),
             null,
             false,
-            null
         );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(Map.of("my_remote_cluster", successfulCluster));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Transform] Fix transform validation to reject PUT and _start when user lacks remote index permissions (#142403)](https://github.com/elastic/elasticsearch/pull/142403)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)