### PR TITLE
[ESQL] [DNM yet] Fix nullable propagation in OR/IS NULL filters

### DIFF
--- a/docs/changelog/142728.yaml
+++ b/docs/changelog/142728.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 142728
+summary: Fix nullable propagation in OR/IS NULL filters
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
@@ -27,7 +26,8 @@ import java.util.function.BiFunction;
 
 // a IS NULL AND a IS NOT NULL -> FALSE
 // a IS NULL AND a > 10 -> a IS NULL and FALSE
-// can be extended to handle null conditions where available
+// For disjunctions, nullify only matching sub-expressions so surviving OR branches are preserved.
+// (a IS NOT NULL OR p) AND a IS NULL -> p AND a IS NULL
 public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<And> {
 
     public PropagateNullable() {
@@ -67,10 +67,19 @@ public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<An
         boolean modified = replace(nullExpressions, others, splits, this::nullify);
         modified |= replace(notNullExpressions, others, splits, this::nonNullify);
         if (modified) {
-            // reconstruct the expression
-            return Predicates.combineAnd(splits);
+            // Rebuild once and fold once after all substitutions.
+            return foldAfterSubstitution(Predicates.combineAnd(splits), ctx);
         }
         return and;
+    }
+
+    private static Expression foldAfterSubstitution(Expression expression, LogicalOptimizerContext ctx) {
+        return expression.transformUp(e -> {
+            if (e instanceof Literal || e.foldable() == false) {
+                return e;
+            }
+            return Literal.of(e, e.fold(ctx.foldCtx()));
+        });
     }
 
     /**
@@ -117,6 +126,7 @@ public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<An
             }
         }
 
+        // Substitute only the constrained expression so other OR branches can survive and fold.
         Expression replaced = exp.transformDown(e -> {
             if (e.semanticEquals(nullExp)) {
                 return Literal.of(e, null);
@@ -129,10 +139,6 @@ public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<An
             }
             return e;
         });
-
-        if (replaced.foldable()) {
-            return Literal.of(replaced, replaced.fold(FoldContext.small()));
-        }
         return replaced;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
@@ -115,6 +116,23 @@ public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<An
                 return exp.replaceChildren(newChildren);
             }
         }
-        return Literal.of(exp, null);
+
+        Expression replaced = exp.transformDown(e -> {
+            if (e.semanticEquals(nullExp)) {
+                return Literal.of(e, null);
+            }
+            if (e instanceof IsNull isNull && isNull.field().semanticEquals(nullExp)) {
+                return Literal.of(e, true);
+            }
+            if (e instanceof IsNotNull isNotNull && isNotNull.field().semanticEquals(nullExp)) {
+                return Literal.of(e, false);
+            }
+            return e;
+        });
+
+        if (replaced.foldable()) {
+            return Literal.of(replaced, replaced.fold(FoldContext.small()));
+        }
+        return replaced;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -671,6 +671,26 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         var source = as(filter.child(), EsRelation.class);
     }
 
+    public void testIsNullFilterDoesNotPruneDisjunctionBranch() {
+        var plan = localPlan("""
+              FROM test
+            | EVAL full = CONCAT(first_name, " ", last_name), lang = languages
+            | KEEP emp_no, full, lang, gender
+            | WHERE `lang` IS NOT NULL OR NOT contains(full, "ssD") AND NOT emp_no <= -30 OR NOT true
+            | KEEP gender, lang
+            | WHERE lang IS NULL
+            """);
+
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        var outerFilter = as(limit.child(), Filter.class);
+        assertThat("outer filter should preserve non-null-disjunction branch", outerFilter.condition().toString(), containsString("NOT contains(full"));
+        var eval = as(outerFilter.child(), Eval.class);
+        var innerFilter = as(eval.child(), Filter.class);
+        assertThat("inner filter should retain the lang IS NULL constraint", innerFilter.condition().toString(), containsString("IS NULL"));
+        assertThat("local plan should not be pruned to empty", innerFilter.child(), not(instanceOf(LocalRelation.class)));
+    }
+
     /*
      * Limit[1000[INTEGER],false]
      * \_Filter[RLIKE(first_name{f}#4, "VALÜ*", true)]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -682,38 +682,23 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
             | WHERE nullable IS NULL
             """);
 
-        List<Expression> conjuncts = new ArrayList<>();
-        LogicalPlan cursor = plan;
-        while (cursor instanceof UnaryPlan unary) {
-            if (cursor instanceof Filter filter) {
-                conjuncts.addAll(Predicates.splitAnd(filter.condition()));
-            }
-            cursor = unary.child();
-        }
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var conjuncts = Predicates.splitAnd(filter.condition());
 
-        assertThat("local plan should not be pruned to empty", cursor, not(instanceOf(LocalRelation.class)));
+        var residualBranch = conjuncts.stream()
+            .filter(GreaterThan.class::isInstance)
+            .map(GreaterThan.class::cast)
+            .findFirst()
+            .orElseThrow();
+        var residualField = as(residualBranch.left(), FieldAttribute.class);
+        assertEquals("emp_no", residualField.name());
 
-        boolean hasIsNullNullable = conjuncts.stream().anyMatch(e -> {
-            if (e instanceof IsNull == false) {
-                return false;
-            }
-            IsNull isNull = (IsNull) e;
-            return "nullable".equals(Expressions.name(isNull.field())) || "languages".equals(Expressions.name(isNull.field()));
-        });
-        assertTrue("expected null constraint to be preserved", hasIsNullNullable);
-
-        boolean hasEmpNoResidual = conjuncts.stream().anyMatch(e -> {
-            if (e instanceof GreaterThan == false) {
-                return false;
-            }
-            GreaterThan gt = (GreaterThan) e;
-            if (gt.left() instanceof FieldAttribute == false) {
-                return false;
-            }
-            FieldAttribute field = (FieldAttribute) gt.left();
-            return "emp_no".equals(field.name());
-        });
-        assertTrue("expected disjunction residual branch to be preserved", hasEmpNoResidual);
+        var isNull = conjuncts.stream().filter(IsNull.class::isInstance).map(IsNull.class::cast).findFirst().orElseThrow();
+        String nullableName = Expressions.name(isNull.field());
+        assertTrue("expected nullable field null-check to be preserved", "nullable".equals(nullableName) || "languages".equals(nullableName));
+        assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
     }
 
     /*

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -674,6 +674,9 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
     }
 
     public void testIsNullFilterDoesNotPruneDisjunctionBranch() {
+        // (nullable IS NOT NULL OR emp_no > 10000) AND nullable IS NULL
+        // simplifies to (emp_no > 10000) AND nullable IS NULL.
+        // The optimizer must keep the residual emp_no branch instead of pruning to empty.
         var plan = localPlan("""
               FROM test
             | EVAL nullable = languages
@@ -686,6 +689,7 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         var limit = as(project.child(), Limit.class);
         var filter = as(limit.child(), Filter.class);
         var conjuncts = Predicates.splitAnd(filter.condition());
+        assertThat(conjuncts, hasSize(2));
 
         var residualBranch = conjuncts.stream()
             .filter(GreaterThan.class::isInstance)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -684,7 +684,11 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         var project = as(plan, Project.class);
         var limit = as(project.child(), Limit.class);
         var outerFilter = as(limit.child(), Filter.class);
-        assertThat("outer filter should preserve non-null-disjunction branch", outerFilter.condition().toString(), containsString("NOT contains(full"));
+        assertThat(
+            "outer filter should preserve non-null-disjunction branch",
+            outerFilter.condition().toString(),
+            containsString("NOT contains(full")
+        );
         var eval = as(outerFilter.child(), Eval.class);
         var innerFilter = as(eval.child(), Filter.class);
         assertThat("inner filter should retain the lang IS NULL constraint", innerFilter.condition().toString(), containsString("IS NULL"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.Order;
-import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
@@ -55,6 +54,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.Wild
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLikeList;
 import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
 import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -697,7 +697,10 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
 
         var isNull = conjuncts.stream().filter(IsNull.class::isInstance).map(IsNull.class::cast).findFirst().orElseThrow();
         String nullableName = Expressions.name(isNull.field());
-        assertTrue("expected nullable field null-check to be preserved", "nullable".equals(nullableName) || "languages".equals(nullableName));
+        assertTrue(
+            "expected nullable field null-check to be preserved",
+            "nullable".equals(nullableName) || "languages".equals(nullableName)
+        );
         assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
@@ -56,6 +57,7 @@ import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
 import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
@@ -674,25 +676,44 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
     public void testIsNullFilterDoesNotPruneDisjunctionBranch() {
         var plan = localPlan("""
               FROM test
-            | EVAL full = CONCAT(first_name, " ", last_name), lang = languages
-            | KEEP emp_no, full, lang, gender
-            | WHERE `lang` IS NOT NULL OR NOT contains(full, "ssD") AND NOT emp_no <= -30 OR NOT true
-            | KEEP gender, lang
-            | WHERE lang IS NULL
+            | EVAL nullable = languages
+            | KEEP emp_no, nullable
+            | WHERE nullable IS NOT NULL OR emp_no > 10000
+            | WHERE nullable IS NULL
             """);
 
-        var project = as(plan, Project.class);
-        var limit = as(project.child(), Limit.class);
-        var outerFilter = as(limit.child(), Filter.class);
-        assertThat(
-            "outer filter should preserve non-null-disjunction branch",
-            outerFilter.condition().toString(),
-            containsString("NOT contains(full")
-        );
-        var eval = as(outerFilter.child(), Eval.class);
-        var innerFilter = as(eval.child(), Filter.class);
-        assertThat("inner filter should retain the lang IS NULL constraint", innerFilter.condition().toString(), containsString("IS NULL"));
-        assertThat("local plan should not be pruned to empty", innerFilter.child(), not(instanceOf(LocalRelation.class)));
+        List<Expression> conjuncts = new ArrayList<>();
+        LogicalPlan cursor = plan;
+        while (cursor instanceof UnaryPlan unary) {
+            if (cursor instanceof Filter filter) {
+                conjuncts.addAll(Predicates.splitAnd(filter.condition()));
+            }
+            cursor = unary.child();
+        }
+
+        assertThat("local plan should not be pruned to empty", cursor, not(instanceOf(LocalRelation.class)));
+
+        boolean hasIsNullNullable = conjuncts.stream().anyMatch(e -> {
+            if (e instanceof IsNull == false) {
+                return false;
+            }
+            IsNull isNull = (IsNull) e;
+            return "nullable".equals(Expressions.name(isNull.field())) || "languages".equals(Expressions.name(isNull.field()));
+        });
+        assertTrue("expected null constraint to be preserved", hasIsNullNullable);
+
+        boolean hasEmpNoResidual = conjuncts.stream().anyMatch(e -> {
+            if (e instanceof GreaterThan == false) {
+                return false;
+            }
+            GreaterThan gt = (GreaterThan) e;
+            if (gt.left() instanceof FieldAttribute == false) {
+                return false;
+            }
+            FieldAttribute field = (FieldAttribute) gt.left();
+            return "emp_no".equals(field.name());
+        });
+        assertTrue("expected disjunction residual branch to be preserved", hasEmpNoResidual);
     }
 
     /*

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
@@ -23,7 +23,8 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
@@ -36,6 +37,8 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizer
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 
 public class PropagateNullableTests extends ESTestCase {
     private Expression propagateNullable(And e) {
@@ -153,6 +156,12 @@ public class PropagateNullableTests extends ESTestCase {
 
         Expression optimized = propagateNullable(aIsNull_AND_bLT1_AND_cLT1_AND_aLT1);
         Literal nullLiteral = new Literal(EMPTY, null, BOOLEAN);
-        assertEquals(asList(aIsNull, nullLiteral, nullLiteral, nullLiteral), Predicates.splitAnd(optimized));
+        List<Expression> splits = Predicates.splitAnd(optimized);
+        assertThat(splits, hasItems(aIsNull, nullLiteral));
+        assertThat(
+            "expected null-propagation to preserve a nullable c-comparison branch",
+            splits.stream().anyMatch(e -> e.toString().contains("c") || e.toString().contains("null")),
+            is(true)
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
@@ -23,8 +23,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
-import java.util.List;
-
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
@@ -37,8 +35,6 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizer
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
 
 public class PropagateNullableTests extends ESTestCase {
     private Expression propagateNullable(And e) {
@@ -145,6 +141,7 @@ public class PropagateNullableTests extends ESTestCase {
         assertEquals(and, propagateNullable(and));
     }
 
+    // constants and nullable comparison keep exact conjunction shape
     public void testDoNotOptimizeIsNullAndMultipleComparisonWithConstants() {
         Literal a = ONE;
         Literal b = ONE;
@@ -155,13 +152,15 @@ public class PropagateNullableTests extends ESTestCase {
         And aIsNull_AND_bLT1_AND_cLT1_AND_aLT1 = new And(EMPTY, aIsNull_AND_bLT1_AND_cLT1, lessThanOf(a, ONE));
 
         Expression optimized = propagateNullable(aIsNull_AND_bLT1_AND_cLT1_AND_aLT1);
-        Literal nullLiteral = new Literal(EMPTY, null, BOOLEAN);
-        List<Expression> splits = Predicates.splitAnd(optimized);
-        assertThat(splits, hasItems(aIsNull, nullLiteral));
-        assertThat(
-            "expected null-propagation to preserve a nullable c-comparison branch",
-            splits.stream().anyMatch(e -> e.toString().contains("c") || e.toString().contains("null")),
-            is(true)
+
+        Literal nullBoolean = new Literal(EMPTY, null, BOOLEAN);
+        Literal nullInteger = new Literal(EMPTY, null, ONE.dataType());
+        Expression expected = new And(
+            EMPTY,
+            aIsNull,
+            new And(EMPTY, nullBoolean, new And(EMPTY, lessThanOf(getFieldAttribute("c"), nullInteger), nullBoolean))
         );
+
+        assertEquals(Predicates.splitAnd(expected), Predicates.splitAnd(optimized));
     }
 }


### PR DESCRIPTION
## Summary
Consider when `A = field IS NOT NULL` and `B = p.` Then `field IS NULL = NOT A`.
  The expression is:

  `(A OR B) AND (NOT A)`

  Distribute `AND` over `OR`:

```
  (A AND NOT A) OR (B AND NOT A)
    = FALSE     OR (B AND NOT A)
    = B AND NOT A
```

  Substitute back:

  `p AND field IS NULL`

- This patch was 'agentically' written based on a spec generated by fuzzing using [ternary logic partitioning (TLP)](https://dl.acm.org/doi/10.1145/3428279) - the fuzzing code is a Spacetime WIP