### PR TITLE
Fix IndexSettingsTests synthetic ID tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -380,18 +380,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/TS Command grouping on text field}
   issue: https://github.com/elastic/elasticsearch/issues/142544
-- class: org.elasticsearch.index.IndexSettingsTests
-  method: testSyntheticIdBadVersion
-  issue: https://github.com/elastic/elasticsearch/issues/142508
-- class: org.elasticsearch.index.IndexSettingsTests
-  method: testSyntheticIdBadCodec
-  issue: https://github.com/elastic/elasticsearch/issues/142509
-- class: org.elasticsearch.index.IndexSettingsTests
-  method: testSyntheticIdBadMode
-  issue: https://github.com/elastic/elasticsearch/issues/142510
-- class: org.elasticsearch.index.IndexSettingsTests
-  method: testSyntheticIdCorrectSettings
-  issue: https://github.com/elastic/elasticsearch/issues/142507
 - class: org.elasticsearch.xpack.esql.datasources.GlobDiscoveryLocalTests
   method: testRecursiveDoubleStarAllFiles
   issue: https://github.com/elastic/elasticsearch/issues/142576

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -931,6 +931,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testSyntheticIdCorrectSettings() {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
         IndexVersion version = IndexVersionUtils.randomVersionBetween(
             IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94,
             IndexVersion.current()
@@ -952,6 +953,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testSyntheticIdBadVersion() {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
         IndexVersion badVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94);
         IndexMode mode = IndexMode.TIME_SERIES;
         String codec = CodecService.DEFAULT_CODEC;
@@ -980,6 +982,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testSyntheticIdBadCodec() {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
         IndexVersion version = IndexVersionUtils.randomVersionBetween(
             IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94,
             IndexVersion.current()
@@ -1017,6 +1020,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testSyntheticIdBadMode() {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
         IndexVersion version = IndexVersionUtils.randomVersionBetween(
             IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94,
             IndexVersion.current()


### PR DESCRIPTION
When test was run with `-Dbuild.snapshot=false` the synthetic id tests would fail because the feature flag would be disabled. Only run the tests if the feature flag is enabled.

Fixes
https://github.com/elastic/elasticsearch/issues/142507
https://github.com/elastic/elasticsearch/issues/142508
https://github.com/elastic/elasticsearch/issues/142509
https://github.com/elastic/elasticsearch/issues/142510