### PR TITLE
Normalize authentication response timing for password realms

### DIFF
--- a/docs/changelog/142714.yaml
+++ b/docs/changelog/142714.yaml
@@ -1,0 +1,5 @@
+area: Authentication
+issues: []
+pr: 142714
+summary: Normalize authentication response timing for password realms
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationResult.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationResult.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * </ol>
  */
 public final class AuthenticationResult<T> {
-    private static final AuthenticationResult<?> NOT_HANDLED = new AuthenticationResult<>(Status.CONTINUE, null, null, null, null);
+    private static final AuthenticationResult<?> NOT_HANDLED = new AuthenticationResult<>(Status.CONTINUE, null, null, null, null, false);
 
     @SuppressWarnings("rawtypes")
     public static final ThreadContextTransient<AuthenticationResult> THREAD_CONTEXT_VALUE = ThreadContextTransient.transientValue(
@@ -62,19 +62,22 @@ public final class AuthenticationResult<T> {
     private final String message;
     private final Exception exception;
     private final Map<String, Object> metadata;
+    private final boolean credentialVerificationPerformed;
 
     private AuthenticationResult(
         Status status,
         @Nullable T value,
         @Nullable String message,
         @Nullable Exception exception,
-        @Nullable Map<String, Object> metadata
+        @Nullable Map<String, Object> metadata,
+        boolean credentialVerificationPerformed
     ) {
         this.status = status;
         this.value = value;
         this.message = message;
         this.exception = exception;
         this.metadata = metadata == null ? Collections.emptyMap() : Collections.unmodifiableMap(metadata);
+        this.credentialVerificationPerformed = credentialVerificationPerformed;
     }
 
     public Status getStatus() {
@@ -98,6 +101,15 @@ public final class AuthenticationResult<T> {
     }
 
     /**
+     * Returns {@code true} if an expensive credential verification (e.g. bcrypt or PBKDF2 hash comparison)
+     * was performed as part of producing this result. Used by the authentication service to normalize
+     * authentication response timing for password-based realms.
+     */
+    public boolean isCredentialVerificationPerformed() {
+        return credentialVerificationPerformed;
+    }
+
+    /**
      * Creates an {@code AuthenticationResult} that indicates that the supplied {@link User}
      * has been successfully authenticated.
      * <p>
@@ -118,7 +130,7 @@ public final class AuthenticationResult<T> {
      */
     public static <T> AuthenticationResult<T> success(T value, @Nullable Map<String, Object> metadata) {
         Objects.requireNonNull(value);
-        return new AuthenticationResult<>(Status.SUCCESS, value, null, null, metadata);
+        return new AuthenticationResult<>(Status.SUCCESS, value, null, null, metadata, true);
     }
 
     /**
@@ -146,7 +158,22 @@ public final class AuthenticationResult<T> {
      */
     public static <T> AuthenticationResult<T> unsuccessful(String message, @Nullable Exception cause) {
         Objects.requireNonNull(message);
-        return new AuthenticationResult<>(Status.CONTINUE, null, message, cause, null);
+        return new AuthenticationResult<>(Status.CONTINUE, null, message, cause, null, false);
+    }
+
+    /**
+     * Creates an unsuccessful {@code AuthenticationResult} that also records whether an expensive
+     * credential verification was performed. This is used to normalize authentication response timing.
+     *
+     * @see #unsuccessful(String, Exception)
+     */
+    public static <T> AuthenticationResult<T> unsuccessful(
+        String message,
+        @Nullable Exception cause,
+        boolean credentialVerificationPerformed
+    ) {
+        Objects.requireNonNull(message);
+        return new AuthenticationResult<>(Status.CONTINUE, null, message, cause, null, credentialVerificationPerformed);
     }
 
     /**
@@ -160,7 +187,21 @@ public final class AuthenticationResult<T> {
      * </p>
      */
     public static <T> AuthenticationResult<T> terminate(String message, @Nullable Exception cause) {
-        return new AuthenticationResult<>(Status.TERMINATE, null, message, cause, null);
+        return new AuthenticationResult<>(Status.TERMINATE, null, message, cause, null, false);
+    }
+
+    /**
+     * Creates a terminating {@code AuthenticationResult} that also records whether an expensive
+     * credential verification was performed. This is used to normalize authentication response timing.
+     *
+     * @see #terminate(String, Exception)
+     */
+    public static <T> AuthenticationResult<T> terminate(
+        String message,
+        @Nullable Exception cause,
+        boolean credentialVerificationPerformed
+    ) {
+        return new AuthenticationResult<>(Status.TERMINATE, null, message, cause, null, credentialVerificationPerformed);
     }
 
     /**
@@ -174,7 +215,7 @@ public final class AuthenticationResult<T> {
      * </p>
      */
     public static <T> AuthenticationResult<T> terminate(String message) {
-        return terminate(message, null);
+        return terminate(message, (Exception) null);
     }
 
     public boolean isAuthenticated() {
@@ -192,6 +233,8 @@ public final class AuthenticationResult<T> {
             + message
             + ", exception="
             + exception
+            + ", credentialVerificationPerformed="
+            + credentialVerificationPerformed
             + '}';
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import javax.crypto.SecretKeyFactory;
@@ -587,6 +588,19 @@ public enum Hasher {
     public static boolean verifyHash(SecureString data, char[] hash) {
         final Hasher hasher = resolveFromHash(hash);
         return hasher.verify(data, hash);
+    }
+
+    private static final SecureString SENTINEL_PASSWORD = new SecureString("sentinel-password-normalization".toCharArray());
+    private static final ConcurrentHashMap<Hasher, char[]> SENTINEL_HASHES = new ConcurrentHashMap<>();
+
+    /**
+     * Performs a hash verification against a pre-computed sentinel value for the given hasher.
+     * This is used to normalize authentication response timing for password-based realms.
+     * The sentinel hash is lazily computed and cached per hasher.
+     */
+    public static void verifyForTimingNormalization(Hasher hasher) {
+        char[] sentinelHash = SENTINEL_HASHES.computeIfAbsent(hasher, h -> h.hash(SENTINEL_PASSWORD));
+        hasher.verify(SENTINEL_PASSWORD, sentinelHash);
     }
 
     private static char[] getPbkdf2Hash(SecureString data, int cost, String prefix) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -25,18 +25,23 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationFailureHandler;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.EmptyAuthorizationInfo;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
+import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
@@ -119,7 +124,12 @@ public class AuthenticationService {
             new ServiceAccountAuthenticator(serviceAccountService, nodeName, meterRegistry),
             new OAuth2TokenAuthenticator(tokenService, meterRegistry),
             new ApiKeyAuthenticator(apiKeyService, nodeName, meterRegistry),
-            new RealmsAuthenticator(numInvalidation, lastSuccessfulAuthCache, meterRegistry)
+            new RealmsAuthenticator(
+                numInvalidation,
+                lastSuccessfulAuthCache,
+                meterRegistry,
+                resolveTimingMitigationHasher(settings, realms)
+            )
         );
     }
 
@@ -450,6 +460,22 @@ public class AuthenticationService {
         public String toString() {
             return "rest request uri [" + request.uri() + "]";
         }
+    }
+
+    /**
+     * Returns the {@link Hasher} to use for normalizing authentication response timing on
+     * password-based authentication, or {@code null} if no active realm performs local password hash verification.
+     */
+    @Nullable
+    private static Hasher resolveTimingMitigationHasher(Settings settings, Realms realms) {
+        boolean hasLocalPasswordRealm = realms.getActiveRealms().stream().anyMatch(realm -> {
+            String type = realm.type();
+            if (NativeRealmSettings.TYPE.equals(type) || FileRealmSettings.TYPE.equals(type)) {
+                return true;
+            }
+            return ReservedRealm.TYPE.equals(type) && XPackSettings.RESERVED_REALM_ENABLED_SETTING.get(settings);
+        });
+        return hasLocalPasswordRealm ? Hasher.resolve(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(settings)) : null;
     }
 
     public static void addSettings(List<Setting<?>> settings) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
@@ -24,6 +24,8 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.support.Hasher;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.support.RealmUserLookup;
 import org.elasticsearch.xpack.security.metric.InstrumentedSecurityActionListener;
@@ -36,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -53,19 +56,33 @@ public class RealmsAuthenticator implements Authenticator {
     private final AtomicLong numInvalidation;
     private final Cache<String, Realm> lastSuccessfulAuthCache;
     private final SecurityMetrics<Realm> authenticationMetrics;
+    private final Runnable timingMitigation;
 
-    public RealmsAuthenticator(AtomicLong numInvalidation, Cache<String, Realm> lastSuccessfulAuthCache, MeterRegistry meterRegistry) {
-        this(numInvalidation, lastSuccessfulAuthCache, meterRegistry, System::nanoTime);
+    public RealmsAuthenticator(
+        AtomicLong numInvalidation,
+        Cache<String, Realm> lastSuccessfulAuthCache,
+        MeterRegistry meterRegistry,
+        Hasher timingMitigationHasher
+    ) {
+        this(
+            numInvalidation,
+            lastSuccessfulAuthCache,
+            meterRegistry,
+            timingMitigationHasher != null ? () -> Hasher.verifyForTimingNormalization(timingMitigationHasher) : null,
+            System::nanoTime
+        );
     }
 
     RealmsAuthenticator(
         AtomicLong numInvalidation,
         Cache<String, Realm> lastSuccessfulAuthCache,
         MeterRegistry meterRegistry,
+        Runnable timingMitigation,
         LongSupplier nanoTimeSupplier
     ) {
         this.numInvalidation = numInvalidation;
         this.lastSuccessfulAuthCache = lastSuccessfulAuthCache;
+        this.timingMitigation = timingMitigation;
         this.authenticationMetrics = new SecurityMetrics<>(
             SecurityMetricType.AUTHC_REALMS,
             meterRegistry,
@@ -156,6 +173,7 @@ public class RealmsAuthenticator implements Authenticator {
 
         final AtomicReference<Realm> authenticatedByRef = new AtomicReference<>();
         final AtomicReference<AuthenticationResult<User>> authenticationResultRef = new AtomicReference<>();
+        final AtomicBoolean credentialVerificationPerformed = new AtomicBoolean(false);
 
         final BiConsumer<Realm, ActionListener<User>> realmAuthenticatingConsumer = (realm, userListener) -> {
             if (realm.supports(authenticationToken)) {
@@ -176,8 +194,10 @@ public class RealmsAuthenticator implements Authenticator {
                             authenticationToken.getClass().getSimpleName(),
                             result
                         );
+                        if (result.isCredentialVerificationPerformed()) {
+                            credentialVerificationPerformed.set(true);
+                        }
                         if (result.getStatus() == AuthenticationResult.Status.SUCCESS) {
-                            // user was authenticated, populate the authenticated by information
                             authenticatedByRef.set(realm);
                             authenticationResultRef.set(result);
                             if (lastSuccessfulAuthCache != null && startInvalidation == numInvalidation.get()) {
@@ -185,7 +205,6 @@ public class RealmsAuthenticator implements Authenticator {
                             }
                             userListener.onResponse(result.getValue());
                         } else {
-                            // the user was not authenticated, call this so we can audit the correct event
                             context.getRequest().realmAuthenticationFailed(authenticationToken, realm.name());
                             if (result.getStatus() == AuthenticationResult.Status.TERMINATE) {
                                 final var resultException = result.getException();
@@ -236,6 +255,7 @@ public class RealmsAuthenticator implements Authenticator {
         final IteratingActionListener<User, Realm> authenticatingListener = new IteratingActionListener<>(
             ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(user -> {
                 if (user == null) {
+                    performTimingMitigationIfNeeded(authenticationToken, credentialVerificationPerformed);
                     consumeNullUser(context, messages, listener);
                 } else {
                     final AuthenticationResult<User> result = authenticationResultRef.get();
@@ -247,6 +267,7 @@ public class RealmsAuthenticator implements Authenticator {
                 }
             }, e -> {
                 if (e == AuthenticationTerminatedSuccessfullyException.INSTANCE) {
+                    performTimingMitigationIfNeeded(authenticationToken, credentialVerificationPerformed);
                     listener.onFailure(context.getRequest().authenticationFailed(authenticationToken));
                 } else {
                     assert e instanceof AuthenticationTerminatedSuccessfullyException == false : e;
@@ -277,6 +298,20 @@ public class RealmsAuthenticator implements Authenticator {
                 e
             );
             listener.onFailure(context.getRequest().exceptionProcessingRequest(e, authenticationToken));
+        }
+    }
+
+    /**
+     * Performs a sentinel hash verification if no realm performed an expensive credential verification
+     * during the authentication attempt. This normalizes the authentication response timing for
+     * password-based realms.
+     *
+     * Only applies to {@link UsernamePasswordToken} authentication, since other token types
+     * (e.g. JWT, Kerberos) do not involve local password hash verification.
+     */
+    private void performTimingMitigationIfNeeded(AuthenticationToken token, AtomicBoolean credentialVerificationPerformed) {
+        if (timingMitigation != null && token instanceof UsernamePasswordToken && credentialVerificationPerformed.get() == false) {
+            timingMitigation.run();
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
@@ -628,7 +628,7 @@ public class NativeUsersStore {
                     listener.onResponse(AuthenticationResult.success(userAndPassword.user()));
                 } else {
                     logger.trace("password mismatch for user [{}] (security index [{}])", userAndPassword, securityIndex.aliasName());
-                    listener.onResponse(AuthenticationResult.unsuccessful("Password authentication failed for " + username, null));
+                    listener.onResponse(AuthenticationResult.unsuccessful("Password authentication failed for " + username, null, true));
                 }
             }
         }, listener::onFailure));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
@@ -168,7 +168,7 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
                             }
                         } else {
                             hashCleanupListener.onResponse(
-                                AuthenticationResult.terminate("failed to authenticate user [" + token.principal() + "]")
+                                AuthenticationResult.terminate("failed to authenticate user [" + token.principal() + "]", null, true)
                             );
                         }
                     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStore.java
@@ -86,7 +86,7 @@ public class FileUserPasswdStore {
             return AuthenticationResult.notHandled();
         }
         if (Hasher.verifyHash(password, hash) == false) {
-            return AuthenticationResult.unsuccessful("Password authentication failed for " + username, null);
+            return AuthenticationResult.unsuccessful("Password authentication failed for " + username, null, true);
         }
         return AuthenticationResult.success(user.get());
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
@@ -178,7 +178,12 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
                             cachedResult.authenticationResult.getStatus(),
                             cachedResult.authenticationResult.getMessage()
                         );
-                        listener.onResponse(cachedResult.authenticationResult);
+                        final var cached = cachedResult.authenticationResult;
+                        listener.onResponse(
+                            cached.getStatus() == AuthenticationResult.Status.TERMINATE
+                                ? AuthenticationResult.terminate(cached.getMessage(), cached.getException())
+                                : AuthenticationResult.unsuccessful(cached.getMessage(), cached.getException())
+                        );
                     } else {
                         logger.trace(
                             "realm [{}], provided credentials for user [{}] do not match (possibly invalid) cached credentials,"

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -382,6 +382,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             mock(),
             MeterRegistry.NOOP
         );
+        Mockito.clearInvocations(firstRealm, secondRealm);
     }
 
     private Realm mockRealm(RealmConfig config) {
@@ -681,6 +682,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             mock(),
             MeterRegistry.NOOP
         );
+        Mockito.clearInvocations(firstRealm, secondRealm);
         User user = new User("_username", "r1");
         when(firstRealm.supports(token)).thenReturn(true);
         mockAuthenticate(firstRealm, token, null);
@@ -1066,6 +1068,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 mock(),
                 MeterRegistry.NOOP
             );
+            Mockito.clearInvocations(firstRealm);
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();
             if (requestIdAlreadyPresent) {
@@ -1143,6 +1146,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 mock(),
                 MeterRegistry.NOOP
             );
+            Mockito.clearInvocations(firstRealm);
             service.authenticate("_action", new InternalRequest(), InternalUsers.SYSTEM_USER, ActionListener.wrap(result -> {
                 if (requestIdAlreadyPresent) {
                     assertThat(expectAuditRequestId(threadPool2.getThreadContext()), is(reqId.get()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -12,10 +12,12 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmDomain;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.metric.SecurityMetricType;
 import org.junit.Before;
@@ -31,6 +34,7 @@ import org.junit.Before;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -110,6 +114,7 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
             numInvalidation,
             lastSuccessfulAuthCache,
             telemetryPlugin.getTelemetryProvider(Settings.EMPTY).getMeterRegistry(),
+            (Runnable) null,
             nanoTimeSupplier
         );
     }
@@ -361,6 +366,131 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
             )
         );
 
+    }
+
+    public void testTimingMitigationFiresForUsernamePasswordToken() {
+        final AtomicInteger mitigationCount = new AtomicInteger(0);
+        final RealmsAuthenticator authenticator = new RealmsAuthenticator(
+            numInvalidation,
+            lastSuccessfulAuthCache,
+            MeterRegistry.NOOP,
+            mitigationCount::incrementAndGet,
+            nanoTimeSupplier
+        );
+
+        final UsernamePasswordToken upToken = new UsernamePasswordToken(username, new SecureString("password".toCharArray()));
+        when(realm1.supports(upToken)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<AuthenticationResult<User>> listener = (ActionListener<AuthenticationResult<User>>) invocationOnMock
+                .getArguments()[1];
+            listener.onResponse(AuthenticationResult.notHandled());
+            return null;
+        }).when(realm1).authenticate(eq(upToken), any());
+        when(realm2.supports(upToken)).thenReturn(false);
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(upToken);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.authenticationFailed(upToken)).thenReturn(e);
+
+        final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
+        authenticator.authenticate(context, future);
+        expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        assertThat(mitigationCount.get(), equalTo(1));
+    }
+
+    public void testTimingMitigationDoesNotFireForNonPasswordToken() {
+        final AtomicInteger mitigationCount = new AtomicInteger(0);
+        final RealmsAuthenticator authenticator = new RealmsAuthenticator(
+            numInvalidation,
+            lastSuccessfulAuthCache,
+            MeterRegistry.NOOP,
+            mitigationCount::incrementAndGet,
+            nanoTimeSupplier
+        );
+
+        when(realm1.supports(authenticationToken)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<AuthenticationResult<User>> listener = (ActionListener<AuthenticationResult<User>>) invocationOnMock
+                .getArguments()[1];
+            listener.onResponse(AuthenticationResult.notHandled());
+            return null;
+        }).when(realm1).authenticate(eq(authenticationToken), any());
+        when(realm2.supports(authenticationToken)).thenReturn(false);
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(authenticationToken);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.authenticationFailed(authenticationToken)).thenReturn(e);
+
+        final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
+        authenticator.authenticate(context, future);
+        expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        assertThat(mitigationCount.get(), equalTo(0));
+    }
+
+    public void testTimingMitigationSkippedWhenNoLocalPasswordRealmsConfigured() {
+        final RealmsAuthenticator authenticator = new RealmsAuthenticator(
+            numInvalidation,
+            lastSuccessfulAuthCache,
+            MeterRegistry.NOOP,
+            (Runnable) null,
+            nanoTimeSupplier
+        );
+
+        final UsernamePasswordToken upToken = new UsernamePasswordToken(username, new SecureString("password".toCharArray()));
+        when(realm1.supports(upToken)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<AuthenticationResult<User>> listener = (ActionListener<AuthenticationResult<User>>) invocationOnMock
+                .getArguments()[1];
+            listener.onResponse(AuthenticationResult.notHandled());
+            return null;
+        }).when(realm1).authenticate(eq(upToken), any());
+        when(realm2.supports(upToken)).thenReturn(false);
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(upToken);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.authenticationFailed(upToken)).thenReturn(e);
+
+        final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
+        authenticator.authenticate(context, future);
+        expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+    }
+
+    public void testTimingMitigationSkippedWhenCredentialVerificationPerformed() {
+        final AtomicInteger mitigationCount = new AtomicInteger(0);
+        final RealmsAuthenticator authenticator = new RealmsAuthenticator(
+            numInvalidation,
+            lastSuccessfulAuthCache,
+            MeterRegistry.NOOP,
+            mitigationCount::incrementAndGet,
+            nanoTimeSupplier
+        );
+
+        final UsernamePasswordToken upToken = new UsernamePasswordToken(username, new SecureString("password".toCharArray()));
+        when(realm1.supports(upToken)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<AuthenticationResult<User>> listener = (ActionListener<AuthenticationResult<User>>) invocationOnMock
+                .getArguments()[1];
+            listener.onResponse(AuthenticationResult.unsuccessful("wrong password", null, true));
+            return null;
+        }).when(realm1).authenticate(eq(upToken), any());
+        when(realm2.supports(upToken)).thenReturn(false);
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(upToken);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.authenticationFailed(upToken)).thenReturn(e);
+
+        final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
+        authenticator.authenticate(context, future);
+        expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        assertThat(mitigationCount.get(), equalTo(0));
     }
 
     private void configureRealmAuthResponse(Realm realm, AuthenticationResult<User> authenticationResult) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtTokenExtractionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtTokenExtractionTests.java
@@ -58,7 +58,8 @@ public class JwtTokenExtractionTests extends ESTestCase {
         RealmsAuthenticator realmsAuthenticator = new RealmsAuthenticator(
             mock(AtomicLong.class),
             (Cache<String, Realm>) mock(Cache.class),
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            null
         );
         final Authenticator.Context context = new Authenticator.Context(
             threadContext,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
@@ -320,6 +320,11 @@ public class HasherTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Error using PBKDF2 implementation from the selected Security Provider"));
     }
 
+    public void testVerifyForTimingNormalization() {
+        Hasher hasher = randomFrom(Hasher.BCRYPT, Hasher.PBKDF2, Hasher.PBKDF2_STRETCH);
+        Hasher.verifyForTimingNormalization(hasher);
+    }
+
     private static void testHasherSelfGenerated(Hasher hasher) {
         // In FIPS 140 mode, passwords for PBKDF2 need to be at least 14 chars
         SecureString passwd = new SecureString(randomAlphaOfLength(between(14, 18)).toCharArray());


### PR DESCRIPTION
Ensure password-based authentication performs consistent work regardless of the lookup result, aligning response timing across all code paths in `NativeUsersStore`, `FileUserPasswdStore`, and `ReservedRealm`.