### PR TITLE
[Build] Avoid Windows cleanTest flake in seed func test

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchTestBasePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchTestBasePluginFuncTest.groovy
@@ -152,8 +152,10 @@ class ElasticsearchTestBasePluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        def result1 = gradleRunner("cleanTest", "cleanTest2", "test", "test2").build()
-        def result2 = gradleRunner("cleanTest", "cleanTest2", "test", "test2").build()
+        // Avoid invoking cleanTest* on Windows; it can flake due to file handle timing when deleting build/test-results/**/binary.
+        // We still need two consecutive task executions to observe two different seeds while reusing the configuration cache.
+        def result1 = gradleRunner("test", "test2", "--rerun-tasks").build()
+        def result2 = gradleRunner("test", "test2", "--rerun-tasks").build()
 
         then:
         def seeds1 = result1.output.findAll(/(?m)TESTSEED=\[([^\]]+)\]/) { it[1] }


### PR DESCRIPTION
## Summary

Mitigate a Windows-only flake in the build-tools TestKit functional tests by avoiding `cleanTest*` (which can fail to delete `build/test-results/**/binary` on Windows) while still asserting that a new test seed is generated for each invocation with configuration-cache reuse.

Closes #142518

## Changes

- Update `ElasticsearchTestBasePluginFuncTest` to avoid invoking `cleanTest` / `cleanTest2` (the observed flaky deletion point on Windows).
- Run `test` and `test2` twice with `--rerun-tasks` so both tasks execute each time (preserves the intent of verifying seed rotation between invocations).

## Branch / backport

This PR is raised against `main`. The `branch:8.19`, `branch:9.2`, and `branch:9.3` labels are applied for backports.

## Test plan

- `./gradlew :build-tools-internal:integTest --tests \"org.elasticsearch.gradle.internal.ElasticsearchTestBasePluginFuncTest\" --console=plain --rerun-tasks`

🤖 This pull request was assisted by Cursor