### PR TITLE
PromQL: auto-bucketing for step

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -20,6 +20,57 @@ sum(avg_over_time(network.cost[5m])):double | step:date
 50.25                                       | 2024-05-10T00:20:00.000Z
 ;
 
+auto_step_default_buckets
+required_capability: promql_command_v0
+required_capability: promql_buckets_parameter
+PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" 1
+| KEEP step
+| SORT step;
+
+step:datetime
+2024-05-10T00:00:00.000Z
+2024-05-10T00:00:10.000Z
+2024-05-10T00:00:20.000Z
+2024-05-10T00:00:30.000Z
+2024-05-10T00:00:40.000Z
+2024-05-10T00:00:50.000Z
+;
+
+auto_step_buckets
+required_capability: promql_command_v0
+required_capability: promql_buckets_parameter
+PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" buckets=3 1
+| KEEP step
+| SORT step;
+
+step:datetime
+2024-05-10T00:00:00.000Z
+2024-05-10T00:00:20.000Z
+2024-05-10T00:00:40.000Z
+;
+
+auto_step_buckets_rounding
+required_capability: promql_command_v0
+required_capability: promql_buckets_parameter
+PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" buckets=20 1
+| KEEP step
+| SORT step;
+
+step:datetime
+2024-05-10T00:00:00.000Z
+2024-05-10T00:00:05.000Z
+2024-05-10T00:00:10.000Z
+2024-05-10T00:00:15.000Z
+2024-05-10T00:00:20.000Z
+2024-05-10T00:00:25.000Z
+2024-05-10T00:00:30.000Z
+2024-05-10T00:00:35.000Z
+2024-05-10T00:00:40.000Z
+2024-05-10T00:00:45.000Z
+2024-05-10T00:00:50.000Z
+2024-05-10T00:00:55.000Z
+;
+
 not_equals_filter
 required_capability: promql_command_v0
 PROMQL index=k8s step=1h cost=(max by (cluster) (network.total_bytes_in{cluster!="prod"}))

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -20,55 +20,19 @@ sum(avg_over_time(network.cost[5m])):double | step:date
 50.25                                       | 2024-05-10T00:20:00.000Z
 ;
 
-auto_step_default_buckets
-required_capability: promql_command_v0
-required_capability: promql_buckets_parameter
-PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" 1
-| KEEP step
-| SORT step;
-
-step:datetime
-2024-05-10T00:00:00.000Z
-2024-05-10T00:00:10.000Z
-2024-05-10T00:00:20.000Z
-2024-05-10T00:00:30.000Z
-2024-05-10T00:00:40.000Z
-2024-05-10T00:00:50.000Z
-;
-
 auto_step_buckets
 required_capability: promql_command_v0
 required_capability: promql_buckets_parameter
-PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" buckets=3 1
+PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:20:00.000Z" buckets=4 1
 | KEEP step
 | SORT step;
 
 step:datetime
 2024-05-10T00:00:00.000Z
-2024-05-10T00:00:20.000Z
-2024-05-10T00:00:40.000Z
-;
-
-auto_step_buckets_rounding
-required_capability: promql_command_v0
-required_capability: promql_buckets_parameter
-PROMQL index=k8s start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:01:00.000Z" buckets=20 1
-| KEEP step
-| SORT step;
-
-step:datetime
-2024-05-10T00:00:00.000Z
-2024-05-10T00:00:05.000Z
-2024-05-10T00:00:10.000Z
-2024-05-10T00:00:15.000Z
-2024-05-10T00:00:20.000Z
-2024-05-10T00:00:25.000Z
-2024-05-10T00:00:30.000Z
-2024-05-10T00:00:35.000Z
-2024-05-10T00:00:40.000Z
-2024-05-10T00:00:45.000Z
-2024-05-10T00:00:50.000Z
-2024-05-10T00:00:55.000Z
+2024-05-10T00:05:00.000Z
+2024-05-10T00:10:00.000Z
+2024-05-10T00:15:00.000Z
+2024-05-10T00:20:00.000Z
 ;
 
 not_equals_filter

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1917,6 +1917,11 @@ public class EsqlCapabilities {
         PROMQL_TIME,
 
         /**
+         * Support for deriving PromQL time buckets from [start, end, buckets] when [step] is omitted.
+         */
+        PROMQL_BUCKETS_PARAMETER,
+
+        /**
          * Queries for unmapped fields return no data instead of an error.
          * Also filters out nulls from results.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
@@ -527,13 +528,7 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
     }
 
     private static Alias createStepBucketAlias(PromqlCommand promqlCommand) {
-        Expression timeBucketSize;
-        if (promqlCommand.isRangeQuery()) {
-            timeBucketSize = promqlCommand.step();
-        } else {
-            // use default lookback for instant queries
-            timeBucketSize = Literal.timeDuration(promqlCommand.source(), DEFAULT_LOOKBACK);
-        }
+        Expression timeBucketSize = resolveTimeBucketSize(promqlCommand);
         Bucket b = new Bucket(
             timeBucketSize.source(),
             promqlCommand.timestamp(),
@@ -543,6 +538,34 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
             ConfigurationAware.CONFIGURATION_MARKER
         );
         return new Alias(b.source(), STEP_COLUMN_NAME, b, promqlCommand.stepId());
+    }
+
+    private static Expression resolveTimeBucketSize(PromqlCommand promqlCommand) {
+        if (promqlCommand.isRangeQuery()) {
+            if (promqlCommand.step().value() != null) {
+                return promqlCommand.step();
+            }
+            return resolveAutoStepFromBuckets(promqlCommand);
+        }
+        // use default lookback for instant queries
+        return Literal.timeDuration(promqlCommand.source(), DEFAULT_LOOKBACK);
+    }
+
+    private static Literal resolveAutoStepFromBuckets(PromqlCommand promqlCommand) {
+        Bucket autoBucket = new Bucket(
+            promqlCommand.buckets().source(),
+            promqlCommand.timestamp(),
+            promqlCommand.buckets(),
+            promqlCommand.start(),
+            promqlCommand.end(),
+            ConfigurationAware.CONFIGURATION_MARKER
+        );
+        long rangeStart = ((Number) promqlCommand.start().value()).longValue();
+        long rangeEnd = ((Number) promqlCommand.end().value()).longValue();
+        var rounding = autoBucket.getDateRounding(FoldContext.small(), rangeStart, rangeEnd);
+        long roundedStart = rounding.round(rangeStart);
+        long nextRoundedValue = rounding.nextRoundingValue(roundedStart);
+        return Literal.timeDuration(promqlCommand.source(), Duration.ofMillis(Math.max(1L, nextRoundedValue - roundedStart)));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -122,8 +122,9 @@ import static org.elasticsearch.xpack.esql.plan.logical.Enrich.Mode;
  */
 public class LogicalPlanBuilder extends ExpressionBuilder {
 
-    private static final String TIME = "time", START = "start", END = "end", STEP = "step", INDEX = "index";
-    private static final Set<String> PROMQL_ALLOWED_PARAMS = Set.of(TIME, START, END, STEP, INDEX);
+    private static final String TIME = "time", START = "start", END = "end", STEP = "step", BUCKETS = "buckets", INDEX = "index";
+    private static final int DEFAULT_PROMQL_BUCKETS = 100;
+    private static final Set<String> PROMQL_ALLOWED_PARAMS = Set.of(TIME, START, END, STEP, BUCKETS, INDEX);
 
     /**
      * Maximum number of commands allowed per query
@@ -1296,6 +1297,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             params.startLiteral(),
             params.endLiteral(),
             params.stepLiteral(),
+            params.bucketsLiteral(),
             valueColumnName,
             new UnresolvedTimestamp(source)
         );
@@ -1318,6 +1320,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         Instant start = null;
         Instant end = null;
         Duration step = null;
+        Integer buckets = null;
         IndexPattern indexPattern = new IndexPattern(source, "*");
 
         Set<String> paramsSeen = new HashSet<>();
@@ -1332,13 +1335,8 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                 case TIME -> time = PromqlParserUtils.parseDate(valueSource, parseParamValueString(paramCtx.value));
                 case START -> start = PromqlParserUtils.parseDate(valueSource, parseParamValueString(paramCtx.value));
                 case END -> end = PromqlParserUtils.parseDate(valueSource, parseParamValueString(paramCtx.value));
-                case STEP -> {
-                    try {
-                        step = Duration.ofSeconds(Integer.parseInt(parseParamValueString(paramCtx.value)));
-                    } catch (NumberFormatException ignore) {
-                        step = PromqlParserUtils.parseDuration(valueSource, parseParamValueString(paramCtx.value));
-                    }
-                }
+                case STEP -> step = parsePositivePromqlDuration(valueSource, parseParamValueString(paramCtx.value), STEP);
+                case BUCKETS -> buckets = parsePositiveInteger(valueSource, parseParamValueString(paramCtx.value), BUCKETS);
                 case INDEX -> indexPattern = parseIndexPattern(paramCtx.value);
                 default -> {
                     String message = "Unknown parameter [{}]";
@@ -1353,19 +1351,22 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
 
         // Validation logic for time parameters
         if (time != null) {
-            if (start != null || end != null || step != null) {
+            // instant query
+            if (step != null || buckets != null || start != null || end != null) {
                 throw new ParsingException(
                     source,
-                    "Specify either [{}] for instant query or [{}], [{}] or [{}] for a range query",
+                    "Specify either [{}] for instant query or any of [{}], [{}], [{}], [{}] for a range query",
                     TIME,
                     STEP,
+                    BUCKETS,
                     START,
                     END
                 );
             }
             start = time;
             end = time;
-        } else if (step != null || start != null || end != null) {
+        } else {
+            // range query
             if (start != null || end != null) {
                 if (start == null || end == null) {
                     throw new ParsingException(
@@ -1384,21 +1385,31 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                     );
                 }
             }
-            if (step == null) {
-                throw new ParsingException(source, "Parameter [{}] must be specified for a range query", STEP);
-            } else if (step.isPositive() == false) {
-                throw new ParsingException(
-                    source,
-                    "invalid parameter \"step\": zero or negative query resolution step widths are not accepted. "
-                        + "Try a positive integer",
-                    step
-                );
+            if (step != null && buckets != null) {
+                throw new ParsingException(source, "Parameters [{}] and [{}] are mutually exclusive for a range query", STEP, BUCKETS);
             }
-        } else {
-            start = Instant.now();
-            end = start;
+            if (step == null && buckets == null) {
+                buckets = DEFAULT_PROMQL_BUCKETS;
+            }
         }
-        return new PromqlParams(source, start, end, step, indexPattern);
+        return new PromqlParams(source, start, end, step, buckets, indexPattern);
+    }
+
+    private Duration parsePositivePromqlDuration(Source source, String value, String parameterName) {
+        Duration parsedValue;
+        try {
+            parsedValue = Duration.ofSeconds(Integer.parseInt(value));
+        } catch (NumberFormatException ignore) {
+            try {
+                parsedValue = PromqlParserUtils.parseDuration(source, value);
+            } catch (ParsingException e) {
+                throw new ParsingException(source, "Invalid value [{}] for parameter [{}]", value, parameterName);
+            }
+        }
+        if (parsedValue.isPositive() == false) {
+            throw new ParsingException(source, "Invalid value [{}] for parameter [{}], expected a positive duration", value, parameterName);
+        }
+        return parsedValue;
     }
 
     private String parseParamName(EsqlBaseParser.PromqlParamNameContext ctx) {
@@ -1437,6 +1448,19 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         } else {
             return new IndexPattern(source(ctx), visitPromqlIndexPattern(ctx.promqlIndexPattern()));
         }
+    }
+
+    private Integer parsePositiveInteger(Source source, String value, String parameterName) {
+        int parsedValue;
+        try {
+            parsedValue = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new ParsingException(source, "Invalid value [{}] for parameter [{}], expected a positive integer", value, parameterName);
+        }
+        if (parsedValue <= 0) {
+            throw new ParsingException(source, "Invalid value [{}] for parameter [{}], expected a positive integer", value, parameterName);
+        }
+        return parsedValue;
     }
 
     public PlanFactory visitMmrCommand(EsqlBaseParser.MmrCommandContext ctx) {
@@ -1485,7 +1509,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
      *
      * @see <a href="https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries">PromQL API documentation</a>
      */
-    public record PromqlParams(Source source, Instant start, Instant end, Duration step, IndexPattern indexPattern) {
+    public record PromqlParams(Source source, Instant start, Instant end, Duration step, Integer buckets, IndexPattern indexPattern) {
 
         public Literal startLiteral() {
             if (start == null) {
@@ -1506,6 +1530,13 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                 return Literal.NULL;
             }
             return Literal.timeDuration(source, step);
+        }
+
+        public Literal bucketsLiteral() {
+            if (buckets == null) {
+                return Literal.NULL;
+            }
+            return Literal.integer(source, buckets);
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -55,6 +55,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
     private final Literal start;
     private final Literal end;
     private final Literal step;
+    private final Literal buckets;
     // TODO: this should be made available through the planner
     private final Expression timestamp;
     private final String valueColumnName;
@@ -70,10 +71,11 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         Literal start,
         Literal end,
         Literal step,
+        Literal buckets,
         String valueColumnName,
         Expression timestamp
     ) {
-        this(source, child, promqlPlan, start, end, step, valueColumnName, new NameId(), new NameId(), timestamp);
+        this(source, child, promqlPlan, start, end, step, buckets, valueColumnName, new NameId(), new NameId(), timestamp);
     }
 
     // Range query constructor
@@ -84,6 +86,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         Literal start,
         Literal end,
         Literal step,
+        Literal buckets,
         String valueColumnName,
         NameId valueId,
         NameId stepId,
@@ -94,6 +97,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         this.start = start;
         this.end = end;
         this.step = step;
+        this.buckets = buckets;
         this.valueColumnName = valueColumnName;
         this.valueId = valueId;
         this.stepId = stepId;
@@ -110,6 +114,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
             start(),
             end(),
             step(),
+            buckets(),
             valueColumnName(),
             valueId(),
             stepId(),
@@ -126,6 +131,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
             start(),
             end(),
             step(),
+            buckets(),
             valueColumnName(),
             valueId(),
             stepId(),
@@ -141,6 +147,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
             start(),
             end(),
             step(),
+            buckets(),
             valueColumnName(),
             valueId(),
             stepId(),
@@ -184,12 +191,16 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         return step;
     }
 
+    public Literal buckets() {
+        return buckets;
+    }
+
     public boolean isInstantQuery() {
-        return step.value() == null;
+        return step.value() == null && buckets.value() == null;
     }
 
     public boolean isRangeQuery() {
-        return step.value() != null;
+        return isInstantQuery() == false;
     }
 
     public String valueColumnName() {
@@ -223,7 +234,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
 
     @Override
     public int hashCode() {
-        return Objects.hash(child(), promqlPlan, start, end, step, valueColumnName, valueId, stepId, timestamp);
+        return Objects.hash(child(), promqlPlan, start, end, step, buckets, valueColumnName, valueId, stepId, timestamp);
     }
 
     @Override
@@ -236,6 +247,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
                 && Objects.equals(start, other.start)
                 && Objects.equals(end, other.end)
                 && Objects.equals(step, other.step)
+                && Objects.equals(buckets, other.buckets)
                 && Objects.equals(valueColumnName, other.valueColumnName)
                 && Objects.equals(valueId, other.valueId)
                 && Objects.equals(stepId, other.stepId)
@@ -252,6 +264,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         sb.append(" start=[").append(start);
         sb.append("] end=[").append(end);
         sb.append("] step=[").append(step);
+        sb.append("] buckets=[").append(buckets);
         sb.append("] valueColumnName=[").append(valueColumnName);
         sb.append("] promql=[<>\n");
         sb.append(promqlPlan.toString());
@@ -270,6 +283,22 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
     @Override
     public void postAnalysisVerification(Failures failures) {
         LogicalPlan p = promqlPlan();
+        boolean hasStep = step.value() != null;
+        boolean hasRangeAndBuckets = start.value() != null && end.value() != null && buckets.value() != null;
+        if (hasStep == false && hasRangeAndBuckets == false) {
+            failures.add(
+                fail(
+                    this,
+                    "unable to create a bucket; provide either [{}] or all of [{}], [{}], and [{}] [{}]",
+                    "step",
+                    "start",
+                    "end",
+                    "buckets",
+                    sourceText()
+                )
+            );
+            return;
+        }
         // TODO(sidosera): Remove once instant query support is added.
         if (isInstantQuery()) {
             failures.add(fail(p, "instant queries are not supported at this time [{}]", sourceText()));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -95,7 +95,21 @@ public class PromqlVerifierTests extends ESTestCase {
     public void testPromqlInstantQuery() {
         assertThat(
             error("PROMQL index=test time=\"2025-10-31T00:00:00Z\" (avg(foo))", tsdb),
-            equalTo("1:48: instant queries are not supported at this time [PROMQL index=test time=\"2025-10-31T00:00:00Z\" (avg(foo))]")
+            containsString("unable to create a bucket; provide either [step] or all of [start], [end], and [buckets]")
+        );
+    }
+
+    public void testPromqlMissingBucketParameters() {
+        assertThat(
+            error("PROMQL index=test avg(foo)", tsdb),
+            containsString("unable to create a bucket; provide either [step] or all of [start], [end], and [buckets]")
+        );
+    }
+
+    public void testPromqlBucketsWithoutRange() {
+        assertThat(
+            error("PROMQL index=test buckets=10 avg(foo)", tsdb),
+            containsString("unable to create a bucket; provide either [step] or all of [start], [end], and [buckets]")
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlAstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlAstTests.java
@@ -67,7 +67,7 @@ public class PromqlAstTests extends ESTestCase {
                     "PROMQL index=test start=0 end=1 step=1m (%s)",
                     "PROMQL index=test start=0 end=1 step=1m foo=(%s)",
                     "PROMQL index=test start=0 end=1 step=1m %s",
-                    "PROMQL %s"
+                    "PROMQL time=0 %s"
                 ).forEach(pattern -> {
                     var query = String.format(Locale.ROOT, pattern, q);
                     LogicalPlan esqlPlan = EsqlParser.INSTANCE.parseQuery(query);


### PR DESCRIPTION
This PR adds automatic step derivation for PromQL range queries in ES|QL when `step` is omitted. The goal is to reduce query boilerplate while keeping bucketed results deterministic.

Range queries can now provide `buckets=<n>` instead of `step`, and when neither parameter is provided the parser defaults to `buckets=100`. During translation to ES|QL, the effective step duration is derived from the same date-rounding logic used by `BUCKET` over `[start, end, buckets]`, and then used to build the `step` column. For example, `start=00:00`, `end=00:01`, `buckets=3` produces steps at `00:00`, `00:20`, and `00:40`; with default buckets over one minute, the inferred step is 10 seconds.

The change also tightens parameter validation: `step` and `buckets` are mutually exclusive for range queries, and both duration/integer values must be positive. A new `PROMQL_BUCKETS_PARAMETER` capability flag gates csv-spec coverage so clusters that do not support this feature remain BWC-safe.

User impact is simpler PromQL authoring and fewer manual step calculations in API and dashboard workflows, without changing rounding semantics.

A limitation is that auto-bucketing currently requires explicit `start` and `end`.  The latter is addressed with https://github.com/elastic/elasticsearch/pull/142580.

~Creating this as a draft right now as the tests don't work yet. I think the issue is that it only creates buckets for time ranges that have data in the index, even when the query yields a constant value per bucket (such as the literal/scalar `1`).~
