### PR TITLE
BinaryDocValuesContainsTermQuery optimization

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -53,6 +53,7 @@ import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
+import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -495,6 +496,11 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                 int getLength() throws IOException {
                     return decoder.decodeLength(doc, entry.numCompressedBlocks);
                 }
+
+                @Override
+                public DocIdSetIterator containsIterator(BytesRef containsTerm) throws IOException {
+                    return decoder.containsTermIterator(entry.numCompressedBlocks, 0, maxDoc - 1, containsTerm);
+                }
             };
         } else {
             // sparse
@@ -678,6 +684,78 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
             int start = uncompressedDocStarts[idxInBlock];
             int end = uncompressedDocStarts[idxInBlock + 1];
             return end - start;
+        }
+
+        DocIdSetIterator containsTermIterator(int numBlocks, int firstDocId, int lastDocId, BytesRef containsTerm) throws IOException {
+            final long firstBlockId = findBlock(firstDocId, numBlocks, 0);
+            final long endBlockId = findBlock(lastDocId, numBlocks, firstBlockId);
+            return new DocIdSetIterator() {
+
+                int currentDocId = -1;
+
+                @Override
+                public int docID() {
+                    return currentDocId;
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return advance(currentDocId + 1);
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return scanToTargetDocId(target);
+                }
+
+                @Override
+                public long cost() {
+                    int maxDoc = lastDocId + 1;
+                    return maxDoc * 10L;
+                }
+
+                long currentBlockId = -1;
+                int blockStartDocId;
+                int blockEndDocId;
+
+                int scanToTargetDocId(int target) throws IOException {
+                    for (long blockId = currentBlockId == -1 ? firstBlockId : currentBlockId; blockId <= endBlockId; blockId++) {
+                        if (blockId != currentBlockId) {
+                            blockStartDocId = (int) docOffsets.get(blockId);
+                            blockEndDocId = (int) docOffsets.get(blockId + 1);
+                        }
+
+                        if (blockEndDocId <= target) {
+                            continue;
+                        }
+
+                        if (blockId != currentBlockId) {
+                            int numDocsInBlock = blockEndDocId - blockStartDocId;
+                            decompressBlock(blockId, numDocsInBlock);
+                        }
+
+                        int startDocId = blockId == firstBlockId ? firstDocId : blockStartDocId;
+                        if (startDocId < target) {
+                            startDocId = target;
+                        }
+                        // lastDocId is inclusive and blockEndDocId is exclusive!
+                        int endDocId = blockId == endBlockId ? lastDocId + 1 : blockEndDocId;
+
+                        for (int docId = startDocId; docId < endDocId; docId++) {
+                            int index = docId - blockStartDocId;
+                            int offset = uncompressedDocStarts[index];
+                            int length = uncompressedDocStarts[index + 1] - offset;
+                            if (BinaryDocValuesContainsTermQuery.contains(uncompressedBlock, offset, length, containsTerm)) {
+                                currentBlockId = blockId;
+                                return currentDocId = docId;
+                            }
+                        }
+                    }
+
+                    currentBlockId = endBlockId;
+                    return currentDocId = DocIdSetIterator.NO_MORE_DOCS;
+                }
+            };
         }
 
         void decodeBulk(int numBlocks, int firstDocId, int lastDocId, int count, BlockLoader.SingletonBytesRefBuilder builder)

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOSupplier;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -228,6 +229,10 @@ public interface BlockLoader {
             boolean toInt,
             boolean binaryMultiValuedFormat
         ) throws IOException;
+
+        default DocIdSetIterator containsIterator(BytesRef containsTerm) throws IOException {
+            return null;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.ConstantScoreScorerSupplier;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
+
+public final class BinaryDocValuesContainsTermQuery extends Query {
+    final String fieldName;
+    final BytesRef containsTerm;
+
+    BinaryDocValuesContainsTermQuery(String fieldName, BytesRef containsTerm) {
+        this.fieldName = Objects.requireNonNull(fieldName);
+        this.containsTerm = Objects.requireNonNull(containsTerm);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        float matchCost = matchCost();
+        return new ConstantScoreWeight(this, boost) {
+
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
+                if (values == null) {
+                    return null;
+                }
+
+                String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
+                final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
+                DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
+                assert countsSkipper != null : "no skipper for counts field [" + countsFieldName + "]";
+                final DocIdSetIterator iterator;
+                if (countsSkipper.maxValue() == 1 && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
+                    iterator = direct.containsIterator(containsTerm);
+                } else {
+                    Predicate<BytesRef> predicate = bytes -> contains(bytes.bytes, bytes.offset, bytes.length, containsTerm);
+                    iterator = TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(counts) {
+                        final MultiValueSeparateCountBinaryDocValuesReader reader = new MultiValueSeparateCountBinaryDocValuesReader();
+
+                        @Override
+                        public boolean matches() throws IOException {
+                            values.advance(counts.docID());
+                            return reader.match(values.binaryValue(), counts.longValue(), predicate);
+                        }
+
+                        @Override
+                        public float matchCost() {
+                            return matchCost;
+                        }
+                    });
+                }
+
+                return ConstantScoreScorerSupplier.fromIterator(iterator, score(), scoreMode, context.reader().maxDoc());
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                 return DocValues.isCacheable(ctx, fieldName);
+            }
+        };
+    }
+
+    float matchCost() {
+        return 10;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    public String toString(String field) {
+        return "BinaryDocValuesLengthQuery(fieldName=" + field + ",containsTerm=" + containsTerm + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        BinaryDocValuesContainsTermQuery that = (BinaryDocValuesContainsTermQuery) o;
+        return Objects.equals(fieldName, that.fieldName) && Objects.equals(containsTerm, that.containsTerm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), fieldName, containsTerm);
+    }
+
+    public static boolean contains(byte[] value, int valueOffset, int valueLength, BytesRef term) {
+        byte first = term.bytes[term.offset];
+        int max = (valueLength - term.length) + valueOffset;
+        for (int i = valueOffset; i <= max; i++) {
+            // Look for first character.
+            if (value[i] != first) {
+                while (++i <= max && value[i] != first)
+                    ;
+            }
+            // Found first character, now look at the rest of value
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + term.length - 1;
+                for (int k = 1; j < end && value[j] == term.bytes[k]; j++, k++)
+                    ;
+                if (j == end) {
+                    // Found whole string.
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -85,7 +85,7 @@ public final class BinaryDocValuesContainsTermQuery extends Query {
 
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                 return DocValues.isCacheable(ctx, fieldName);
+                return DocValues.isCacheable(ctx, fieldName);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
@@ -10,12 +10,16 @@
 package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -55,6 +59,15 @@ public final class SlowCustomBinaryDocValuesWildcardQuery extends AbstractBinary
     @Override
     protected float matchCost() {
         return 1000f; // This is just expensive, not sure what the actual cost is.
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (pattern.length() > 3 && pattern.startsWith("*") && pattern.endsWith("*") && pattern.contains(" ") == false) {
+            return new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(pattern.substring(1, pattern.length() - 1)));
+        } else {
+            return super.rewrite(indexSearcher);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery.contains;
+
+public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
+
+    public void testContainsExactMatch() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("foobar");
+        assertTrue(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsPrefix() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("foo");
+        assertTrue(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsSuffix() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("bar");
+        assertTrue(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsMiddle() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("oob");
+        assertTrue(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsSingleChar() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("b");
+        assertTrue(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsNoMatch() {
+        byte[] value = "foobar".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("baz");
+        assertFalse(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsTermLongerThanValue() {
+        byte[] value = "foo".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("foobar");
+        assertFalse(contains(value, 0, value.length, term));
+    }
+
+    public void testContainsEmptyValue() {
+        byte[] value = new byte[0];
+        BytesRef term = new BytesRef("foo");
+        assertFalse(contains(value, 0, value.length, term));
+    }
+
+    public void testWithOffset() {
+        byte[] value = "1234567890research".getBytes(StandardCharsets.UTF_8);
+        BytesRef term = new BytesRef("search");
+        assertTrue(contains(value, 10, value.length, term));
+    }
+
+    public void testSingleValued() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                // doc 0: "elasticsearch" -> contains "search"
+                addSingleValueDoc(writer, fieldName, "elasticsearch");
+                // doc 1: "kibana" -> does not contain "search"
+                addSingleValueDoc(writer, fieldName, "kibana");
+                // doc 2: "research" -> contains "search"
+                addSingleValueDoc(writer, fieldName, "research");
+                // doc 3: "logstash" -> does not contain "search"
+                addSingleValueDoc(writer, fieldName, "logstash");
+                // doc 4: "searching" -> contains "search"
+                addSingleValueDoc(writer, fieldName, "searching");
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"));
+                    assertEquals(3, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testMultiValued() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                // doc 0: ["hello", "world"] -> "world" does not contain "ell", "hello" does
+                addMultiValueDoc(writer, fieldName, "hello", "world");
+                // doc 1: ["foo", "bar"] -> neither contains "ell"
+                addMultiValueDoc(writer, fieldName, "foo", "bar");
+                // doc 2: ["wellcome", "to"] -> "wellcome" contains "ell"
+                addMultiValueDoc(writer, fieldName, "wellcome", "to");
+                // doc 3: ["abc"] -> does not contain "ell"
+                addSingleValueDoc(writer, fieldName, "abc");
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("ell"));
+                    assertEquals(2, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testNoField() throws IOException {
+        String fieldName = "field";
+
+        // no field in index
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"));
+                    assertEquals(0, searcher.count(query));
+                }
+            }
+        }
+
+        // no field in one segment
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                addSingleValueDoc(writer, fieldName, "testing");
+                writer.commit();
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"));
+                    assertEquals(1, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testNoMatch() throws IOException {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                addSingleValueDoc(writer, fieldName, "hello");
+                addSingleValueDoc(writer, fieldName, "world");
+                addMultiValueDoc(writer, fieldName, "foo", "bar");
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("xyz"));
+                    assertEquals(0, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testEqualsAndHashCode() {
+        BinaryDocValuesContainsTermQuery q1 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"));
+        BinaryDocValuesContainsTermQuery q2 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"));
+        BinaryDocValuesContainsTermQuery q3 = new BinaryDocValuesContainsTermQuery("other", new BytesRef("term"));
+        BinaryDocValuesContainsTermQuery q4 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("other"));
+
+        assertEquals(q1, q2);
+        assertEquals(q1.hashCode(), q2.hashCode());
+        assertNotEquals(q1, q3);
+        assertNotEquals(q1, q4);
+    }
+
+    private static void addSingleValueDoc(RandomIndexWriter writer, String fieldName, String value) throws IOException {
+        Document document = new Document();
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(fieldName, false);
+        field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
+        var countField = NumericDocValuesField.indexedField(fieldName + ".counts", 1);
+        document.add(field);
+        document.add(countField);
+        writer.addDocument(document);
+    }
+
+    private static void addMultiValueDoc(RandomIndexWriter writer, String fieldName, String... values) throws IOException {
+        Document document = new Document();
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(fieldName, false);
+        for (String value : values) {
+            field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
+        }
+        var countField = NumericDocValuesField.indexedField(fieldName + ".counts", field.count());
+        document.add(field);
+        document.add(countField);
+        writer.addDocument(document);
+    }
+
+    private static RandomIndexWriter newRandomIndexWriter(Directory dir) throws IOException {
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        iwc.setCodec(TestUtil.alwaysDocValuesFormat(new ES819TSDBDocValuesFormat()));
+        return new RandomIndexWriter(random(), dir, iwc);
+    }
+
+}


### PR DESCRIPTION
* Rewrite to SlowBinaryDocValuesContainsTermQuery from SlowCustomBinaryDocValuesWildcardQuery if pattern starts and ends with `*`.
* Perform contains operation in bulk style.