### PR TITLE
Include shard ID in fetch task description

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -400,7 +400,7 @@ public class TasksIT extends ESIntegTestCase {
                 );
                 case SearchTransportService.FETCH_ID_ACTION_NAME -> assertTrue(
                     taskInfo.description(),
-                    Regex.simpleMatch("id[*], size[1], lastEmittedDoc[null]", taskInfo.description())
+                    Regex.simpleMatch("id[*], size[1], lastEmittedDoc[null], shardId[[test][*]]", taskInfo.description())
                 );
                 case NODE_SEARCH_ACTION_NAME -> assertEquals("NodeQueryRequest", taskInfo.description());
                 default -> fail("Unexpected action [" + taskInfo.action() + "] with description [" + taskInfo.description() + "]");

--- a/server/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
@@ -108,4 +108,13 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
     public RankDocShardInfo getRankDocks() {
         return this.rankDocs;
     }
+
+    @Override
+    public String getDescription() {
+        StringBuilder sb = new StringBuilder(super.getDescription());
+        if (shardSearchRequest != null) {
+            sb.append(", shardId[").append(shardSearchRequest.shardId()).append(']');
+        }
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
This change appends ShardId information including the index name and the shard number to the description of ShardFetchSearchRequest, which in turn is used in the task API output for that specific request.

Closes #142517
