### PR TITLE
Replace procrun with sc.exe for all basic Windows service control operations

### DIFF
--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ScCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ScCommand.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.windows.service;
+
+import joptsimple.OptionSet;
+
+import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.ProcessInfo;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.UserException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base command for controlling Windows services via {@code sc.exe}.
+ *
+ * <p>Unlike {@link ProcrunCommand}, which delegates to the Apache procrun executable for all service
+ * operations, this class uses the standard Windows {@code sc.exe} tool for service control operations
+ * (start, stop, delete). This avoids procrun's unreliable behavior around service state transitions,
+ * particularly during stop where procrun may return before the service has fully stopped and may
+ * incorrectly report errors.
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-config">sc.exe docs</a>
+ */
+abstract class ScCommand extends Command {
+
+    private final String scCommand;
+
+    /**
+     * Constructs a CLI subcommand that will internally call {@code sc.exe}.
+     * @param desc A help description for this subcommand
+     * @param scCommand The sc.exe verb to run (e.g. "start", "stop", "delete")
+     */
+    protected ScCommand(String desc, String scCommand) {
+        super(desc);
+        this.scCommand = scCommand;
+    }
+
+    @Override
+    protected void execute(Terminal terminal, OptionSet options, ProcessInfo processInfo) throws Exception {
+        String serviceId = getServiceId(options, processInfo.envVars());
+        preExecute(terminal, processInfo, serviceId);
+
+        List<String> command = List.of("sc.exe", scCommand, serviceId);
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        Process process = startProcess(processBuilder);
+        String output = readStdout(process);
+        int ret = process.waitFor();
+
+        if (ret != ExitCodes.OK) {
+            throw new UserException(ret, getFailureMessage(serviceId) + (output.isEmpty() ? "" : ": " + output));
+        }
+
+        postExecute(terminal, processInfo, serviceId);
+        terminal.println(getSuccessMessage(serviceId));
+    }
+
+    /** Reads all stdout from the process into a trimmed string. */
+    static String readStdout(Process process) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (sb.isEmpty() == false) {
+                    sb.append(System.lineSeparator());
+                }
+                sb.append(line);
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    /** Determines the service id for the Elasticsearch service that should be used. */
+    private static String getServiceId(OptionSet options, Map<String, String> env) throws UserException {
+        List<?> args = options.nonOptionArguments();
+        if (args.size() > 1) {
+            throw new UserException(ExitCodes.USAGE, "too many arguments, expected one service id");
+        }
+        final String serviceId;
+        if (args.size() > 0) {
+            serviceId = args.get(0).toString();
+        } else {
+            serviceId = env.getOrDefault("SERVICE_ID", "elasticsearch-service-x64");
+        }
+        return serviceId;
+    }
+
+    /**
+     * A hook to add logging and validation before executing the sc.exe command.
+     * @throws UserException if there is a problem with the command invocation
+     */
+    protected void preExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws UserException {}
+
+    /**
+     * A hook for additional work after the sc.exe command succeeds (e.g. polling for stop completion).
+     * @throws UserException if there is a problem after the command
+     */
+    protected void postExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws Exception {}
+
+    /** Returns a message that should be output on success of the sc.exe command. */
+    protected abstract String getSuccessMessage(String serviceId);
+
+    /** Returns a message that should be output on failure of the sc.exe command. */
+    protected abstract String getFailureMessage(String serviceId);
+
+    // package private to allow tests to override
+    Process startProcess(ProcessBuilder processBuilder) throws IOException {
+        return processBuilder.start();
+    }
+}

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommand.java
@@ -10,11 +10,13 @@
 package org.elasticsearch.windows.service;
 
 /**
- * Removes the Elasticsearch Windows service, first stopping it if it is running.
+ * Removes the Elasticsearch Windows service.
+ *
+ * <p>Uses {@code sc.exe delete} to remove the service registration from the Windows Service Control Manager.
  */
-class WindowsServiceRemoveCommand extends ProcrunCommand {
+class WindowsServiceRemoveCommand extends ScCommand {
     WindowsServiceRemoveCommand() {
-        super("Remove the Elasticsearch Windows Service", "DS");
+        super("Remove the Elasticsearch Windows Service", "delete");
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStartCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStartCommand.java
@@ -12,9 +12,9 @@ package org.elasticsearch.windows.service;
 /**
  * Starts the Elasticsearch Windows service.
  */
-class WindowsServiceStartCommand extends ProcrunCommand {
+class WindowsServiceStartCommand extends ScCommand {
     WindowsServiceStartCommand() {
-        super("Starts the Elasticsearch Windows Service", "ES");
+        super("Starts the Elasticsearch Windows Service", "start");
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
@@ -9,21 +9,129 @@
 
 package org.elasticsearch.windows.service;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cli.ProcessInfo;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.UserException;
+
+import java.time.Duration;
+import java.util.Locale;
+
 /**
  * Stops the Elasticsearch Windows service.
+ *
+ * <p>After issuing the stop command, this polls the service status via {@code sc.exe query} until the
+ * service reaches the {@code STOPPED} state or a timeout is reached. This is necessary because the
+ * Windows Service Control Manager returns immediately with {@code STOP_PENDING}, and Elasticsearch
+ * can take minutes to shut down gracefully.
  */
-class WindowsServiceStopCommand extends ProcrunCommand {
+class WindowsServiceStopCommand extends ScCommand {
+    private static final Logger logger = LogManager.getLogger(WindowsServiceStopCommand.class);
+
+    static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofMinutes(5);
+    static final Duration POLL_INTERVAL = Duration.ofSeconds(2);
+
     WindowsServiceStopCommand() {
-        super("Stops the Elasticsearch Windows Service", "SS");
+        super("Stops the Elasticsearch Windows Service", "stop");
+    }
+
+    @Override
+    protected void postExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws Exception {
+        Duration timeout = getStopTimeout(pinfo);
+        waitForStopped(terminal, serviceId, timeout);
+    }
+
+    /**
+     * Polls {@code sc.exe query} until the service reaches STOPPED state or the timeout expires.
+     */
+    void waitForStopped(Terminal terminal, String serviceId, Duration timeout) throws UserException {
+        terminal.println(String.format(Locale.ROOT, "Waiting for service '%s' to stop...", serviceId));
+        long start = System.currentTimeMillis();
+        while (true) {
+            String state = queryServiceState(serviceId);
+            if ("STOPPED".equalsIgnoreCase(state)) {
+                return;
+            }
+
+            Duration elapsed = Duration.ofMillis(System.currentTimeMillis() - start);
+            if (elapsed.compareTo(timeout) > 0) {
+                String msg = String.format(
+                    Locale.ROOT,
+                    "Timed out after %s waiting for service '%s' to stop (last state: %s)",
+                    elapsed,
+                    serviceId,
+                    state
+                );
+                logger.warn(msg);
+                terminal.errorPrintln(msg);
+                throw new UserException(1, msg);
+            }
+
+            logger.debug("Service [{}] still in state [{}], waiting...", serviceId, state);
+            terminal.println(Terminal.Verbosity.VERBOSE, String.format(Locale.ROOT, "Service '%s' still %s...", serviceId, state));
+            try {
+                Thread.sleep(POLL_INTERVAL.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new UserException(1, "Interrupted while waiting for service '" + serviceId + "' to stop");
+            }
+        }
+    }
+
+    /**
+     * Queries the current state of the service via {@code sc.exe query}.
+     * Returns the state string (e.g. "RUNNING", "STOPPED", "STOP_PENDING") or "UNKNOWN" on failure.
+     */
+    String queryServiceState(String serviceId) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("sc.exe", "query", serviceId);
+            Process process = startProcess(pb);
+            String output = ScCommand.readStdout(process);
+            process.waitFor();
+            return parseState(output);
+        } catch (Exception e) {
+            logger.warn("Failed to query service state for [{}]", serviceId, e);
+            return "UNKNOWN";
+        }
+    }
+
+    /**
+     * Parses the STATE field from {@code sc.exe query} output.
+     * The output contains a line like: {@code STATE : 4  RUNNING} or {@code STATE : 1  STOPPED}.
+     */
+    static String parseState(String output) {
+        for (String line : output.split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("STATE")) {
+                int lastSpace = trimmed.lastIndexOf(' ');
+                if (lastSpace > 0) {
+                    return trimmed.substring(lastSpace + 1).trim();
+                }
+            }
+        }
+        return "UNKNOWN";
+    }
+
+    private static Duration getStopTimeout(ProcessInfo pinfo) {
+        String timeoutStr = pinfo.envVars().get("ES_STOP_TIMEOUT");
+        if (timeoutStr != null && timeoutStr.isBlank() == false) {
+            try {
+                return Duration.ofSeconds(Long.parseLong(timeoutStr));
+            } catch (NumberFormatException e) {
+                logger.warn("Invalid ES_STOP_TIMEOUT value [{}], using default", timeoutStr);
+            }
+        }
+        return DEFAULT_STOP_TIMEOUT;
     }
 
     @Override
     protected String getSuccessMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "The service '%s' has been stopped", serviceId);
+        return String.format(Locale.ROOT, "The service '%s' has been stopped", serviceId);
     }
 
     @Override
     protected String getFailureMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "Failed stopping '%s' service", serviceId);
+        return String.format(Locale.ROOT, "Failed stopping '%s' service", serviceId);
     }
 }

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ScCommandTestCase.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ScCommandTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.windows.service;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.cli.CommandTestCase;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Base test case for commands that use {@code sc.exe} for service control.
+ */
+public abstract class ScCommandTestCase extends CommandTestCase {
+
+    int mockProcessExit = 0;
+    String mockProcessOutput = "";
+    ScCallValidator mockScCallValidator = null;
+
+    @ParametersFactory
+    public static Iterable<Object[]> spaceInPathProvider() {
+        return List.of(new Object[] { true }, new Object[] { false });
+    }
+
+    protected ScCommandTestCase(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
+    interface ScCallValidator {
+        void validate(List<String> command);
+    }
+
+    record ScCall(String verb, String serviceId) {}
+
+    class MockProcess extends Process {
+        private final InputStream stdout;
+
+        MockProcess(String output) {
+            this.stdout = new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            throw new AssertionError("should not access output stream");
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return mockProcessExit;
+        }
+
+        @Override
+        public int exitValue() {
+            return mockProcessExit;
+        }
+
+        @Override
+        public void destroy() {
+            throw new AssertionError("should not kill sc.exe process");
+        }
+    }
+
+    protected Process mockProcess(ProcessBuilder processBuilder) throws IOException {
+        if (mockScCallValidator != null) {
+            mockScCallValidator.validate(processBuilder.command());
+        }
+        return new MockProcess(mockProcessOutput);
+    }
+
+    static ScCall parseScCall(List<String> command) {
+        assertThat(command, hasSize(3));
+        assertThat(command.get(0), equalTo("sc.exe"));
+        return new ScCall(command.get(1), command.get(2));
+    }
+
+    @Before
+    public void resetMockProcess() {
+        mockProcessExit = 0;
+        mockProcessOutput = "";
+        mockScCallValidator = null;
+    }
+
+    protected abstract String getScVerb();
+
+    protected abstract String getDefaultSuccessMessage();
+
+    protected abstract String getDefaultFailureMessage();
+
+    public void testDefaultCommand() throws Exception {
+        mockScCallValidator = (command) -> {
+            ScCall scCall = parseScCall(command);
+            assertThat(scCall.verb(), equalTo(getScVerb()));
+            assertThat(scCall.serviceId(), equalTo("elasticsearch-service-x64"));
+        };
+        assertOkWithOutput(containsString(getDefaultSuccessMessage()), emptyString());
+    }
+
+    public void testFailure() throws Exception {
+        mockProcessExit = 5;
+        assertThat(executeMain(), equalTo(5));
+        assertThat(terminal.getErrorOutput(), containsString(getDefaultFailureMessage()));
+    }
+
+    public void testServiceId() throws Exception {
+        assertUsage(containsString("too many arguments"), "servicename", "servicename");
+        terminal.reset();
+        mockScCallValidator = (command) -> {
+            ScCall scCall = parseScCall(command);
+            assertThat(scCall.serviceId(), equalTo("my-service-id"));
+        };
+        assertOkWithOutput(
+            containsString(getDefaultSuccessMessage().replace("elasticsearch-service-x64", "my-service-id")),
+            emptyString(),
+            "my-service-id"
+        );
+    }
+
+    public void testServiceIdFromEnv() throws Exception {
+        envVars.put("SERVICE_ID", "my-service-id");
+        mockScCallValidator = (command) -> {
+            ScCall scCall = parseScCall(command);
+            assertThat(scCall.serviceId(), equalTo("my-service-id"));
+        };
+        assertOkWithOutput(containsString(getDefaultSuccessMessage().replace("elasticsearch-service-x64", "my-service-id")), emptyString());
+    }
+}

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cli.Command;
 
 import java.io.IOException;
 
-public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase {
+public class WindowsServiceRemoveCommandTests extends ScCommandTestCase {
 
     public WindowsServiceRemoveCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -30,8 +30,8 @@ public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase 
     }
 
     @Override
-    protected String getCommand() {
-        return "DS";
+    protected String getScVerb() {
+        return "delete";
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cli.Command;
 
 import java.io.IOException;
 
-public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
+public class WindowsServiceStartCommandTests extends ScCommandTestCase {
 
     public WindowsServiceStartCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -30,8 +30,8 @@ public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
     }
 
     @Override
-    protected String getCommand() {
-        return "ES";
+    protected String getScVerb() {
+        return "start";
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
@@ -12,8 +12,12 @@ package org.elasticsearch.windows.service;
 import org.elasticsearch.cli.Command;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class WindowsServiceStopCommandTests extends ScCommandTestCase {
 
     public WindowsServiceStopCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -21,17 +25,32 @@ public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
 
     @Override
     protected Command newCommand() {
+        return newStopCommand(null);
+    }
+
+    private WindowsServiceStopCommand newStopCommand(String[] queryStates) {
         return new WindowsServiceStopCommand() {
+            private final AtomicInteger queryCount = new AtomicInteger(0);
+
             @Override
             Process startProcess(ProcessBuilder processBuilder) throws IOException {
                 return mockProcess(processBuilder);
+            }
+
+            @Override
+            String queryServiceState(String serviceId) {
+                if (queryStates == null) {
+                    return "STOPPED";
+                }
+                int idx = Math.min(queryCount.getAndIncrement(), queryStates.length - 1);
+                return queryStates[idx];
             }
         };
     }
 
     @Override
-    protected String getCommand() {
-        return "SS";
+    protected String getScVerb() {
+        return "stop";
     }
 
     @Override
@@ -42,5 +61,78 @@ public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
     @Override
     protected String getDefaultFailureMessage() {
         return "Failed stopping 'elasticsearch-service-x64' service";
+    }
+
+    public void testStopWaitsForStopped() throws Exception {
+        Command cmd = newStopCommand(new String[] { "STOP_PENDING", "STOP_PENDING", "STOPPED" });
+        String output = execute(cmd);
+        assertThat(output, containsString("The service 'elasticsearch-service-x64' has been stopped"));
+    }
+
+    public void testStopImmediatelyStopped() throws Exception {
+        Command cmd = newStopCommand(new String[] { "STOPPED" });
+        String output = execute(cmd);
+        assertThat(output, containsString("The service 'elasticsearch-service-x64' has been stopped"));
+    }
+
+    public void testStopTimeout() throws Exception {
+        envVars.put("ES_STOP_TIMEOUT", "1");
+        WindowsServiceStopCommand cmd = new WindowsServiceStopCommand() {
+            @Override
+            Process startProcess(ProcessBuilder processBuilder) throws IOException {
+                return mockProcess(processBuilder);
+            }
+
+            @Override
+            String queryServiceState(String serviceId) {
+                return "STOP_PENDING";
+            }
+        };
+        int exitCode = cmd.main(new String[0], terminal, new org.elasticsearch.cli.ProcessInfo(sysprops, envVars, esHomeDir));
+        assertThat(exitCode, equalTo(1));
+        assertThat(terminal.getErrorOutput(), containsString("Timed out"));
+    }
+
+    public void testParseStateStopped() {
+        String output = """
+            SERVICE_NAME: elasticsearch-service-x64
+                    TYPE               : 10  WIN32_OWN_PROCESS
+                    STATE              : 1  STOPPED
+                    WIN32_EXIT_CODE    : 0  (0x0)
+                    SERVICE_EXIT_CODE  : 0  (0x0)
+                    CHECKPOINT         : 0x0
+                    WAIT_HINT          : 0x0
+            """;
+        assertThat(WindowsServiceStopCommand.parseState(output), equalTo("STOPPED"));
+    }
+
+    public void testParseStateRunning() {
+        String output = """
+            SERVICE_NAME: elasticsearch-service-x64
+                    TYPE               : 10  WIN32_OWN_PROCESS
+                    STATE              : 4  RUNNING
+                    WIN32_EXIT_CODE    : 0  (0x0)
+                    SERVICE_EXIT_CODE  : 0  (0x0)
+                    CHECKPOINT         : 0x0
+                    WAIT_HINT          : 0x0
+            """;
+        assertThat(WindowsServiceStopCommand.parseState(output), equalTo("RUNNING"));
+    }
+
+    public void testParseStateStopPending() {
+        String output = """
+            SERVICE_NAME: elasticsearch-service-x64
+                    TYPE               : 10  WIN32_OWN_PROCESS
+                    STATE              : 3  STOP_PENDING
+                    WIN32_EXIT_CODE    : 0  (0x0)
+                    SERVICE_EXIT_CODE  : 0  (0x0)
+                    CHECKPOINT         : 0x0
+                    WAIT_HINT          : 0x0
+            """;
+        assertThat(WindowsServiceStopCommand.parseState(output), equalTo("STOP_PENDING"));
+    }
+
+    public void testParseStateUnknownOutput() {
+        assertThat(WindowsServiceStopCommand.parseState("garbage output"), equalTo("UNKNOWN"));
     }
 }


### PR DESCRIPTION
Procrun is unreliable for service state transitions, particularly during stop where it may return before the service has fully stopped and incorrectly report errors (see https://github.com/elastic/elasticsearch/pull/137451). 

The new ScCommand base class calls sc.exe directly, and the stop command includes a busy-wait polling loop to ensure the service reaches the STOPPED state before returning.

I left install and manager aside; manager starts the Apache procrun UI (and I think we can just get rid of it, but that would be for another PR); install is tightly coupled with how procrun works, e.g. adding registry keys procrun reads when it's started by the SCM to understand what to do. It will need to be replaced when we replace procrun for the service itself too. 

Co-authored by cursor-agent
