### PR TITLE
Replace procrun with Windows API calls for all basic Windows service control operations

### DIFF
--- a/distribution/tools/windows-service-cli/WINDOWS_SERVICE_CONTROL_PLAN.md
+++ b/distribution/tools/windows-service-cli/WINDOWS_SERVICE_CONTROL_PLAN.md
@@ -1,0 +1,147 @@
+# Windows Service Control: Replacing Procrun for Service Operations
+
+## Background
+
+Elasticsearch can run as a Windows service, using Apache Commons Daemon (procrun) for support.
+The `windows-service-cli` module provides CLI subcommands for install, remove, start, stop, and
+a GUI manager, all of which currently delegate to the procrun executable (`elasticsearch-service-x64.exe`).
+
+Procrun has proven unreliable for service control operations, particularly during stop:
+- It may return before the service has fully stopped.
+- It may incorrectly report errors during state transitions.
+- It suffers from race conditions with the Windows Service Control Manager (SCM).
+
+These issues were documented and partially addressed in commit 45e38c1, which switched the
+**packaging tests** from procrun to `sc.exe` for start, stop, and delete, and added a busy-wait
+polling loop for stop.
+
+The goal is to replace procrun for the **production** service control commands (start, stop, remove)
+while keeping procrun for install and manager, which are inherently procrun-specific operations.
+
+## Options Considered
+
+### Option 1: Shell out to `sc.exe`
+
+Replace the procrun-based start, stop, and remove commands with calls to the standard Windows
+`sc.exe` command-line tool.
+
+**Pros:**
+- Simple implementation, mirrors what the tests already do.
+- `sc.exe` is always available on Windows (`C:\Windows\System32`).
+- No native code or FFI complexity.
+
+**Cons:**
+- Still spawns external processes.
+- `sc.exe stop` returns immediately with STOP_PENDING, so a polling loop is still needed.
+- The polling loop itself requires spawning additional `sc.exe query` processes.
+- Output parsing is locale-dependent.
+
+**Status:** Implemented on branch `spacetime/windows-service-control-sc`.
+
+### Option 2: Panama FFI direct calls to Windows SCM APIs
+
+Use the Java Foreign Function & Memory API (Panama FFI) to call the Windows Service Control Manager
+APIs from `advapi32.dll` directly, without spawning any external processes.
+
+**Pros:**
+- No process spawning; direct API calls are faster and more reliable.
+- Full access to `SERVICE_STATUS_PROCESS` fields (`dwWaitHint`, `dwCheckPoint`) for a proper
+  SCM-compliant polling loop during stop.
+- Better error handling via `GetLastError` codes; no locale-dependent output parsing.
+- Consistent with existing patterns in the codebase (`JdkKernel32Library` in `libs/native`).
+
+**Cons:**
+- More code to write (struct layouts, method handles, handle lifecycle management).
+- Requires careful handling of JDK version differences (Panama was preview in JDK 21, finalized in 22).
+
+**Status:** Chosen approach. Implemented on branch `spacetime/windows-service-control-ffi`.
+
+### Option 3: Add SCM bindings to `libs/native` (alongside `JdkKernel32Library`)
+
+Same as Option 2, but placing the `advapi32.dll` bindings into the shared `libs/native` library.
+
+**Rejected** because:
+- The `NativeLibrary` interface is sealed; adding `Advapi32Library` would require modifying the
+  sealed permits list, the `NativeLibraryProvider` infrastructure, and `JdkNativeLibraryProvider`.
+- `NativeLibraryProvider` validates that all permitted subclasses have implementations, so every
+  platform (Linux, Mac) would need to provide a stub for a Windows-only library.
+- The SCM APIs are a narrow concern of the service CLI, not used by the server or any other module.
+
+## Chosen Plan: Option 2 with a Separate MRJAR Library
+
+### Architecture
+
+Create a new library project `libs/windows-service-control` containing the Panama FFI bindings
+for the Windows SCM APIs. The `windows-service-cli` module depends on this library.
+
+The library is built as a Multi-Release JAR (using the `elasticsearch.mrjar` Gradle plugin) to
+handle differences between JDK 21 (where Panama is a preview API) and JDK 22+ (where it is final).
+
+### Windows APIs Required (from `advapi32.dll`)
+
+| Function                 | Signature                                                    | Purpose                          |
+|--------------------------|--------------------------------------------------------------|----------------------------------|
+| `OpenSCManagerW`         | `(LPCWSTR, LPCWSTR, DWORD) -> SC_HANDLE`                    | Open SCM database                |
+| `OpenServiceW`           | `(SC_HANDLE, LPCWSTR, DWORD) -> SC_HANDLE`                   | Open handle to existing service  |
+| `StartServiceW`          | `(SC_HANDLE, DWORD, LPCWSTR*) -> BOOL`                       | Start a service                  |
+| `ControlService`         | `(SC_HANDLE, DWORD, SERVICE_STATUS*) -> BOOL`                | Send stop control code           |
+| `DeleteService`          | `(SC_HANDLE) -> BOOL`                                        | Mark service for deletion        |
+| `QueryServiceStatusEx`   | `(SC_HANDLE, SC_STATUS_TYPE, LPBYTE, DWORD, LPDWORD) -> BOOL`| Poll service status              |
+| `CloseServiceHandle`     | `(SC_HANDLE) -> BOOL`                                        | Close SCM/service handles        |
+
+Plus `GetLastError` from `kernel32.dll` for error reporting.
+
+### Key Data Structure
+
+`SERVICE_STATUS_PROCESS` (36 bytes):
+- `dwServiceType`, `dwCurrentState`, `dwControlsAccepted`, `dwWin32ExitCode`,
+  `dwServiceSpecificExitCode`, `dwCheckPoint`, `dwWaitHint`, `dwProcessId`, `dwServiceFlags`
+
+The `dwCurrentState` field provides the service state (STOPPED, RUNNING, STOP_PENDING, etc.).
+The `dwWaitHint` and `dwCheckPoint` fields enable a proper SCM-compliant wait loop during stop.
+
+### Project Structure
+
+```
+libs/windows-service-control/
+  build.gradle                                    # elasticsearch.build + elasticsearch.mrjar
+  src/main/java/org/elasticsearch/service/windows/
+    WindowsServiceControl.java                    # Public API: start, stop, delete, queryStatus
+    ScmHandle.java                                # AutoCloseable wrapper for SC_HANDLE pairs
+    Advapi32.java                                 # Panama FFI bindings for advapi32.dll
+    PanamaUtil.java                               # Small utility methods for Arena/VarHandle compat
+  src/main22/java/org/elasticsearch/service/windows/
+    PanamaUtil.java                               # JDK 22+ overrides for changed Panama APIs
+```
+
+### JDK 21 vs 22+ Compatibility
+
+The Panama FFI API changed between JDK 21 (preview) and JDK 22 (final) in a few ways that
+affect us:
+
+| API                          | JDK 21 (preview)              | JDK 22+ (final)                     |
+|------------------------------|-------------------------------|--------------------------------------|
+| `Arena.allocateArray`        | `arena.allocateArray(layout, count)` | `arena.allocate(layout, count)` |
+| `MemoryLayout.varHandle`     | Returns `VarHandle` directly  | Returns `VarHandle` with extra offset coordinate |
+| `MemorySegment.getUtf8String`| `segment.getUtf8String(off)`  | `segment.getString(off)`             |
+
+These are handled by `PanamaUtil` in the base source set (JDK 21 preview API) with overrides
+in `src/main22/` for the finalized API. This is the same pattern used by `libs/native` with its
+`ArenaUtil` and `MemorySegmentUtil` classes. The utility methods are copied rather than shared,
+since they are trivial and avoid coupling to the `libs/native` module.
+
+### Scope of Changes to `windows-service-cli`
+
+- `WindowsServiceStartCommand`, `WindowsServiceStopCommand`, `WindowsServiceRemoveCommand` are
+  rewritten to use the new library instead of extending `ProcrunCommand`.
+- A new `ScmCommand` base class (or similar) replaces `ProcrunCommand` for these three commands.
+- `WindowsServiceInstallCommand` and `WindowsServiceManagerCommand` remain unchanged (still use procrun).
+- `ProcrunCommand` is kept for install and manager.
+- Tests are updated to mock at the `WindowsServiceControl` API level rather than at the process level.
+
+### What Stays with Procrun
+
+- **Install** (`//IS/`): Procrun's install writes JVM configuration (classpath, start/stop class,
+  JVM options, etc.) to the Windows Registry under its own keys. `CreateServiceW` alone cannot
+  replace this; it only registers the service binary path with the SCM.
+- **Manager** (`prunmgr.exe`): A GUI tool that must be launched as a process.

--- a/distribution/tools/windows-service-cli/build.gradle
+++ b/distribution/tools/windows-service-cli/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(":libs:cli")
   compileOnly project(":distribution:tools:server-cli")
+  compileOnly project(":libs:windows-service-control")
 
   testImplementation project(":test:framework")
 }

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ScmCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ScmCommand.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.windows.service;
+
+import joptsimple.OptionSet;
+
+import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.ProcessInfo;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.UserException;
+import org.elasticsearch.service.windows.WindowsServiceControl;
+import org.elasticsearch.service.windows.WindowsServiceException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base command for controlling Windows services via the Service Control Manager.
+ *
+ * <p>Uses {@link WindowsServiceControl} to interact with the SCM, which can be backed by
+ * native Panama FFI calls (production) or a mock implementation (tests).
+ */
+abstract class ScmCommand extends Command {
+
+    private final WindowsServiceControl serviceControl;
+
+    /**
+     * Constructs a CLI subcommand that uses the SCM for service control.
+     * @param desc A help description for this subcommand
+     * @param serviceControl the service control implementation to use
+     */
+    protected ScmCommand(String desc, WindowsServiceControl serviceControl) {
+        super(desc);
+        this.serviceControl = serviceControl;
+    }
+
+    protected WindowsServiceControl getServiceControl() {
+        return serviceControl;
+    }
+
+    @Override
+    protected void execute(Terminal terminal, OptionSet options, ProcessInfo processInfo) throws Exception {
+        String serviceId = getServiceId(options, processInfo.envVars());
+        preExecute(terminal, processInfo, serviceId);
+
+        try {
+            executeServiceCommand(serviceControl, serviceId);
+        } catch (WindowsServiceException e) {
+            throw new UserException(ExitCodes.CODE_ERROR, getFailureMessage(serviceId) + ": " + e.getMessage());
+        }
+
+        postExecute(terminal, processInfo, serviceId);
+        terminal.println(getSuccessMessage(serviceId));
+    }
+
+    /**
+     * Performs the actual service control operation.
+     * @param serviceControl the service control API
+     * @param serviceId the service name
+     * @throws WindowsServiceException if the operation fails
+     */
+    protected abstract void executeServiceCommand(WindowsServiceControl serviceControl, String serviceId) throws WindowsServiceException;
+
+    /** Determines the service id for the Elasticsearch service that should be used. */
+    private static String getServiceId(OptionSet options, Map<String, String> env) throws UserException {
+        List<?> args = options.nonOptionArguments();
+        if (args.size() > 1) {
+            throw new UserException(ExitCodes.USAGE, "too many arguments, expected one service id");
+        }
+        final String serviceId;
+        if (args.size() > 0) {
+            serviceId = args.get(0).toString();
+        } else {
+            serviceId = env.getOrDefault("SERVICE_ID", "elasticsearch-service-x64");
+        }
+        return serviceId;
+    }
+
+    /**
+     * A hook to add logging and validation before executing the service command.
+     * @throws UserException if there is a problem with the command invocation
+     */
+    protected void preExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws UserException {}
+
+    /**
+     * A hook for additional work after the service command succeeds (e.g. polling for stop completion).
+     * @throws Exception if there is a problem after the command
+     */
+    protected void postExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws Exception {}
+
+    /** Returns a message that should be output on success. */
+    protected abstract String getSuccessMessage(String serviceId);
+
+    /** Returns a message that should be output on failure. */
+    protected abstract String getFailureMessage(String serviceId);
+}

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommand.java
@@ -9,21 +9,38 @@
 
 package org.elasticsearch.windows.service;
 
+import org.elasticsearch.service.windows.WindowsServiceControl;
+import org.elasticsearch.service.windows.WindowsServiceException;
+
+import java.util.Locale;
+
 /**
- * Removes the Elasticsearch Windows service, first stopping it if it is running.
+ * Removes the Elasticsearch Windows service.
+ *
+ * <p>Uses the SCM {@code DeleteService} API to mark the service for deletion.
  */
-class WindowsServiceRemoveCommand extends ProcrunCommand {
+class WindowsServiceRemoveCommand extends ScmCommand {
+
     WindowsServiceRemoveCommand() {
-        super("Remove the Elasticsearch Windows Service", "DS");
+        this(WindowsServiceControl.create());
+    }
+
+    WindowsServiceRemoveCommand(WindowsServiceControl serviceControl) {
+        super("Remove the Elasticsearch Windows Service", serviceControl);
+    }
+
+    @Override
+    protected void executeServiceCommand(WindowsServiceControl serviceControl, String serviceId) throws WindowsServiceException {
+        serviceControl.deleteService(serviceId);
     }
 
     @Override
     protected String getSuccessMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "The service '%s' has been removed", serviceId);
+        return String.format(Locale.ROOT, "The service '%s' has been removed", serviceId);
     }
 
     @Override
     protected String getFailureMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "Failed removing '%s' service", serviceId);
+        return String.format(Locale.ROOT, "Failed removing '%s' service", serviceId);
     }
 }

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStartCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStartCommand.java
@@ -9,21 +9,36 @@
 
 package org.elasticsearch.windows.service;
 
+import org.elasticsearch.service.windows.WindowsServiceControl;
+import org.elasticsearch.service.windows.WindowsServiceException;
+
+import java.util.Locale;
+
 /**
  * Starts the Elasticsearch Windows service.
  */
-class WindowsServiceStartCommand extends ProcrunCommand {
+class WindowsServiceStartCommand extends ScmCommand {
+
     WindowsServiceStartCommand() {
-        super("Starts the Elasticsearch Windows Service", "ES");
+        this(WindowsServiceControl.create());
+    }
+
+    WindowsServiceStartCommand(WindowsServiceControl serviceControl) {
+        super("Starts the Elasticsearch Windows Service", serviceControl);
+    }
+
+    @Override
+    protected void executeServiceCommand(WindowsServiceControl serviceControl, String serviceId) throws WindowsServiceException {
+        serviceControl.startService(serviceId);
     }
 
     @Override
     protected String getSuccessMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "The service '%s' has been started", serviceId);
+        return String.format(Locale.ROOT, "The service '%s' has been started", serviceId);
     }
 
     @Override
     protected String getFailureMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "Failed starting '%s' service", serviceId);
+        return String.format(Locale.ROOT, "Failed starting '%s' service", serviceId);
     }
 }

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
@@ -20,6 +20,7 @@ import org.elasticsearch.service.windows.WindowsServiceException;
 
 import java.time.Duration;
 import java.util.Locale;
+import java.util.function.Predicate;
 
 /**
  * Stops the Elasticsearch Windows service.
@@ -37,6 +38,7 @@ class WindowsServiceStopCommand extends ScmCommand {
     static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofMinutes(5);
     static final Duration MIN_POLL_INTERVAL = Duration.ofSeconds(1);
     static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(10);
+    static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(2);
 
     WindowsServiceStopCommand() {
         this(WindowsServiceControl.create());
@@ -53,18 +55,16 @@ class WindowsServiceStopCommand extends ScmCommand {
 
     @Override
     protected void postExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws Exception {
-        Duration timeout = getStopTimeout(pinfo);
-        waitForStopped(terminal, serviceId, timeout);
+        waitForStopped(terminal, serviceId, getStopTimeout(pinfo));
     }
 
     /**
      * Polls the service status until it reaches STOPPED or the timeout expires.
      * Uses {@code dwWaitHint} from the service to determine poll intervals.
      */
-    void waitForStopped(Terminal terminal, String serviceId, Duration timeout) throws UserException {
+    void waitForStopped(Terminal terminal, String serviceId, Predicate<Duration> isTimedOut) throws UserException {
         terminal.println(String.format(Locale.ROOT, "Waiting for service '%s' to stop...", serviceId));
         long start = System.currentTimeMillis();
-        int lastCheckPoint = -1;
 
         while (true) {
             ServiceStatus status = queryStatus(serviceId);
@@ -73,7 +73,7 @@ class WindowsServiceStopCommand extends ScmCommand {
             }
 
             Duration elapsed = Duration.ofMillis(System.currentTimeMillis() - start);
-            if (elapsed.compareTo(timeout) > 0) {
+            if (isTimedOut.test(elapsed)) {
                 String msg = String.format(
                     Locale.ROOT,
                     "Timed out after %s waiting for service '%s' to stop (last state: %s)",
@@ -92,10 +92,6 @@ class WindowsServiceStopCommand extends ScmCommand {
                 );
             }
 
-            if (status.checkPoint() != lastCheckPoint) {
-                lastCheckPoint = status.checkPoint();
-            }
-
             Duration pollInterval = computePollInterval(status);
             logger.debug("Service [{}] in state [{}], waiting [{}]", serviceId, status.stateName(), pollInterval);
             terminal.println(
@@ -104,6 +100,8 @@ class WindowsServiceStopCommand extends ScmCommand {
             );
 
             try {
+                // It is OK call sleep here, we need to wait for the service to stop
+                // noinspection BusyWait
                 Thread.sleep(pollInterval.toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -131,7 +129,7 @@ class WindowsServiceStopCommand extends ScmCommand {
             }
             return Duration.ofMillis(interval);
         }
-        return Duration.ofSeconds(2);
+        return DEFAULT_POLL_INTERVAL;
     }
 
     ServiceStatus queryStatus(String serviceId) {
@@ -143,16 +141,23 @@ class WindowsServiceStopCommand extends ScmCommand {
         }
     }
 
-    private static Duration getStopTimeout(ProcessInfo pinfo) {
+    private static Predicate<Duration> getStopTimeout(ProcessInfo pinfo) {
         String timeoutStr = pinfo.envVars().get("ES_STOP_TIMEOUT");
         if (timeoutStr != null && timeoutStr.isBlank() == false) {
             try {
-                return Duration.ofSeconds(Long.parseLong(timeoutStr));
+                long timeoutInSeconds = Long.parseLong(timeoutStr);
+                if (timeoutInSeconds > 0) {
+                    var timeout = Duration.ofSeconds(timeoutInSeconds);
+                    return elapsed -> elapsed.compareTo(timeout) > 0;
+                } else {
+                    // 0 means no timeout
+                    return elapsed -> false;
+                }
             } catch (NumberFormatException e) {
                 logger.warn("Invalid ES_STOP_TIMEOUT value [{}], using default", timeoutStr);
             }
         }
-        return DEFAULT_STOP_TIMEOUT;
+        return elapsed -> elapsed.compareTo(DEFAULT_STOP_TIMEOUT) > 0;
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceStopCommand.java
@@ -9,21 +9,159 @@
 
 package org.elasticsearch.windows.service;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cli.ProcessInfo;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.UserException;
+import org.elasticsearch.service.windows.ServiceStatus;
+import org.elasticsearch.service.windows.WindowsServiceControl;
+import org.elasticsearch.service.windows.WindowsServiceException;
+
+import java.time.Duration;
+import java.util.Locale;
+
 /**
  * Stops the Elasticsearch Windows service.
+ *
+ * <p>After issuing the stop command via the SCM, this polls the service status until it reaches
+ * the {@code STOPPED} state or a timeout is reached. This is necessary because the SCM returns
+ * immediately with {@code STOP_PENDING}, and Elasticsearch can take minutes to shut down gracefully.
+ *
+ * <p>The polling loop respects the service's {@code dwWaitHint} and {@code dwCheckPoint} fields
+ * from {@code SERVICE_STATUS_PROCESS} for SCM-compliant waiting behavior.
  */
-class WindowsServiceStopCommand extends ProcrunCommand {
+class WindowsServiceStopCommand extends ScmCommand {
+    private static final Logger logger = LogManager.getLogger(WindowsServiceStopCommand.class);
+
+    static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofMinutes(5);
+    static final Duration MIN_POLL_INTERVAL = Duration.ofSeconds(1);
+    static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(10);
+
     WindowsServiceStopCommand() {
-        super("Stops the Elasticsearch Windows Service", "SS");
+        this(WindowsServiceControl.create());
+    }
+
+    WindowsServiceStopCommand(WindowsServiceControl serviceControl) {
+        super("Stops the Elasticsearch Windows Service", serviceControl);
+    }
+
+    @Override
+    protected void executeServiceCommand(WindowsServiceControl serviceControl, String serviceId) throws WindowsServiceException {
+        serviceControl.stopService(serviceId);
+    }
+
+    @Override
+    protected void postExecute(Terminal terminal, ProcessInfo pinfo, String serviceId) throws Exception {
+        Duration timeout = getStopTimeout(pinfo);
+        waitForStopped(terminal, serviceId, timeout);
+    }
+
+    /**
+     * Polls the service status until it reaches STOPPED or the timeout expires.
+     * Uses {@code dwWaitHint} from the service to determine poll intervals.
+     */
+    void waitForStopped(Terminal terminal, String serviceId, Duration timeout) throws UserException {
+        terminal.println(String.format(Locale.ROOT, "Waiting for service '%s' to stop...", serviceId));
+        long start = System.currentTimeMillis();
+        int lastCheckPoint = -1;
+
+        while (true) {
+            ServiceStatus status = queryStatus(serviceId);
+            if (status.state() == ServiceStatus.STOPPED) {
+                return;
+            }
+
+            Duration elapsed = Duration.ofMillis(System.currentTimeMillis() - start);
+            if (elapsed.compareTo(timeout) > 0) {
+                String msg = String.format(
+                    Locale.ROOT,
+                    "Timed out after %s waiting for service '%s' to stop (last state: %s)",
+                    elapsed,
+                    serviceId,
+                    status.stateName()
+                );
+                logger.warn(msg);
+                terminal.errorPrintln(msg);
+                throw new UserException(1, msg);
+            }
+
+            if (status.state() == ServiceStatus.UNKNOWN) {
+                terminal.errorPrintln(
+                    String.format(Locale.ROOT, "WARNING: Unable to query status of service '%s'; will keep waiting...", serviceId)
+                );
+            }
+
+            if (status.checkPoint() != lastCheckPoint) {
+                lastCheckPoint = status.checkPoint();
+            }
+
+            Duration pollInterval = computePollInterval(status);
+            logger.debug("Service [{}] in state [{}], waiting [{}]", serviceId, status.stateName(), pollInterval);
+            terminal.println(
+                Terminal.Verbosity.VERBOSE,
+                String.format(Locale.ROOT, "Service '%s' still %s...", serviceId, status.stateName())
+            );
+
+            try {
+                Thread.sleep(pollInterval.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new UserException(1, "Interrupted while waiting for service '" + serviceId + "' to stop");
+            }
+        }
+    }
+
+    /**
+     * Computes the poll interval based on the service's {@code dwWaitHint}.
+     * Microsoft recommends using one-tenth of the wait hint, but no less than 1 second
+     * and no more than 10 seconds.
+     *
+     * @see <a href="https://learn.microsoft.com/en-us/windows/win32/services/stopping-a-service">
+     *      Stopping a Service (Microsoft Learn)</a>
+     */
+    static Duration computePollInterval(ServiceStatus status) {
+        int waitHint = status.waitHint();
+        if (waitHint > 0) {
+            long interval = waitHint / 10;
+            if (interval < MIN_POLL_INTERVAL.toMillis()) {
+                return MIN_POLL_INTERVAL;
+            } else if (interval > MAX_POLL_INTERVAL.toMillis()) {
+                return MAX_POLL_INTERVAL;
+            }
+            return Duration.ofMillis(interval);
+        }
+        return Duration.ofSeconds(2);
+    }
+
+    ServiceStatus queryStatus(String serviceId) {
+        try {
+            return getServiceControl().queryStatus(serviceId);
+        } catch (WindowsServiceException e) {
+            logger.warn("Failed to query service status for [{}]", serviceId, e);
+            return ServiceStatus.unknown();
+        }
+    }
+
+    private static Duration getStopTimeout(ProcessInfo pinfo) {
+        String timeoutStr = pinfo.envVars().get("ES_STOP_TIMEOUT");
+        if (timeoutStr != null && timeoutStr.isBlank() == false) {
+            try {
+                return Duration.ofSeconds(Long.parseLong(timeoutStr));
+            } catch (NumberFormatException e) {
+                logger.warn("Invalid ES_STOP_TIMEOUT value [{}], using default", timeoutStr);
+            }
+        }
+        return DEFAULT_STOP_TIMEOUT;
     }
 
     @Override
     protected String getSuccessMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "The service '%s' has been stopped", serviceId);
+        return String.format(Locale.ROOT, "The service '%s' has been stopped", serviceId);
     }
 
     @Override
     protected String getFailureMessage(String serviceId) {
-        return String.format(java.util.Locale.ROOT, "Failed stopping '%s' service", serviceId);
+        return String.format(Locale.ROOT, "Failed stopping '%s' service", serviceId);
     }
 }

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ScmCommandTestCase.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ScmCommandTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.windows.service;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.cli.CommandTestCase;
+import org.elasticsearch.service.windows.ServiceStatus;
+import org.elasticsearch.service.windows.WindowsServiceControl;
+import org.elasticsearch.service.windows.WindowsServiceException;
+import org.junit.Before;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Base test case for commands that use {@link WindowsServiceControl} for service control.
+ * Provides a {@link MockWindowsServiceControl} that tests can configure.
+ */
+public abstract class ScmCommandTestCase extends CommandTestCase {
+
+    MockWindowsServiceControl mockServiceControl;
+
+    @ParametersFactory
+    public static Iterable<Object[]> spaceInPathProvider() {
+        return List.of(new Object[] { true }, new Object[] { false });
+    }
+
+    protected ScmCommandTestCase(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
+    /**
+     * A mock implementation of {@link WindowsServiceControl} that records calls and can be
+     * configured to throw exceptions.
+     */
+    static class MockWindowsServiceControl implements WindowsServiceControl {
+        String lastOperation;
+        String lastServiceId;
+        WindowsServiceException startException;
+        WindowsServiceException stopException;
+        WindowsServiceException deleteException;
+        WindowsServiceException queryException;
+        ServiceStatus queryResult = new ServiceStatus(ServiceStatus.STOPPED, 0, 0, 0);
+
+        @Override
+        public void startService(String serviceId) throws WindowsServiceException {
+            lastOperation = "start";
+            lastServiceId = serviceId;
+            if (startException != null) {
+                throw startException;
+            }
+        }
+
+        @Override
+        public void stopService(String serviceId) throws WindowsServiceException {
+            lastOperation = "stop";
+            lastServiceId = serviceId;
+            if (stopException != null) {
+                throw stopException;
+            }
+        }
+
+        @Override
+        public void deleteService(String serviceId) throws WindowsServiceException {
+            lastOperation = "delete";
+            lastServiceId = serviceId;
+            if (deleteException != null) {
+                throw deleteException;
+            }
+        }
+
+        @Override
+        public ServiceStatus queryStatus(String serviceId) throws WindowsServiceException {
+            if (queryException != null) {
+                throw queryException;
+            }
+            return queryResult;
+        }
+    }
+
+    @Before
+    public void resetMock() {
+        mockServiceControl = new MockWindowsServiceControl();
+    }
+
+    protected abstract String getDefaultSuccessMessage();
+
+    protected abstract String getDefaultFailureMessage();
+
+    protected abstract String getExpectedOperation();
+
+    public void testDefaultCommand() throws Exception {
+        assertOkWithOutput(containsString(getDefaultSuccessMessage()), emptyString());
+        assertThat(mockServiceControl.lastOperation, equalTo(getExpectedOperation()));
+        assertThat(mockServiceControl.lastServiceId, equalTo("elasticsearch-service-x64"));
+    }
+
+    public void testServiceId() throws Exception {
+        assertUsage(containsString("too many arguments"), "servicename", "servicename");
+        terminal.reset();
+        assertOkWithOutput(
+            containsString(getDefaultSuccessMessage().replace("elasticsearch-service-x64", "my-service-id")),
+            emptyString(),
+            "my-service-id"
+        );
+        assertThat(mockServiceControl.lastServiceId, equalTo("my-service-id"));
+    }
+
+    public void testServiceIdFromEnv() throws Exception {
+        envVars.put("SERVICE_ID", "my-service-id");
+        assertOkWithOutput(containsString(getDefaultSuccessMessage().replace("elasticsearch-service-x64", "my-service-id")), emptyString());
+        assertThat(mockServiceControl.lastServiceId, equalTo("my-service-id"));
+    }
+}

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
@@ -10,10 +10,13 @@
 package org.elasticsearch.windows.service;
 
 import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.service.windows.WindowsServiceException;
 
-import java.io.IOException;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
-public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase {
+public class WindowsServiceRemoveCommandTests extends ScmCommandTestCase {
 
     public WindowsServiceRemoveCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -21,17 +24,12 @@ public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase 
 
     @Override
     protected Command newCommand() {
-        return new WindowsServiceRemoveCommand() {
-            @Override
-            Process startProcess(ProcessBuilder processBuilder) throws IOException {
-                return mockProcess(processBuilder);
-            }
-        };
+        return new WindowsServiceRemoveCommand(mockServiceControl);
     }
 
     @Override
-    protected String getCommand() {
-        return "DS";
+    protected String getExpectedOperation() {
+        return "delete";
     }
 
     @Override
@@ -42,5 +40,13 @@ public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase 
     @Override
     protected String getDefaultFailureMessage() {
         return "Failed removing 'elasticsearch-service-x64' service";
+    }
+
+    public void testFailure() throws Exception {
+        mockServiceControl.deleteException = new WindowsServiceException("Service does not exist", 1060);
+        int exitCode = executeMain();
+        assertThat(exitCode, equalTo(ExitCodes.CODE_ERROR));
+        assertThat(terminal.getErrorOutput(), containsString(getDefaultFailureMessage()));
+        assertThat(terminal.getErrorOutput(), containsString("Service does not exist"));
     }
 }

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
@@ -10,10 +10,13 @@
 package org.elasticsearch.windows.service;
 
 import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.service.windows.WindowsServiceException;
 
-import java.io.IOException;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
-public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
+public class WindowsServiceStartCommandTests extends ScmCommandTestCase {
 
     public WindowsServiceStartCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -21,17 +24,12 @@ public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
 
     @Override
     protected Command newCommand() {
-        return new WindowsServiceStartCommand() {
-            @Override
-            Process startProcess(ProcessBuilder processBuilder) throws IOException {
-                return mockProcess(processBuilder);
-            }
-        };
+        return new WindowsServiceStartCommand(mockServiceControl);
     }
 
     @Override
-    protected String getCommand() {
-        return "ES";
+    protected String getExpectedOperation() {
+        return "start";
     }
 
     @Override
@@ -42,5 +40,13 @@ public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
     @Override
     protected String getDefaultFailureMessage() {
         return "Failed starting 'elasticsearch-service-x64' service";
+    }
+
+    public void testFailure() throws Exception {
+        mockServiceControl.startException = new WindowsServiceException("Access denied", 5);
+        int exitCode = executeMain();
+        assertThat(exitCode, equalTo(ExitCodes.CODE_ERROR));
+        assertThat(terminal.getErrorOutput(), containsString(getDefaultFailureMessage()));
+        assertThat(terminal.getErrorOutput(), containsString("Access denied"));
     }
 }

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
@@ -10,10 +10,18 @@
 package org.elasticsearch.windows.service;
 
 import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.ProcessInfo;
+import org.elasticsearch.service.windows.ServiceStatus;
+import org.elasticsearch.service.windows.WindowsServiceException;
 
-import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class WindowsServiceStopCommandTests extends ScmCommandTestCase {
 
     public WindowsServiceStopCommandTests(boolean spaceInPath) {
         super(spaceInPath);
@@ -21,17 +29,27 @@ public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
 
     @Override
     protected Command newCommand() {
-        return new WindowsServiceStopCommand() {
+        return newStopCommand(null);
+    }
+
+    private WindowsServiceStopCommand newStopCommand(ServiceStatus[] queryResults) {
+        return new WindowsServiceStopCommand(mockServiceControl) {
+            private final AtomicInteger queryCount = new AtomicInteger(0);
+
             @Override
-            Process startProcess(ProcessBuilder processBuilder) throws IOException {
-                return mockProcess(processBuilder);
+            ServiceStatus queryStatus(String serviceId) {
+                if (queryResults == null) {
+                    return new ServiceStatus(ServiceStatus.STOPPED, 0, 0, 0);
+                }
+                int idx = Math.min(queryCount.getAndIncrement(), queryResults.length - 1);
+                return queryResults[idx];
             }
         };
     }
 
     @Override
-    protected String getCommand() {
-        return "SS";
+    protected String getExpectedOperation() {
+        return "stop";
     }
 
     @Override
@@ -42,5 +60,84 @@ public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
     @Override
     protected String getDefaultFailureMessage() {
         return "Failed stopping 'elasticsearch-service-x64' service";
+    }
+
+    public void testFailure() throws Exception {
+        mockServiceControl.stopException = new WindowsServiceException("Access denied", 5);
+        int exitCode = executeMain();
+        assertThat(exitCode, equalTo(ExitCodes.CODE_ERROR));
+        assertThat(terminal.getErrorOutput(), containsString(getDefaultFailureMessage()));
+        assertThat(terminal.getErrorOutput(), containsString("Access denied"));
+    }
+
+    public void testStopWaitsForStopped() throws Exception {
+        ServiceStatus[] statuses = new ServiceStatus[] {
+            new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 1000),
+            new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 2, 1000),
+            new ServiceStatus(ServiceStatus.STOPPED, 0, 0, 0) };
+        Command cmd = newStopCommand(statuses);
+        String output = execute(cmd);
+        assertThat(output, containsString("The service 'elasticsearch-service-x64' has been stopped"));
+    }
+
+    public void testStopImmediatelyStopped() throws Exception {
+        ServiceStatus[] statuses = new ServiceStatus[] { new ServiceStatus(ServiceStatus.STOPPED, 0, 0, 0) };
+        Command cmd = newStopCommand(statuses);
+        String output = execute(cmd);
+        assertThat(output, containsString("The service 'elasticsearch-service-x64' has been stopped"));
+    }
+
+    public void testStopTimeout() throws Exception {
+        envVars.put("ES_STOP_TIMEOUT", "1");
+        WindowsServiceStopCommand cmd = new WindowsServiceStopCommand(mockServiceControl) {
+            @Override
+            ServiceStatus queryStatus(String serviceId) {
+                return new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 1000);
+            }
+        };
+        int exitCode = cmd.main(new String[0], terminal, new ProcessInfo(sysprops, envVars, esHomeDir));
+        assertThat(exitCode, equalTo(1));
+        assertThat(terminal.getErrorOutput(), containsString("Timed out"));
+    }
+
+    public void testComputePollIntervalFromWaitHint() {
+        ServiceStatus status = new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 30000);
+        Duration interval = WindowsServiceStopCommand.computePollInterval(status);
+        assertThat(interval, equalTo(Duration.ofSeconds(3)));
+    }
+
+    public void testComputePollIntervalMinimum() {
+        ServiceStatus status = new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 100);
+        Duration interval = WindowsServiceStopCommand.computePollInterval(status);
+        assertThat(interval, equalTo(WindowsServiceStopCommand.MIN_POLL_INTERVAL));
+    }
+
+    public void testComputePollIntervalMaximum() {
+        ServiceStatus status = new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 500000);
+        Duration interval = WindowsServiceStopCommand.computePollInterval(status);
+        assertThat(interval, equalTo(WindowsServiceStopCommand.MAX_POLL_INTERVAL));
+    }
+
+    public void testComputePollIntervalNoHint() {
+        ServiceStatus status = new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 0);
+        Duration interval = WindowsServiceStopCommand.computePollInterval(status);
+        assertThat(interval, equalTo(Duration.ofSeconds(2)));
+    }
+
+    public void testQueryStatusFailureReturnsUnknown() {
+        mockServiceControl.queryException = new WindowsServiceException("Query failed", 1);
+        WindowsServiceStopCommand cmd = new WindowsServiceStopCommand(mockServiceControl);
+        ServiceStatus result = cmd.queryStatus("test-service");
+        assertThat(result.state(), equalTo(ServiceStatus.UNKNOWN));
+    }
+
+    public void testUnknownStatusKeepsPolling() throws Exception {
+        ServiceStatus[] statuses = new ServiceStatus[] {
+            new ServiceStatus(ServiceStatus.STOP_PENDING, 0, 1, 1000),
+            ServiceStatus.unknown(),
+            new ServiceStatus(ServiceStatus.STOPPED, 0, 0, 0) };
+        Command cmd = newStopCommand(statuses);
+        String output = execute(cmd);
+        assertThat(output, containsString("The service 'elasticsearch-service-x64' has been stopped"));
     }
 }

--- a/libs/windows-service-control/build.gradle
+++ b/libs/windows-service-control/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.mrjar'
+
+dependencies {
+  compileOnly project(':libs:core')
+  compileOnly project(':libs:logging')
+
+  testImplementation project(":test:framework")
+}
+
+tasks.named('forbiddenApisMain').configure {
+  enabled = false
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/Advapi32.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/Advapi32.java
@@ -30,6 +30,9 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
  */
 class Advapi32 {
 
+    // See https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+    public static final int ERROR_INSUFFICIENT_BUFFER = 0x7A;
+
     // --- Access rights ---
 
     /** Required to connect to the SCM and enumerate/open services. */

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/Advapi32.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/Advapi32.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+/**
+ * Panama FFI bindings for the Windows Service Control Manager APIs in {@code advapi32.dll}.
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/windows/win32/services/service-functions">Service Functions</a>
+ */
+class Advapi32 {
+
+    // --- Access rights ---
+
+    /** Required to connect to the SCM and enumerate/open services. */
+    static final int SC_MANAGER_ALL_ACCESS = 0xF003F;
+
+    /** Full access to a service object. */
+    static final int SERVICE_ALL_ACCESS = 0xF01FF;
+
+    // --- Service control codes ---
+
+    static final int SERVICE_CONTROL_STOP = 0x00000001;
+
+    // --- Service states ---
+
+    static final int SERVICE_STOPPED = 0x00000001;
+    static final int SERVICE_START_PENDING = 0x00000002;
+    static final int SERVICE_STOP_PENDING = 0x00000003;
+    static final int SERVICE_RUNNING = 0x00000004;
+
+    // --- QueryServiceStatusEx info level ---
+
+    static final int SC_STATUS_PROCESS_INFO = 0;
+
+    // --- SERVICE_STATUS_PROCESS layout (36 bytes on 32-bit aligned fields) ---
+
+    static final StructLayout SERVICE_STATUS_PROCESS_LAYOUT = MemoryLayout.structLayout(
+        JAVA_INT.withName("dwServiceType"),
+        JAVA_INT.withName("dwCurrentState"),
+        JAVA_INT.withName("dwControlsAccepted"),
+        JAVA_INT.withName("dwWin32ExitCode"),
+        JAVA_INT.withName("dwServiceSpecificExitCode"),
+        JAVA_INT.withName("dwCheckPoint"),
+        JAVA_INT.withName("dwWaitHint"),
+        JAVA_INT.withName("dwProcessId"),
+        JAVA_INT.withName("dwServiceFlags")
+    );
+
+    static final VarHandle dwCurrentState$vh = PanamaUtil.varHandleWithoutOffset(
+        SERVICE_STATUS_PROCESS_LAYOUT,
+        groupElement("dwCurrentState")
+    );
+    static final VarHandle dwWin32ExitCode$vh = PanamaUtil.varHandleWithoutOffset(
+        SERVICE_STATUS_PROCESS_LAYOUT,
+        groupElement("dwWin32ExitCode")
+    );
+    static final VarHandle dwCheckPoint$vh = PanamaUtil.varHandleWithoutOffset(SERVICE_STATUS_PROCESS_LAYOUT, groupElement("dwCheckPoint"));
+    static final VarHandle dwWaitHint$vh = PanamaUtil.varHandleWithoutOffset(SERVICE_STATUS_PROCESS_LAYOUT, groupElement("dwWaitHint"));
+
+    // --- SERVICE_STATUS layout (used by ControlService, 28 bytes) ---
+
+    static final StructLayout SERVICE_STATUS_LAYOUT = MemoryLayout.structLayout(
+        JAVA_INT.withName("dwServiceType"),
+        JAVA_INT.withName("dwCurrentState"),
+        JAVA_INT.withName("dwControlsAccepted"),
+        JAVA_INT.withName("dwWin32ExitCode"),
+        JAVA_INT.withName("dwServiceSpecificExitCode"),
+        JAVA_INT.withName("dwCheckPoint"),
+        JAVA_INT.withName("dwWaitHint")
+    );
+
+    // --- GetLastError capture ---
+
+    private static final StructLayout CAPTURE_GETLASTERROR_LAYOUT = Linker.Option.captureStateLayout();
+    private static final Linker.Option CAPTURE_GETLASTERROR_OPTION = Linker.Option.captureCallState("GetLastError");
+    private static final VarHandle GetLastError$vh = PanamaUtil.varHandleWithoutOffset(
+        CAPTURE_GETLASTERROR_LAYOUT,
+        groupElement("GetLastError")
+    );
+
+    // --- Function handles ---
+
+    private static final SymbolLookup LOOKUP;
+
+    static {
+        System.loadLibrary("advapi32");
+        SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
+        LOOKUP = name -> loaderLookup.find(name).or(() -> Linker.nativeLinker().defaultLookup().find(name));
+    }
+
+    private static MethodHandle downcall(String name, FunctionDescriptor descriptor) {
+        return PanamaUtil.downcallHandle(PanamaUtil.findFunction(LOOKUP, name), descriptor, CAPTURE_GETLASTERROR_OPTION);
+    }
+
+    // SC_HANDLE OpenSCManagerW(LPCWSTR lpMachineName, LPCWSTR lpDatabaseName, DWORD dwDesiredAccess)
+    private static final MethodHandle OpenSCManagerW$mh = downcall(
+        "OpenSCManagerW",
+        FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_INT)
+    );
+
+    // SC_HANDLE OpenServiceW(SC_HANDLE hSCManager, LPCWSTR lpServiceName, DWORD dwDesiredAccess)
+    private static final MethodHandle OpenServiceW$mh = downcall(
+        "OpenServiceW",
+        FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_INT)
+    );
+
+    // BOOL StartServiceW(SC_HANDLE hService, DWORD dwNumServiceArgs, LPCWSTR *lpServiceArgVectors)
+    private static final MethodHandle StartServiceW$mh = downcall(
+        "StartServiceW",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS)
+    );
+
+    // BOOL ControlService(SC_HANDLE hService, DWORD dwControl, LPSERVICE_STATUS lpServiceStatus)
+    private static final MethodHandle ControlService$mh = downcall(
+        "ControlService",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS)
+    );
+
+    // BOOL DeleteService(SC_HANDLE hService)
+    private static final MethodHandle DeleteService$mh = downcall("DeleteService", FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    // BOOL QueryServiceStatusEx(SC_HANDLE hService, SC_STATUS_TYPE InfoLevel, LPBYTE lpBuffer, DWORD cbBufSize, LPDWORD pcbBytesNeeded)
+    private static final MethodHandle QueryServiceStatusEx$mh = downcall(
+        "QueryServiceStatusEx",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS)
+    );
+
+    // BOOL CloseServiceHandle(SC_HANDLE hSCObject)
+    private static final MethodHandle CloseServiceHandle$mh = downcall("CloseServiceHandle", FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    // --- Instance state for GetLastError ---
+
+    private final MemorySegment lastErrorState;
+
+    Advapi32() {
+        this.lastErrorState = Arena.ofAuto().allocate(CAPTURE_GETLASTERROR_LAYOUT);
+    }
+
+    int getLastError() {
+        return (int) GetLastError$vh.get(lastErrorState);
+    }
+
+    MemorySegment openSCManager(int desiredAccess) {
+        try {
+            return (MemorySegment) OpenSCManagerW$mh.invokeExact(lastErrorState, MemorySegment.NULL, MemorySegment.NULL, desiredAccess);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    MemorySegment openService(MemorySegment scManager, MemorySegment serviceName, int desiredAccess) {
+        try {
+            return (MemorySegment) OpenServiceW$mh.invokeExact(lastErrorState, scManager, serviceName, desiredAccess);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    boolean startService(MemorySegment service) {
+        try {
+            return ((int) StartServiceW$mh.invokeExact(lastErrorState, service, 0, MemorySegment.NULL)) != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    boolean controlService(MemorySegment service, int control, MemorySegment serviceStatus) {
+        try {
+            return ((int) ControlService$mh.invokeExact(lastErrorState, service, control, serviceStatus)) != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    boolean deleteService(MemorySegment service) {
+        try {
+            return ((int) DeleteService$mh.invokeExact(lastErrorState, service)) != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    boolean queryServiceStatusEx(MemorySegment service, MemorySegment buffer, int bufferSize, MemorySegment bytesNeeded) {
+        try {
+            return ((int) QueryServiceStatusEx$mh.invokeExact(
+                lastErrorState,
+                service,
+                SC_STATUS_PROCESS_INFO,
+                buffer,
+                bufferSize,
+                bytesNeeded
+            )) != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    boolean closeServiceHandle(MemorySegment handle) {
+        try {
+            return ((int) CloseServiceHandle$mh.invokeExact(lastErrorState, handle)) != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/NativeWindowsServiceControl.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/NativeWindowsServiceControl.java
@@ -93,15 +93,19 @@ class NativeWindowsServiceControl implements WindowsServiceControl {
             try {
                 MemorySegment service = openService(scManager, serviceId, arena);
                 try {
-                    MemorySegment buffer = arena.allocate(Advapi32.SERVICE_STATUS_PROCESS_LAYOUT);
                     MemorySegment bytesNeeded = arena.allocate(JAVA_INT);
-                    if (advapi32.queryServiceStatusEx(
-                        service,
-                        buffer,
-                        (int) Advapi32.SERVICE_STATUS_PROCESS_LAYOUT.byteSize(),
-                        bytesNeeded
-                    ) == false) {
-                        throw new WindowsServiceException("Failed to query status of service '" + serviceId + "'", advapi32.getLastError());
+                    // Call QueryServiceStatusEx with a NULL buffer to get the required buffer size
+                    advapi32.queryServiceStatusEx(service, MemorySegment.NULL, 0, bytesNeeded);
+                    var lastError = advapi32.getLastError();
+                    if (lastError != Advapi32.ERROR_INSUFFICIENT_BUFFER) {
+                        throw new WindowsServiceException("Failed to query status of service '" + serviceId + "'", lastError);
+                    }
+
+                    // Then call it again with a correctly sized buffer
+                    var bufferSize = bytesNeeded.get(JAVA_INT, 0);
+                    MemorySegment buffer = arena.allocate(bufferSize);
+                    if (advapi32.queryServiceStatusEx(service, buffer, bufferSize, bytesNeeded) == false) {
+                        throw new WindowsServiceException("Failed to query status of service '" + serviceId + "'", lastError);
                     }
                     return new ServiceStatus(
                         (int) Advapi32.dwCurrentState$vh.get(buffer),

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/NativeWindowsServiceControl.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/NativeWindowsServiceControl.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+/**
+ * Native implementation of {@link WindowsServiceControl} using Panama FFI calls to {@code advapi32.dll}.
+ *
+ * <p>Each operation opens handles to the SCM and service, performs the operation, and closes
+ * the handles in a try-finally block to prevent leaks.
+ */
+class NativeWindowsServiceControl implements WindowsServiceControl {
+
+    private final Advapi32 advapi32;
+
+    NativeWindowsServiceControl() {
+        this.advapi32 = new Advapi32();
+    }
+
+    @Override
+    public void startService(String serviceId) throws WindowsServiceException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment scManager = openScManager();
+            try {
+                MemorySegment service = openService(scManager, serviceId, arena);
+                try {
+                    if (advapi32.startService(service) == false) {
+                        throw new WindowsServiceException("Failed to start service '" + serviceId + "'", advapi32.getLastError());
+                    }
+                } finally {
+                    advapi32.closeServiceHandle(service);
+                }
+            } finally {
+                advapi32.closeServiceHandle(scManager);
+            }
+        }
+    }
+
+    @Override
+    public void stopService(String serviceId) throws WindowsServiceException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment scManager = openScManager();
+            try {
+                MemorySegment service = openService(scManager, serviceId, arena);
+                try {
+                    MemorySegment serviceStatus = arena.allocate(Advapi32.SERVICE_STATUS_LAYOUT);
+                    if (advapi32.controlService(service, Advapi32.SERVICE_CONTROL_STOP, serviceStatus) == false) {
+                        throw new WindowsServiceException("Failed to stop service '" + serviceId + "'", advapi32.getLastError());
+                    }
+                } finally {
+                    advapi32.closeServiceHandle(service);
+                }
+            } finally {
+                advapi32.closeServiceHandle(scManager);
+            }
+        }
+    }
+
+    @Override
+    public void deleteService(String serviceId) throws WindowsServiceException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment scManager = openScManager();
+            try {
+                MemorySegment service = openService(scManager, serviceId, arena);
+                try {
+                    if (advapi32.deleteService(service) == false) {
+                        throw new WindowsServiceException("Failed to delete service '" + serviceId + "'", advapi32.getLastError());
+                    }
+                } finally {
+                    advapi32.closeServiceHandle(service);
+                }
+            } finally {
+                advapi32.closeServiceHandle(scManager);
+            }
+        }
+    }
+
+    @Override
+    public ServiceStatus queryStatus(String serviceId) throws WindowsServiceException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment scManager = openScManager();
+            try {
+                MemorySegment service = openService(scManager, serviceId, arena);
+                try {
+                    MemorySegment buffer = arena.allocate(Advapi32.SERVICE_STATUS_PROCESS_LAYOUT);
+                    MemorySegment bytesNeeded = arena.allocate(JAVA_INT);
+                    if (advapi32.queryServiceStatusEx(
+                        service,
+                        buffer,
+                        (int) Advapi32.SERVICE_STATUS_PROCESS_LAYOUT.byteSize(),
+                        bytesNeeded
+                    ) == false) {
+                        throw new WindowsServiceException("Failed to query status of service '" + serviceId + "'", advapi32.getLastError());
+                    }
+                    return new ServiceStatus(
+                        (int) Advapi32.dwCurrentState$vh.get(buffer),
+                        (int) Advapi32.dwWin32ExitCode$vh.get(buffer),
+                        (int) Advapi32.dwCheckPoint$vh.get(buffer),
+                        (int) Advapi32.dwWaitHint$vh.get(buffer)
+                    );
+                } finally {
+                    advapi32.closeServiceHandle(service);
+                }
+            } finally {
+                advapi32.closeServiceHandle(scManager);
+            }
+        }
+    }
+
+    private MemorySegment openScManager() throws WindowsServiceException {
+        MemorySegment handle = advapi32.openSCManager(Advapi32.SC_MANAGER_ALL_ACCESS);
+        if (handle.equals(MemorySegment.NULL) || handle.address() == 0) {
+            throw new WindowsServiceException("Failed to open Service Control Manager", advapi32.getLastError());
+        }
+        return handle;
+    }
+
+    private MemorySegment openService(MemorySegment scManager, String serviceId, Arena arena) throws WindowsServiceException {
+        MemorySegment serviceName = PanamaUtil.allocateWideString(arena, serviceId);
+        MemorySegment handle = advapi32.openService(scManager, serviceName, Advapi32.SERVICE_ALL_ACCESS);
+        if (handle.equals(MemorySegment.NULL) || handle.address() == 0) {
+            throw new WindowsServiceException("Failed to open service '" + serviceId + "'", advapi32.getLastError());
+        }
+        return handle;
+    }
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/PanamaUtil.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/PanamaUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+
+/**
+ * Compatibility utilities for Panama FFI across JDK versions.
+ *
+ * <p>The base implementation targets JDK 21 preview APIs. The {@code main22} source set
+ * overrides methods where the API changed between JDK 21 (preview) and JDK 22 (final).
+ */
+class PanamaUtil {
+
+    private static final Linker LINKER = Linker.nativeLinker();
+
+    static MethodHandle downcallHandle(MemorySegment address, FunctionDescriptor descriptor, Linker.Option... options) {
+        return LINKER.downcallHandle(address, descriptor, options);
+    }
+
+    static MemorySegment findFunction(SymbolLookup lookup, String name) {
+        return lookup.find(name).orElseThrow(() -> new LinkageError("Native function " + name + " could not be found"));
+    }
+
+    /**
+     * Return a {@link VarHandle} to access an element within the given layout.
+     * In JDK 21, {@code MemoryLayout.varHandle} returns a VarHandle directly.
+     * In JDK 22+, it returns one with an extra offset coordinate that must be removed.
+     */
+    static VarHandle varHandleWithoutOffset(MemoryLayout layout, MemoryLayout.PathElement element) {
+        return layout.varHandle(element);
+    }
+
+    /**
+     * Allocate a wide (UTF-16LE) string in the given arena, null-terminated.
+     */
+    static MemorySegment allocateWideString(java.lang.foreign.Arena arena, String s) {
+        byte[] bytes = (s + "\0").getBytes(StandardCharsets.UTF_16LE);
+        MemorySegment segment = arena.allocateArray(JAVA_BYTE, bytes.length);
+        segment.copyFrom(MemorySegment.ofArray(bytes));
+        return segment;
+    }
+
+    private PanamaUtil() {}
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/ServiceStatus.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/ServiceStatus.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+/**
+ * Represents the status of a Windows service as returned by the SCM.
+ *
+ * @param state the current state (one of the {@code SERVICE_*} constants, e.g. {@link #STOPPED})
+ * @param win32ExitCode the Win32 exit code reported by the service
+ * @param checkPoint a progress value during lengthy operations
+ * @param waitHint estimated time in milliseconds for a pending operation
+ */
+public record ServiceStatus(int state, int win32ExitCode, int checkPoint, int waitHint) {
+
+    public static final int STOPPED = Advapi32.SERVICE_STOPPED;
+    public static final int START_PENDING = Advapi32.SERVICE_START_PENDING;
+    public static final int STOP_PENDING = Advapi32.SERVICE_STOP_PENDING;
+    public static final int RUNNING = Advapi32.SERVICE_RUNNING;
+
+    /**
+     * Synthetic state indicating that the service status could not be queried.
+     * This value is never returned by the Windows SCM API.
+     */
+    public static final int UNKNOWN = -1;
+
+    public String stateName() {
+        return switch (state) {
+            case STOPPED -> "STOPPED";
+            case START_PENDING -> "START_PENDING";
+            case STOP_PENDING -> "STOP_PENDING";
+            case RUNNING -> "RUNNING";
+            case UNKNOWN -> "UNKNOWN";
+            default -> "UNKNOWN(" + state + ")";
+        };
+    }
+
+    /**
+     * Creates a ServiceStatus representing a failed query.
+     */
+    public static ServiceStatus unknown() {
+        return new ServiceStatus(UNKNOWN, 0, 0, 0);
+    }
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/WindowsServiceControl.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/WindowsServiceControl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+/**
+ * Interface for controlling Windows services via the Service Control Manager.
+ *
+ * <p>The default implementation ({@link NativeWindowsServiceControl}) uses Panama FFI to call
+ * the Windows SCM APIs directly. Tests can provide mock implementations.
+ */
+public interface WindowsServiceControl {
+
+    /**
+     * Starts the specified service.
+     * @param serviceId the service name
+     * @throws WindowsServiceException if the service could not be started
+     */
+    void startService(String serviceId) throws WindowsServiceException;
+
+    /**
+     * Sends a stop control code to the specified service.
+     * This returns after the stop has been initiated; the service may still be in STOP_PENDING state.
+     * @param serviceId the service name
+     * @throws WindowsServiceException if the stop command could not be sent
+     */
+    void stopService(String serviceId) throws WindowsServiceException;
+
+    /**
+     * Marks the specified service for deletion from the SCM database.
+     * @param serviceId the service name
+     * @throws WindowsServiceException if the service could not be deleted
+     */
+    void deleteService(String serviceId) throws WindowsServiceException;
+
+    /**
+     * Queries the current status of the specified service.
+     * @param serviceId the service name
+     * @return the current service status
+     * @throws WindowsServiceException if the status could not be queried
+     */
+    ServiceStatus queryStatus(String serviceId) throws WindowsServiceException;
+
+    /**
+     * Creates the default native implementation backed by Panama FFI calls to advapi32.dll.
+     */
+    static WindowsServiceControl create() {
+        return new NativeWindowsServiceControl();
+    }
+}

--- a/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/WindowsServiceException.java
+++ b/libs/windows-service-control/src/main/java/org/elasticsearch/service/windows/WindowsServiceException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+/**
+ * Exception thrown when a Windows service control operation fails.
+ */
+public class WindowsServiceException extends Exception {
+
+    private final int errorCode;
+
+    public WindowsServiceException(String message, int errorCode) {
+        super(message + " (error code: " + errorCode + ")");
+        this.errorCode = errorCode;
+    }
+
+    public WindowsServiceException(String message) {
+        super(message);
+        this.errorCode = 0;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/libs/windows-service-control/src/main22/java/org/elasticsearch/service/windows/PanamaUtil.java
+++ b/libs/windows-service-control/src/main22/java/org/elasticsearch/service/windows/PanamaUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.service.windows;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+
+/**
+ * JDK 22+ overrides for Panama FFI compatibility.
+ */
+class PanamaUtil {
+
+    private static final Linker LINKER = Linker.nativeLinker();
+
+    static MethodHandle downcallHandle(MemorySegment address, FunctionDescriptor descriptor, Linker.Option... options) {
+        return LINKER.downcallHandle(address, descriptor, options);
+    }
+
+    static MemorySegment findFunction(SymbolLookup lookup, String name) {
+        return lookup.find(name).orElseThrow(() -> new LinkageError("Native function " + name + " could not be found"));
+    }
+
+    static VarHandle varHandleWithoutOffset(MemoryLayout layout, MemoryLayout.PathElement element) {
+        return MethodHandles.insertCoordinates(layout.varHandle(element), 1, 0L);
+    }
+
+    static MemorySegment allocateWideString(Arena arena, String s) {
+        byte[] bytes = (s + "\0").getBytes(StandardCharsets.UTF_16LE);
+        MemorySegment segment = arena.allocate(JAVA_BYTE, bytes.length);
+        segment.copyFrom(MemorySegment.ofArray(bytes));
+        return segment;
+    }
+
+    private PanamaUtil() {}
+}


### PR DESCRIPTION
Alternative to https://github.com/elastic/elasticsearch/pull/142639

Replace ProcrunCommand with ScmCommand for all basic service control operations. 

The new ScmCommand base class calls the Windows API directly, and the stop command includes a busy-wait polling loop that implements the documented pattern of waiting to ensure the service reaches the STOPPED state before returning.

Like in the linked PR, I left install and manager aside; manager starts the Apache procrun UI (and I think we can just get rid of it, but that would be for another PR); install is tightly coupled with how procrun works, e.g. adding registry keys procrun reads when it's started by the SCM to understand what to do. It will need to be replaced when we replace procrun for the service itself too.

Co-authored by cursor-agent
