### PR TITLE
Avoid NPE when parsing StreamsMetadata from XContent

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/StreamsMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/StreamsMetadata.java
@@ -38,9 +38,9 @@ public class StreamsMetadata extends AbstractNamedDiffable<Metadata.ProjectCusto
     private static final ParseField LOGS_ECS_ENABLED = new ParseField("logs_ecs_enabled");
     private static final ParseField LOGS_OTEL_ENABLED = new ParseField("logs_otel_enabled");
     private static final ConstructingObjectParser<StreamsMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE, false, args -> {
-        boolean logsEnabled = (boolean) args[0];
-        boolean logsOtelEnabled = (boolean) args[2];
-        boolean logsECSEnabled = (boolean) args[1];
+        boolean logsEnabled = args[0] != null && (boolean) args[0];
+        boolean logsECSEnabled = args[1] != null && (boolean) args[1];
+        boolean logsOtelEnabled = args[2] != null && (boolean) args[2];
         return new StreamsMetadata(logsEnabled, logsECSEnabled, logsOtelEnabled);
     });
     static {


### PR DESCRIPTION
The enabled flags were marked as optional, but cast as a boolean they could cause a `NullPointerException` that looked like:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "args[2]" is null
	at org.elasticsearch.cluster.metadata.StreamsMetadata.lambda$static$0(StreamsMetadata.java:43)
	at org.elasticsearch.xcontent.ConstructingObjectParser.lambda$new$2(ConstructingObjectParser.java:130)
```

Relates to #141564
