### PR TITLE
Allow test clusters to set `node.processors`.

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -112,7 +112,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         "discovery.seed_providers",
         "cluster.deprecation_indexing.enabled",
         "cluster.initial_master_nodes",
-        "xpack.security.enabled"
+        "xpack.security.enabled",
+        "node.processors"
 
     );
 


### PR DESCRIPTION
Setting this can be useful for ad-hoc local benchmarking. If not set, the default is to just use 2 processors.