### PR TITLE
Update broken link in analysis-synonym-graph-tokenfilter.md

### DIFF
--- a/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 The `synonym_graph` token filter allows to easily handle [synonyms](docs-content://solutions/search/full-text/search-with-synonyms.md), including multi-word synonyms correctly during the analysis process.
 
-In order to properly handle multi-word synonyms this token filter creates a [graph token stream](docs-content://manage-data/data-store/text-analysis/token-graphs.md) during processing. For more information, refer to [Synonym token filter](reference/text-analysis/analysis-synonym-tokenfilter.md).
+In order to properly handle multi-word synonyms this token filter creates a [graph token stream](docs-content://manage-data/data-store/text-analysis/token-graphs.md) during processing. For more information, refer to [Synonym token filter](/reference/text-analysis/analysis-synonym-tokenfilter.md).
 
 ::::{note}
 :name: synonym-graph-index-note

--- a/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 The `synonym_graph` token filter allows to easily handle [synonyms](docs-content://solutions/search/full-text/search-with-synonyms.md), including multi-word synonyms correctly during the analysis process.
 
-In order to properly handle multi-word synonyms this token filter creates a [graph token stream](docs-content://manage-data/data-store/text-analysis/token-graphs.md) during processing. For more information on this topic and its various complexities, please read the [Lucene’s TokenStreams are actually graphs](http://blog.mikemccandless.com/2012/04/lucenes-tokenstreams-are-actually.md) blog post.
+In order to properly handle multi-word synonyms this token filter creates a [graph token stream](docs-content://manage-data/data-store/text-analysis/token-graphs.md) during processing. For more information, refer to [Synonym token filter](reference/text-analysis/analysis-synonym-tokenfilter.md).
 
 ::::{note}
 :name: synonym-graph-index-note


### PR DESCRIPTION
Since the previously linked blog post no longer exists, I have added a link to this page instead: https://www.elastic.co/docs/reference/text-analysis/analysis-synonym-tokenfilter


Resolves [#5152](https://github.com/elastic/docs-content/issues/5152)