### PR TITLE
Mute entitlements warning for esql-datasource-s3

### DIFF
--- a/x-pack/plugin/esql-datasource-s3/src/main/config/log4j2.properties
+++ b/x-pack/plugin/esql-datasource-s3/src/main/config/log4j2.properties
@@ -1,0 +1,3 @@
+logger.entitlements_esql_datasource_s3.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.esql-datasource-s3.ALL-UNNAMED
+logger.entitlements_esql_datasource_s3.level = error
+


### PR DESCRIPTION
The usual suspect with AWS credentials, this should be muted.
Relates to https://github.com/elastic/elasticsearch/pull/141678, no backports needed.