### PR TITLE
Refactor csv test data loader

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -423,8 +423,7 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
     @Override
     protected boolean clusterHasCapability(EsqlCapabilities.Cap capability) {
         try {
-            return super.clusterHasCapability(capability)
-                && hasCapabilities(remoteClusterClient(), List.of(capability.capabilityName()));
+            return super.clusterHasCapability(capability) && hasCapabilities(remoteClusterClient(), List.of(capability.capabilityName()));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.SpecReader;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
-import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -422,68 +421,10 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
     }
 
     @Override
-    protected boolean supportsExponentialHistograms() {
+    protected boolean clusterHasCapability(EsqlCapabilities.Cap capability) {
         try {
-            return RestEsqlTestCase.hasCapabilities(
-                client(),
-                List.of(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW.capabilityName())
-            )
-                && RestEsqlTestCase.hasCapabilities(
-                    remoteClusterClient(),
-                    List.of(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW.capabilityName())
-                );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    protected boolean supportsTDigestField() {
-        try {
-            return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW.capabilityName()))
-                && RestEsqlTestCase.hasCapabilities(
-                    remoteClusterClient(),
-                    List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW.capabilityName())
-                );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    protected boolean supportsTDigestFieldAsMetric() {
-        try {
-            return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC.capabilityName()))
-                && RestEsqlTestCase.hasCapabilities(
-                    remoteClusterClient(),
-                    List.of(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC.capabilityName())
-                );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    protected boolean supportsHistogramDataType() {
-        try {
-            return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION.capabilityName()))
-                && RestEsqlTestCase.hasCapabilities(
-                    remoteClusterClient(),
-                    List.of(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION.capabilityName())
-                );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    protected boolean supportsBFloat16ElementType() {
-        try {
-            return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT.capabilityName()))
-                && RestEsqlTestCase.hasCapabilities(
-                    remoteClusterClient(),
-                    List.of(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT.capabilityName())
-                );
+            return super.clusterHasCapability(capability)
+                && hasCapabilities(remoteClusterClient(), List.of(capability.capabilityName()));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
@@ -16,16 +16,13 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
 import org.elasticsearch.xpack.esql.plugin.ComputeService;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
-import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.util.List;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class EsqlSpecIT extends EsqlSpecTestCase {
@@ -53,24 +50,6 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
     @Override
     protected boolean supportsSourceFieldMapping() {
         return cluster.getNumNodes() == 1;
-    }
-
-    @Override
-    protected boolean supportsExponentialHistograms() {
-        return RestEsqlTestCase.hasCapabilities(
-            client(),
-            List.of(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW.capabilityName())
-        );
-    }
-
-    @Override
-    protected boolean supportsTDigestField() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW.capabilityName()));
-    }
-
-    @Override
-    protected boolean supportsTDigestFieldAsMetric() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC.capabilityName()));
     }
 
     @Before

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -201,11 +201,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
                 supportsSourceFieldMapping(),
                 supportsSemanticTextInference(),
                 timeSeriesOnly(),
-                supportsExponentialHistograms(),
-                supportsTDigestField(),
-                supportsHistogramDataType(),
-                supportsBFloat16ElementType(),
-                supportsTDigestFieldAsMetric()
+                this::clusterHasCapability
             );
             return null;
         });
@@ -372,26 +368,6 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
      */
     protected boolean clusterHasCapability(EsqlCapabilities.Cap capability) {
         return hasCapabilities(client(), List.of(capability.capabilityName()));
-    }
-
-    protected boolean supportsExponentialHistograms() {
-        return clusterHasCapability(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW);
-    }
-
-    protected boolean supportsTDigestField() {
-        return clusterHasCapability(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW);
-    }
-
-    protected boolean supportsTDigestFieldAsMetric() {
-        return clusterHasCapability(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC);
-    }
-
-    protected boolean supportsHistogramDataType() {
-        return clusterHasCapability(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION);
-    }
-
-    protected boolean supportsBFloat16ElementType() {
-        return clusterHasCapability(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT);
     }
 
     protected void doTest() throws Throwable {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -366,27 +366,32 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         return true;
     }
 
+    /**
+     * Returns true if the cluster under test supports the given ESQL capability.
+     * Subclasses may override this to check additional clusters (e.g. remote clusters in CCS).
+     */
+    protected boolean clusterHasCapability(EsqlCapabilities.Cap capability) {
+        return hasCapabilities(client(), List.of(capability.capabilityName()));
+    }
+
     protected boolean supportsExponentialHistograms() {
-        return RestEsqlTestCase.hasCapabilities(
-            client(),
-            List.of(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW.capabilityName())
-        );
+        return clusterHasCapability(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW);
     }
 
     protected boolean supportsTDigestField() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW.capabilityName()));
+        return clusterHasCapability(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW);
     }
 
     protected boolean supportsTDigestFieldAsMetric() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC.capabilityName()));
+        return clusterHasCapability(EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC);
     }
 
     protected boolean supportsHistogramDataType() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION.capabilityName()));
+        return clusterHasCapability(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION);
     }
 
     protected boolean supportsBFloat16ElementType() {
-        return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT.capabilityName()));
+        return clusterHasCapability(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT);
     }
 
     protected void doTest() throws Throwable {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -391,8 +391,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     }
 
     private List<String> availableIndices() throws IOException {
-        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), cap -> false)
-            .stream()
+        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), cap -> false).stream()
             .filter(x -> x.requiresInferenceEndpoint() == false)
             .map(x -> x.indexName())
             .toList();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -391,7 +391,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     }
 
     private List<String> availableIndices() throws IOException {
-        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), false, false, false, false, false)
+        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), cap -> false)
             .stream()
             .filter(x -> x.requiresInferenceEndpoint() == false)
             .map(x -> x.indexName())

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -30,10 +30,10 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -49,9 +49,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -480,30 +480,22 @@ public class CsvTestsDataLoader {
             }
             if (load) {
                 if (indexes) {
-                    loadDataSets(
-                        client,
-                        true,
-                        true,
-                        false,
-                        false,
-                        cap -> true,
-                        (restClient, indexName, indexMapping, indexSettings) -> {
-                            // don't use ESRestTestCase methods here or, if you do, test running the main method before making the change
-                            StringBuilder jsonBody = new StringBuilder("{");
-                            if (indexSettings != null && indexSettings.isEmpty() == false) {
-                                jsonBody.append("\"settings\":");
-                                jsonBody.append(Strings.toString(indexSettings));
-                                jsonBody.append(",");
-                            }
-                            jsonBody.append("\"mappings\":");
-                            jsonBody.append(indexMapping);
-                            jsonBody.append("}");
-
-                            Request request = new Request("PUT", "/" + indexName);
-                            request.setJsonEntity(jsonBody.toString());
-                            restClient.performRequest(request);
+                    loadDataSets(client, true, true, false, false, cap -> true, (restClient, indexName, indexMapping, indexSettings) -> {
+                        // don't use ESRestTestCase methods here or, if you do, test running the main method before making the change
+                        StringBuilder jsonBody = new StringBuilder("{");
+                        if (indexSettings != null && indexSettings.isEmpty() == false) {
+                            jsonBody.append("\"settings\":");
+                            jsonBody.append(Strings.toString(indexSettings));
+                            jsonBody.append(",");
                         }
-                    );
+                        jsonBody.append("\"mappings\":");
+                        jsonBody.append(indexMapping);
+                        jsonBody.append("}");
+
+                        Request request = new Request("PUT", "/" + indexName);
+                        request.setJsonEntity(jsonBody.toString());
+                        restClient.performRequest(request);
+                    });
                 }
                 if (policies) {
                     loadEnrichPolicies(client);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -474,7 +475,7 @@ public class CsvTestsDataLoader {
                     deleteEnrichPolicies(client);
                 }
                 if (indexes) {
-                    deleteIndexes(client, true, true, false, false, true, true, true, true, true);
+                    deleteIndexes(client, true, true, false, false, cap -> true);
                 }
             }
             if (load) {
@@ -485,11 +486,7 @@ public class CsvTestsDataLoader {
                         true,
                         false,
                         false,
-                        true,
-                        true,
-                        true,
-                        true,
-                        true,
+                        cap -> true,
                         (restClient, indexName, indexMapping, indexSettings) -> {
                             // don't use ESRestTestCase methods here or, if you do, test running the main method before making the change
                             StringBuilder jsonBody = new StringBuilder("{");
@@ -523,11 +520,7 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled,
         boolean requiresTimeSeries,
-        boolean exponentialHistogramFieldSupported,
-        boolean tDigestFieldSupported,
-        boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported,
-        boolean tDigestMetricFieldSupported
+        Predicate<EsqlCapabilities.Cap> capabilityCheck
     ) throws IOException {
         Set<TestDataset> testDataSets = new HashSet<>();
 
@@ -536,11 +529,7 @@ public class CsvTestsDataLoader {
                 && (supportsIndexModeLookup || isLookupDataset(dataset) == false)
                 && (supportsSourceFieldMapping || isSourceMappingDataset(dataset) == false)
                 && (requiresTimeSeries == false || isTimeSeries(dataset))
-                && (exponentialHistogramFieldSupported || containsExponentialHistogramFields(dataset) == false)
-                && (tDigestFieldSupported || containsTDigestFields(dataset) == false)
-                && (tDigestMetricFieldSupported || containsTDigestMetricFields(dataset) == false)
-                && (histogramFieldSupported || containsHistogramFields(dataset) == false)
-                && (bFloat16ElementTypeSupported || containsBFloat16ElementType(dataset) == false)) {
+                && dataset.requiredCapabilities.stream().allMatch(capabilityCheck)) {
                 testDataSets.add(dataset);
             }
         }
@@ -563,60 +552,6 @@ public class CsvTestsDataLoader {
         return mappingNode.get("_source") != null;
     }
 
-    private static boolean containsExponentialHistogramFields(TestDataset dataset) throws IOException {
-        return containsFieldWithProperties(dataset, Map.of("type", "exponential_histogram"));
-    }
-
-    private static boolean containsTDigestFields(TestDataset dataset) throws IOException {
-        return containsFieldWithProperties(dataset, Map.of("type", "tdigest"));
-    }
-
-    private static boolean containsTDigestMetricFields(TestDataset dataset) throws IOException {
-        return containsFieldWithProperties(dataset, Map.of("type", "tdigest", "time_series_metric", "histogram"));
-    }
-
-    private static boolean containsBFloat16ElementType(TestDataset dataset) throws IOException {
-        return containsFieldWithProperties(dataset, Map.of("element_type", "bfloat16"));
-    }
-
-    private static boolean containsFieldWithProperties(TestDataset dataset, Map<String, Object> properties) throws IOException {
-        if (dataset.mappingFileName() == null || properties.isEmpty()) {
-            return false;
-        }
-
-        Map<?, ?> mappingNode = new ObjectMapper().readValue(dataset.streamMapping(), Map.class);
-        Object mappingProperties = mappingNode.get("properties");
-        if (mappingProperties instanceof Map<?, ?> mappingPropertiesMap) {
-            for (Object field : mappingPropertiesMap.values()) {
-                if (field instanceof Map<?, ?> fieldMap && fieldMap.entrySet().containsAll(properties.entrySet())) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static boolean containsHistogramFields(TestDataset dataset) throws IOException {
-        if (dataset.mappingFileName() == null) {
-            return false;
-        }
-        JsonNode mappingNode = new ObjectMapper().readTree(dataset.streamMapping());
-        JsonNode properties = mappingNode.get("properties");
-        if (properties != null) {
-            for (var fieldWithValue : properties.properties()) {
-                JsonNode fieldProperties = fieldWithValue.getValue();
-                if (fieldProperties != null) {
-                    JsonNode typeNode = fieldProperties.get("type");
-                    if (typeNode != null && typeNode.asText().equals("histogram")) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
     private static boolean isTimeSeries(TestDataset dataset) throws IOException {
         Settings settings = dataset.loadSettings();
         String mode = settings.get("index.mode");
@@ -629,18 +564,7 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled
     ) throws IOException {
-        loadDataSetIntoEs(
-            client,
-            supportsIndexModeLookup,
-            supportsSourceFieldMapping,
-            inferenceEnabled,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        loadDataSetIntoEs(client, supportsIndexModeLookup, supportsSourceFieldMapping, inferenceEnabled, false, cap -> false);
     }
 
     public static void loadDataSetIntoEs(
@@ -649,11 +573,7 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled,
         boolean timeSeriesOnly,
-        boolean exponentialHistogramFieldSupported,
-        boolean tDigestFieldSupported,
-        boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported,
-        boolean tDigestMetricFieldSupported
+        Predicate<EsqlCapabilities.Cap> capabilityCheck
     ) throws IOException {
         loadDataSets(
             client,
@@ -661,11 +581,7 @@ public class CsvTestsDataLoader {
             supportsSourceFieldMapping,
             inferenceEnabled,
             timeSeriesOnly,
-            exponentialHistogramFieldSupported,
-            tDigestFieldSupported,
-            histogramFieldSupported,
-            bFloat16ElementTypeSupported,
-            tDigestMetricFieldSupported,
+            capabilityCheck,
             (restClient, indexName, indexMapping, indexSettings) -> {
                 ESRestTestCase.createIndex(
                     restClient,
@@ -688,11 +604,7 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled,
         boolean timeSeriesOnly,
-        boolean exponentialHistogramFieldSupported,
-        boolean tDigestFieldSupported,
-        boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported,
-        boolean tDigestMetricFieldSupported,
+        Predicate<EsqlCapabilities.Cap> capabilityCheck,
         IndexCreator indexCreator
     ) throws IOException {
         Set<String> loadedDatasets = new HashSet<>();
@@ -702,11 +614,7 @@ public class CsvTestsDataLoader {
             supportsSourceFieldMapping,
             inferenceEnabled,
             timeSeriesOnly,
-            exponentialHistogramFieldSupported,
-            tDigestFieldSupported,
-            histogramFieldSupported,
-            bFloat16ElementTypeSupported,
-            tDigestMetricFieldSupported
+            capabilityCheck
         )) {
             load(client, dataset, indexCreator);
             loadedDatasets.add(dataset.indexName);
@@ -749,11 +657,7 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled,
         boolean timeSeriesOnly,
-        boolean exponentialHistogramFieldSupported,
-        boolean tDigestFieldSupported,
-        boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported,
-        boolean tDigestMetricFieldSupported
+        Predicate<EsqlCapabilities.Cap> capabilityCheck
     ) throws IOException {
         logger.info("Deleting test datasets");
         for (var dataset : availableDatasetsForEs(
@@ -761,11 +665,7 @@ public class CsvTestsDataLoader {
             supportsSourceFieldMapping,
             inferenceEnabled,
             timeSeriesOnly,
-            exponentialHistogramFieldSupported,
-            tDigestFieldSupported,
-            histogramFieldSupported,
-            bFloat16ElementTypeSupported,
-            tDigestMetricFieldSupported
+            capabilityCheck
         )) {
             deleteIndex(client, dataset.indexName());
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentType;
@@ -193,7 +194,9 @@ public class CsvTestsDataLoader {
     private static final TestDataset DENSE_VECTOR_TEXT = new TestDataset("dense_vector_text");
     private static final TestDataset MV_TEXT = new TestDataset("mv_text");
     private static final TestDataset DENSE_VECTOR = new TestDataset("dense_vector");
-    private static final TestDataset DENSE_VECTOR_BFLOAT16 = new TestDataset("dense_vector_bfloat16");
+    private static final TestDataset DENSE_VECTOR_BFLOAT16 = new TestDataset("dense_vector_bfloat16").withRequiredCapabilities(
+        List.of(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT)
+    );
     private static final TestDataset DENSE_VECTOR_ARITHMETIC = new TestDataset("dense_vector_arithmetic");
     private static final TestDataset COLORS = new TestDataset("colors");
     private static final TestDataset COLORS_CMYK_LOOKUP = new TestDataset("colors_cmyk").withSetting("lookup-settings.json");
@@ -202,19 +205,26 @@ public class CsvTestsDataLoader {
         "exp_histo_sample",
         "exp_histo_sample-mappings.json",
         "exp_histo_sample.csv"
-    ).withSetting("exp_histo_sample-settings.json");
-    private static final TestDataset TDIGEST_STANDARD_INDEX = new TestDataset("tdigest_standard_index");
-    private static final TestDataset HISTOGRAM_STANDARD_INDEX = new TestDataset("histogram_standard_index");
+    ).withSetting("exp_histo_sample-settings.json")
+        .withRequiredCapabilities(List.of(EsqlCapabilities.Cap.EXPONENTIAL_HISTOGRAM_TECH_PREVIEW));
+    private static final TestDataset TDIGEST_STANDARD_INDEX = new TestDataset("tdigest_standard_index").withRequiredCapabilities(
+        List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW)
+    );
+    private static final TestDataset HISTOGRAM_STANDARD_INDEX = new TestDataset("histogram_standard_index").withRequiredCapabilities(
+        List.of(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION)
+    );
     private static final TestDataset TDIGEST_TIMESERIES_INDEX = new TestDataset(
         "tdigest_timeseries_index",
         "tdigest_timeseries_index-mappings.json",
         "tdigest_standard_index.csv"
-    ).withSetting("tdigest_timeseries_index-settings.json");
+    ).withSetting("tdigest_timeseries_index-settings.json")
+        .withRequiredCapabilities(List.of(EsqlCapabilities.Cap.TDIGEST_TECH_PREVIEW, EsqlCapabilities.Cap.TDIGEST_TIME_SERIES_METRIC));
     private static final TestDataset HISTOGRAM_TIMESERIES_INDEX = new TestDataset(
         "histogram_timeseries_index",
         "mapping-histogram_time_series_index.json",
         "histogram_standard_index.csv"
-    ).withSetting("settings-histogram_time_series_index.json");
+    ).withSetting("settings-histogram_time_series_index.json")
+        .withRequiredCapabilities(List.of(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION));
     private static final TestDataset MANY_NUMBERS = new TestDataset("many_numbers");
     private static final TestDataset MMR_TEXT_VECTOR_KEYWORD = new TestDataset("mmr_text_vector_keyword");
 
@@ -1228,14 +1238,15 @@ public class CsvTestsDataLoader {
         boolean allowSubFields,
         @Nullable Map<String, String> typeMapping, // Override mappings read from mappings file
         @Nullable Map<String, String> dynamicTypeMapping, // Define mappings not in the mapping files, but available from field-caps
-        boolean requiresInferenceEndpoint
+        boolean requiresInferenceEndpoint,
+        List<EsqlCapabilities.Cap> requiredCapabilities
     ) {
         public TestDataset(String indexName, String mappingFileName, String dataFileName) {
-            this(indexName, mappingFileName, dataFileName, null, true, null, null, false);
+            this(indexName, mappingFileName, dataFileName, null, true, null, null, false, List.of());
         }
 
         public TestDataset(String indexName) {
-            this(indexName, "mapping-" + indexName + ".json", indexName + ".csv", null, true, null, null, false);
+            this(indexName, "mapping-" + indexName + ".json", indexName + ".csv", null, true, null, null, false, List.of());
         }
 
         public TestDataset withIndex(String indexName) {
@@ -1247,7 +1258,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1260,7 +1272,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1273,7 +1286,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1286,7 +1300,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1299,7 +1314,8 @@ public class CsvTestsDataLoader {
                 false,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1312,7 +1328,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1325,7 +1342,8 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                requiresInferenceEndpoint
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 
@@ -1338,7 +1356,22 @@ public class CsvTestsDataLoader {
                 allowSubFields,
                 typeMapping,
                 dynamicTypeMapping,
-                needsInference
+                needsInference,
+                requiredCapabilities
+            );
+        }
+
+        public TestDataset withRequiredCapabilities(List<EsqlCapabilities.Cap> requiredCapabilities) {
+            return new TestDataset(
+                indexName,
+                mappingFileName,
+                dataFileName,
+                settingFileName,
+                allowSubFields,
+                typeMapping,
+                dynamicTypeMapping,
+                requiresInferenceEndpoint,
+                requiredCapabilities
             );
         }
 


### PR DESCRIPTION
Refactor CsvTestDataLoader to keep a list of the required capabilities for each data set, and check them when attempting to load that data set.  This will curtail the proliferation of boolean flags to LoadDataSetIntoEs, as well as keeping the requirements for each data set close to the data set creation.  It also deletes a bunch of kludgy code.

I used Cursor agent with the `Claude 4.6 Opus (Thinking)` model to do this refactor.