### PR TITLE
Fix ShardFieldStats.liveDocsBytes

### DIFF
--- a/docs/changelog/142711.yaml
+++ b/docs/changelog/142711.yaml
@@ -1,0 +1,5 @@
+area: Engine
+issues: []
+pr: 142711
+summary: Fix `ShardFieldStats.liveDocsBytes`
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -327,7 +327,7 @@ public abstract class Engine implements Closeable {
     private static long getLiveDocsBytes(Bits liveDocs) {
         int words = FixedBitSet.bits2words(liveDocs.length());
         return ShardFieldStats.FIXED_BITSET_BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
-            RamUsageEstimator.sizeOf(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * words)
+            RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * words
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/LiveDocsEstimationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/LiveDocsEstimationTests.java
@@ -36,8 +36,9 @@ public class LiveDocsEstimationTests extends IndexShardTestCase {
         assertNull(shard.getShardFieldStats());
         recoverShardFromStore(shard);
 
-        // index some documents
-        int numDocs = 10;
+        // Use enough docs so the live docs FixedBitSet backing array requires multiple words (>64 bits),
+        // ensuring the byte estimation scales with segment size rather than being a constant.
+        int numDocs = randomIntBetween(100, 1000);
         for (int i = 0; i < numDocs; i++) {
             indexDoc(shard, "_doc", "first_" + i, """
                 {


### PR DESCRIPTION
The estimate was wrong because RamUsageEstimator.sizeOf(Long) returns a constant, fixed.

Assisted by cursor
