### PR TITLE
[8.19] Fix thread assertion in RewriteableTests.testRewriteAndFetchWithExecutorOnFailure for synchronous failures (#142449)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -165,6 +165,7 @@ tests:
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024
 
+
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -165,7 +165,6 @@ tests:
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024
 
-
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -150,6 +150,7 @@ public class RewriteableTests extends ESTestCase {
             assertTrue("Timed out waiting for rewrite to complete", latch.await(10, TimeUnit.SECONDS));
             assertNotNull("Exception should be caught", caughtException.get());
             assertThat(caughtException.get().getMessage(), containsString("Simulated async failure"));
+            assertThat("Should not complete on transport thread", completionThreadName.get(), not(containsString("transport")));
         } finally {
             ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix thread assertion in RewriteableTests.testRewriteAndFetchWithExecutorOnFailure for synchronous failures(#142449)](https://github.com/elastic/elasticsearch/pull/142449)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)