### PR TITLE
Enable secure local Prometheus remote_write

### DIFF
--- a/dev-tools/prometheus-local/README.md
+++ b/dev-tools/prometheus-local/README.md
@@ -10,12 +10,12 @@ Prometheus scrapes itself and forwards samples to Elasticsearch via the Promethe
 
 ## Start
 
-Start Elasticsearch from source and ensure it listens on a non-loopback interface.
+Start Elasticsearch from source and ensure it listens on a non-loopback interface
+so that Prometheus in Docker can reach it.
 
 ```bash
 ./gradlew run --configuration-cache \
     -Dtests.es.http.host=0.0.0.0 \
-    -Dtests.es.xpack.security.enabled=false \
     -Dtests.es.xpack.ml.enabled=false \
     -Drun.license_type=trial \
     -Dtests.heap.size=4G \
@@ -36,9 +36,3 @@ docker compose up -d
   - `rate(prometheus_remote_storage_samples_total[1m])`
 - Query PromQL in Kibana Discover (example query):
   - `PROMQL step=1m rate(prometheus_remote_storage_samples_total[1m])`
-
-## Notes
-
-- The `remote_write` URL points at `host.docker.internal`, which resolves to the host from Docker Desktop (macOS/Windows).
-- Your Elasticsearch instance must listen on a non-loopback interface (for example `0.0.0.0:9200`).
-- Kibana uses `docker.elastic.co/kibana/kibana:9.4.0-SNAPSHOT` and points to Elasticsearch at `http://host.docker.internal:9200`.

--- a/dev-tools/prometheus-local/docker-compose.yml
+++ b/dev-tools/prometheus-local/docker-compose.yml
@@ -12,15 +12,44 @@ services:
       - "--storage.tsdb.path=/prometheus"
       - "--web.enable-lifecycle"
     restart: unless-stopped
+  kibana_settings:
+    image: curlimages/curl:latest
+    container_name: kibana-settings
+    restart: 'no'
+    command:
+      - /bin/sh
+      - -c
+      - |
+          echo "Setup kibana_system password"
+          start_time=$$(date +%s)
+          timeout=60
+          until curl -s -u "elastic:password" -X POST "http://host.docker.internal:9200/_security/user/kibana_system/_password" \
+            -H "Content-Type: application/json" \
+            -d "{\"password\":\"password\"}" | grep -q "^{}"; do
+            if [ $$(($$(date +%s) - $$start_time)) -ge $$timeout ]; then
+              echo "Error: Elasticsearch timeout while setting kibana_system password"
+              exit 1
+            fi
+            sleep 2
+          done
   kibana:
+    depends_on:
+      kibana_settings:
+        condition: service_completed_successfully
     image: docker.elastic.co/kibana/kibana:9.4.0-SNAPSHOT
     container_name: es-local-kibana
     ports:
       - "5601:5601"
     environment:
+      SERVER_NAME: kibana
       ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
+      ELASTICSEARCH_USERNAME: kibana_system
+      ELASTICSEARCH_PASSWORD: password
       SERVER_HOST: "0.0.0.0"
       XPACK_SECURITY_ENABLED: "false"
+      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: "prometheus-local-eso-encryption-key-32"
+      ELASTICSEARCH_PUBLICBASEURL: http://host.docker.internal:9200
+      XPACK_SPACES_DEFAULTSOLUTION: "oblt"
     restart: unless-stopped
 
 volumes:

--- a/dev-tools/prometheus-local/prometheus.yml
+++ b/dev-tools/prometheus-local/prometheus.yml
@@ -9,3 +9,6 @@ scrape_configs:
 
 remote_write:
   - url: "http://host.docker.internal:9200/_prometheus/api/v1/write"
+    basic_auth:
+      username: "elastic"
+      password: "password"


### PR DESCRIPTION
This change updates the local `dev-tools/prometheus-local` stack to work with Elasticsearch security enabled instead of relying on an unauthenticated setup. Security is required for certain Kibana features like alerting and the streams UI.

The docker-compose flow now adds a one-shot `kibana_settings` container that waits for Elasticsearch and sets the `kibana_system` password before Kibana starts. Kibana is configured to authenticate as `kibana_system`, and Prometheus `remote_write` now includes basic auth credentials. For example, Prometheus can now push metrics to `/_prometheus/api/v1/write` on a security-enabled local node using `elastic/password`, and Kibana can connect without manual password bootstrap.

Credentials are still static dev values (the default `elastic/password` credentials used when starting Elasticsearch from source) and this setup remains intended for local development only.
