### PR TITLE
Update timeout on yaml rest tests because they often exceed 1h

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -273,9 +273,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointServiceNodeTests
   method: testGetCheckpointStats
   issue: https://github.com/elastic/elasticsearch/issues/141112
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/240_base_conversion/numeric_family, to_integer first argument, integer not a string}
-  issue: https://github.com/elastic/elasticsearch/issues/141113
 - class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
   method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
   issue: https://github.com/elastic/elasticsearch/issues/141200
@@ -338,9 +335,6 @@ tests:
 - class: org.elasticsearch.compute.operator.topn.TopNOomRaceTests
   method: testRace {repeats = 50}
   issue: https://github.com/elastic/elasticsearch/issues/141773
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/50_index_patterns/disjoint_mappings}
-  issue: https://github.com/elastic/elasticsearch/issues/141856
 - class: org.elasticsearch.compute.lucene.read.ValueSourceReaderTypeConversionTests
   method: testLoadAll
   issue: https://github.com/elastic/elasticsearch/issues/141954

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -45,7 +45,7 @@ import static java.util.Collections.singletonMap;
 
 /** Runs rest tests against external cluster */
 // TODO: Remove this timeout increase once this test suite is broken up
-@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = 90 * TimeUnits.MINUTE)
 public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(
         "x_pack_rest_user",


### PR DESCRIPTION
What is happening now is that whichever test happens to be running when the timeout threshold is crossed will get muted by the CI automation. Once sufficient tests are muted, the timeout is no longer crossed. This means arbitrary tests are muted, not the ones that actually take the longest.

Extending the timeout is an interim measure and should be followed up by one or both of these options:
* Investigate the slowest tests and decide if they are needed or could be simplified, and try to reduce the total time to within reason
* Split the tests into groups that are run on separate test runs, probably in parallel. This costs more in infrastructure, but with less risk of reduce coverage

Fixes #141113
Fixes #141856
