### PR TITLE
Adds base64 format to the dense vector field type docs

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -13,8 +13,15 @@ The `dense_vector` field type stores dense vectors of numeric values. Dense vect
 
 The `dense_vector` type does not support aggregations or sorting.
 
-You add a `dense_vector` field as an array of numeric values based on [`element_type`](#dense-vector-params) with `float` by default:
+You can provide vectors in two different input formats:
 
+- Array of floats: A JSON array of numeric values representing each vector dimension.
+- Base64-encoded string: A Base64-encoded binary representation of the vector. More compact than float arrays, reducing payload size and improving efficiency for large vectors and bulk indexing.
+
+The following example creates an index with a `dense_vector` field (using default [`element_type`](#dense-vector-params) `float`) and indexes documents using each format:
+
+::::{tab-set}
+:::{tab-item} Array of floats
 ```console
 PUT my-index
 {
@@ -43,6 +50,38 @@ PUT my-index/_doc/2
   "my_vector" : [-0.5, 10, 10]
 }
 ```
+:::
+:::{tab-item} Base64-encoded string
+```console
+PUT my-index
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "dense_vector",
+        "dims": 3
+      },
+      "my_text" : {
+        "type" : "keyword"
+      }
+    }
+  }
+}
+
+PUT my-index/_doc/1
+{
+  "my_text" : "text1",
+  "my_vector" : "PwAAAEEgAABAwAAA"
+}
+
+PUT my-index/_doc/2
+{
+  "my_text" : "text2",
+  "my_vector" : "vwAAAEEgAABBIAAA"
+}
+```
+:::
+::::
 
 ::::{note}
 Unlike most other data types, dense vectors are always single-valued. It is not possible to store multiple values in one `dense_vector` field.


### PR DESCRIPTION
This PR adds an explanation of supported vector input formats to the beginning of the Dense vector field type page and includes a Base64 example alongside the existing numeric array example using tabs.

Related issue: https://github.com/elastic/docs-content/issues/4800
Related PR: https://github.com/elastic/docs-content/pull/5135