### PR TITLE
[8.19] Fixing for NPE when there is no query specified for the standard retriever (#142479)

### DIFF
--- a/docs/changelog/142479.yaml
+++ b/docs/changelog/142479.yaml
@@ -1,0 +1,6 @@
+area: Ranking
+issues:
+ - 142336
+pr: 142479
+summary: Fixing for NPE when there is no query specified for the standard retriever
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
@@ -522,3 +522,19 @@ setup:
   - match: {hits.hits.4.fields.name.0: "coyote"}
   - match: {hits.hits.4.fields.count.0: 10}
   - match: {hits.hits.4.fields.color.0: "gray"}
+
+---
+"standard retriever with empty body":
+
+  - do:
+      search:
+        index: animals
+        body:
+          track_total_hits: true
+          fields: [ "text", "keyword" ]
+          retriever:
+            standard: {}
+          size: 10
+
+  - match: { hits.total.value : 15 }
+  - length: { hits.hits: 10 }

--- a/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -143,13 +144,13 @@ public final class StandardRetrieverBuilder extends RetrieverBuilder implements 
 
     @Override
     public QueryBuilder topDocsQuery() {
+        var query = this.queryBuilder == null ? new MatchAllQueryBuilder() : this.queryBuilder;
         if (preFilterQueryBuilders.isEmpty()) {
-            QueryBuilder qb = queryBuilder;
-            qb.queryName(this.retrieverName);
-            return qb;
+            query.queryName(this.retrieverName);
+            return query;
         }
-        var ret = new BoolQueryBuilder().filter(queryBuilder).queryName(this.retrieverName);
-        preFilterQueryBuilders.stream().forEach(ret::filter);
+        var ret = new BoolQueryBuilder().filter(query).queryName(this.retrieverName);
+        preFilterQueryBuilders.forEach(ret::filter);
         return ret;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/retriever/StandardRetrieverBuilderParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/StandardRetrieverBuilderParsingTests.java
@@ -175,26 +175,24 @@ public class StandardRetrieverBuilderParsingTests extends AbstractXContentTestCa
     public void testTopDocsQuery() throws IOException {
         StandardRetrieverBuilder standardRetriever = createTestInstance();
         final int preFilters = standardRetriever.preFilterQueryBuilders.size();
-        if (standardRetriever.queryBuilder == null) {
-            if (preFilters > 0) {
-                expectThrows(IllegalArgumentException.class, standardRetriever::topDocsQuery);
-            }
-        } else {
-            QueryBuilder topDocsQuery = standardRetriever.topDocsQuery();
-            assertNotNull(topDocsQuery);
-            if (preFilters > 0) {
-                assertThat(topDocsQuery, instanceOf(BoolQueryBuilder.class));
-                assertThat(((BoolQueryBuilder) topDocsQuery).filter().size(), equalTo(1 + preFilters));
-                assertThat(((BoolQueryBuilder) topDocsQuery).filter().get(0), instanceOf(standardRetriever.queryBuilder.getClass()));
-                for (int i = 0; i < preFilters; i++) {
-                    assertThat(
-                        ((BoolQueryBuilder) topDocsQuery).filter().get(i + 1),
-                        instanceOf(standardRetriever.preFilterQueryBuilders.get(i).getClass())
-                    );
-                }
+        QueryBuilder topDocsQuery = standardRetriever.topDocsQuery();
+        assertNotNull(topDocsQuery);
+        if (preFilters > 0) {
+            assertThat(topDocsQuery, instanceOf(BoolQueryBuilder.class));
+            BoolQueryBuilder boolQuery = (BoolQueryBuilder) topDocsQuery;
+            assertThat(boolQuery.filter().size(), equalTo(1 + preFilters));
+            if (standardRetriever.queryBuilder != null) {
+                assertThat(boolQuery.filter().get(0), instanceOf(standardRetriever.queryBuilder.getClass()));
             } else {
-                assertThat(topDocsQuery, instanceOf(standardRetriever.queryBuilder.getClass()));
+                assertThat(boolQuery.filter().get(0), instanceOf(MatchAllQueryBuilder.class));
             }
+            for (int i = 0; i < preFilters; i++) {
+                assertThat(boolQuery.filter().get(i + 1), instanceOf(standardRetriever.preFilterQueryBuilders.get(i).getClass()));
+            }
+        } else if (standardRetriever.queryBuilder != null) {
+            assertThat(topDocsQuery, instanceOf(standardRetriever.queryBuilder.getClass()));
+        } else {
+            assertThat(topDocsQuery, instanceOf(MatchAllQueryBuilder.class));
         }
     }
 

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -27,7 +27,9 @@ import static org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilder.RRF_RETRIEVER
 public class RankRRFFeatures implements FeatureSpecification {
 
     public static final NodeFeature LINEAR_RETRIEVER_SUPPORTED = new NodeFeature("linear_retriever_supported");
-
+    public static final NodeFeature STANDARD_RETRIEVER_FIX_FOR_EMPTY_QUERY_IN_COMPOUND_RETRIEVERS = new NodeFeature(
+        "standard_retriever.fix_for_empty_query_in_compound_retrievers"
+    );
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(RRFRetrieverBuilder.RRF_RETRIEVER_SUPPORTED, RRF_RETRIEVER_COMPOSITION_SUPPORTED, LINEAR_RETRIEVER_SUPPORTED);
@@ -42,7 +44,8 @@ public class RankRRFFeatures implements FeatureSpecification {
             LINEAR_RETRIEVER_MINSCORE_FIX,
             LinearRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
             RRFRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
-            NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX
+            NESTED_RETRIEVER_MIN_SCORE_TOTAL_HITS_FIX,
+            STANDARD_RETRIEVER_FIX_FOR_EMPTY_QUERY_IN_COMPOUND_RETRIEVERS
         );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -30,6 +30,7 @@ public class RankRRFFeatures implements FeatureSpecification {
     public static final NodeFeature STANDARD_RETRIEVER_FIX_FOR_EMPTY_QUERY_IN_COMPOUND_RETRIEVERS = new NodeFeature(
         "standard_retriever.fix_for_empty_query_in_compound_retrievers"
     );
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(RRFRetrieverBuilder.RRF_RETRIEVER_SUPPORTED, RRF_RETRIEVER_COMPOSITION_SUPPORTED, LINEAR_RETRIEVER_SUPPORTED);

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
@@ -400,3 +400,79 @@ setup:
   - match: { hits.hits.1._id: "3" }
   - match: { hits.hits.1.fields.text.0: "term" }
   - match: { hits.hits.1.fields.keyword.0: "keyword" }
+
+---
+"rrf retriever with a standard retriever with no query but a sort":
+  - requires:
+      cluster_features: [ "standard_retriever.fix_for_empty_query_in_compound_retrievers" ]
+      reason: "requires fix for unspecified query in standard retrievers when combined in compound retrievers"
+
+
+  - do:
+      search:
+        index: test
+        body:
+          track_total_hits: true
+          fields: [ "text", "keyword" ]
+          retriever:
+            rrf:
+              retrievers: [
+                {
+                  standard: {
+                    sort:
+                      {
+                        keyword: {
+                          order: desc
+                        }
+                      }
+                  }
+                },
+                {
+                  knn: {
+                    field: vector,
+                    query_vector: [ 0.0 ],
+                    k: 3,
+                    num_candidates: 3
+                  }
+                }
+              ]
+              rank_window_size: 100
+              rank_constant: 1
+          size: 2
+
+  - match: { hits.total.value : 3 }
+  - length: { hits.hits : 2 }
+
+---
+"rrf retriever with a standard retriever with no query and no filter":
+  - requires:
+      cluster_features: [ "standard_retriever.fix_for_empty_query_in_compound_retrievers" ]
+      reason: "requires fix for unspecified query in standard retrievers when combined in compound retrievers"
+
+  - do:
+      search:
+        index: test
+        body:
+          track_total_hits: true
+          fields: [ "text", "keyword" ]
+          retriever:
+            rrf:
+              retrievers: [
+                {
+                  standard: {}
+                },
+                {
+                  knn: {
+                    field: vector,
+                    query_vector: [ 0.0 ],
+                    k: 3,
+                    num_candidates: 3
+                  }
+                }
+              ]
+              rank_window_size: 100
+              rank_constant: 1
+          size: 2
+
+  - match: { hits.total.value : 3 }
+  - length: { hits.hits: 2 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fixing for NPE when there is no query specified for the standard retriever (#142479)](https://github.com/elastic/elasticsearch/pull/142479)

<!--- Backport version: 9.4.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)