### PR TITLE
Only reset scheduler factory after all ongoing requests are stopped

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -51,6 +51,7 @@ import org.elasticsearch.transport.netty4.NettyAllocator;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
@@ -257,8 +258,15 @@ class AzureClientProvider extends AbstractLifecycleComponent {
     protected void doStop() {
         closed = true;
         connectionProvider.dispose();
-        eventLoopGroup.shutdownGracefully();
-        Schedulers.setFactory(STOPPED_FACTORY);
+        try {
+            eventLoopGroup.shutdownGracefully().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interrupted while shutting down the event loop group", e);
+        } catch (ExecutionException e) {
+            logger.warn("Error shutting down the event loop group", e);
+        }
+        Schedulers.resetFactory();
     }
 
     @Override
@@ -418,24 +426,4 @@ class AzureClientProvider extends AbstractLifecycleComponent {
 
         void requestCompleted(OperationPurpose purpose, HttpMethod method, URL url, RequestMetrics metrics);
     }
-
-    /**
-     * A factory that doesn't allow the creation of any more Schedulers
-     */
-    private static final Schedulers.Factory STOPPED_FACTORY = new Schedulers.Factory() {
-        @Override
-        public Scheduler newBoundedElastic(int threadCap, int queuedTaskCap, ThreadFactory threadFactory, int ttlSeconds) {
-            throw new AlreadyClosedException("AzureClientProvider is already closed");
-        }
-
-        @Override
-        public Scheduler newParallel(int parallelism, ThreadFactory threadFactory) {
-            throw new AlreadyClosedException("AzureClientProvider is already closed");
-        }
-
-        @Override
-        public Scheduler newSingle(ThreadFactory threadFactory) {
-            throw new AlreadyClosedException("AzureClientProvider is already closed");
-        }
-    };
 }

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -51,7 +51,6 @@ import org.elasticsearch.transport.netty4.NettyAllocator;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
@@ -258,15 +257,7 @@ class AzureClientProvider extends AbstractLifecycleComponent {
     protected void doStop() {
         closed = true;
         connectionProvider.dispose();
-        try {
-            eventLoopGroup.shutdownGracefully().get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.warn("Interrupted while shutting down the event loop group", e);
-        } catch (ExecutionException e) {
-            logger.warn("Error shutting down the event loop group", e);
-        }
-        Schedulers.resetFactory();
+        eventLoopGroup.shutdownGracefully().addListener(f -> Schedulers.resetFactory());
     }
 
     @Override

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -258,7 +258,7 @@ class AzureClientProvider extends AbstractLifecycleComponent {
         closed = true;
         connectionProvider.dispose();
         eventLoopGroup.shutdownGracefully();
-        Schedulers.resetFactory();
+        Schedulers.setFactory(STOPPED_FACTORY);
     }
 
     @Override
@@ -418,4 +418,24 @@ class AzureClientProvider extends AbstractLifecycleComponent {
 
         void requestCompleted(OperationPurpose purpose, HttpMethod method, URL url, RequestMetrics metrics);
     }
+
+    /**
+     * A factory that doesn't allow the creation of any more Schedulers
+     */
+    private static final Schedulers.Factory STOPPED_FACTORY = new Schedulers.Factory() {
+        @Override
+        public Scheduler newBoundedElastic(int threadCap, int queuedTaskCap, ThreadFactory threadFactory, int ttlSeconds) {
+            throw new AlreadyClosedException("AzureClientProvider is already closed");
+        }
+
+        @Override
+        public Scheduler newParallel(int parallelism, ThreadFactory threadFactory) {
+            throw new AlreadyClosedException("AzureClientProvider is already closed");
+        }
+
+        @Override
+        public Scheduler newSingle(ThreadFactory threadFactory) {
+            throw new AlreadyClosedException("AzureClientProvider is already closed");
+        }
+    };
 }


### PR DESCRIPTION
Fixes #142423

We hijacked thread creation in the Azure client by calling `Schedulers.setFactory` 

https://github.com/elastic/elasticsearch/blob/ce37e1ae60974af1a6664a56f0479b1c3d354111/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java#L233-L253

Our options for shutting down the cached `Scheduler`s it creates are limited:

```
* One cannot directly {@link Scheduler#dispose() dispose} the common instances, as they are cached and shared
* between callers. They can however be all {@link #shutdownNow() shut down} together, or replaced by a
* {@link #setFactory(Factory) change in Factory}.
```

We achieved this when closing the `AzureClientProvider` by calling `Schedulers.resetFactory`, but this replaces the custom factory with the default one which uses the `ThreadFactory` passed.

If we close the `AzureClientProvider` while there are ongoing requests, and we don't wait until the `EventLoopGroup` is shut down before calling `resetFactory`, it's possible those cached thread pools get recreated by the still-running threads after our call to `resetFactory`. Which causes leaking threads and caused the test failure we see here.