### PR TITLE
Log preflight health on master-eligible nodes when no health node exists

### DIFF
--- a/docs/changelog/142665.yaml
+++ b/docs/changelog/142665.yaml
@@ -1,0 +1,6 @@
+area: Health
+issues:
+ - 99415
+pr: 142665
+summary: Log preflight health on master-eligible nodes when no health node exists
+type: bug

--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -130,6 +130,7 @@ public class HealthPeriodicLogger extends AbstractLifecycleComponent implements 
     private final Clock clock;
 
     private volatile boolean isHealthNode = false;
+    private volatile boolean hasNoHealthNode = false;
 
     // This semaphore is used to ensure only one schedule is currently running and to wait for this run to finish before closing
     private final Semaphore currentlyRunning = new Semaphore(1, true);
@@ -249,9 +250,18 @@ public class HealthPeriodicLogger extends AbstractLifecycleComponent implements 
         DiscoveryNode healthNode = HealthNode.findHealthNode(event.state());
         if (healthNode == null) {
             this.isHealthNode = false;
-            this.maybeCancelJob();
+            if (this.clusterService.localNode().isMasterNode()) {
+                // No health node exists, likely because preflight checks are failing.
+                // Master-eligible nodes can still report preflight health locally.
+                this.hasNoHealthNode = true;
+                maybeScheduleJob();
+            } else {
+                this.hasNoHealthNode = false;
+                this.maybeCancelJob();
+            }
             return;
         }
+        this.hasNoHealthNode = false;
         final boolean isCurrentlyHealthNode = healthNode.getId().equals(this.clusterService.localNode().getId());
         if (this.isHealthNode != isCurrentlyHealthNode) {
             this.isHealthNode = isCurrentlyHealthNode;
@@ -479,10 +489,11 @@ public class HealthPeriodicLogger extends AbstractLifecycleComponent implements 
     }
 
     /**
-     * Create the SchedulerEngine.Job if this node is the health node
+     * Create the SchedulerEngine.Job if this node is the health node, or if there is no health node
+     * and this node is master-eligible (to report preflight health).
      */
     private void maybeScheduleJob() {
-        if (this.isHealthNode == false) {
+        if (this.isHealthNode == false && this.hasNoHealthNode == false) {
             return;
         }
 
@@ -554,6 +565,11 @@ public class HealthPeriodicLogger extends AbstractLifecycleComponent implements 
     // Visible for testing
     boolean isHealthNode() {
         return isHealthNode;
+    }
+
+    // Visible for testing
+    boolean hasNoHealthNode() {
+        return hasNoHealthNode;
     }
 
     // Visible for testing

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -236,11 +236,17 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
         });
         assertTrue(scheduler.get().scheduledJobIds().contains(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME));
 
-        // Changing the health node should cancel the run
+        // When health node disappears but local node is master-eligible, job stays scheduled (preflight fallback)
         ClusterState noHealthNode = ClusterStateCreationUtils.state(node2, node1, new DiscoveryNode[] { node1, node2 });
         testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", noHealthNode, stateWithLocalHealthNode));
         assertFalse(testHealthPeriodicLogger.isHealthNode());
-        assertFalse(scheduler.get().scheduledJobIds().contains(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME));
+        assertTrue(testHealthPeriodicLogger.hasNoHealthNode());
+        assertTrue(scheduler.get().scheduledJobIds().contains(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME));
+
+        // When health node reappears, the preflight fallback flag is cleared
+        testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", stateWithLocalHealthNode, noHealthNode));
+        assertTrue(testHealthPeriodicLogger.isHealthNode());
+        assertFalse(testHealthPeriodicLogger.hasNoHealthNode());
     }
 
     public void testEnabled() {
@@ -784,6 +790,101 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
         assertEquals(0, logs.size());
         assertEquals(4, metrics.size());
+    }
+
+    public void testMasterEligibleNodeSchedulesJobWhenNoHealthNode() throws Exception {
+        HealthService testHealthService = this.getMockedHealthService();
+
+        testHealthPeriodicLogger = createAndInitHealthPeriodicLogger(clusterService, testHealthService, true);
+
+        // node2 is master-eligible and the local node; emit a cluster state with no health node
+        ClusterState noHealthNode = ClusterStateCreationUtils.state(node2, node1, new DiscoveryNode[] { node1, node2 });
+        testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", noHealthNode, ClusterState.EMPTY_STATE));
+
+        assertFalse(testHealthPeriodicLogger.isHealthNode());
+        assertTrue(testHealthPeriodicLogger.hasNoHealthNode());
+
+        AtomicReference<SchedulerEngine> scheduler = new AtomicReference<>();
+        assertBusy(() -> {
+            var s = testHealthPeriodicLogger.getScheduler();
+            assertNotNull(s);
+            scheduler.set(s);
+        });
+        assertTrue(
+            "master-eligible node should schedule job when no health node exists",
+            scheduler.get().scheduledJobIds().contains(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME)
+        );
+    }
+
+    public void testNonMasterEligibleNodeDoesNotScheduleJobWhenNoHealthNode() throws Exception {
+        DiscoveryNode dataOnlyNode = DiscoveryNodeUtils.builder("data_only").roles(Set.of(DiscoveryNodeRole.DATA_ROLE)).build();
+        ClusterState stateWithDataOnlyLocal = ClusterStateCreationUtils.state(
+            dataOnlyNode,
+            node1,
+            new DiscoveryNode[] { node1, dataOnlyNode }
+        );
+        ClusterService dataNodeClusterService = createClusterService(stateWithDataOnlyLocal, this.threadPool, clusterSettings);
+        try {
+            HealthService testHealthService = this.getMockedHealthService();
+            HealthPeriodicLogger dataNodeLogger = createAndInitHealthPeriodicLogger(dataNodeClusterService, testHealthService, true);
+            try {
+                // No health node in cluster state
+                ClusterState noHealthNode = ClusterStateCreationUtils.state(
+                    dataOnlyNode,
+                    node1,
+                    new DiscoveryNode[] { node1, dataOnlyNode }
+                );
+                dataNodeLogger.clusterChanged(new ClusterChangedEvent("test", noHealthNode, ClusterState.EMPTY_STATE));
+
+                assertFalse(dataNodeLogger.isHealthNode());
+                assertFalse("data-only node should not activate preflight fallback", dataNodeLogger.hasNoHealthNode());
+            } finally {
+                dataNodeLogger.stop();
+                dataNodeLogger.close();
+            }
+        } finally {
+            dataNodeClusterService.close();
+        }
+    }
+
+    public void testPreflightFallbackClearedWhenHealthNodeAppears() throws Exception {
+        HealthService testHealthService = this.getMockedHealthService();
+
+        testHealthPeriodicLogger = createAndInitHealthPeriodicLogger(clusterService, testHealthService, true);
+
+        // Start with no health node -- master-eligible node enters preflight fallback
+        ClusterState noHealthNode = ClusterStateCreationUtils.state(node2, node1, new DiscoveryNode[] { node1, node2 });
+        testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", noHealthNode, ClusterState.EMPTY_STATE));
+        assertTrue(testHealthPeriodicLogger.hasNoHealthNode());
+        assertFalse(testHealthPeriodicLogger.isHealthNode());
+
+        // Health node appears -- preflight fallback should be cleared
+        testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", stateWithLocalHealthNode, noHealthNode));
+        assertFalse(testHealthPeriodicLogger.hasNoHealthNode());
+        assertTrue(testHealthPeriodicLogger.isHealthNode());
+    }
+
+    public void testPreflightFallbackTriggersHealthLogging() throws Exception {
+        AtomicBoolean calledGetHealth = new AtomicBoolean();
+        HealthService testHealthService = this.getMockedHealthService();
+        doAnswer(invocation -> {
+            ActionListener<List<HealthIndicatorResult>> listener = invocation.getArgument(4);
+            assertNotNull(listener);
+            calledGetHealth.set(true);
+            listener.onResponse(getTestIndicatorResults());
+            return null;
+        }).when(testHealthService).getHealth(any(), isNull(), anyBoolean(), anyInt(), any());
+
+        testHealthPeriodicLogger = createAndInitHealthPeriodicLogger(this.clusterService, testHealthService, true);
+
+        // No health node -- master-eligible node enters preflight fallback
+        ClusterState noHealthNode = ClusterStateCreationUtils.state(node2, node1, new DiscoveryNode[] { node1, node2 });
+        testHealthPeriodicLogger.clusterChanged(new ClusterChangedEvent("test", noHealthNode, ClusterState.EMPTY_STATE));
+        assertTrue(testHealthPeriodicLogger.hasNoHealthNode());
+
+        SchedulerEngine.Event event = new SchedulerEngine.Event(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME, 0, 0);
+        testHealthPeriodicLogger.triggered(event);
+        assertBusy(() -> assertTrue("getHealth should be called during preflight fallback", calledGetHealth.get()));
     }
 
     private void verifyLoggerIsReadyToRun(HealthPeriodicLogger healthPeriodicLogger) {


### PR DESCRIPTION
## Summary

Fixes #99415

`HealthPeriodicLogger` only emits logs on the currently-selected health node, but if preflight checks are failing (e.g. no stable master) there may be no health node selected at all. This means the most critical health problems go completely unreported in logs.

This PR adds a fallback so that **master-eligible nodes** will schedule and run health logging when no health node is present. When a health node is subsequently elected, the fallback is cleared and normal single-node logging resumes.

### Changes

- **`HealthPeriodicLogger`**: Added a `hasNoHealthNode` flag. In `clusterChanged()`, when no health node exists and the local node is master-eligible, the logging job is scheduled instead of cancelled. Non-master-eligible nodes still cancel. When a health node reappears the flag is cleared.
- **`HealthPeriodicLoggerTests`**: Updated the existing job scheduling test and added four new tests covering:
  - Master-eligible node schedules the job when no health node exists
  - Data-only node does not activate the fallback
  - Fallback flag is cleared when a health node appears
  - `getHealth` is actually invoked during fallback mode

## Test plan

- [x] All existing `HealthPeriodicLoggerTests` pass (updated `testJobScheduling` to reflect new behavior)
- [x] New unit tests: `testMasterEligibleNodeSchedulesJobWhenNoHealthNode`, `testNonMasterEligibleNodeDoesNotScheduleJobWhenNoHealthNode`, `testPreflightFallbackClearedWhenHealthNodeAppears`, `testPreflightFallbackTriggersHealthLogging`
- [x] `spotlessJavaCheck` passes
