### PR TITLE
Unmute promql tests (fixed in #142411)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -389,18 +389,6 @@ tests:
 - class: org.elasticsearch.benchmark.vector.scorer.VectorScorerOSQBenchmarkTests
   method: testBulkScalarVsVectorized {p0=768 p1=1 p2=MMAP p3=MAXIMUM_INNER_PRODUCT}
   issue: https://github.com/elastic/elasticsearch/issues/142413
-- class: org.elasticsearch.xpack.esql.expression.promql.function.PromqlKibanaDefinitionGeneratorTests
-  method: testGenerateDefinitions
-  issue: https://github.com/elastic/elasticsearch/issues/142417
-- class: org.elasticsearch.xpack.esql.parser.promql.PromqlParserTests
-  method: testInstantVectorExpectedWithGrouping
-  issue: https://github.com/elastic/elasticsearch/issues/142418
-- class: org.elasticsearch.xpack.esql.parser.promql.PromqlParserTests
-  method: testRangeVectorExpected
-  issue: https://github.com/elastic/elasticsearch/issues/142419
-- class: org.elasticsearch.xpack.esql.parser.promql.PromqlParserTests
-  method: testInstantVectorExpected
-  issue: https://github.com/elastic/elasticsearch/issues/142420
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testFieldDataStats
   issue: https://github.com/elastic/elasticsearch/issues/142424


### PR DESCRIPTION
Fixed in #142411. Tests pass locally.

Made with [Cursor](https://cursor.com)