### PR TITLE
ES|QL: Fix CSV tests for MMR

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -422,9 +422,6 @@ tests:
 - class: org.elasticsearch.compute.operator.MMROperatorTests
   method: testSimpleLargeInput
   issue: https://github.com/elastic/elasticsearch/issues/142437
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with query vector variable}
-  issue: https://github.com/elastic/elasticsearch/issues/142438
 - class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
   method: testIndexPoints
   issue: https://github.com/elastic/elasticsearch/issues/142439
@@ -434,27 +431,9 @@ tests:
 - class: org.elasticsearch.compute.operator.MMROperatorTests
   method: testSimpleSmallInput
   issue: https://github.com/elastic/elasticsearch/issues/142436
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.Simple MMR diversification}
-  issue: https://github.com/elastic/elasticsearch/issues/142441
 - class: org.elasticsearch.xpack.esql.core.util.RemoteClusterUtilsTests
   method: testQualifyAndJoinIndices
   issue: https://github.com/elastic/elasticsearch/issues/142442
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with static query vector high lambda}
-  issue: https://github.com/elastic/elasticsearch/issues/142444
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with byte vector and query vector}
-  issue: https://github.com/elastic/elasticsearch/issues/142445
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with static query vector low lambda}
-  issue: https://github.com/elastic/elasticsearch/issues/142446
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with bit vector and query vector}
-  issue: https://github.com/elastic/elasticsearch/issues/142447
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:mmr.MMR with hex string bit vector and query vector}
-  issue: https://github.com/elastic/elasticsearch/issues/142448
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/142426

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MMROperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MMROperator.java
@@ -139,9 +139,6 @@ public class MMROperator extends CompleteInputCollectorOperator {
         // gather our documents and their vectors
         List<PagePositionDocVector> docsAndVectors = gatherAllDocsAndVectors();
 
-        // set our doc ranks and final mappings for diversification
-        docsAndVectors.sort(Comparator.comparing(PagePositionDocVector::doc));
-
         // keep this mapping so we know where the docs came from
         Map<Integer, Tuple<Integer, Integer>> mapRankToPageAndPosition = new HashMap<>();
         List<RankDoc> docs = new ArrayList<>();
@@ -202,6 +199,7 @@ public class MMROperator extends CompleteInputCollectorOperator {
         int pageCounter = 0;
         for (Page inputPage : inputPages) {
             var pagePositionsToKeep = filtersByPagePosition.getOrDefault(pageCounter, null);
+            pageCounter++;
             if (pagePositionsToKeep == null || pagePositionsToKeep.isEmpty()) {
                 continue;
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MMROperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MMROperator.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;


### PR DESCRIPTION
closes #142438 #142441 #142444 #142445 #142446 #142447 #142448

the CSV tests can generate multiple input pages, in the `MMROperator` because we never increased `pageCounter` we ended up filtering the same positions on every page.
this either meant outputting more rows than we need or running into `ArrayIndexOutOfBoundsException`.

we still have the operator tests that are failing - I need to look into those to see if all pages are actually properly released.