### PR TITLE
Fix IndexingPressureIT#testWriteCanRejectOnPrimaryBasedOnMaxOperationSize

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -126,9 +126,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
   method: testNodesCachesStats
   issue: https://github.com/elastic/elasticsearch/issues/129863
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-  issue: https://github.com/elastic/elasticsearch/issues/130281
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testFilterCacheStats
   issue: https://github.com/elastic/elasticsearch/issues/124447

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -437,7 +437,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
         }));
 
         final ThreadPool replicaThreadPool = internalCluster().getInstance(ThreadPool.class, replicaName);
-        final ThreadPool primaryThreadPool = internalCluster().getInstance(ThreadPool.class, replicaName);
+        final ThreadPool primaryThreadPool = internalCluster().getInstance(ThreadPool.class, primaryName);
         try (
             Releasable blockedPrimaryWriteThreadsRelease = blockWriteThreadPool(primaryThreadPool);
             Releasable blockedReplicaWriteThreadsRelease = blockWriteThreadPool(replicaThreadPool)


### PR DESCRIPTION
Block the correct (primary) thread pool instead of the replica's.

Closes #130281

