### PR TITLE
Unmute ` FieldExtractorIT testTsIndexConflictingTypes`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -374,9 +374,6 @@ tests:
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
-- class: org.elasticsearch.xpack.esql.qa.multi_node.FieldExtractorIT
-  method: testTsIndexConflictingTypes {null}
-  issue: https://github.com/elastic/elasticsearch/issues/142410
 - class: org.elasticsearch.benchmark.vector.scorer.VectorScorerOSQBenchmarkTests
   method: testBulkScalarVsVectorized {p0=768 p1=1 p2=MMAP p3=MAXIMUM_INNER_PRODUCT}
   issue: https://github.com/elastic/elasticsearch/issues/142413


### PR DESCRIPTION
We were not able to reproduce or explain the test failure, so we unmute the test and we will monitor for new failures.

Closes #142410 