### PR TITLE
[9.3] Fix ShutdownPrepareService formatting exception (#142482)

### DIFF
--- a/docs/changelog/142482.yaml
+++ b/docs/changelog/142482.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 142482
+summary: Fix `ShutdownPrepareService` string formatting
+type: bug

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -165,7 +165,10 @@ public class ShutdownPrepareService {
                 millisWaited += pollPeriod.millis();
                 if (TimeValue.ZERO.equals(timeout) == false && millisWaited >= timeout.millis()) {
                     logger.warn(
-                        format("timed out after waiting [%s] for [%d] " + taskName + " tasks to finish", timeout.toString(), tasksRemaining)
+                        "timed out after waiting [{}] for [{}] {} tasks to finish",
+                        timeout.toString(),
+                        tasksRemaining.size(),
+                        taskName
                     );
                     return;
                 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix ShutdownPrepareService formatting exception (#142482)