### PR TITLE
[ES|QL] unmute SubqueryInFromWithRerankInSubquery

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -419,9 +419,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/TS Command grouping on text field}
   issue: https://github.com/elastic/elasticsearch/issues/142544
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:subquery.SubqueryInFromWithRerankInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/142552
 - class: org.elasticsearch.index.IndexSettingsTests
   method: testSyntheticIdBadVersion
   issue: https://github.com/elastic/elasticsearch/issues/142508


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/142552
This is already fixed by https://github.com/elastic/elasticsearch/pull/142539