### PR TITLE
Make blob cache promote lock-free.

### DIFF
--- a/docs/changelog/142745.yaml
+++ b/docs/changelog/142745.yaml
@@ -1,0 +1,5 @@
+area: Searchable Snapshots
+issues: []
+pr: 142745
+summary: Make blob cache promote lock-free
+type: enhancement

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -446,6 +446,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.FieldExtractorIT
   method: testTsIndexConflictingTypes {null}
   issue: https://github.com/elastic/elasticsearch/issues/142410
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/142739
 
 # Examples:
 #

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -308,6 +308,15 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         return ((LFUCache) cache).epoch.get();
     }
 
+    // used in tests
+    void drainPendingPromotions() {
+        if (cache instanceof LFUCache lfuCache) {
+            synchronized (this) {
+                lfuCache.drainPendingPromotions();
+            }
+        }
+    }
+
     private interface Cache<K, T> extends Releasable {
         CacheEntry<T> get(K cacheKey, long fileLength, int region);
 
@@ -1734,6 +1743,17 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
     private class LFUCache implements Cache<KeyType, CacheFileRegion<KeyType>> {
 
         class LFUCacheEntry extends CacheEntry<CacheFileRegion<KeyType>> {
+            private static final VarHandle VH_LAST_ACCESSED_EPOCH;
+
+            static {
+                try {
+                    var lookup = MethodHandles.lookup();
+                    VH_LAST_ACCESSED_EPOCH = lookup.findVarHandle(lookup.lookupClass(), "lastAccessedEpoch", long.class);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
             LFUCacheEntry prev;
             LFUCacheEntry next;
             int freq;
@@ -1762,6 +1782,8 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         private final LFUCacheEntry[] freqs;
         private final int maxFreq;
         private final DecayAndNewEpochTask decayAndNewEpochTask;
+
+        private final ConcurrentLinkedQueue<LFUCacheEntry> pendingPromotions = new ConcurrentLinkedQueue<>();
 
         private final AtomicLong epoch = new AtomicLong();
         private final AtomicLong initialFreeRegions = new AtomicLong();
@@ -2037,12 +2059,20 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         }
 
         private void maybePromote(long epoch, LFUCacheEntry entry) {
-            synchronized (SharedBlobCacheService.this) {
-                if (epoch > entry.lastAccessedEpoch && entry.freq < maxFreq - 1 && entry.chunk.isEvicted() == false) {
+            long lastAccessed = entry.lastAccessedEpoch;
+            if (epoch > lastAccessed && LFUCacheEntry.VH_LAST_ACCESSED_EPOCH.compareAndSet(entry, lastAccessed, epoch)) {
+                pendingPromotions.add(entry);
+            }
+        }
+
+        private void drainPendingPromotions() {
+            assert Thread.holdsLock(SharedBlobCacheService.this);
+            LFUCacheEntry entry;
+            while ((entry = pendingPromotions.poll()) != null) {
+                if (entry.chunk.isEvicted() == false && entry.freq < maxFreq - 1) {
+                    assert entry.prev != null : "non-evicted entry must be linked";
                     unlink(entry);
-                    // go 2 up per epoch, allowing us to decay 1 every epoch.
                     entry.freq = Math.min(entry.freq + 2, maxFreq - 1);
-                    entry.lastAccessedEpoch = epoch;
                     pushEntryToBack(entry);
                 }
             }
@@ -2124,6 +2154,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
          */
         private SharedBytes.IO maybeEvictAndTake(Runnable evictedNotification) {
             assert Thread.holdsLock(SharedBlobCacheService.this);
+            drainPendingPromotions();
             long currentEpoch = epoch.get(); // must be captured before attempting to evict a freq 0
             SharedBytes.IO freq0 = maybeEvictAndTakeForFrequency(evictedNotification, 0);
             if (freqs[0] == null) {
@@ -2196,6 +2227,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
          */
         public boolean maybeEvictLeastUsed() {
             synchronized (SharedBlobCacheService.this) {
+                drainPendingPromotions();
                 for (LFUCacheEntry entry = freqs[0]; entry != null; entry = entry.next) {
                     boolean evicted = entry.chunk.tryEvict();
                     if (evicted && entry.chunk.volatileIO() != null) {
@@ -2214,6 +2246,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
             long end;
             synchronized (SharedBlobCacheService.this) {
                 afterLock = threadPool.rawRelativeTimeInMillis();
+                drainPendingPromotions();
                 appendLevel1ToLevel0();
                 for (int i = 2; i < maxFreq; i++) {
                     assert freqs[i - 1] == null;

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -65,6 +65,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.blobcache.BlobCacheMetrics.BLOB_CACHE_COUNT_OF_EVICTED_REGIONS_TOTAL;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
@@ -496,6 +497,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
             final var region0Again = cacheService.get(cacheKey1, size(250), 0);
             assertSame(region0Again, region0);
+            cacheService.drainPendingPromotions();
             assertEquals(3, cacheService.getFreq(region0));
             assertEquals(1, cacheService.getFreq(region1));
             assertEquals(1, cacheService.getFreq(region2));
@@ -503,6 +505,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             triggerDecay.run();
 
             cacheService.get(cacheKey1, size(250), 0);
+            cacheService.drainPendingPromotions();
             assertEquals(4, cacheService.getFreq(region0));
             cacheService.get(cacheKey1, size(250), 0);
             assertEquals(4, cacheService.getFreq(region0));
@@ -512,6 +515,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             // ensure no freq=0 entries
             cacheService.get(cacheKey2, size(250), 1);
             cacheService.get(cacheKey3, size(250), 1);
+            cacheService.drainPendingPromotions();
             assertEquals(2, cacheService.getFreq(region1));
             assertEquals(2, cacheService.getFreq(region2));
 
@@ -529,6 +533,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             // ensure no freq=0 entries
             cacheService.get(cacheKey2, size(250), 1);
             cacheService.get(cacheKey3, size(250), 1);
+            cacheService.drainPendingPromotions();
             assertEquals(2, cacheService.getFreq(region1));
             assertEquals(2, cacheService.getFreq(region2));
 
@@ -723,7 +728,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
             Map<Integer, Integer> freqs = new HashMap<>();
             for (int i = maxRounds; i < regions + maxRounds; ++i) {
-                int freq = cacheService.getFreq(cacheService.get(cacheKey, fileLength, i)) - 2;
+                var entry = cacheService.get(cacheKey, fileLength, i);
+                cacheService.drainPendingPromotions();
+                int freq = cacheService.getFreq(entry) - 2;
                 freqs.compute(freq, (k, v) -> v == null ? 1 : v + 1);
                 if (Integer.bitCount(i) == 1) {
                     logger.debug("did {} gets", i);
@@ -1089,6 +1096,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             // touch some random cache entries
             var usedCacheKeys = Set.copyOf(randomSubsetOf(cacheEntries.keySet()));
             usedCacheKeys.forEach(key -> cacheService.get(key, regionSize, 0));
+            cacheService.drainPendingPromotions();
 
             cacheEntries.forEach(
                 (key, entry) -> assertThat(cacheService.getFreq(entry), usedCacheKeys.contains(key) ? equalTo(3) : equalTo(1))
@@ -2112,6 +2120,304 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             assertBusy(() -> assertThat(factoryClosed.get(), is(true)));
         } finally {
             threadPool.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that pending (deferred) promotions are drained before eviction decisions,
+     * so recently-accessed entries are promoted and protected from premature eviction.
+     */
+    public void testDeferredPromotionProtectsFromEviction() throws IOException {
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            assertEquals(5, cacheService.freeRegionCount());
+
+            final var protectedKey1 = generateCacheKey();
+            final var protectedKey2 = generateCacheKey();
+            final var victimKey1 = generateCacheKey();
+            final var victimKey2 = generateCacheKey();
+            final var victimKey3 = generateCacheKey();
+
+            final var protectedRegion1 = cacheService.get(protectedKey1, size(250), 0);
+            final var protectedRegion2 = cacheService.get(protectedKey2, size(250), 0);
+            final var victimRegion1 = cacheService.get(victimKey1, size(250), 0);
+            final var victimRegion2 = cacheService.get(victimKey2, size(250), 0);
+            final var victimRegion3 = cacheService.get(victimKey3, size(250), 0);
+            assertEquals(0, cacheService.freeRegionCount());
+
+            // decay to move all entries to freq 0 and advance epoch to 1
+            cacheService.maybeScheduleDecayAndNewEpoch();
+            taskQueue.runAllRunnableTasks();
+            assertThat(cacheService.epoch(), equalTo(1L));
+
+            assertEquals(0, cacheService.getFreq(protectedRegion1));
+            assertEquals(0, cacheService.getFreq(protectedRegion2));
+            assertEquals(0, cacheService.getFreq(victimRegion1));
+
+            // access the protected entries at epoch 1 (creates deferred promotions)
+            cacheService.get(protectedKey1, size(250), 0);
+            cacheService.get(protectedKey2, size(250), 0);
+
+            // maybeEvictLeastUsed drains pending promotions before scanning freq 0,
+            // so protected entries move to freq 2 and only victims can be evicted
+            assertThat(cacheService.maybeEvictLeastUsed(), is(true));
+            assertEquals(1, cacheService.freeRegionCount());
+
+            assertEquals(2, cacheService.getFreq(protectedRegion1));
+            assertEquals(2, cacheService.getFreq(protectedRegion2));
+            assertFalse(protectedRegion1.isEvicted());
+            assertFalse(protectedRegion2.isEvicted());
+
+            // one of the victims was evicted
+            long evictedVictims = Stream.of(victimRegion1, victimRegion2, victimRegion3)
+                .filter(SharedBlobCacheService.CacheFileRegion::isEvicted)
+                .count();
+            assertEquals(1, evictedVictims);
+        }
+    }
+
+    /**
+     * Verifies that a pending promotion for an entry that was force-evicted is silently
+     * skipped during drain, without corruption or exceptions.
+     */
+    public void testPromotionOfEvictedEntryIsSkipped() throws IOException {
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(300)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            assertEquals(3, cacheService.freeRegionCount());
+
+            final var key1 = generateCacheKey();
+            final var key2 = generateCacheKey();
+            final var key3 = generateCacheKey();
+
+            final var region1 = cacheService.get(key1, size(250), 0);
+            final var region2 = cacheService.get(key2, size(250), 0);
+            final var region3 = cacheService.get(key3, size(250), 0);
+            assertEquals(0, cacheService.freeRegionCount());
+
+            // advance epoch to 1
+            cacheService.maybeScheduleDecayAndNewEpoch();
+            taskQueue.runAllRunnableTasks();
+            assertThat(cacheService.epoch(), equalTo(1L));
+
+            // access all entries at epoch 1, creating deferred promotions for all three
+            cacheService.get(key1, size(250), 0);
+            cacheService.get(key2, size(250), 0);
+            cacheService.get(key3, size(250), 0);
+
+            // force-evict key1 while its promotion is still pending in the queue
+            assertEquals(1, cacheService.forceEvict(k -> k.equals(key1)));
+            assertTrue(region1.isEvicted());
+
+            // trigger decay, which drains pending promotions;
+            // key1's promotion should be silently skipped
+            cacheService.maybeScheduleDecayAndNewEpoch();
+            taskQueue.runAllRunnableTasks();
+            assertThat(cacheService.epoch(), equalTo(2L));
+
+            // key2 and key3: promoted 0->2 during drain, then decayed to 1
+            assertEquals(1, cacheService.getFreq(region2));
+            assertEquals(1, cacheService.getFreq(region3));
+            assertFalse(region2.isEvicted());
+            assertFalse(region3.isEvicted());
+        }
+    }
+
+    /**
+     * Verifies that multiple accesses to the same entry within a single epoch result
+     * in exactly one promotion (+2 frequency), not multiple.
+     */
+    public void testMultipleAccessesSameEpochDoNotOverPromote() throws IOException {
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(200)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            final var key = generateCacheKey();
+            final var region = cacheService.get(key, size(250), 0);
+            assertEquals(1, cacheService.getFreq(region));
+
+            // advance epoch to 1
+            cacheService.maybeScheduleDecayAndNewEpoch();
+            taskQueue.runAllRunnableTasks();
+            assertThat(cacheService.epoch(), equalTo(1L));
+            assertEquals(0, cacheService.getFreq(region));
+
+            // access the same entry many times within the same epoch;
+            // only the first access should enqueue a promotion
+            for (int i = 0; i < 10; i++) {
+                cacheService.get(key, size(250), 0);
+            }
+
+            // should be promoted by exactly +2, not +20
+            cacheService.drainPendingPromotions();
+            assertEquals(2, cacheService.getFreq(region));
+        }
+    }
+
+    /**
+     * Verifies that concurrent accesses to the same entry within a single epoch result in
+     * exactly one promotion (+2 frequency), not more. The CAS on lastAccessedEpoch ensures
+     * that only one thread wins per epoch transition, bounding over-promotion.
+     */
+    public void testConcurrentAccessSameEntryBoundedPromotion() throws Exception {
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+        ThreadPool threadPool = new TestThreadPool("testConcurrentAccessSameEntryBoundedPromotion");
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                threadPool,
+                threadPool.executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            final var key = generateCacheKey();
+            final var region = cacheService.get(key, size(250), 0);
+            assertEquals(1, cacheService.getFreq(region));
+
+            // advance epoch to 1
+            cacheService.maybeScheduleDecayAndNewEpoch();
+            assertBusy(() -> assertThat(cacheService.epoch(), equalTo(1L)));
+            assertEquals(0, cacheService.getFreq(region));
+
+            // many threads concurrently access the same entry at epoch 1
+            final int numThreads = between(2, 16);
+            final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+            List<Thread> threads = IntStream.range(0, numThreads).mapToObj(t -> new Thread(() -> {
+                safeAwait(barrier);
+                for (int i = 0; i < 100; i++) {
+                    cacheService.get(key, size(250), 0);
+                }
+            })).toList();
+
+            threads.forEach(Thread::start);
+            for (Thread thread : threads) {
+                safeJoin(thread);
+                assertFalse("Thread did not finish in time", thread.isAlive());
+            }
+
+            // CAS deduplication: exactly one promotion enqueued, so freq is exactly +2
+            cacheService.drainPendingPromotions();
+            assertEquals(2, cacheService.getFreq(region));
+        } finally {
+            threadPool.shutdownNow();
+        }
+    }
+
+    /**
+     * Exercises concurrent gets (which enqueue deferred promotions) alongside eviction and decay
+     * to verify no assertion errors or data structure corruption under contention.
+     */
+    public void testConcurrentDeferredPromotions() throws Exception {
+        final int numRegions = between(10, 30);
+        final int numKeys = between(1, 100);
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(numRegions * 100L)).getStringRep())
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
+            .put("path.home", createTempDir())
+            .build();
+        ThreadPool threadPool = new TestThreadPool("testConcurrentDeferredPromotions");
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                threadPool,
+                threadPool.executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            final long fileLength = size(500);
+            final TestCacheKey[] keys = new TestCacheKey[numKeys];
+            for (int i = 0; i < numKeys; i++) {
+                keys[i] = generateCacheKey();
+            }
+
+            final int numThreads = between(2, 8);
+            final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+            List<Thread> threadList = IntStream.range(0, numThreads).mapToObj(t -> {
+                final int iterations = between(100, 500);
+                final int[] keyIndices = IntStream.range(0, iterations)
+                    .map(i -> randomIntBetween(0, numKeys - 1))
+                    .toArray();
+                final int[] decayEvery = IntStream.range(0, iterations)
+                    .map(i -> between(0, 49))
+                    .toArray();
+                return new Thread(() -> {
+                    safeAwait(barrier);
+                    for (int i = 0; i < iterations; i++) {
+                        try {
+                            cacheService.get(keys[keyIndices[i]], fileLength, 0);
+                        } catch (AlreadyClosedException e) {
+                            // expected when eviction races with get
+                        }
+                        if (decayEvery[i] == 0) {
+                            cacheService.computeDecay();
+                        }
+                    }
+                });
+            }).toList();
+
+            threadList.forEach(Thread::start);
+            for (Thread thread : threadList) {
+                safeJoin(thread);
+                assertFalse("Thread did not finish in time", thread.isAlive());
+            }
+        } finally {
+            threadPool.shutdownNow();
         }
     }
 

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -2390,12 +2390,8 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             final CyclicBarrier barrier = new CyclicBarrier(numThreads);
             List<Thread> threadList = IntStream.range(0, numThreads).mapToObj(t -> {
                 final int iterations = between(100, 500);
-                final int[] keyIndices = IntStream.range(0, iterations)
-                    .map(i -> randomIntBetween(0, numKeys - 1))
-                    .toArray();
-                final int[] decayEvery = IntStream.range(0, iterations)
-                    .map(i -> between(0, 49))
-                    .toArray();
+                final int[] keyIndices = IntStream.range(0, iterations).map(i -> randomIntBetween(0, numKeys - 1)).toArray();
+                final int[] decayEvery = IntStream.range(0, iterations).map(i -> between(0, 49)).toArray();
                 return new Thread(() -> {
                     safeAwait(barrier);
                     for (int i = 0; i < iterations; i++) {


### PR DESCRIPTION
Deferring the promotion until next time we need a new chunk is safe and thus takes out the promotion work from the hot path.

Assisted by cursor
