### PR TITLE
[9.2] Fix thread assertion in RewriteableTests.testRewriteAndFetchWithExecutorOnFailure for synchronous failures (#142449)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -474,6 +474,7 @@ tests:
   method: testRewriteAndFetchWithExecutorOnFailure
   issue: https://github.com/elastic/elasticsearch/issues/142140
 
+
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -470,10 +470,6 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=tsdb/05_dimension_and_metric_in_non_tsdb_index/can shadow metrics}
   issue: https://github.com/elastic/elasticsearch/issues/141869
-- class: org.elasticsearch.index.query.RewriteableTests
-  method: testRewriteAndFetchWithExecutorOnFailure
-  issue: https://github.com/elastic/elasticsearch/issues/142140
-
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -150,7 +150,7 @@ public class RewriteableTests extends ESTestCase {
             assertTrue("Timed out waiting for rewrite to complete", latch.await(10, TimeUnit.SECONDS));
             assertNotNull("Exception should be caught", caughtException.get());
             assertThat(caughtException.get().getMessage(), containsString("Simulated async failure"));
-            assertThat("Should complete on search thread pool", completionThreadName.get(), containsString("search"));
+            assertThat("Should not complete on transport thread", completionThreadName.get(), not(containsString("transport")));
         } finally {
             ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix thread assertion in RewriteableTests.testRewriteAndFetchWithExecutorOnFailure for synchronous failures (#142449)](https://github.com/elastic/elasticsearch/pull/142449)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)