### PR TITLE
[9.1] Remove checkstyle restriction on ! operator (#141989)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,10 +267,8 @@ Please follow these formatting guidelines:
   consistency.
 * Note that Javadoc and block comments i.e. `/* ... */` are not formatted,
   but line comments i.e. `// ...` are.
-* Negative boolean expressions must use the form `foo == false` instead of
-  `!foo` for better readability of the code. This is enforced via
-  Checkstyle. Conversely, you should not write e.g. `if (foo == true)`, but
-  just `if (foo)`.
+* Negative boolean expressions should use the form `foo == false` instead of
+  `!foo` where this improves readability. Conversely, you should not write e.g. `if (foo == true)`, but just `if (foo)`.
 
 #### Editor / IDE support
 

--- a/build-tools-internal/src/main/resources/checkstyle.xml
+++ b/build-tools-internal/src/main/resources/checkstyle.xml
@@ -187,18 +187,6 @@
       <message key="descendant.token.max" value="Do not check for equality with 'true', since it is implied" />
     </module>
 
-    <!-- Forbid using '!' for logical negations in favour of checking against 'false' explicitly. -->
-    <!-- This is only reported in the IDE for now because there are many violations -->
-    <module name="DescendantToken">
-        <property name="id" value="BooleanNegation" />
-        <property name="tokens" value="EXPR"/>
-        <property name="limitedTokens" value="LNOT"/>
-        <property name="maximumNumber" value="0"/>
-        <message
-            key="descendant.token.max"
-            value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
-    </module>
-
     <module name="NeedBraces">
         <!-- We have many generated equals classes with LITERAL_IF and no braces, so we don't check IF or ELSE -->
         <property name="tokens" value="LITERAL_DO,LITERAL_FOR,LITERAL_WHILE"/>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Remove checkstyle restriction on ! operator (#141989)](https://github.com/elastic/elasticsearch/pull/141989)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)