### PR TITLE
Experiment with buffered reading the es819 doc values's term dictionary.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BufferedFilterIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BufferedFilterIndexInput.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A buffered {@link IndexInput} implementation that wraps another {@link IndexInput}.
+ * This combines the functionality of Lucene's {@code FilterIndexInput} (wrapping another input)
+ * with {@code BufferedIndexInput} (providing buffering for efficient reads).
+ * <p>
+ * This is useful when you need to add buffering on top of an existing {@link IndexInput}
+ * that may not be efficiently buffered, such as when reading from remote storage.
+ */
+public class BufferedFilterIndexInput extends IndexInput implements RandomAccessInput {
+
+    private static final ByteBuffer EMPTY_BYTEBUFFER = ByteBuffer.allocate(0).order(ByteOrder.LITTLE_ENDIAN);
+
+    /** Default buffer size */
+    public static final int BUFFER_SIZE = 1024;
+
+    /** Minimum buffer size allowed */
+    public static final int MIN_BUFFER_SIZE = 8;
+
+    /** The wrapped input */
+    protected final IndexInput in;
+
+    private final long length;
+    private final int bufferSize;
+
+    protected ByteBuffer buffer = EMPTY_BYTEBUFFER;
+    private long bufferStart = 0; // position in file of buffer
+
+    /**
+     * Creates a buffered wrapper around the given {@link IndexInput} with the default buffer size.
+     *
+     * @param in the underlying input to wrap
+     */
+    public BufferedFilterIndexInput(IndexInput in) {
+        this(in, BUFFER_SIZE);
+    }
+
+    /**
+     * Creates a buffered wrapper around the given {@link IndexInput} with a specific buffer size.
+     *
+     * @param in the underlying input to wrap
+     * @param bufferSize the buffer size to use
+     */
+    public BufferedFilterIndexInput(IndexInput in, int bufferSize) {
+        super(in.toString());
+        this.in = in;
+        this.length = in.length();
+        int bufSize = Math.max(MIN_BUFFER_SIZE, (int) Math.min(bufferSize, length));
+        checkBufferSize(bufSize);
+        this.bufferSize = bufSize;
+    }
+
+    /**
+     * Private constructor for slicing.
+     */
+    private BufferedFilterIndexInput(IndexInput in, int bufferSize, long length) {
+        super(in.toString());
+        this.in = in;
+        this.length = length;
+        this.bufferSize = bufferSize;
+    }
+
+    private void checkBufferSize(int bufferSize) {
+        if (bufferSize < MIN_BUFFER_SIZE) {
+            throw new IllegalArgumentException("bufferSize must be at least MIN_BUFFER_SIZE (got " + bufferSize + ")");
+        }
+    }
+
+    /**
+     * Returns the underlying {@link IndexInput}.
+     */
+    public IndexInput getDelegate() {
+        return in;
+    }
+
+    @Override
+    public final long length() {
+        return length;
+    }
+
+    /**
+     * Returns the buffer size.
+     */
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    @Override
+    public final byte readByte() throws IOException {
+        if (buffer.hasRemaining() == false) {
+            refill();
+        }
+        return buffer.get();
+    }
+
+    @Override
+    public final void readBytes(byte[] b, int offset, int len) throws IOException {
+        readBytes(b, offset, len, true);
+    }
+
+    @Override
+    public final void readBytes(byte[] b, int offset, int len, boolean useBuffer) throws IOException {
+        int available = buffer.remaining();
+        if (len <= available) {
+            // the buffer contains enough data to satisfy this request
+            if (len > 0) { // to allow b to be null if len is 0...
+                buffer.get(b, offset, len);
+            }
+        } else {
+            // the buffer does not have enough data. First serve all we've got.
+            if (available > 0) {
+                buffer.get(b, offset, available);
+                offset += available;
+                len -= available;
+            }
+            // and now, read the remaining 'len' bytes:
+            if (useBuffer && len < bufferSize) {
+                // If the amount left to read is small enough, and
+                // we are allowed to use our buffer, do it in the usual
+                // buffered way: fill the buffer and copy from it:
+                refill();
+                if (buffer.remaining() < len) {
+                    // Throw an exception when refill() could not read len bytes:
+                    buffer.get(b, offset, buffer.remaining());
+                    throw new EOFException("read past EOF: " + this);
+                } else {
+                    buffer.get(b, offset, len);
+                }
+            } else {
+                // The amount left to read is larger than the buffer or we've been asked to not use our buffer -
+                // there's no performance reason not to read it all at once.
+                long currentPos = bufferStart + buffer.position();
+                long after = currentPos + len;
+                if (after > length()) {
+                    throw new EOFException("read past EOF: " + this);
+                }
+                in.seek(currentPos);
+                in.readBytes(b, offset, len);
+                bufferStart = after;
+                buffer.limit(0); // trigger refill() on read
+            }
+        }
+    }
+
+    @Override
+    public final short readShort() throws IOException {
+        if (Short.BYTES <= buffer.remaining()) {
+            return buffer.getShort();
+        } else {
+            return super.readShort();
+        }
+    }
+
+    @Override
+    public final int readInt() throws IOException {
+        if (Integer.BYTES <= buffer.remaining()) {
+            return buffer.getInt();
+        } else {
+            return super.readInt();
+        }
+    }
+
+    @Override
+    public final long readLong() throws IOException {
+        if (Long.BYTES <= buffer.remaining()) {
+            return buffer.getLong();
+        } else {
+            return super.readLong();
+        }
+    }
+
+    @Override
+    public final int readVInt() throws IOException {
+        if (5 <= buffer.remaining()) {
+            return ByteBufferStreamInput.readVInt(buffer);
+        } else {
+            return super.readVInt();
+        }
+    }
+
+    @Override
+    public final long readVLong() throws IOException {
+        if (10 <= buffer.remaining()) {
+            return ByteBufferStreamInput.readVLong(buffer);
+        } else {
+            return super.readVLong();
+        }
+    }
+
+    // RandomAccessInput methods
+
+    private long resolvePositionInBuffer(long pos, int width) throws IOException {
+        long index = pos - bufferStart;
+        if (index >= 0 && index <= buffer.limit() - width) {
+            return index;
+        }
+        if (index < 0) {
+            // if we're moving backwards, then try and fill up the previous page rather than
+            // starting again at the current pos, to avoid successive backwards reads reloading
+            // the same data over and over again. We also check that we can read `width`
+            // bytes without going over the end of the buffer
+            bufferStart = Math.max(bufferStart - bufferSize, pos + width - bufferSize);
+            bufferStart = Math.max(bufferStart, 0);
+            bufferStart = Math.min(bufferStart, pos);
+        } else {
+            // we're moving forwards, reset the buffer to start at pos
+            bufferStart = pos;
+        }
+        buffer.limit(0); // trigger refill() on read
+        in.seek(bufferStart);
+        refill();
+        return pos - bufferStart;
+    }
+
+    @Override
+    public final byte readByte(long pos) throws IOException {
+        long index = resolvePositionInBuffer(pos, Byte.BYTES);
+        return buffer.get((int) index);
+    }
+
+    @Override
+    public final short readShort(long pos) throws IOException {
+        long index = resolvePositionInBuffer(pos, Short.BYTES);
+        return buffer.getShort((int) index);
+    }
+
+    @Override
+    public final int readInt(long pos) throws IOException {
+        long index = resolvePositionInBuffer(pos, Integer.BYTES);
+        return buffer.getInt((int) index);
+    }
+
+    @Override
+    public final long readLong(long pos) throws IOException {
+        long index = resolvePositionInBuffer(pos, Long.BYTES);
+        return buffer.getLong((int) index);
+    }
+
+    // Bulk read methods
+
+    @Override
+    public void readFloats(float[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Float.BYTES, remainingDst);
+            buffer.asFloatBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Float.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = Float.intBitsToFloat(readInt());
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readLongs(long[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Long.BYTES, remainingDst);
+            buffer.asLongBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Long.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = readLong();
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readInts(int[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Integer.BYTES, remainingDst);
+            buffer.asIntBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Integer.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = readInt();
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
+    protected void refill() throws IOException {
+        long start = bufferStart + buffer.position();
+        long end = start + bufferSize;
+        if (end > length()) { // don't read past EOF
+            end = length();
+        }
+        int newLength = (int) (end - start);
+        if (newLength <= 0) {
+            throw new EOFException("read past EOF: " + this);
+        }
+
+        if (buffer == EMPTY_BYTEBUFFER) {
+            buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.LITTLE_ENDIAN); // allocate buffer lazily
+            in.seek(bufferStart);
+        }
+        buffer.position(0);
+        buffer.limit(newLength);
+        bufferStart = start;
+        in.seek(bufferStart);
+        in.readBytes(buffer.array(), buffer.arrayOffset(), newLength);
+        buffer.position(newLength);
+        // Make sure buffer is in correct state
+        assert buffer.order() == ByteOrder.LITTLE_ENDIAN : buffer.order();
+        assert buffer.position() == newLength;
+        buffer.flip();
+    }
+
+    @Override
+    public final long getFilePointer() {
+        return bufferStart + buffer.position();
+    }
+
+    @Override
+    public final void seek(long pos) throws IOException {
+        if (pos >= bufferStart && pos < (bufferStart + buffer.limit())) {
+            buffer.position((int) (pos - bufferStart)); // seek within buffer
+        } else {
+            bufferStart = pos;
+            buffer.limit(0); // trigger refill() on read
+            in.seek(pos);
+        }
+    }
+
+    @Override
+    public IndexInput clone() {
+        BufferedFilterIndexInput clone = (BufferedFilterIndexInput) super.clone();
+        clone.buffer = EMPTY_BYTEBUFFER;
+        clone.bufferStart = getFilePointer();
+        return clone;
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        if (offset < 0 || length < 0 || offset + length > this.length) {
+            throw new IllegalArgumentException(
+                "slice() "
+                    + sliceDescription
+                    + " out of bounds: offset="
+                    + offset
+                    + ",length="
+                    + length
+                    + ",fileLength="
+                    + this.length
+                    + ": "
+                    + this
+            );
+        }
+        return new SlicedBufferedFilterIndexInput(in.slice(sliceDescription, offset, length), bufferSize);
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    /**
+     * A sliced view of a {@link BufferedFilterIndexInput}.
+     */
+    private static final class SlicedBufferedFilterIndexInput extends BufferedFilterIndexInput {
+
+        SlicedBufferedFilterIndexInput(IndexInput slice, int bufferSize) {
+            super(slice, Math.max(MIN_BUFFER_SIZE, (int) Math.min(bufferSize, slice.length())), slice.length());
+        }
+
+        @Override
+        public IndexInput clone() {
+            BufferedFilterIndexInput clone = (BufferedFilterIndexInput) super.clone();
+            clone.buffer = EMPTY_BYTEBUFFER;
+            clone.bufferStart = getFilePointer();
+            return clone;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -1330,7 +1330,9 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
             this.entry = entry;
             RandomAccessInput addressesSlice = data.randomAccessSlice(entry.termsAddressesOffset, entry.termsAddressesLength);
             blockAddresses = DirectMonotonicReader.getInstance(entry.termsAddressesMeta, addressesSlice, merging);
-            bytes = data.slice("terms", entry.termsDataOffset, entry.termsDataLength);
+            //  Use a buffered index input here, since LZ#decompress(...) does many individual readByte() invocations and
+            //  using a buffered index put better amortizes i/o overhead across readByte() invocations.
+            bytes = new BufferedFilterIndexInput(data.slice("terms", entry.termsDataOffset, entry.termsDataLength));
             blockMask = (1L << TERMS_DICT_BLOCK_LZ4_SHIFT) - 1;
             RandomAccessInput indexAddressesSlice = data.randomAccessSlice(
                 entry.termsIndexAddressesOffset,

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -1330,8 +1330,8 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
             this.entry = entry;
             RandomAccessInput addressesSlice = data.randomAccessSlice(entry.termsAddressesOffset, entry.termsAddressesLength);
             blockAddresses = DirectMonotonicReader.getInstance(entry.termsAddressesMeta, addressesSlice, merging);
-            //  Use a buffered index input here, since LZ#decompress(...) does many individual readByte() invocations and
-            //  using a buffered index put better amortizes i/o overhead across readByte() invocations.
+            // Use a buffered index input here, since LZ#decompress(...) does many individual readByte() invocations and
+            // using a buffered index put better amortizes i/o overhead across readByte() invocations.
             bytes = new BufferedFilterIndexInput(data.slice("terms", entry.termsDataOffset, entry.termsDataLength));
             blockMask = (1L << TERMS_DICT_BLOCK_LZ4_SHIFT) - 1;
             RandomAccessInput indexAddressesSlice = data.randomAccessSlice(

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/BufferedFilterIndexInputTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/BufferedFilterIndexInputTests.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+import java.io.IOException;
+
+public class BufferedFilterIndexInputTests extends LuceneTestCase {
+
+    public void testReadByte() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 256; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    for (int i = 0; i < 256; i++) {
+                        assertEquals((byte) i, in.readByte());
+                    }
+                }
+            }
+        }
+    }
+
+    public void testReadBytes() throws IOException {
+        try (Directory dir = newDirectory()) {
+            byte[] data = new byte[10000];
+            random().nextBytes(data);
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeBytes(data, data.length);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    byte[] result = new byte[data.length];
+                    in.readBytes(result, 0, result.length);
+                    assertArrayEquals(data, result);
+                }
+            }
+        }
+    }
+
+    public void testReadBytesLargerThanBuffer() throws IOException {
+        try (Directory dir = newDirectory()) {
+            // Create data larger than the default buffer size
+            byte[] data = new byte[BufferedFilterIndexInput.BUFFER_SIZE * 3];
+            random().nextBytes(data);
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeBytes(data, data.length);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    byte[] result = new byte[data.length];
+                    in.readBytes(result, 0, result.length);
+                    assertArrayEquals(data, result);
+                }
+            }
+        }
+    }
+
+    public void testReadInt() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeInt(12345);
+                out.writeInt(-98765);
+                out.writeInt(Integer.MAX_VALUE);
+                out.writeInt(Integer.MIN_VALUE);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(12345, in.readInt());
+                    assertEquals(-98765, in.readInt());
+                    assertEquals(Integer.MAX_VALUE, in.readInt());
+                    assertEquals(Integer.MIN_VALUE, in.readInt());
+                }
+            }
+        }
+    }
+
+    public void testReadLong() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeLong(123456789012345L);
+                out.writeLong(-987654321098765L);
+                out.writeLong(Long.MAX_VALUE);
+                out.writeLong(Long.MIN_VALUE);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(123456789012345L, in.readLong());
+                    assertEquals(-987654321098765L, in.readLong());
+                    assertEquals(Long.MAX_VALUE, in.readLong());
+                    assertEquals(Long.MIN_VALUE, in.readLong());
+                }
+            }
+        }
+    }
+
+    public void testReadShort() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeShort((short) 12345);
+                out.writeShort((short) -9876);
+                out.writeShort(Short.MAX_VALUE);
+                out.writeShort(Short.MIN_VALUE);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals((short) 12345, in.readShort());
+                    assertEquals((short) -9876, in.readShort());
+                    assertEquals(Short.MAX_VALUE, in.readShort());
+                    assertEquals(Short.MIN_VALUE, in.readShort());
+                }
+            }
+        }
+    }
+
+    public void testReadVInt() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeVInt(0);
+                out.writeVInt(127);
+                out.writeVInt(128);
+                out.writeVInt(16383);
+                out.writeVInt(Integer.MAX_VALUE);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(0, in.readVInt());
+                    assertEquals(127, in.readVInt());
+                    assertEquals(128, in.readVInt());
+                    assertEquals(16383, in.readVInt());
+                    assertEquals(Integer.MAX_VALUE, in.readVInt());
+                }
+            }
+        }
+    }
+
+    public void testReadVLong() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeVLong(0L);
+                out.writeVLong(127L);
+                out.writeVLong(128L);
+                out.writeVLong(Long.MAX_VALUE);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(0L, in.readVLong());
+                    assertEquals(127L, in.readVLong());
+                    assertEquals(128L, in.readVLong());
+                    assertEquals(Long.MAX_VALUE, in.readVLong());
+                }
+            }
+        }
+    }
+
+    public void testSeek() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 1000; i++) {
+                    out.writeInt(i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    // Seek forward
+                    in.seek(400); // 100th int
+                    assertEquals(100, in.readInt());
+
+                    // Seek backward
+                    in.seek(0);
+                    assertEquals(0, in.readInt());
+
+                    // Seek to end
+                    in.seek(3996); // Last int
+                    assertEquals(999, in.readInt());
+                }
+            }
+        }
+    }
+
+    public void testSeekWithinBuffer() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 100; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    // Read to populate buffer
+                    in.readByte();
+                    in.readByte();
+
+                    // Seek within buffer (should not refill)
+                    in.seek(0);
+                    assertEquals(0, in.getFilePointer());
+                    assertEquals((byte) 0, in.readByte());
+                }
+            }
+        }
+    }
+
+    public void testGetFilePointer() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 100; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(0, in.getFilePointer());
+                    in.readByte();
+                    assertEquals(1, in.getFilePointer());
+                    in.readInt();
+                    assertEquals(5, in.getFilePointer());
+                    in.seek(50);
+                    assertEquals(50, in.getFilePointer());
+                }
+            }
+        }
+    }
+
+    public void testLength() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 100; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(100, in.length());
+                }
+            }
+        }
+    }
+
+    public void testSlice() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 100; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    try (IndexInput slice = in.slice("slice", 10, 20)) {
+                        assertEquals(20, slice.length());
+                        assertEquals((byte) 10, slice.readByte());
+                        assertEquals((byte) 11, slice.readByte());
+                    }
+                }
+            }
+        }
+    }
+
+    public void testClone() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 100; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    in.readByte();
+                    in.readByte();
+
+                    IndexInput clone = in.clone();
+                    // Clone should start at same position
+                    assertEquals(in.getFilePointer(), clone.getFilePointer());
+                    // Clone reads independently
+                    assertEquals((byte) 2, clone.readByte());
+                    assertEquals(3, clone.getFilePointer());
+                    assertEquals(2, in.getFilePointer()); // Original unchanged
+                }
+            }
+        }
+    }
+
+    public void testRandomAccessReadByte() throws IOException {
+        try (Directory dir = newDirectory()) {
+            byte[] data = new byte[1000];
+            random().nextBytes(data);
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeBytes(data, data.length);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    RandomAccessInput rai = in;
+                    for (int i = 0; i < 100; i++) {
+                        int pos = random().nextInt(data.length);
+                        assertEquals(data[pos], rai.readByte(pos));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testRandomAccessReadInt() throws IOException {
+        try (Directory dir = newDirectory()) {
+            int[] data = new int[250];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = random().nextInt();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int value : data) {
+                    out.writeInt(value);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    RandomAccessInput rai = in;
+                    for (int i = 0; i < 100; i++) {
+                        int index = random().nextInt(data.length);
+                        assertEquals(data[index], rai.readInt(index * 4L));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testRandomAccessReadLong() throws IOException {
+        try (Directory dir = newDirectory()) {
+            long[] data = new long[125];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = random().nextLong();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (long value : data) {
+                    out.writeLong(value);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    RandomAccessInput rai = in;
+                    for (int i = 0; i < 100; i++) {
+                        int index = random().nextInt(data.length);
+                        assertEquals(data[index], rai.readLong(index * 8L));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testRandomAccessReadShort() throws IOException {
+        try (Directory dir = newDirectory()) {
+            short[] data = new short[500];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (short) random().nextInt();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (short value : data) {
+                    out.writeShort(value);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    RandomAccessInput rai = in;
+                    for (int i = 0; i < 100; i++) {
+                        int index = random().nextInt(data.length);
+                        assertEquals(data[index], rai.readShort(index * 2L));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testReadInts() throws IOException {
+        try (Directory dir = newDirectory()) {
+            int[] data = new int[500];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = random().nextInt();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int value : data) {
+                    out.writeInt(value);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    int[] result = new int[data.length];
+                    in.readInts(result, 0, result.length);
+                    assertArrayEquals(data, result);
+                }
+            }
+        }
+    }
+
+    public void testReadLongs() throws IOException {
+        try (Directory dir = newDirectory()) {
+            long[] data = new long[500];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = random().nextLong();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (long value : data) {
+                    out.writeLong(value);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    long[] result = new long[data.length];
+                    in.readLongs(result, 0, result.length);
+                    assertArrayEquals(data, result);
+                }
+            }
+        }
+    }
+
+    public void testReadFloats() throws IOException {
+        try (Directory dir = newDirectory()) {
+            float[] data = new float[500];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = random().nextFloat();
+            }
+
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (float value : data) {
+                    out.writeInt(Float.floatToIntBits(value));
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    float[] result = new float[data.length];
+                    in.readFloats(result, 0, result.length);
+                    for (int i = 0; i < data.length; i++) {
+                        assertEquals(data[i], result[i], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testBufferSize() throws IOException {
+        try (Directory dir = newDirectory()) {
+            // Create a file larger than the requested buffer size
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < 1000; i++) {
+                    out.writeByte((byte) i);
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw, 512)) {
+                    assertEquals(512, in.getBufferSize());
+                }
+            }
+        }
+    }
+
+    public void testGetDelegate() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                out.writeByte((byte) 1);
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertSame(raw, in.getDelegate());
+                }
+            }
+        }
+    }
+
+    public void testEmptyFile() throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                // Write nothing
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    assertEquals(0, in.length());
+                    assertEquals(0, in.getFilePointer());
+                }
+            }
+        }
+    }
+
+    public void testBackwardSeekRefillsBuffer() throws IOException {
+        try (Directory dir = newDirectory()) {
+            // Create data larger than buffer
+            int size = BufferedFilterIndexInput.BUFFER_SIZE * 3;
+            try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+                for (int i = 0; i < size; i++) {
+                    out.writeByte((byte) (i % 256));
+                }
+            }
+
+            try (IndexInput raw = dir.openInput("test", IOContext.DEFAULT)) {
+                try (BufferedFilterIndexInput in = new BufferedFilterIndexInput(raw)) {
+                    // Read past buffer
+                    in.seek(BufferedFilterIndexInput.BUFFER_SIZE * 2);
+                    in.readByte();
+
+                    // Seek backward
+                    in.seek(100);
+                    assertEquals((byte) 100, in.readByte());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Without this change:

```
repeat 5 curl -s -k -XPOST -H "Content-Type: application/json" -d '{"query": "FROM hits | STATS c = COUNT(*) BY URL | SORT c DESC | LIMIT 10"}' "http://localhost:9200/_query" | jq .took
45754
40921
42920
40591
42044
```

With this change:

```
repeat 5 curl -s -k -XPOST -H "Content-Type: application/json" -d '{"query": "FROM hits | STATS c = COUNT(*) BY URL | SORT c DESC | LIMIT 10"}' "http://localhost:9200/_query" | jq .took
39294
37159
34956
35790
34297
```

The `URL` field in both cases was configured with `cardinality` set to `high` (default), which triggers the usage of sorted set doc values.