### PR TITLE
ESQL: Lock HeapAttack tests to 2 cpus

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
@@ -23,6 +23,9 @@ public class Clusters {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("esql.query.allow_partial_results", "false")
             .setting("logger.org.elasticsearch.compute.lucene.read", "DEBUG")
+            /*
+             * Lock to two processors and 512mb of RAM to make the tests more consistent.
+             */
             .setting("node.processors", "2")
             .jvmArg("-Xmx512m");
         String javaVersion = JvmInfo.jvmInfo().version();

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
@@ -23,6 +23,7 @@ public class Clusters {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("esql.query.allow_partial_results", "false")
             .setting("logger.org.elasticsearch.compute.lucene.read", "DEBUG")
+            .setting("node.processors", "2")
             .jvmArg("-Xmx512m");
         String javaVersion = JvmInfo.jvmInfo().version();
         if (javaVersion.equals("20") || javaVersion.equals("21")) {


### PR DESCRIPTION
Locks the HeapAttack tests to running on nodes with 2 cpus a piece. Well, sort of. It configures `node.processors` which sets the thread pool sizes. That's as good as we're going to get with just the test configs.

It should make the tests more consistent. Without this, the nodes will size their thread pools based on the number of CPUs on each node. That'll the tests run differently on your laptop or my laptop or CI.
