### PR TITLE
ESQL: mention MV_EXPAND on multivalued fields page

### DIFF
--- a/docs/reference/query-languages/esql/esql-multivalued-fields.md
+++ b/docs/reference/query-languages/esql/esql-multivalued-fields.md
@@ -264,6 +264,8 @@ Work around this limitation by converting the field to single value with one of:
 * [`MV_MIN`](/reference/query-languages/esql/functions-operators/mv-functions.md#esql-mv_min)
 * [`MV_SUM`](/reference/query-languages/esql/functions-operators/mv-functions.md#esql-mv_sum)
 
+To filter on individual values in a multivalued field (for example, to keep only rows where the field contains a given value), use the [`MV_EXPAND`](/reference/query-languages/esql/commands/mv_expand.md#esql-mv_expand) command to expand the field into one row per value, then apply `WHERE` to the expanded column.
+
 ```console
 POST /_query
 {

--- a/docs/reference/query-languages/esql/esql-multivalued-fields.md
+++ b/docs/reference/query-languages/esql/esql-multivalued-fields.md
@@ -264,7 +264,7 @@ Work around this limitation by converting the field to single value with one of:
 * [`MV_MIN`](/reference/query-languages/esql/functions-operators/mv-functions.md#esql-mv_min)
 * [`MV_SUM`](/reference/query-languages/esql/functions-operators/mv-functions.md#esql-mv_sum)
 
-To filter on individual values in a multivalued field (for example, to keep only rows where the field contains a given value), use the [`MV_EXPAND`](/reference/query-languages/esql/commands/mv_expand.md#esql-mv_expand) command to expand the field into one row per value, then apply `WHERE` to the expanded column.
+To filter on individual values in a multivalued field (for example, to keep only rows where the field contains a given value), use the [`MV_EXPAND`](/reference/query-languages/esql/commands/mv_expand.md) command to expand the field into one row per value, then apply `WHERE` to the expanded column.
 
 ```console
 POST /_query


### PR DESCRIPTION
Adds a paragraph to the "ES|QL multivalued fields" docs explaining that to filter on individual values in a multivalued field you can use the `MV_EXPAND` command to expand the field into one row per value, then apply `WHERE`. Includes a link to the MV_EXPAND command reference.

Fixes #105357 