### PR TITLE
Fix ESQL overflowing division error message for doubles

### DIFF
--- a/docs/changelog/142741.yaml
+++ b/docs/changelog/142741.yaml
@@ -1,0 +1,6 @@
+pr: 142741
+summary: "Fix ESQL overflowing division error message for doubles"
+area: ES|QL
+type: bug
+issues:
+  - 138798

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -125,7 +125,10 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
     static double processDoubles(double lhs, double rhs) {
         double value = lhs / rhs;
         if (Double.isNaN(value) || Double.isInfinite(value)) {
-            throw new ArithmeticException("/ by zero");
+            if (rhs == 0.0) {
+                throw new ArithmeticException("/ by zero");
+            }
+            throw new ArithmeticException("result overflow");
         }
         return value;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -65,13 +65,16 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                     if (lhs.type() != DataType.DOUBLE || rhs.type() != DataType.DOUBLE) {
                         return List.of();
                     }
-                    double v = ((Double) lhs.getValue()) / ((Double) rhs.getValue());
+                    double lhsVal = (Double) lhs.getValue();
+                    double rhsVal = (Double) rhs.getValue();
+                    double v = lhsVal / rhsVal;
                     if (Double.isFinite(v)) {
                         return List.of();
                     }
+                    String reason = rhsVal == 0.0 ? "/ by zero" : "result overflow";
                     return List.of(
                         "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
-                        "Line 1:1: java.lang.ArithmeticException: / by zero"
+                        "Line 1:1: java.lang.ArithmeticException: " + reason
                     );
                 },
                 false


### PR DESCRIPTION
## Summary

Fixes #138798

When dividing doubles that produce an infinite result due to overflow (e.g., `1e308 / 0.1`), the error message incorrectly reported `/ by zero`. This PR distinguishes between actual division by zero and result overflow by checking whether the divisor is zero before choosing the error message.

**Changes:**
- `Div.processDoubles()`: When the result is `NaN` or `Infinite`, check if `rhs == 0.0` before throwing. If the divisor is zero, throw `"/ by zero"`; otherwise throw `"result overflow"`.
- `DivTests.java`: Updated the warning message expectations to use `"result overflow"` when the divisor is non-zero.

**Before:**
```
ROW x = 1e308 / 0.1
```
```
Warning: java.lang.ArithmeticException: / by zero
```

**After:**
```
ROW x = 1e308 / 0.1
```
```
Warning: java.lang.ArithmeticException: result overflow
```

## Test plan
- [x] Existing `DivTests` pass with updated expectations
- [x] `ROW x = 1e308 / 0.1` returns null with "result overflow" warning
- [x] `ROW x = 1.0 / 0.0` still returns null with "/ by zero" warning
- [x] Integer/long/unsigned_long division by zero still reports "/ by zero"