### PR TITLE
Fix testTrackerClearShutdown: use non-zero startTimeMillis

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotShutdownProgressTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotShutdownProgressTrackerTests.java
@@ -69,7 +69,7 @@ public class SnapshotShutdownProgressTrackerTests extends ESTestCase {
         IndexShardSnapshotStatus newStatus = IndexShardSnapshotStatus.newInitializing(new ShardGeneration("shard-gen-string-for-test"));
         switch (stage) {
             case DONE -> {
-                final long startTimeMillis = randomLongBetween(0, 1000);
+                final long startTimeMillis = randomLongBetween(1, 1000);
                 final long endTimeMillis = randomLongBetween(startTimeMillis, startTimeMillis + 1000);
                 newStatus.moveToStarted(startTimeMillis, 1, 10, 2L, 20L);
                 newStatus.moveToFinalize();


### PR DESCRIPTION
randomLongBetween(0, 1000) can yield 0, which triggers the assertion in IndexShardSnapshotStatus.moveToDone that startTimeMillis != 0. Use randomLongBetween(1, 1000) so the test satisfies the invariant.