### PR TITLE
Optimize ST_SIMPLIFY by extracting from shape doc-values

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -12,11 +12,15 @@ package org.elasticsearch.benchmark.spatial;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CentroidCalculator;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
@@ -38,29 +42,37 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Benchmarks for geometry doc-value writing and reading in both legacy and V2 formats.
+ * Benchmarks for geometry doc-value writing and reading in both legacy and V2 formats,
+ * plus WKT/WKB serialization for comparison.
  *
  * <p>Measures:
  * <ul>
- *   <li>Write throughput for legacy vs V2 format</li>
- *   <li>Read throughput: centroid, extent, tree visitation, geometry reconstruction</li>
+ *   <li>Write throughput for legacy vs V2 format vs WKT vs WKB</li>
+ *   <li>Read throughput: centroid, extent, tree visitation, geometry reconstruction, WKT/WKB parsing</li>
  *   <li>Storage size comparison (reported via setup output)</li>
  * </ul>
  *
  * <p>Run with: {@code ./gradlew :benchmarks:run --args 'GeometryDocValueBenchmark'}
  */
 @Fork(1)
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
 public class GeometryDocValueBenchmark {
+
+    static {
+        LogConfigurator.loadLog4jPlugins();
+        LogConfigurator.configureESLogging();
+    }
 
     @Param({ "point", "simplePoly", "complexPoly", "multiPoint" })
     public String geometryType;
@@ -72,6 +84,9 @@ public class GeometryDocValueBenchmark {
 
     private BytesRef legacyBytes;
     private BytesRef v2Bytes;
+
+    private String wktString;
+    private byte[] wkbBytes;
 
     private final GeometryDocValueReader reader = new GeometryDocValueReader();
 
@@ -91,23 +106,23 @@ public class GeometryDocValueBenchmark {
         legacyBytes = GeometryDocValueWriter.writeLegacy(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator);
         v2Bytes = GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
 
+        wktString = WellKnownText.toWKT(geometry);
+        wkbBytes = WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN);
+
         if (sizeReported == false) {
             sizeReported = true;
             System.out.println("=== Storage size for " + geometryType + " ===");
             System.out.println("  Triangles:    " + tessellatedFields.size());
             System.out.println("  Legacy bytes: " + legacyBytes.length);
             System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println(
-                "  Delta:        "
-                    + (v2Bytes.length - legacyBytes.length)
-                    + " bytes ("
-                    + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length)
-                    + ")"
-            );
+            System.out.println("  V2 delta:     " + (v2Bytes.length - legacyBytes.length) + " bytes ("
+                + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length) + ")");
+            System.out.println("  WKT chars:    " + wktString.length());
+            System.out.println("  WKB bytes:    " + wkbBytes.length);
         }
     }
 
-    // ---- Write benchmarks ----
+    // ---- Doc-value write benchmarks ----
 
     @Benchmark
     public BytesRef writeLegacy() throws IOException {
@@ -117,6 +132,18 @@ public class GeometryDocValueBenchmark {
     @Benchmark
     public BytesRef writeV2() throws IOException {
         return GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+    }
+
+    // ---- WKT/WKB write benchmarks ----
+
+    @Benchmark
+    public String writeWKT() {
+        return WellKnownText.toWKT(geometry);
+    }
+
+    @Benchmark
+    public byte[] writeWKB() {
+        return WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN);
     }
 
     // ---- Read centroid benchmarks ----
@@ -171,7 +198,7 @@ public class GeometryDocValueBenchmark {
         bh.consume(visitor.count);
     }
 
-    // ---- Geometry reconstruction benchmark (V2 only) ----
+    // ---- Geometry reconstruction / parsing benchmarks ----
 
     @Benchmark
     public void reconstructGeometryV2(Blackhole bh) throws IOException {
@@ -179,12 +206,24 @@ public class GeometryDocValueBenchmark {
         bh.consume(reader.getGeometry(CoordinateEncoder.GEO));
     }
 
+    @Benchmark
+    public Geometry parseWKT() throws IOException, ParseException {
+        return WellKnownText.fromWKT(GeometryValidator.NOOP, false, wktString);
+    }
+
+    @Benchmark
+    public Geometry parseWKB() {
+        return WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, wkbBytes);
+    }
+
     // ---- Helper methods ----
 
     private static Geometry createGeometry(String type) {
         return switch (type) {
             case "point" -> new Point(5.0, 10.0);
-            case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
+            case "simplePoly" -> new Polygon(
+                new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 })
+            );
             case "complexPoly" -> createStarPolygon(500);
             case "multiPoint" -> createMultiPoint(100);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.spatial;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
+import org.elasticsearch.lucene.spatial.CentroidCalculator;
+import org.elasticsearch.lucene.spatial.CoordinateEncoder;
+import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
+import org.elasticsearch.lucene.spatial.GeometryDocValueWriter;
+import org.elasticsearch.lucene.spatial.TriangleTreeVisitor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for geometry doc-value writing and reading in both legacy and V2 formats.
+ *
+ * <p>Measures:
+ * <ul>
+ *   <li>Write throughput for legacy vs V2 format</li>
+ *   <li>Read throughput: centroid, extent, tree visitation, geometry reconstruction</li>
+ *   <li>Storage size comparison (reported via setup output)</li>
+ * </ul>
+ *
+ * <p>Run with: {@code ./gradlew :benchmarks:run --args 'GeometryDocValueBenchmark'}
+ */
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class GeometryDocValueBenchmark {
+
+    @Param({ "point", "simplePoly", "complexPoly", "multiPoint" })
+    public String geometryType;
+
+    private Geometry geometry;
+    private Geometry normalizedGeometry;
+    private List<IndexableField> tessellatedFields;
+    private CentroidCalculator centroidCalculator;
+
+    private BytesRef legacyBytes;
+    private BytesRef v2Bytes;
+
+    private final GeometryDocValueReader reader = new GeometryDocValueReader();
+
+    private boolean sizeReported;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        geometry = createGeometry(geometryType);
+
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "benchmark");
+        normalizedGeometry = indexer.normalize(geometry);
+        tessellatedFields = indexer.getIndexableFields(normalizedGeometry);
+
+        centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(geometry);
+
+        legacyBytes = GeometryDocValueWriter.writeLegacy(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator);
+        v2Bytes = GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+
+        if (sizeReported == false) {
+            sizeReported = true;
+            System.out.println("=== Storage size for " + geometryType + " ===");
+            System.out.println("  Triangles:    " + tessellatedFields.size());
+            System.out.println("  Legacy bytes: " + legacyBytes.length);
+            System.out.println("  V2 bytes:     " + v2Bytes.length);
+            System.out.println("  Delta:        " + (v2Bytes.length - legacyBytes.length) + " bytes ("
+                + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length) + ")");
+        }
+    }
+
+    // ---- Write benchmarks ----
+
+    @Benchmark
+    public BytesRef writeLegacy() throws IOException {
+        return GeometryDocValueWriter.writeLegacy(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator);
+    }
+
+    @Benchmark
+    public BytesRef writeV2() throws IOException {
+        return GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+    }
+
+    // ---- Read centroid benchmarks ----
+
+    @Benchmark
+    public void readCentroidLegacy(Blackhole bh) throws IOException {
+        reader.reset(legacyBytes);
+        bh.consume(reader.getCentroidX());
+        bh.consume(reader.getCentroidY());
+        bh.consume(reader.getDimensionalShapeType());
+        bh.consume(reader.getSumCentroidWeight());
+    }
+
+    @Benchmark
+    public void readCentroidV2(Blackhole bh) throws IOException {
+        reader.reset(v2Bytes);
+        bh.consume(reader.getCentroidX());
+        bh.consume(reader.getCentroidY());
+        bh.consume(reader.getDimensionalShapeType());
+        bh.consume(reader.getSumCentroidWeight());
+    }
+
+    // ---- Read extent benchmarks ----
+
+    @Benchmark
+    public void readExtentLegacy(Blackhole bh) throws IOException {
+        reader.reset(legacyBytes);
+        bh.consume(reader.getExtent());
+    }
+
+    @Benchmark
+    public void readExtentV2(Blackhole bh) throws IOException {
+        reader.reset(v2Bytes);
+        bh.consume(reader.getExtent());
+    }
+
+    // ---- Tree visit benchmarks ----
+
+    @Benchmark
+    public void visitTreeLegacy(Blackhole bh) throws IOException {
+        reader.reset(legacyBytes);
+        CountingVisitor visitor = new CountingVisitor();
+        reader.visit(visitor);
+        bh.consume(visitor.count);
+    }
+
+    @Benchmark
+    public void visitTreeV2(Blackhole bh) throws IOException {
+        reader.reset(v2Bytes);
+        CountingVisitor visitor = new CountingVisitor();
+        reader.visit(visitor);
+        bh.consume(visitor.count);
+    }
+
+    // ---- Geometry reconstruction benchmark (V2 only) ----
+
+    @Benchmark
+    public void reconstructGeometryV2(Blackhole bh) throws IOException {
+        reader.reset(v2Bytes);
+        bh.consume(reader.getGeometry(CoordinateEncoder.GEO));
+    }
+
+    // ---- Helper methods ----
+
+    private static Geometry createGeometry(String type) {
+        return switch (type) {
+            case "point" -> new Point(5.0, 10.0);
+            case "simplePoly" -> new Polygon(
+                new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 })
+            );
+            case "complexPoly" -> createStarPolygon(500);
+            case "multiPoint" -> createMultiPoint(100);
+            default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
+        };
+    }
+
+    /**
+     * Creates a star-shaped polygon with many vertices that tessellates into many triangles.
+     * The polygon alternates between an outer and inner radius, creating a gear/star shape
+     * with {@code numPoints} teeth.
+     */
+    private static Polygon createStarPolygon(int numPoints) {
+        int totalVertices = numPoints * 2;
+        double[] lons = new double[totalVertices + 1];
+        double[] lats = new double[totalVertices + 1];
+        double centerLon = 0.0;
+        double centerLat = 0.0;
+        double outerRadius = 10.0;
+        double innerRadius = 5.0;
+
+        for (int i = 0; i < totalVertices; i++) {
+            double angle = 2.0 * Math.PI * i / totalVertices;
+            double radius = (i % 2 == 0) ? outerRadius : innerRadius;
+            lons[i] = centerLon + radius * Math.cos(angle);
+            lats[i] = centerLat + radius * Math.sin(angle);
+        }
+        lons[totalVertices] = lons[0];
+        lats[totalVertices] = lats[0];
+        return new Polygon(new LinearRing(lons, lats));
+    }
+
+    private static MultiPoint createMultiPoint(int count) {
+        List<Point> points = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            double lon = -180.0 + (360.0 * i / count);
+            double lat = -90.0 + (180.0 * i / count);
+            points.add(new Point(lon, lat));
+        }
+        return new MultiPoint(points);
+    }
+
+    private static class CountingVisitor implements TriangleTreeVisitor {
+        int count;
+
+        @Override
+        public void visitPoint(int x, int y) {
+            count++;
+        }
+
+        @Override
+        public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
+            count++;
+        }
+
+        @Override
+        public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
+            count++;
+        }
+
+        @Override
+        public boolean push() {
+            return true;
+        }
+
+        @Override
+        public boolean pushX(int minX) {
+            return true;
+        }
+
+        @Override
+        public boolean pushY(int minY) {
+            return true;
+        }
+
+        @Override
+        public boolean push(int maxX, int maxY) {
+            return true;
+        }
+
+        @Override
+        public boolean push(int minX, int minY, int maxX, int maxY) {
+            return true;
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -28,6 +28,7 @@ import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.lucene.spatial.GeometryDocValueWriter;
 import org.elasticsearch.lucene.spatial.TriangleTreeVisitor;
+import org.elasticsearch.lucene.spatial.VertexLookupTable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -75,7 +76,7 @@ public class GeometryDocValueBenchmark {
         LogConfigurator.configureESLogging();
     }
 
-    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly" })
+    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly", "largePoly" })
     public String geometryType;
 
     private Geometry geometry;
@@ -114,16 +115,51 @@ public class GeometryDocValueBenchmark {
 
         if (sizeReported == false) {
             sizeReported = true;
-            System.out.println("=== Storage size for " + geometryType + " ===");
-            System.out.println("  Triangles:    " + tessellatedFields.size());
-            System.out.println("  Legacy bytes: " + legacyBytes.length);
-            System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println(
-                "  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")"
-            );
-            System.out.println("  WKT chars:    " + wktString.length());
-            System.out.println("  WKB bytes:    " + wkbBytes.length);
+            reportSizes();
         }
+    }
+
+    private void reportSizes() throws IOException {
+        System.out.println("=== Storage size for " + geometryType + " ===");
+        System.out.println("  Triangles:    " + tessellatedFields.size());
+        System.out.println("  Legacy bytes: " + legacyBytes.length);
+        System.out.println("  V2 bytes:     " + v2Bytes.length);
+        System.out.println("  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")");
+        System.out.println("  WKT chars:    " + wktString.length());
+        System.out.println("  WKB bytes:    " + wkbBytes.length);
+
+        // V2 component-level breakdown
+        if (autoBytes.length != legacyBytes.length) {
+            reportV2Breakdown();
+        }
+    }
+
+    private void reportV2Breakdown() throws IOException {
+        // Count unique vertices by building a vertex table the same way the writer does
+        VertexLookupTable.Builder vtb = VertexLookupTable.builder();
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "benchmark");
+        Geometry norm = indexer.normalize(geometry);
+        List<IndexableField> fields = indexer.getIndexableFields(norm);
+        byte[] scratch = new byte[7 * Integer.BYTES];
+        for (IndexableField field : fields) {
+            BytesRef br = field.binaryValue();
+            System.arraycopy(br.bytes, br.offset, scratch, 0, 7 * Integer.BYTES);
+            org.apache.lucene.document.ShapeField.DecodedTriangle dt = new org.apache.lucene.document.ShapeField.DecodedTriangle();
+            org.apache.lucene.document.ShapeField.decodeTriangle(scratch, dt);
+            vtb.addVertex(dt.aX, dt.aY);
+            vtb.addVertex(dt.bX, dt.bY);
+            vtb.addVertex(dt.cX, dt.cY);
+        }
+        int numVertices = vtb.size();
+
+        org.elasticsearch.common.io.stream.BytesStreamOutput vtTableOut = new org.elasticsearch.common.io.stream.BytesStreamOutput();
+        vtb.writeTo(vtTableOut);
+        int vertexTableSize = (int) vtTableOut.position();
+
+        System.out.println("  --- V2 breakdown ---");
+        System.out.println("  Unique vertices:      " + numVertices);
+        System.out.println("  Vertex table bytes:   " + vertexTableSize);
+        System.out.printf("  V2/Legacy:            %.1f%%%n", (double) v2Bytes.length / legacyBytes.length * 100);
     }
 
     // ---- Doc-value write benchmarks ----
@@ -201,6 +237,7 @@ public class GeometryDocValueBenchmark {
             case "complexLine" -> createComplexLine(500);
             case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
             case "complexPoly" -> createStarPolygon(500);
+            case "largePoly" -> createCoastlinePolygon(2000);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
         };
     }
@@ -234,6 +271,30 @@ public class GeometryDocValueBenchmark {
         }
         lons[totalVertices] = lons[0];
         lats[totalVertices] = lats[0];
+        return new Polygon(new LinearRing(lons, lats));
+    }
+
+    /**
+     * Simulates a coastline polygon spanning ~20 degrees of longitude and ~15 degrees of latitude,
+     * similar to a medium-sized country boundary in the rally geoshape track.
+     */
+    private static Polygon createCoastlinePolygon(int numPoints) {
+        double centerLon = 2.0;
+        double centerLat = 46.0;
+        double[] lons = new double[numPoints + 1];
+        double[] lats = new double[numPoints + 1];
+
+        for (int i = 0; i < numPoints; i++) {
+            double angle = 2.0 * Math.PI * i / numPoints;
+            double baseRadius = 8.0;
+            double noise = 2.0 * Math.sin(angle * 7) + 1.0 * Math.sin(angle * 13) + 0.5 * Math.sin(angle * 31);
+            double radius = baseRadius + noise;
+            double lonScale = 1.2;
+            lons[i] = centerLon + radius * lonScale * Math.cos(angle);
+            lats[i] = Math.max(-89.9, Math.min(89.9, centerLat + radius * Math.sin(angle)));
+        }
+        lons[numPoints] = lons[0];
+        lats[numPoints] = lats[0];
         return new Polygon(new LinearRing(lons, lats));
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -28,6 +28,7 @@ import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.lucene.spatial.GeometryDocValueWriter;
 import org.elasticsearch.lucene.spatial.TriangleTreeVisitor;
+import org.elasticsearch.lucene.spatial.VertexLookupTable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -75,7 +76,7 @@ public class GeometryDocValueBenchmark {
         LogConfigurator.configureESLogging();
     }
 
-    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly" })
+    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly", "largePoly" })
     public String geometryType;
 
     private Geometry geometry;
@@ -114,16 +115,67 @@ public class GeometryDocValueBenchmark {
 
         if (sizeReported == false) {
             sizeReported = true;
-            System.out.println("=== Storage size for " + geometryType + " ===");
-            System.out.println("  Triangles:    " + tessellatedFields.size());
-            System.out.println("  Legacy bytes: " + legacyBytes.length);
-            System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println(
-                "  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")"
-            );
-            System.out.println("  WKT chars:    " + wktString.length());
-            System.out.println("  WKB bytes:    " + wkbBytes.length);
+            reportSizes();
         }
+    }
+
+    private void reportSizes() throws IOException {
+        System.out.println("=== Storage size for " + geometryType + " ===");
+        System.out.println("  Triangles:    " + tessellatedFields.size());
+        System.out.println("  Legacy bytes: " + legacyBytes.length);
+        System.out.println("  V2 bytes:     " + v2Bytes.length);
+        System.out.println("  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")");
+        System.out.println("  WKT chars:    " + wktString.length());
+        System.out.println("  WKB bytes:    " + wkbBytes.length);
+
+        // V2 component-level breakdown
+        if (autoBytes.length != legacyBytes.length) {
+            reportV2Breakdown();
+        }
+    }
+
+    private void reportV2Breakdown() throws IOException {
+        // Measure vertex table separately: build vertex table the same way the writer does
+        VertexLookupTable.Builder vtb = VertexLookupTable.builder();
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "benchmark");
+        Geometry norm = indexer.normalize(geometry);
+        List<IndexableField> fields = indexer.getIndexableFields(norm);
+        // Add vertices from tessellation (same path as V2TriangleTreeWriter)
+        byte[] scratch = new byte[7 * Integer.BYTES];
+        for (IndexableField field : fields) {
+            BytesRef br = field.binaryValue();
+            System.arraycopy(br.bytes, br.offset, scratch, 0, 7 * Integer.BYTES);
+            org.apache.lucene.document.ShapeField.DecodedTriangle dt = new org.apache.lucene.document.ShapeField.DecodedTriangle();
+            org.apache.lucene.document.ShapeField.decodeTriangle(scratch, dt);
+            vtb.addVertex(dt.aX, dt.aY);
+            vtb.addVertex(dt.bX, dt.bY);
+            vtb.addVertex(dt.cX, dt.cY);
+        }
+        int numVertices = vtb.size();
+
+        // Write vertex table to measure its size
+        org.elasticsearch.common.io.stream.BytesStreamOutput vtTableOut = new org.elasticsearch.common.io.stream.BytesStreamOutput();
+        vtb.writeTo(vtTableOut);
+        int vertexTableSize = (int) vtTableOut.position();
+
+        // Also measure what it would be with the old fixed-size format: numVertices VInt + 8 bytes/vertex
+        int oldVertexTableSize = vIntSize(numVertices) + numVertices * 8;
+
+        System.out.println("  --- V2 breakdown ---");
+        System.out.println("  Unique vertices:      " + numVertices);
+        System.out.println("  Vertex table (delta): " + vertexTableSize + " bytes");
+        System.out.println("  Vertex table (fixed): " + oldVertexTableSize + " bytes");
+        System.out.printf("  VT compression:       %.1f%%%n", (double) vertexTableSize / oldVertexTableSize * 100);
+        System.out.printf("  V2/Legacy:            %.1f%%%n", (double) v2Bytes.length / legacyBytes.length * 100);
+    }
+
+    private static int vIntSize(int value) {
+        int size = 1;
+        while ((value & ~0x7F) != 0) {
+            size++;
+            value >>>= 7;
+        }
+        return size;
     }
 
     // ---- Doc-value write benchmarks ----
@@ -201,6 +253,7 @@ public class GeometryDocValueBenchmark {
             case "complexLine" -> createComplexLine(500);
             case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
             case "complexPoly" -> createStarPolygon(500);
+            case "largePoly" -> createCoastlinePolygon(2000);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
         };
     }
@@ -234,6 +287,30 @@ public class GeometryDocValueBenchmark {
         }
         lons[totalVertices] = lons[0];
         lats[totalVertices] = lats[0];
+        return new Polygon(new LinearRing(lons, lats));
+    }
+
+    /**
+     * Simulates a coastline polygon spanning ~20 degrees of longitude and ~15 degrees of latitude,
+     * similar to a medium-sized country boundary in the rally geoshape track.
+     */
+    private static Polygon createCoastlinePolygon(int numPoints) {
+        double centerLon = 2.0;
+        double centerLat = 46.0;
+        double[] lons = new double[numPoints + 1];
+        double[] lats = new double[numPoints + 1];
+
+        for (int i = 0; i < numPoints; i++) {
+            double angle = 2.0 * Math.PI * i / numPoints;
+            double baseRadius = 8.0;
+            double noise = 2.0 * Math.sin(angle * 7) + 1.0 * Math.sin(angle * 13) + 0.5 * Math.sin(angle * 31);
+            double radius = baseRadius + noise;
+            double lonScale = 1.2;
+            lons[i] = centerLon + radius * lonScale * Math.cos(angle);
+            lats[i] = Math.max(-89.9, Math.min(89.9, centerLat + radius * Math.sin(angle)));
+        }
+        lons[numPoints] = lons[0];
+        lats[numPoints] = lats[0];
         return new Polygon(new LinearRing(lons, lats));
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -97,8 +97,13 @@ public class GeometryDocValueBenchmark {
             System.out.println("  Triangles:    " + tessellatedFields.size());
             System.out.println("  Legacy bytes: " + legacyBytes.length);
             System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println("  Delta:        " + (v2Bytes.length - legacyBytes.length) + " bytes ("
-                + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length) + ")");
+            System.out.println(
+                "  Delta:        "
+                    + (v2Bytes.length - legacyBytes.length)
+                    + " bytes ("
+                    + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length)
+                    + ")"
+            );
         }
     }
 
@@ -179,9 +184,7 @@ public class GeometryDocValueBenchmark {
     private static Geometry createGeometry(String type) {
         return switch (type) {
             case "point" -> new Point(5.0, 10.0);
-            case "simplePoly" -> new Polygon(
-                new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 })
-            );
+            case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
             case "complexPoly" -> createStarPolygon(500);
             case "multiPoint" -> createMultiPoint(100);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -28,7 +28,6 @@ import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.lucene.spatial.GeometryDocValueWriter;
 import org.elasticsearch.lucene.spatial.TriangleTreeVisitor;
-import org.elasticsearch.lucene.spatial.VertexLookupTable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -76,7 +75,7 @@ public class GeometryDocValueBenchmark {
         LogConfigurator.configureESLogging();
     }
 
-    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly", "largePoly" })
+    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly" })
     public String geometryType;
 
     private Geometry geometry;
@@ -115,67 +114,16 @@ public class GeometryDocValueBenchmark {
 
         if (sizeReported == false) {
             sizeReported = true;
-            reportSizes();
+            System.out.println("=== Storage size for " + geometryType + " ===");
+            System.out.println("  Triangles:    " + tessellatedFields.size());
+            System.out.println("  Legacy bytes: " + legacyBytes.length);
+            System.out.println("  V2 bytes:     " + v2Bytes.length);
+            System.out.println(
+                "  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")"
+            );
+            System.out.println("  WKT chars:    " + wktString.length());
+            System.out.println("  WKB bytes:    " + wkbBytes.length);
         }
-    }
-
-    private void reportSizes() throws IOException {
-        System.out.println("=== Storage size for " + geometryType + " ===");
-        System.out.println("  Triangles:    " + tessellatedFields.size());
-        System.out.println("  Legacy bytes: " + legacyBytes.length);
-        System.out.println("  V2 bytes:     " + v2Bytes.length);
-        System.out.println("  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")");
-        System.out.println("  WKT chars:    " + wktString.length());
-        System.out.println("  WKB bytes:    " + wkbBytes.length);
-
-        // V2 component-level breakdown
-        if (autoBytes.length != legacyBytes.length) {
-            reportV2Breakdown();
-        }
-    }
-
-    private void reportV2Breakdown() throws IOException {
-        // Measure vertex table separately: build vertex table the same way the writer does
-        VertexLookupTable.Builder vtb = VertexLookupTable.builder();
-        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "benchmark");
-        Geometry norm = indexer.normalize(geometry);
-        List<IndexableField> fields = indexer.getIndexableFields(norm);
-        // Add vertices from tessellation (same path as V2TriangleTreeWriter)
-        byte[] scratch = new byte[7 * Integer.BYTES];
-        for (IndexableField field : fields) {
-            BytesRef br = field.binaryValue();
-            System.arraycopy(br.bytes, br.offset, scratch, 0, 7 * Integer.BYTES);
-            org.apache.lucene.document.ShapeField.DecodedTriangle dt = new org.apache.lucene.document.ShapeField.DecodedTriangle();
-            org.apache.lucene.document.ShapeField.decodeTriangle(scratch, dt);
-            vtb.addVertex(dt.aX, dt.aY);
-            vtb.addVertex(dt.bX, dt.bY);
-            vtb.addVertex(dt.cX, dt.cY);
-        }
-        int numVertices = vtb.size();
-
-        // Write vertex table to measure its size
-        org.elasticsearch.common.io.stream.BytesStreamOutput vtTableOut = new org.elasticsearch.common.io.stream.BytesStreamOutput();
-        vtb.writeTo(vtTableOut);
-        int vertexTableSize = (int) vtTableOut.position();
-
-        // Also measure what it would be with the old fixed-size format: numVertices VInt + 8 bytes/vertex
-        int oldVertexTableSize = vIntSize(numVertices) + numVertices * 8;
-
-        System.out.println("  --- V2 breakdown ---");
-        System.out.println("  Unique vertices:      " + numVertices);
-        System.out.println("  Vertex table (delta): " + vertexTableSize + " bytes");
-        System.out.println("  Vertex table (fixed): " + oldVertexTableSize + " bytes");
-        System.out.printf("  VT compression:       %.1f%%%n", (double) vertexTableSize / oldVertexTableSize * 100);
-        System.out.printf("  V2/Legacy:            %.1f%%%n", (double) v2Bytes.length / legacyBytes.length * 100);
-    }
-
-    private static int vIntSize(int value) {
-        int size = 1;
-        while ((value & ~0x7F) != 0) {
-            size++;
-            value >>>= 7;
-        }
-        return size;
     }
 
     // ---- Doc-value write benchmarks ----
@@ -253,7 +201,6 @@ public class GeometryDocValueBenchmark {
             case "complexLine" -> createComplexLine(500);
             case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
             case "complexPoly" -> createStarPolygon(500);
-            case "largePoly" -> createCoastlinePolygon(2000);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
         };
     }
@@ -287,30 +234,6 @@ public class GeometryDocValueBenchmark {
         }
         lons[totalVertices] = lons[0];
         lats[totalVertices] = lats[0];
-        return new Polygon(new LinearRing(lons, lats));
-    }
-
-    /**
-     * Simulates a coastline polygon spanning ~20 degrees of longitude and ~15 degrees of latitude,
-     * similar to a medium-sized country boundary in the rally geoshape track.
-     */
-    private static Polygon createCoastlinePolygon(int numPoints) {
-        double centerLon = 2.0;
-        double centerLat = 46.0;
-        double[] lons = new double[numPoints + 1];
-        double[] lats = new double[numPoints + 1];
-
-        for (int i = 0; i < numPoints; i++) {
-            double angle = 2.0 * Math.PI * i / numPoints;
-            double baseRadius = 8.0;
-            double noise = 2.0 * Math.sin(angle * 7) + 1.0 * Math.sin(angle * 13) + 0.5 * Math.sin(angle * 31);
-            double radius = baseRadius + noise;
-            double lonScale = 1.2;
-            lons[i] = centerLon + radius * lonScale * Math.cos(angle);
-            lats[i] = Math.max(-89.9, Math.min(89.9, centerLat + radius * Math.sin(angle)));
-        }
-        lons[numPoints] = lons[0];
-        lats[numPoints] = lats[0];
         return new Polygon(new LinearRing(lons, lats));
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -118,8 +118,9 @@ public class GeometryDocValueBenchmark {
             System.out.println("  Triangles:    " + tessellatedFields.size());
             System.out.println("  Legacy bytes: " + legacyBytes.length);
             System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println("  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2")
-                + ")");
+            System.out.println(
+                "  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2") + ")"
+            );
             System.out.println("  WKT chars:    " + wktString.length());
             System.out.println("  WKB bytes:    " + wkbBytes.length);
         }
@@ -198,9 +199,7 @@ public class GeometryDocValueBenchmark {
             case "multiPoint" -> createMultiPoint(100);
             case "simpleLine" -> new Line(new double[] { 0, 5, 10, 15, 20 }, new double[] { 0, 5, 0, 5, 0 });
             case "complexLine" -> createComplexLine(500);
-            case "simplePoly" -> new Polygon(
-                new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 })
-            );
+            case "simplePoly" -> new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
             case "complexPoly" -> createStarPolygon(500);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
         };

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/spatial/GeometryDocValueBenchmark.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Line;
 import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
@@ -54,8 +55,8 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Measures:
  * <ul>
- *   <li>Write throughput for legacy vs V2 format vs WKT vs WKB</li>
- *   <li>Read throughput: centroid, extent, tree visitation, geometry reconstruction, WKT/WKB parsing</li>
+ *   <li>Write throughput: legacy, V2, auto-select, WKT, WKB</li>
+ *   <li>Read throughput: tree visitation, geometry reconstruction, WKT/WKB parsing</li>
  *   <li>Storage size comparison (reported via setup output)</li>
  * </ul>
  *
@@ -74,7 +75,7 @@ public class GeometryDocValueBenchmark {
         LogConfigurator.configureESLogging();
     }
 
-    @Param({ "point", "simplePoly", "complexPoly", "multiPoint" })
+    @Param({ "point", "multiPoint", "simpleLine", "complexLine", "simplePoly", "complexPoly" })
     public String geometryType;
 
     private Geometry geometry;
@@ -84,6 +85,7 @@ public class GeometryDocValueBenchmark {
 
     private BytesRef legacyBytes;
     private BytesRef v2Bytes;
+    private BytesRef autoBytes;
 
     private String wktString;
     private byte[] wkbBytes;
@@ -104,7 +106,8 @@ public class GeometryDocValueBenchmark {
         centroidCalculator.add(geometry);
 
         legacyBytes = GeometryDocValueWriter.writeLegacy(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator);
-        v2Bytes = GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+        v2Bytes = GeometryDocValueWriter.writeV2(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+        autoBytes = GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
 
         wktString = WellKnownText.toWKT(geometry);
         wkbBytes = WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN);
@@ -115,8 +118,8 @@ public class GeometryDocValueBenchmark {
             System.out.println("  Triangles:    " + tessellatedFields.size());
             System.out.println("  Legacy bytes: " + legacyBytes.length);
             System.out.println("  V2 bytes:     " + v2Bytes.length);
-            System.out.println("  V2 delta:     " + (v2Bytes.length - legacyBytes.length) + " bytes ("
-                + String.format("%.1f%%", 100.0 * (v2Bytes.length - legacyBytes.length) / legacyBytes.length) + ")");
+            System.out.println("  Auto bytes:   " + autoBytes.length + " (" + (autoBytes.length == legacyBytes.length ? "legacy" : "V2")
+                + ")");
             System.out.println("  WKT chars:    " + wktString.length());
             System.out.println("  WKB bytes:    " + wkbBytes.length);
         }
@@ -131,6 +134,11 @@ public class GeometryDocValueBenchmark {
 
     @Benchmark
     public BytesRef writeV2() throws IOException {
+        return GeometryDocValueWriter.writeV2(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
+    }
+
+    @Benchmark
+    public BytesRef writeAuto() throws IOException {
         return GeometryDocValueWriter.write(tessellatedFields, CoordinateEncoder.GEO, centroidCalculator, List.of(normalizedGeometry));
     }
 
@@ -144,40 +152,6 @@ public class GeometryDocValueBenchmark {
     @Benchmark
     public byte[] writeWKB() {
         return WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN);
-    }
-
-    // ---- Read centroid benchmarks ----
-
-    @Benchmark
-    public void readCentroidLegacy(Blackhole bh) throws IOException {
-        reader.reset(legacyBytes);
-        bh.consume(reader.getCentroidX());
-        bh.consume(reader.getCentroidY());
-        bh.consume(reader.getDimensionalShapeType());
-        bh.consume(reader.getSumCentroidWeight());
-    }
-
-    @Benchmark
-    public void readCentroidV2(Blackhole bh) throws IOException {
-        reader.reset(v2Bytes);
-        bh.consume(reader.getCentroidX());
-        bh.consume(reader.getCentroidY());
-        bh.consume(reader.getDimensionalShapeType());
-        bh.consume(reader.getSumCentroidWeight());
-    }
-
-    // ---- Read extent benchmarks ----
-
-    @Benchmark
-    public void readExtentLegacy(Blackhole bh) throws IOException {
-        reader.reset(legacyBytes);
-        bh.consume(reader.getExtent());
-    }
-
-    @Benchmark
-    public void readExtentV2(Blackhole bh) throws IOException {
-        reader.reset(v2Bytes);
-        bh.consume(reader.getExtent());
     }
 
     // ---- Tree visit benchmarks ----
@@ -201,8 +175,8 @@ public class GeometryDocValueBenchmark {
     // ---- Geometry reconstruction / parsing benchmarks ----
 
     @Benchmark
-    public void reconstructGeometryV2(Blackhole bh) throws IOException {
-        reader.reset(v2Bytes);
+    public void reconstructGeometry(Blackhole bh) throws IOException {
+        reader.reset(autoBytes);
         bh.consume(reader.getGeometry(CoordinateEncoder.GEO));
     }
 
@@ -221,34 +195,43 @@ public class GeometryDocValueBenchmark {
     private static Geometry createGeometry(String type) {
         return switch (type) {
             case "point" -> new Point(5.0, 10.0);
+            case "multiPoint" -> createMultiPoint(100);
+            case "simpleLine" -> new Line(new double[] { 0, 5, 10, 15, 20 }, new double[] { 0, 5, 0, 5, 0 });
+            case "complexLine" -> createComplexLine(500);
             case "simplePoly" -> new Polygon(
                 new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 })
             );
             case "complexPoly" -> createStarPolygon(500);
-            case "multiPoint" -> createMultiPoint(100);
             default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
         };
     }
 
+    private static Line createComplexLine(int numPoints) {
+        double[] lons = new double[numPoints];
+        double[] lats = new double[numPoints];
+        for (int i = 0; i < numPoints; i++) {
+            double t = (double) i / (numPoints - 1);
+            lons[i] = -170.0 + 340.0 * t;
+            lats[i] = 30.0 * Math.sin(t * 10.0 * Math.PI);
+        }
+        return new Line(lons, lats);
+    }
+
     /**
      * Creates a star-shaped polygon with many vertices that tessellates into many triangles.
-     * The polygon alternates between an outer and inner radius, creating a gear/star shape
-     * with {@code numPoints} teeth.
      */
     private static Polygon createStarPolygon(int numPoints) {
         int totalVertices = numPoints * 2;
         double[] lons = new double[totalVertices + 1];
         double[] lats = new double[totalVertices + 1];
-        double centerLon = 0.0;
-        double centerLat = 0.0;
         double outerRadius = 10.0;
         double innerRadius = 5.0;
 
         for (int i = 0; i < totalVertices; i++) {
             double angle = 2.0 * Math.PI * i / totalVertices;
             double radius = (i % 2 == 0) ? outerRadius : innerRadius;
-            lons[i] = centerLon + radius * Math.cos(angle);
-            lats[i] = centerLat + radius * Math.sin(angle);
+            lons[i] = radius * Math.cos(angle);
+            lats[i] = radius * Math.sin(angle);
         }
         lons[totalVertices] = lons[0];
         lats[totalVertices] = lats[0];

--- a/docs/changelog/142757.yaml
+++ b/docs/changelog/142757.yaml
@@ -1,0 +1,5 @@
+area: "ES|QL"
+issues: []
+pr: 142757
+summary: Optimize ST_SIMPLIFY by extracting from shape doc-values
+type: enhancement

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -446,7 +446,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
             LegacyGeoShapeParser parser,
             Map<String, String> meta
         ) {
-            super(name, IndexType.terms(indexed, false), false, parser, orientation, meta);
+            super(name, IndexType.terms(indexed, false), false, parser, orientation, IndexVersions.ZERO, meta);
             this.queryProcessor = new LegacyGeoShapeQueryProcessor(this);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -225,6 +225,7 @@ public class IndexVersions {
     public static final IndexVersion TIME_SERIES_DOC_VALUES_FORMAT_VERSION_3 = def(9_072_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES = def(9_073_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion DISABLE_SEQUENCE_NUMBERS = def(9_074_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion GEOMETRY_DOC_VALUES_V2 = def(9_075_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -156,6 +156,15 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         }
 
         /**
+         * Returns true if the doc-values for this field support geometry reconstruction.
+         * Point fields always support reconstruction. Shape fields only support it for
+         * indices created with V2 doc-values format.
+         */
+        public boolean supportsGeometryDocValueReconstruction() {
+            return false;
+        }
+
+        /**
          * Gets the formatter by name.
          */
         protected abstract Function<List<T>, List<Object>> getFormatter(String format);

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -161,5 +161,10 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
         protected Object nullValueAsSource(T nullValue) {
             return nullValue == null ? null : nullValue.toWKT();
         }
+
+        @Override
+        public boolean supportsGeometryDocValueReconstruction() {
+            return true;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -10,18 +10,23 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
+import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.Extent;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -170,6 +175,91 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                 builder.appendInt(extent.posLeft);
                 builder.appendInt(extent.posRight);
                 builder.endPositionEntry();
+            }
+
+            @Override
+            public void close() {
+                breaker.addWithoutBreaking(-BLOCK_LOADER_ESTIMATED_SIZE);
+            }
+        }
+
+        /**
+         * Block loader that reconstructs geometry from binary doc-values and returns WKB-encoded bytes.
+         * Used when the optimizer determines that reading from doc-values is sufficient (e.g. when the
+         * field is consumed by ST_SIMPLIFY rather than returned directly).
+         */
+        protected static class GeometryBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
+            private final String fieldName;
+            private final CoordinateEncoder encoder;
+
+            protected GeometryBlockLoader(String fieldName, CoordinateEncoder encoder) {
+                this.fieldName = fieldName;
+                this.encoder = encoder;
+            }
+
+            @Override
+            public BlockLoader.AllReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
+                breaker.addEstimateBytesAndMaybeBreak(BLOCK_LOADER_ESTIMATED_SIZE, "load blocks");
+                BinaryDocValues binaryDocValues = context.reader().getBinaryDocValues(fieldName);
+                if (binaryDocValues == null) {
+                    breaker.addWithoutBreaking(-BLOCK_LOADER_ESTIMATED_SIZE);
+                    return ConstantNull.READER;
+                }
+                return new GeometryReader(breaker, binaryDocValues, encoder);
+            }
+
+            @Override
+            public BlockLoader.Builder builder(BlockLoader.BlockFactory factory, int expectedCount) {
+                return factory.bytesRefs(expectedCount);
+            }
+        }
+
+        private static class GeometryReader implements BlockLoader.AllReader {
+            private final GeometryDocValueReader reader = new GeometryDocValueReader();
+            private final CircuitBreaker breaker;
+            private final BinaryDocValues binaryDocValues;
+            private final CoordinateEncoder encoder;
+
+            private GeometryReader(CircuitBreaker breaker, BinaryDocValues binaryDocValues, CoordinateEncoder encoder) {
+                this.breaker = breaker;
+                this.binaryDocValues = binaryDocValues;
+                this.encoder = encoder;
+            }
+
+            @Override
+            public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
+                throws IOException {
+                try (var builder = factory.bytesRefs(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        read(binaryDocValues, docs.get(i), builder);
+                    }
+                    return builder.build();
+                }
+            }
+
+            @Override
+            public void read(int docId, BlockLoader.StoredFields storedFields, BlockLoader.Builder builder) throws IOException {
+                read(binaryDocValues, docId, (BlockLoader.BytesRefBuilder) builder);
+            }
+
+            private void read(BinaryDocValues binaryDocValues, int doc, BlockLoader.BytesRefBuilder builder) throws IOException {
+                if (binaryDocValues.advanceExact(doc) == false) {
+                    builder.appendNull();
+                    return;
+                }
+                reader.reset(binaryDocValues.binaryValue());
+                Geometry geometry = reader.getGeometry(encoder);
+                if (geometry == null) {
+                    builder.appendNull();
+                    return;
+                }
+                byte[] wkb = WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN);
+                builder.appendBytesRef(new BytesRef(wkb));
+            }
+
+            @Override
+            public boolean canReuse(int startingDocID) {
+                return true;
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -198,12 +198,12 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             @Override
-            public BlockLoader.AllReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
+            public BlockLoader.ColumnAtATimeReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
                 breaker.addEstimateBytesAndMaybeBreak(BLOCK_LOADER_ESTIMATED_SIZE, "load blocks");
                 BinaryDocValues binaryDocValues = context.reader().getBinaryDocValues(fieldName);
                 if (binaryDocValues == null) {
                     breaker.addWithoutBreaking(-BLOCK_LOADER_ESTIMATED_SIZE);
-                    return ConstantNull.READER;
+                    return ConstantNull.COLUMN_READER;
                 }
                 return new GeometryReader(breaker, binaryDocValues, encoder);
             }
@@ -214,7 +214,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
         }
 
-        private static class GeometryReader implements BlockLoader.AllReader {
+        private static class GeometryReader implements BlockLoader.ColumnAtATimeReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
             private final CircuitBreaker breaker;
             private final BinaryDocValues binaryDocValues;
@@ -235,11 +235,6 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                     }
                     return builder.build();
                 }
-            }
-
-            @Override
-            public void read(int docId, BlockLoader.StoredFields storedFields, BlockLoader.Builder builder) throws IOException {
-                read(binaryDocValues, docId, (BlockLoader.BytesRefBuilder) builder);
             }
 
             private void read(BinaryDocValues binaryDocValues, int doc, BlockLoader.BytesRefBuilder builder) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.lucene.spatial.Extent;
@@ -61,6 +63,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
     public abstract static class AbstractShapeGeometryFieldType<T> extends AbstractGeometryFieldType<T> {
 
         private final Orientation orientation;
+        private final IndexVersion indexCreatedVersion;
 
         protected AbstractShapeGeometryFieldType(
             String name,
@@ -68,14 +71,27 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             boolean isStored,
             Parser<T> parser,
             Orientation orientation,
+            IndexVersion indexCreatedVersion,
             Map<String, String> meta
         ) {
             super(name, indexType, isStored, parser, null, meta);
             this.orientation = orientation;
+            this.indexCreatedVersion = indexCreatedVersion;
         }
 
         public Orientation orientation() {
             return this.orientation;
+        }
+
+        /**
+         * Returns true if the doc-values for this field use the V2 format that supports
+         * geometry reconstruction via {@link GeometryDocValueReader#getGeometry}. Indices
+         * created before {@link IndexVersions#GEOMETRY_DOC_VALUES_V2} use the legacy format,
+         * which only supports reconstruction of point geometries.
+         */
+        @Override
+        public boolean supportsGeometryDocValueReconstruction() {
+            return indexCreatedVersion.onOrAfter(IndexVersions.GEOMETRY_DOC_VALUES_V2);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/BinaryShapeDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/BinaryShapeDocValuesField.java
@@ -24,36 +24,35 @@ public class BinaryShapeDocValuesField extends CustomDocValuesField {
     private final List<IndexableField> fields;
     private final CoordinateEncoder coordinateEncoder;
     private final CentroidCalculator centroidCalculator;
-    private final List<Geometry> normalizedGeometries;
+    private final List<Geometry> geometries;
 
     public BinaryShapeDocValuesField(String name, CoordinateEncoder coordinateEncoder) {
         super(name);
         this.fields = new ArrayList<>();
         this.coordinateEncoder = coordinateEncoder;
         this.centroidCalculator = new CentroidCalculator();
-        this.normalizedGeometries = new ArrayList<>();
+        this.geometries = new ArrayList<>();
     }
 
     /**
-     * Add tessellated fields and both the original and normalized geometry.
-     * The original geometry is used for centroid calculation (better precision for edge cases
-     * like coordinates > 180 longitude). The normalized geometry is used for connectivity
-     * (its vertex ordering after dateline normalization is what gets stored in doc-values).
+     * Add tessellated fields and the original geometry. The original (pre-normalization) geometry
+     * is used for both centroid calculation and connectivity reconstruction. Using the original
+     * rather than the normalized geometry produces doc-values that are closer to the source,
+     * differing only in coordinate quantization.
      *
-     * @param fields              tessellated triangle fields from the indexer
-     * @param originalGeometry    the original geometry for centroid calculation
-     * @param normalizedGeometry  the normalized geometry for connectivity/reconstruction
+     * @param fields   tessellated triangle fields from the indexer
+     * @param geometry the original geometry
      */
-    public void add(List<IndexableField> fields, Geometry originalGeometry, Geometry normalizedGeometry) {
+    public void add(List<IndexableField> fields, Geometry geometry) {
         this.fields.addAll(fields);
-        this.centroidCalculator.add(originalGeometry);
-        this.normalizedGeometries.add(normalizedGeometry);
+        this.centroidCalculator.add(geometry);
+        this.geometries.add(geometry);
     }
 
     @Override
     public BytesRef binaryValue() {
         try {
-            return GeometryDocValueWriter.write(fields, coordinateEncoder, centroidCalculator, normalizedGeometries);
+            return GeometryDocValueWriter.write(fields, coordinateEncoder, centroidCalculator, geometries);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to encode shape", e);
         }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/BinaryShapeDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/BinaryShapeDocValuesField.java
@@ -24,23 +24,36 @@ public class BinaryShapeDocValuesField extends CustomDocValuesField {
     private final List<IndexableField> fields;
     private final CoordinateEncoder coordinateEncoder;
     private final CentroidCalculator centroidCalculator;
+    private final List<Geometry> normalizedGeometries;
 
     public BinaryShapeDocValuesField(String name, CoordinateEncoder coordinateEncoder) {
         super(name);
         this.fields = new ArrayList<>();
         this.coordinateEncoder = coordinateEncoder;
         this.centroidCalculator = new CentroidCalculator();
+        this.normalizedGeometries = new ArrayList<>();
     }
 
-    public void add(List<IndexableField> fields, Geometry geometry) {
+    /**
+     * Add tessellated fields and both the original and normalized geometry.
+     * The original geometry is used for centroid calculation (better precision for edge cases
+     * like coordinates > 180 longitude). The normalized geometry is used for connectivity
+     * (its vertex ordering after dateline normalization is what gets stored in doc-values).
+     *
+     * @param fields              tessellated triangle fields from the indexer
+     * @param originalGeometry    the original geometry for centroid calculation
+     * @param normalizedGeometry  the normalized geometry for connectivity/reconstruction
+     */
+    public void add(List<IndexableField> fields, Geometry originalGeometry, Geometry normalizedGeometry) {
         this.fields.addAll(fields);
-        this.centroidCalculator.add(geometry);
+        this.centroidCalculator.add(originalGeometry);
+        this.normalizedGeometries.add(normalizedGeometry);
     }
 
     @Override
     public BytesRef binaryValue() {
         try {
-            return GeometryDocValueWriter.write(fields, coordinateEncoder, centroidCalculator);
+            return GeometryDocValueWriter.write(fields, coordinateEncoder, centroidCalculator, normalizedGeometries);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to encode shape", e);
         }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/DimensionalShapeType.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/DimensionalShapeType.java
@@ -19,22 +19,45 @@ import org.elasticsearch.geometry.ShapeType;
  * types for when the geometry is a {@link GeometryCollection} and
  * more information about what the highest-dimensional sub-shape
  * is.
+ *
+ * <p>The high bit (0x80) of the serialized byte is used as a format version marker in
+ * geometry doc-values. When set, it indicates the new format (V2) with a vertex lookup
+ * table and connectivity information for geometry reconstruction. When clear, it indicates
+ * the legacy format with inline coordinate deltas.
  */
 public enum DimensionalShapeType {
     POINT,
     LINE,
     POLYGON;
 
+    /** Bit mask for the format version marker in the serialized byte. */
+    static final int VERSION_BIT = 0x80;
+
     private static DimensionalShapeType[] values = values();
 
     public static DimensionalShapeType fromOrdinalByte(byte ordinal) {
-        return values[Byte.toUnsignedInt(ordinal)];
+        return values[Byte.toUnsignedInt(ordinal) & ~VERSION_BIT];
     }
 
+    /** Returns true if the serialized byte indicates the V2 format (vertex table + connectivity). */
+    public static boolean isV2Format(byte rawByte) {
+        return (Byte.toUnsignedInt(rawByte) & VERSION_BIT) != 0;
+    }
+
+    /** Writes this type in legacy (V1) format without the version bit. */
     public void writeTo(BytesStreamOutput out) {
         out.writeByte((byte) ordinal());
     }
 
+    /** Writes this type in V2 format with the version bit set. */
+    public void writeV2To(BytesStreamOutput out) {
+        out.writeByte((byte) (ordinal() | VERSION_BIT));
+    }
+
+    /**
+     * Reads the raw byte and returns the DimensionalShapeType (stripping the version bit).
+     * Use {@link #isV2Format(byte)} on the raw byte to determine the format version.
+     */
     public static DimensionalShapeType readFrom(ByteArrayStreamInput in) {
         return fromOrdinalByte(in.readByte());
     }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
@@ -49,11 +49,8 @@ public class GeometryConnectivityReader {
      * If a single geometry was stored, returns a list of one element.
      * If the result is a single geometry, callers can use {@link #readGeometry} instead.
      */
-    public static List<Geometry> readGeometries(
-        ByteArrayStreamInput input,
-        VertexLookupTable vertexTable,
-        CoordinateEncoder encoder
-    ) throws IOException {
+    public static List<Geometry> readGeometries(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
         int numGeometries = input.readVInt();
         List<Geometry> geometries = new ArrayList<>(numGeometries);
         for (int i = 0; i < numGeometries; i++) {
@@ -66,11 +63,8 @@ public class GeometryConnectivityReader {
      * Convenience method that reads the connectivity and returns a single geometry.
      * If multiple geometries were stored, wraps them in a {@link GeometryCollection}.
      */
-    public static Geometry readGeometry(
-        ByteArrayStreamInput input,
-        VertexLookupTable vertexTable,
-        CoordinateEncoder encoder
-    ) throws IOException {
+    public static Geometry readGeometry(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
         List<Geometry> geometries = readGeometries(input, vertexTable, encoder);
         if (geometries.size() == 1) {
             return geometries.get(0);
@@ -78,11 +72,8 @@ public class GeometryConnectivityReader {
         return new GeometryCollection<>(geometries);
     }
 
-    private static Geometry readSingleGeometry(
-        ByteArrayStreamInput input,
-        VertexLookupTable vertexTable,
-        CoordinateEncoder encoder
-    ) throws IOException {
+    private static Geometry readSingleGeometry(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
         byte type = input.readByte();
         return switch (type) {
             case TYPE_POINT -> readPoint(input, vertexTable, encoder);
@@ -102,8 +93,7 @@ public class GeometryConnectivityReader {
         return new Point(encoder.decodeX(vertexTable.getX(ordinal)), encoder.decodeY(vertexTable.getY(ordinal)));
     }
 
-    private static Line readLine(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
-        throws IOException {
+    private static Line readLine(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder) throws IOException {
         int numVertices = input.readVInt();
         double[] x = new double[numVertices];
         double[] y = new double[numVertices];

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.spatial;
+
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_GEOMETRYCOLLECTION;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_LINE;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_MULTILINE;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_MULTIPOINT;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_MULTIPOLYGON;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_POINT;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_POLYGON;
+
+/**
+ * Reads the vertex connectivity/ordering written by {@link GeometryConnectivityWriter}
+ * and reconstructs the original {@link Geometry} objects using the coordinates from a
+ * {@link VertexLookupTable} decoded through a {@link CoordinateEncoder}.
+ *
+ * <p>The reconstructed geometry uses quantized coordinates (from the Lucene spatial grid)
+ * rather than the exact original doubles, which is acceptable for all current use cases.
+ */
+public class GeometryConnectivityReader {
+
+    private GeometryConnectivityReader() {}
+
+    /**
+     * Reads the connectivity section and returns the list of reconstructed geometries.
+     * If a single geometry was stored, returns a list of one element.
+     * If the result is a single geometry, callers can use {@link #readGeometry} instead.
+     */
+    public static List<Geometry> readGeometries(
+        ByteArrayStreamInput input,
+        VertexLookupTable vertexTable,
+        CoordinateEncoder encoder
+    ) throws IOException {
+        int numGeometries = input.readVInt();
+        List<Geometry> geometries = new ArrayList<>(numGeometries);
+        for (int i = 0; i < numGeometries; i++) {
+            geometries.add(readSingleGeometry(input, vertexTable, encoder));
+        }
+        return geometries;
+    }
+
+    /**
+     * Convenience method that reads the connectivity and returns a single geometry.
+     * If multiple geometries were stored, wraps them in a {@link GeometryCollection}.
+     */
+    public static Geometry readGeometry(
+        ByteArrayStreamInput input,
+        VertexLookupTable vertexTable,
+        CoordinateEncoder encoder
+    ) throws IOException {
+        List<Geometry> geometries = readGeometries(input, vertexTable, encoder);
+        if (geometries.size() == 1) {
+            return geometries.get(0);
+        }
+        return new GeometryCollection<>(geometries);
+    }
+
+    private static Geometry readSingleGeometry(
+        ByteArrayStreamInput input,
+        VertexLookupTable vertexTable,
+        CoordinateEncoder encoder
+    ) throws IOException {
+        byte type = input.readByte();
+        return switch (type) {
+            case TYPE_POINT -> readPoint(input, vertexTable, encoder);
+            case TYPE_LINE -> readLine(input, vertexTable, encoder);
+            case TYPE_POLYGON -> readPolygon(input, vertexTable, encoder);
+            case TYPE_MULTIPOINT -> readMultiPoint(input, vertexTable, encoder);
+            case TYPE_MULTILINE -> readMultiLine(input, vertexTable, encoder);
+            case TYPE_MULTIPOLYGON -> readMultiPolygon(input, vertexTable, encoder);
+            case TYPE_GEOMETRYCOLLECTION -> readGeometryCollection(input, vertexTable, encoder);
+            default -> throw new IllegalArgumentException("Unknown geometry connectivity type: " + type);
+        };
+    }
+
+    private static Point readPoint(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int ordinal = input.readVInt();
+        return new Point(encoder.decodeX(vertexTable.getX(ordinal)), encoder.decodeY(vertexTable.getY(ordinal)));
+    }
+
+    private static Line readLine(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int numVertices = input.readVInt();
+        double[] x = new double[numVertices];
+        double[] y = new double[numVertices];
+        for (int i = 0; i < numVertices; i++) {
+            int ordinal = input.readVInt();
+            x[i] = encoder.decodeX(vertexTable.getX(ordinal));
+            y[i] = encoder.decodeY(vertexTable.getY(ordinal));
+        }
+        return new Line(x, y);
+    }
+
+    private static Polygon readPolygon(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int numRings = input.readVInt();
+        LinearRing outerRing = readRing(input, vertexTable, encoder);
+        if (numRings == 1) {
+            return new Polygon(outerRing);
+        }
+        List<LinearRing> holes = new ArrayList<>(numRings - 1);
+        for (int i = 1; i < numRings; i++) {
+            holes.add(readRing(input, vertexTable, encoder));
+        }
+        return new Polygon(outerRing, holes);
+    }
+
+    /** Reads a ring, restoring the closing vertex that was omitted during writing. */
+    private static LinearRing readRing(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int numVertices = input.readVInt();
+        double[] x = new double[numVertices + 1]; // +1 for closing vertex
+        double[] y = new double[numVertices + 1];
+        for (int i = 0; i < numVertices; i++) {
+            int ordinal = input.readVInt();
+            x[i] = encoder.decodeX(vertexTable.getX(ordinal));
+            y[i] = encoder.decodeY(vertexTable.getY(ordinal));
+        }
+        // Close the ring
+        x[numVertices] = x[0];
+        y[numVertices] = y[0];
+        return new LinearRing(x, y);
+    }
+
+    private static MultiPoint readMultiPoint(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int count = input.readVInt();
+        List<Point> points = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            int ordinal = input.readVInt();
+            points.add(new Point(encoder.decodeX(vertexTable.getX(ordinal)), encoder.decodeY(vertexTable.getY(ordinal))));
+        }
+        return new MultiPoint(points);
+    }
+
+    private static MultiLine readMultiLine(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int count = input.readVInt();
+        List<Line> lines = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            int numVertices = input.readVInt();
+            double[] x = new double[numVertices];
+            double[] y = new double[numVertices];
+            for (int j = 0; j < numVertices; j++) {
+                int ordinal = input.readVInt();
+                x[j] = encoder.decodeX(vertexTable.getX(ordinal));
+                y[j] = encoder.decodeY(vertexTable.getY(ordinal));
+            }
+            lines.add(new Line(x, y));
+        }
+        return new MultiLine(lines);
+    }
+
+    private static MultiPolygon readMultiPolygon(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int count = input.readVInt();
+        List<Polygon> polygons = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            int numRings = input.readVInt();
+            LinearRing outerRing = readRing(input, vertexTable, encoder);
+            if (numRings == 1) {
+                polygons.add(new Polygon(outerRing));
+            } else {
+                List<LinearRing> holes = new ArrayList<>(numRings - 1);
+                for (int j = 1; j < numRings; j++) {
+                    holes.add(readRing(input, vertexTable, encoder));
+                }
+                polygons.add(new Polygon(outerRing, holes));
+            }
+        }
+        return new MultiPolygon(polygons);
+    }
+
+    private static GeometryCollection<Geometry> readGeometryCollection(
+        ByteArrayStreamInput input,
+        VertexLookupTable vertexTable,
+        CoordinateEncoder encoder
+    ) throws IOException {
+        int count = input.readVInt();
+        List<Geometry> geometries = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            geometries.add(readSingleGeometry(input, vertexTable, encoder));
+        }
+        return new GeometryCollection<>(geometries);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityReader.java
@@ -19,6 +19,7 @@ import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_M
 import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_MULTIPOLYGON;
 import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_POINT;
 import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_POLYGON;
+import static org.elasticsearch.lucene.spatial.GeometryConnectivityWriter.TYPE_RECTANGLE;
 
 /**
  * Reads the vertex connectivity/ordering written by {@link GeometryConnectivityWriter}
@@ -83,6 +85,7 @@ public class GeometryConnectivityReader {
             case TYPE_MULTILINE -> readMultiLine(input, vertexTable, encoder);
             case TYPE_MULTIPOLYGON -> readMultiPolygon(input, vertexTable, encoder);
             case TYPE_GEOMETRYCOLLECTION -> readGeometryCollection(input, vertexTable, encoder);
+            case TYPE_RECTANGLE -> readRectangle(input, vertexTable, encoder);
             default -> throw new IllegalArgumentException("Unknown geometry connectivity type: " + type);
         };
     }
@@ -134,6 +137,17 @@ public class GeometryConnectivityReader {
         x[numVertices] = x[0];
         y[numVertices] = y[0];
         return new LinearRing(x, y);
+    }
+
+    private static Rectangle readRectangle(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)
+        throws IOException {
+        int minOrdinal = input.readVInt();
+        int maxOrdinal = input.readVInt();
+        double minX = encoder.decodeX(vertexTable.getX(minOrdinal));
+        double minY = encoder.decodeY(vertexTable.getY(minOrdinal));
+        double maxX = encoder.decodeX(vertexTable.getX(maxOrdinal));
+        double maxY = encoder.decodeY(vertexTable.getY(maxOrdinal));
+        return new Rectangle(minX, maxX, maxY, minY);
     }
 
     private static MultiPoint readMultiPoint(ByteArrayStreamInput input, VertexLookupTable vertexTable, CoordinateEncoder encoder)

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.spatial;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.GeometryVisitor;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Writes the vertex connectivity/ordering information for a geometry using vertex ordinals
+ * from a {@link VertexLookupTable}. This captures the structure of the original geometry
+ * (which rings belong to which polygon, the order of vertices in each ring/line, etc.)
+ * so that the geometry can be faithfully reconstructed from the doc-values.
+ *
+ * <p>The connectivity is encoded as a recursive structure matching the geometry type hierarchy:
+ * <pre>
+ *   POINT(0):            ordinal(VInt)
+ *   LINE(1):             numVertices(VInt), ordinals...(VInt)
+ *   POLYGON(2):          numRings(VInt), [numVertices(VInt), ordinals...(VInt)]...
+ *   MULTIPOINT(3):       count(VInt), ordinals...(VInt)
+ *   MULTILINE(4):        count(VInt), [numVertices(VInt), ordinals...(VInt)]...
+ *   MULTIPOLYGON(5):     count(VInt), [POLYGON encoding]...
+ *   GEOMETRYCOLLECTION(6): count(VInt), [recursive geometry]...
+ * </pre>
+ *
+ * <p>Polygon rings are stored WITHOUT the closing vertex (which always equals the first vertex)
+ * to save space. The closing vertex is restored during reading.
+ */
+public class GeometryConnectivityWriter {
+
+    static final byte TYPE_POINT = 0;
+    static final byte TYPE_LINE = 1;
+    static final byte TYPE_POLYGON = 2;
+    static final byte TYPE_MULTIPOINT = 3;
+    static final byte TYPE_MULTILINE = 4;
+    static final byte TYPE_MULTIPOLYGON = 5;
+    static final byte TYPE_GEOMETRYCOLLECTION = 6;
+
+    private GeometryConnectivityWriter() {}
+
+    /**
+     * Writes connectivity for a list of normalized geometries using vertex ordinals
+     * from the given lookup table builder.
+     */
+    public static void writeTo(
+        StreamOutput out,
+        List<Geometry> normalizedGeometries,
+        CoordinateEncoder encoder,
+        VertexLookupTable.Builder vertexTableBuilder
+    ) throws IOException {
+        out.writeVInt(normalizedGeometries.size());
+        ConnectivityVisitor visitor = new ConnectivityVisitor(out, encoder, vertexTableBuilder);
+        for (Geometry geometry : normalizedGeometries) {
+            geometry.visit(visitor);
+        }
+    }
+
+    private static class ConnectivityVisitor implements GeometryVisitor<Void, IOException> {
+        private final StreamOutput out;
+        private final CoordinateEncoder encoder;
+        private final VertexLookupTable.Builder vertexTableBuilder;
+
+        ConnectivityVisitor(StreamOutput out, CoordinateEncoder encoder, VertexLookupTable.Builder vertexTableBuilder) {
+            this.out = out;
+            this.encoder = encoder;
+            this.vertexTableBuilder = vertexTableBuilder;
+        }
+
+        /** Maps a geometry coordinate to its vertex ordinal, adding to the table if needed. */
+        private int resolveOrdinal(double x, double y) {
+            int encodedX = encoder.encodeX(encoder.normalizeX(x));
+            int encodedY = encoder.encodeY(encoder.normalizeY(y));
+            int ordinal = vertexTableBuilder.getOrdinal(encodedX, encodedY);
+            if (ordinal == -1) {
+                // Vertex from the original geometry that wasn't in any tessellated triangle
+                // (rare, but possible for degenerate geometries). Add it to the table.
+                ordinal = vertexTableBuilder.addVertex(encodedX, encodedY);
+            }
+            return ordinal;
+        }
+
+        @Override
+        public Void visit(Point point) throws IOException {
+            out.writeByte(TYPE_POINT);
+            out.writeVInt(resolveOrdinal(point.getX(), point.getY()));
+            return null;
+        }
+
+        @Override
+        public Void visit(Line line) throws IOException {
+            out.writeByte(TYPE_LINE);
+            out.writeVInt(line.length());
+            for (int i = 0; i < line.length(); i++) {
+                out.writeVInt(resolveOrdinal(line.getX(i), line.getY(i)));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(Polygon polygon) throws IOException {
+            out.writeByte(TYPE_POLYGON);
+            int numRings = 1 + polygon.getNumberOfHoles();
+            out.writeVInt(numRings);
+            writeRing(polygon.getPolygon());
+            for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
+                writeRing(polygon.getHole(i));
+            }
+            return null;
+        }
+
+        /** Writes a ring without the closing vertex (which equals the first vertex). */
+        private void writeRing(LinearRing ring) throws IOException {
+            int numVertices = ring.length() - 1; // exclude closing vertex
+            out.writeVInt(numVertices);
+            for (int i = 0; i < numVertices; i++) {
+                out.writeVInt(resolveOrdinal(ring.getX(i), ring.getY(i)));
+            }
+        }
+
+        @Override
+        public Void visit(MultiPoint multiPoint) throws IOException {
+            out.writeByte(TYPE_MULTIPOINT);
+            out.writeVInt(multiPoint.size());
+            for (int i = 0; i < multiPoint.size(); i++) {
+                out.writeVInt(resolveOrdinal(multiPoint.get(i).getX(), multiPoint.get(i).getY()));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiLine multiLine) throws IOException {
+            out.writeByte(TYPE_MULTILINE);
+            out.writeVInt(multiLine.size());
+            for (Line line : multiLine) {
+                out.writeVInt(line.length());
+                for (int i = 0; i < line.length(); i++) {
+                    out.writeVInt(resolveOrdinal(line.getX(i), line.getY(i)));
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiPolygon multiPolygon) throws IOException {
+            out.writeByte(TYPE_MULTIPOLYGON);
+            out.writeVInt(multiPolygon.size());
+            for (Polygon polygon : multiPolygon) {
+                int numRings = 1 + polygon.getNumberOfHoles();
+                out.writeVInt(numRings);
+                writeRing(polygon.getPolygon());
+                for (int j = 0; j < polygon.getNumberOfHoles(); j++) {
+                    writeRing(polygon.getHole(j));
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(GeometryCollection<?> collection) throws IOException {
+            out.writeByte(TYPE_GEOMETRYCOLLECTION);
+            out.writeVInt(collection.size());
+            for (Geometry geometry : collection) {
+                geometry.visit(this);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(Rectangle rectangle) throws IOException {
+            // Encode rectangle as a polygon with 4 vertices (5 including close, stored as 4)
+            out.writeByte(TYPE_POLYGON);
+            out.writeVInt(1); // one ring (outer)
+            out.writeVInt(4); // 4 vertices (without closing)
+            out.writeVInt(resolveOrdinal(rectangle.getMinX(), rectangle.getMinY()));
+            out.writeVInt(resolveOrdinal(rectangle.getMaxX(), rectangle.getMinY()));
+            out.writeVInt(resolveOrdinal(rectangle.getMaxX(), rectangle.getMaxY()));
+            out.writeVInt(resolveOrdinal(rectangle.getMinX(), rectangle.getMaxY()));
+            return null;
+        }
+
+        @Override
+        public Void visit(LinearRing ring) throws IOException {
+            throw new IllegalArgumentException("Cannot write connectivity for LinearRing directly");
+        }
+
+        @Override
+        public Void visit(Circle circle) throws IOException {
+            throw new IllegalArgumentException("Cannot write connectivity for Circle");
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
@@ -41,6 +41,7 @@ import java.util.List;
  *   MULTILINE(4):        count(VInt), [numVertices(VInt), ordinals...(VInt)]...
  *   MULTIPOLYGON(5):     count(VInt), [POLYGON encoding]...
  *   GEOMETRYCOLLECTION(6): count(VInt), [recursive geometry]...
+ *   RECTANGLE(7):        minOrdinal(VInt), maxOrdinal(VInt)
  * </pre>
  *
  * <p>Polygon rings are stored WITHOUT the closing vertex (which always equals the first vertex)
@@ -55,6 +56,7 @@ public class GeometryConnectivityWriter {
     static final byte TYPE_MULTILINE = 4;
     static final byte TYPE_MULTIPOLYGON = 5;
     static final byte TYPE_GEOMETRYCOLLECTION = 6;
+    static final byte TYPE_RECTANGLE = 7;
 
     private GeometryConnectivityWriter() {}
 
@@ -187,14 +189,9 @@ public class GeometryConnectivityWriter {
 
         @Override
         public Void visit(Rectangle rectangle) throws IOException {
-            // Encode rectangle as a polygon with 4 vertices (5 including close, stored as 4)
-            out.writeByte(TYPE_POLYGON);
-            out.writeVInt(1); // one ring (outer)
-            out.writeVInt(4); // 4 vertices (without closing)
+            out.writeByte(TYPE_RECTANGLE);
             out.writeVInt(resolveOrdinal(rectangle.getMinX(), rectangle.getMinY()));
-            out.writeVInt(resolveOrdinal(rectangle.getMaxX(), rectangle.getMinY()));
             out.writeVInt(resolveOrdinal(rectangle.getMaxX(), rectangle.getMaxY()));
-            out.writeVInt(resolveOrdinal(rectangle.getMinX(), rectangle.getMaxY()));
             return null;
         }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryConnectivityWriter.java
@@ -61,18 +61,22 @@ public class GeometryConnectivityWriter {
     private GeometryConnectivityWriter() {}
 
     /**
-     * Writes connectivity for a list of normalized geometries using vertex ordinals
-     * from the given lookup table builder.
+     * Writes connectivity for a list of geometries using vertex ordinals from the given
+     * lookup table builder. The original (pre-normalization) geometries are used so that
+     * reconstruction produces output as close to the source as possible. This should only differ
+     * from normalized geometries when crossing the dateline, in which case the normalization
+     * splits the geometry before we create and store the triangle tree. For these cases,
+     * the vertex table will contain some additional elements not in the triangle tree.
      */
     public static void writeTo(
         StreamOutput out,
-        List<Geometry> normalizedGeometries,
+        List<Geometry> geometries,
         CoordinateEncoder encoder,
         VertexLookupTable.Builder vertexTableBuilder
     ) throws IOException {
-        out.writeVInt(normalizedGeometries.size());
+        out.writeVInt(geometries.size());
         ConnectivityVisitor visitor = new ConnectivityVisitor(out, encoder, vertexTableBuilder);
-        for (Geometry geometry : normalizedGeometries) {
+        for (Geometry geometry : geometries) {
             geometry.visit(visitor);
         }
     }
@@ -88,14 +92,20 @@ public class GeometryConnectivityWriter {
             this.vertexTableBuilder = vertexTableBuilder;
         }
 
-        /** Maps a geometry coordinate to its vertex ordinal, adding to the table if needed. */
+        /**
+         * Maps a geometry coordinate to its vertex ordinal, adding to the table if needed.
+         * Coordinates are normalized before encoding, so original geometry coordinates
+         * (e.g. longitude &gt; 180 for dateline-crossing shapes) map correctly.
+         */
         private int resolveOrdinal(double x, double y) {
             int encodedX = encoder.encodeX(encoder.normalizeX(x));
             int encodedY = encoder.encodeY(encoder.normalizeY(y));
             int ordinal = vertexTableBuilder.getOrdinal(encodedX, encodedY);
             if (ordinal == -1) {
-                // Vertex from the original geometry that wasn't in any tessellated triangle
-                // (rare, but possible for degenerate geometries). Add it to the table.
+                // Vertex from the original geometry that wasn't in any tessellated triangle.
+                // This happens for degenerate geometries (co-linear tessellation) and for
+                // dateline-crossing shapes where the original has different vertices than
+                // the normalized/tessellated form.
                 ordinal = vertexTableBuilder.addVertex(encodedX, encodedY);
             }
             return ordinal;

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -11,38 +11,55 @@ package org.elasticsearch.lucene.spatial;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
 
 /**
- * A reusable Geometry doc value reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
- * {@link GeometryDocValueWriter}.
+ * A reusable Geometry doc value reader that supports two binary formats:
  *
+ * <p><b>Legacy format</b> (DimensionalShapeType high bit clear):
+ * <pre>
+ * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1) | sumWeight(VLong) | extent | tree(coordinate deltas)
+ * </pre>
  *
- * -----------------------------------------
- * |   The binary format of the tree       |
- * -----------------------------------------
- * -----------------------------------------  --
- * |    centroid-x-coord (4 bytes)         |    |
- * -----------------------------------------    |
- * |    centroid-y-coord (4 bytes)         |    |
- * -----------------------------------------    |
- * |    DimensionalShapeType (1 byte)      |    | Centroid-related header
- * -----------------------------------------    |
- * |  Sum of weights (VLong 1-8 bytes)     |    |
- * -----------------------------------------  --
- * |         Extent (var-encoding)         |
- * -----------------------------------------
- * |         Triangle Tree                 |
- * -----------------------------------------
- * -----------------------------------------
+ * <p><b>V2 format</b> (DimensionalShapeType high bit set):
+ * <pre>
+ * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1, 0x80 set) | sumWeight(VLong) | extent |
+ * vertexTable | treeLength(VInt) | tree(vertex ordinals) | connectivity
+ * </pre>
+ *
+ * <p>The format is detected automatically on first access after {@link #reset(BytesRef)}.
+ * Reading the centroid or extent never loads the vertex table, keeping analytics-only
+ * access paths fast. The vertex table sits between the extent and the tree, so it is
+ * available before both sections that reference it.
  */
 public class GeometryDocValueReader {
     private final ByteArrayStreamInput input;
     private final Extent extent;
-    private int treeOffset;
+
     private int docValueOffset;
     private BytesRef bytesRef;
+
+    /** True if the doc value uses the V2 format with vertex table and connectivity. */
+    private boolean v2Format;
+
+    /** True once extent has been parsed. */
+    private boolean extentLoaded;
+
+    /** Position right after the extent in the byte array. */
+    private int afterExtentOffset;
+
+    /** Offset of the tree data within the byte array. Set after vertex table is loaded (V2) or after extent (legacy). */
+    private int treeOffset;
+    /** Length of the tree data in bytes (V2 only). */
+    private int treeLength;
+
+    /** Lazily loaded vertex table (V2 only). Null until first needed. */
+    private VertexLookupTable vertexTable;
+
+    /** Position of the connectivity data (V2 only). Set after vertex table + tree length are known. */
+    private int connectivityOffset;
 
     public GeometryDocValueReader() {
         this.extent = new Extent();
@@ -50,40 +67,30 @@ public class GeometryDocValueReader {
     }
 
     /**
-     * reset the geometry.
+     * Reset the reader for a new document's doc-value bytes.
      */
     public void reset(BytesRef bytesRef) throws IOException {
-        this.bytesRef = bytesRef; // Needed only for supporting Writable, maintaining original offset, not adjusted on from input
+        this.bytesRef = bytesRef;
         this.input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         docValueOffset = bytesRef.offset;
+        extentLoaded = false;
+        afterExtentOffset = 0;
         treeOffset = 0;
+        treeLength = 0;
+        vertexTable = null;
+        connectivityOffset = 0;
+        // Detect format from the DimensionalShapeType byte (offset 8)
+        input.setPosition(docValueOffset + 8);
+        v2Format = DimensionalShapeType.isV2Format(input.readByte());
     }
 
-    /**
-     * returns the {@link Extent} of this geometry.
-     */
-    public Extent getExtent() throws IOException {
-        if (treeOffset == 0) {
-            getSumCentroidWeight(); // skip CENTROID_HEADER + var-long sum-weight
-            Extent.readFromCompressed(input, extent);
-            treeOffset = input.getPosition();
-        } else {
-            input.setPosition(treeOffset);
-        }
-        return extent;
-    }
+    // ---- Centroid header: accessible at fixed offsets, no parsing needed ----
 
-    /**
-     * returns the encoded X coordinate of the centroid.
-     */
     public int getCentroidX() throws IOException {
-        input.setPosition(docValueOffset + 0);
+        input.setPosition(docValueOffset);
         return input.readInt();
     }
 
-    /**
-     * returns the encoded Y coordinate of the centroid.
-     */
     public int getCentroidY() throws IOException {
         input.setPosition(docValueOffset + 4);
         return input.readInt();
@@ -99,18 +106,101 @@ public class GeometryDocValueReader {
         return Double.longBitsToDouble(input.readVLong());
     }
 
+    // ---- Extent: parsed once, does NOT load vertex table ----
+
     /**
-     * Visit the triangle tree with the provided visitor
+     * Returns the bounding box extent. Parsed lazily on first call after reset.
+     * Does not load the vertex table.
+     */
+    public Extent getExtent() throws IOException {
+        ensureExtentLoaded();
+        return extent;
+    }
+
+    private void ensureExtentLoaded() throws IOException {
+        if (extentLoaded == false) {
+            getSumCentroidWeight(); // positions input after the VLong sumWeight
+            Extent.readFromCompressed(input, extent);
+            afterExtentOffset = input.getPosition();
+            if (v2Format == false) {
+                // Legacy: tree starts right after extent
+                treeOffset = afterExtentOffset;
+            }
+            extentLoaded = true;
+        }
+    }
+
+    // ---- Vertex table: loaded lazily (V2 only), skipped for extent-only reads ----
+
+    private void ensureVertexTableLoaded() throws IOException {
+        if (vertexTable == null) {
+            ensureExtentLoaded();
+            if (v2Format == false) {
+                throw new UnsupportedOperationException("Vertex table is not available in legacy doc-value format");
+            }
+            // V2: vertex table is right after extent
+            input.setPosition(afterExtentOffset);
+            vertexTable = VertexLookupTable.readFrom(input);
+            treeLength = input.readVInt();
+            treeOffset = input.getPosition();
+            connectivityOffset = treeOffset + treeLength;
+        }
+    }
+
+    /**
+     * Returns the vertex lookup table. Only available in V2 format.
+     */
+    public VertexLookupTable getVertexTable() throws IOException {
+        ensureVertexTableLoaded();
+        return vertexTable;
+    }
+
+    // ---- Tree visitation ----
+
+    /**
+     * Visit the triangle tree with the provided visitor.
+     * For V2 format, the vertex table is loaded on first call (lazy).
+     * For legacy format, coordinates are read inline from the tree.
      */
     public void visit(TriangleTreeVisitor visitor) throws IOException {
-        Extent geometryExtent = getExtent();
-        int thisMaxX = geometryExtent.maxX();
-        int thisMinX = geometryExtent.minX();
-        int thisMaxY = geometryExtent.maxY();
-        int thisMinY = geometryExtent.minY();
-        if (visitor.push(thisMinX, thisMinY, thisMaxX, thisMaxY)) {
-            TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY);
+        ensureExtentLoaded();
+        int thisMaxX = extent.maxX();
+        int thisMinX = extent.minX();
+        int thisMaxY = extent.maxY();
+        int thisMinY = extent.minY();
+        if (visitor.push(thisMinX, thisMinY, thisMaxX, thisMaxY) == false) {
+            return;
         }
+        if (v2Format) {
+            ensureVertexTableLoaded();
+            input.setPosition(treeOffset);
+            TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY, vertexTable);
+        } else {
+            input.setPosition(treeOffset);
+            TriangleTreeReader.visitLegacy(input, visitor, thisMaxX, thisMaxY);
+        }
+    }
+
+    // ---- Geometry reconstruction: V2 only ----
+
+    /**
+     * Reconstructs the original geometry from the vertex connectivity section.
+     * Only available for V2 format doc-values. Returns null for legacy format.
+     *
+     * @param encoder the coordinate encoder to decode vertex coordinates
+     * @return the reconstructed geometry, or null if legacy format
+     */
+    public Geometry getGeometry(CoordinateEncoder encoder) throws IOException {
+        if (v2Format == false) {
+            return null;
+        }
+        ensureVertexTableLoaded();
+        input.setPosition(connectivityOffset);
+        return GeometryConnectivityReader.readGeometry(input, vertexTable, encoder);
+    }
+
+    public boolean isV2Format() {
+        return v2Format;
     }
 
     public BytesRef getBytesRef() {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -182,10 +182,10 @@ public class GeometryDocValueReader {
         if (v2Format) {
             ensureVertexTableLoaded();
             input.setPosition(treeOffset);
-            TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY, vertexTable);
+            V2TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY, vertexTable);
         } else {
             input.setPosition(treeOffset);
-            TriangleTreeReader.visitLegacy(input, visitor, thisMaxX, thisMaxY);
+            TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p><b>V2 format</b> (DimensionalShapeType high bit set):
  * <pre>
  * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1, 0x80 set) | sumWeight(VLong) | extent |
- * treeLength(VInt) | tree(vertex ordinals) | connectivityLength(VInt) | connectivity | vertexTable
+ * treeLength(VInt) | tree(vertex ordinals) | connectivityLength(4) | connectivity | vertexTable
  * </pre>
  *
  * <p>The format is detected automatically on first access after {@link #reset(BytesRef)}.
@@ -146,12 +146,12 @@ public class GeometryDocValueReader {
             if (v2Format == false) {
                 throw new UnsupportedOperationException("Vertex table is not available in legacy doc-value format");
             }
-            // V2 layout after tree: connectivityLength(VInt) | connectivity | vertexTable
+            // V2 layout after tree: connectivityLength(4 bytes) | connectivity | vertexTable
             input.setPosition(treeOffset + treeLength);
-            int connectivityLength = input.readVInt();
+            int connectivityLength = input.readInt();
             connectivityOffset = input.getPosition();
             input.setPosition(connectivityOffset + connectivityLength);
-            vertexTable = VertexLookupTable.readFrom(input);
+            vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -12,8 +12,12 @@ package org.elasticsearch.lucene.spatial;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.Point;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A reusable Geometry doc value reader that supports two binary formats:
@@ -181,22 +185,80 @@ public class GeometryDocValueReader {
         }
     }
 
-    // ---- Geometry reconstruction: V2 only ----
+    // ---- Geometry reconstruction ----
 
     /**
-     * Reconstructs the original geometry from the vertex connectivity section.
-     * Only available for V2 format doc-values. Returns null for legacy format.
+     * Reconstructs the original geometry from the doc-value.
+     *
+     * <p>For V2 format, reads from the connectivity section.
+     * For legacy format, point-only geometries (Point, MultiPoint) are reconstructed
+     * by visiting the triangle tree, since vertex ordering is irrelevant for points.
+     * Returns null for legacy format with non-point geometries.
      *
      * @param encoder the coordinate encoder to decode vertex coordinates
-     * @return the reconstructed geometry, or null if legacy format
+     * @return the reconstructed geometry, or null if not reconstructable
      */
     public Geometry getGeometry(CoordinateEncoder encoder) throws IOException {
-        if (v2Format == false) {
-            return null;
+        if (v2Format) {
+            ensureVertexTableLoaded();
+            input.setPosition(connectivityOffset);
+            return GeometryConnectivityReader.readGeometry(input, vertexTable, encoder);
         }
-        ensureVertexTableLoaded();
-        input.setPosition(connectivityOffset);
-        return GeometryConnectivityReader.readGeometry(input, vertexTable, encoder);
+        // Legacy format: reconstruct point geometries from the triangle tree
+        if (getDimensionalShapeType() == DimensionalShapeType.POINT) {
+            return reconstructPointsFromTree(encoder);
+        }
+        return null;
+    }
+
+    /**
+     * Reconstructs a Point or MultiPoint geometry by visiting the legacy triangle tree
+     * and collecting all point coordinates. Since points have no ordering, the tree
+     * contains all the information needed for reconstruction.
+     */
+    private Geometry reconstructPointsFromTree(CoordinateEncoder encoder) throws IOException {
+        List<Point> points = new ArrayList<>();
+        visit(new TriangleTreeVisitor() {
+            @Override
+            public void visitPoint(int x, int y) {
+                points.add(new Point(encoder.decodeX(x), encoder.decodeY(y)));
+            }
+
+            @Override
+            public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {}
+
+            @Override
+            public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {}
+
+            @Override
+            public boolean push() {
+                return true;
+            }
+
+            @Override
+            public boolean pushX(int minX) {
+                return true;
+            }
+
+            @Override
+            public boolean pushY(int minY) {
+                return true;
+            }
+
+            @Override
+            public boolean push(int maxX, int maxY) {
+                return true;
+            }
+
+            @Override
+            public boolean push(int minX, int minY, int maxX, int maxY) {
+                return true;
+            }
+        });
+        if (points.size() == 1) {
+            return points.get(0);
+        }
+        return new MultiPoint(points);
     }
 
     public boolean isV2Format() {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -151,7 +151,7 @@ public class GeometryDocValueReader {
             int connectivityLength = input.readInt();
             connectivityOffset = input.getPosition();
             input.setPosition(connectivityOffset + connectivityLength);
-            vertexTable = VertexLookupTable.readFrom(input);
+            vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p><b>V2 format</b> (DimensionalShapeType high bit set):
  * <pre>
  * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1, 0x80 set) | sumWeight(VLong) | extent |
- * treeLength(VInt) | tree(vertex ordinals) | connectivityLength(4) | connectivity | vertexTable
+ * treeLength(VInt) | tree(vertex ordinals) | connectivityLength(VInt) | connectivity | vertexTable
  * </pre>
  *
  * <p>The format is detected automatically on first access after {@link #reset(BytesRef)}.
@@ -146,12 +146,12 @@ public class GeometryDocValueReader {
             if (v2Format == false) {
                 throw new UnsupportedOperationException("Vertex table is not available in legacy doc-value format");
             }
-            // V2 layout after tree: connectivityLength(4 bytes) | connectivity | vertexTable
+            // V2 layout after tree: connectivityLength(VInt) | connectivity | vertexTable
             input.setPosition(treeOffset + treeLength);
-            int connectivityLength = input.readInt();
+            int connectivityLength = input.readVInt();
             connectivityOffset = input.getPosition();
             input.setPosition(connectivityOffset + connectivityLength);
-            vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
+            vertexTable = VertexLookupTable.readFrom(input);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -30,13 +30,13 @@ import java.util.List;
  * <p><b>V2 format</b> (DimensionalShapeType high bit set):
  * <pre>
  * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1, 0x80 set) | sumWeight(VLong) | extent |
- * vertexTable | treeLength(VInt) | tree(vertex ordinals) | connectivity
+ * treeLength(VInt) | tree(vertex ordinals) | vertexTable | connectivity
  * </pre>
  *
  * <p>The format is detected automatically on first access after {@link #reset(BytesRef)}.
  * Reading the centroid or extent never loads the vertex table, keeping analytics-only
- * access paths fast. The vertex table sits between the extent and the tree, so it is
- * available before both sections that reference it.
+ * access paths fast. The tree length prefix allows the reader to skip past the tree to
+ * reach the vertex table (loaded lazily on first tree visit or geometry reconstruction).
  */
 public class GeometryDocValueReader {
     private final ByteArrayStreamInput input;
@@ -54,7 +54,7 @@ public class GeometryDocValueReader {
     /** Position right after the extent in the byte array. */
     private int afterExtentOffset;
 
-    /** Offset of the tree data within the byte array. Set after vertex table is loaded (V2) or after extent (legacy). */
+    /** Offset of the tree data within the byte array. Set after extent is loaded (V2: after treeLength; legacy: right after extent). */
     private int treeOffset;
     /** Length of the tree data in bytes (V2 only). */
     private int treeLength;
@@ -62,7 +62,7 @@ public class GeometryDocValueReader {
     /** Lazily loaded vertex table (V2 only). Null until first needed. */
     private VertexLookupTable vertexTable;
 
-    /** Position of the connectivity data (V2 only). Set after vertex table + tree length are known. */
+    /** Position of the connectivity data (V2 only). Set after vertex table is loaded from after the tree. */
     private int connectivityOffset;
 
     public GeometryDocValueReader() {
@@ -126,7 +126,11 @@ public class GeometryDocValueReader {
             getSumCentroidWeight(); // positions input after the VLong sumWeight
             Extent.readFromCompressed(input, extent);
             afterExtentOffset = input.getPosition();
-            if (v2Format == false) {
+            if (v2Format) {
+                // V2: tree length prefix sits between extent and tree
+                treeLength = input.readVInt();
+                treeOffset = input.getPosition();
+            } else {
                 // Legacy: tree starts right after extent
                 treeOffset = afterExtentOffset;
             }
@@ -142,12 +146,10 @@ public class GeometryDocValueReader {
             if (v2Format == false) {
                 throw new UnsupportedOperationException("Vertex table is not available in legacy doc-value format");
             }
-            // V2: vertex table is right after extent
-            input.setPosition(afterExtentOffset);
+            // V2: vertex table is right after the tree data
+            input.setPosition(treeOffset + treeLength);
             vertexTable = VertexLookupTable.readFrom(input);
-            treeLength = input.readVInt();
-            treeOffset = input.getPosition();
-            connectivityOffset = treeOffset + treeLength;
+            connectivityOffset = input.getPosition();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueReader.java
@@ -30,13 +30,13 @@ import java.util.List;
  * <p><b>V2 format</b> (DimensionalShapeType high bit set):
  * <pre>
  * centroid-x(4) | centroid-y(4) | DimensionalShapeType(1, 0x80 set) | sumWeight(VLong) | extent |
- * treeLength(VInt) | tree(vertex ordinals) | vertexTable | connectivity
+ * treeLength(VInt) | tree(vertex ordinals) | connectivityLength(4) | connectivity | vertexTable
  * </pre>
  *
  * <p>The format is detected automatically on first access after {@link #reset(BytesRef)}.
  * Reading the centroid or extent never loads the vertex table, keeping analytics-only
- * access paths fast. The tree length prefix allows the reader to skip past the tree to
- * reach the vertex table (loaded lazily on first tree visit or geometry reconstruction).
+ * access paths fast. The tree and connectivity length prefixes allow the reader to skip
+ * to the vertex table at the end (loaded lazily on first tree visit or geometry reconstruction).
  */
 public class GeometryDocValueReader {
     private final ByteArrayStreamInput input;
@@ -62,7 +62,7 @@ public class GeometryDocValueReader {
     /** Lazily loaded vertex table (V2 only). Null until first needed. */
     private VertexLookupTable vertexTable;
 
-    /** Position of the connectivity data (V2 only). Set after vertex table is loaded from after the tree. */
+    /** Position of the connectivity data (V2 only). Set when vertex table is loaded. */
     private int connectivityOffset;
 
     public GeometryDocValueReader() {
@@ -146,10 +146,12 @@ public class GeometryDocValueReader {
             if (v2Format == false) {
                 throw new UnsupportedOperationException("Vertex table is not available in legacy doc-value format");
             }
-            // V2: vertex table is right after the tree data
+            // V2 layout after tree: connectivityLength(4 bytes) | connectivity | vertexTable
             input.setPosition(treeOffset + treeLength);
-            vertexTable = VertexLookupTable.readFrom(input);
+            int connectivityLength = input.readInt();
             connectivityOffset = input.getPosition();
+            input.setPosition(connectivityOffset + connectivityLength);
+            vertexTable = VertexLookupTable.readFrom(input);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -64,10 +64,38 @@ import java.util.List;
  * <p>The vertex lookup table is placed between the extent and the tree so that reading
  * just the centroid and/or extent (common for analytics) does not require loading it,
  * while it is available before both the tree and the connectivity section that need it.
+ *
+ * <p>The {@link #write} method automatically selects the optimal format: point-only
+ * geometries (Point, MultiPoint) use the legacy format since vertex ordering is irrelevant
+ * and the legacy format is more compact. All other geometries use V2 format. The reader
+ * can reconstruct point geometries from the legacy tree without connectivity data.
  */
 public class GeometryDocValueWriter {
 
     private GeometryDocValueWriter() {}
+
+    /**
+     * Serialize the geometry, automatically selecting the optimal format.
+     * Point-only geometries (Point, MultiPoint) use the legacy format since vertex ordering
+     * is irrelevant and the legacy format is more compact. All other geometries use V2 format
+     * with vertex table and connectivity for geometry reconstruction.
+     *
+     * @param fields               the tessellated triangle fields from the indexer
+     * @param coordinateEncoder    encoder for quantizing coordinates to the integer grid
+     * @param centroidCalculator   calculator with accumulated centroid data
+     * @param normalizedGeometries the normalized geometries whose connectivity to preserve (unused for points)
+     */
+    public static BytesRef write(
+        List<IndexableField> fields,
+        CoordinateEncoder coordinateEncoder,
+        CentroidCalculator centroidCalculator,
+        List<Geometry> normalizedGeometries
+    ) throws IOException {
+        if (centroidCalculator.getDimensionalShapeType() == DimensionalShapeType.POINT) {
+            return writeLegacy(fields, coordinateEncoder, centroidCalculator);
+        }
+        return writeV2(fields, coordinateEncoder, centroidCalculator, normalizedGeometries);
+    }
 
     /**
      * Serialize the geometry into a BytesRef in V2 format with vertex table and connectivity.
@@ -77,7 +105,7 @@ public class GeometryDocValueWriter {
      * @param centroidCalculator   calculator with accumulated centroid data
      * @param normalizedGeometries the normalized geometries whose connectivity to preserve
      */
-    public static BytesRef write(
+    public static BytesRef writeV2(
         List<IndexableField> fields,
         CoordinateEncoder coordinateEncoder,
         CentroidCalculator centroidCalculator,

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -37,10 +37,12 @@ import java.util.List;
  * -----------------------------------------------
  * |   Triangle Tree (ordinal-based)             |
  * -----------------------------------------------
- * |   Vertex Lookup Table                       |
- * |   numVertices(VInt) + [x(4),y(4)]...        |
+ * |   Connectivity Length (4 bytes)               |
  * -----------------------------------------------
  * |   Vertex Connectivity                       |
+ * -----------------------------------------------
+ * |   Vertex Lookup Table                       |
+ * |   numVertices(VInt) + [x(4),y(4)]...        |
  * -----------------------------------------------
  * </pre>
  *
@@ -61,11 +63,13 @@ import java.util.List;
  * -----------------------------------------------
  * </pre>
  *
- * <p>The vertex lookup table is placed after the tree so that the writer can stream
- * extent, tree length, and tree data directly without buffering. The reader uses the
- * tree length to skip past the tree to reach the vertex table and connectivity sections.
- * Reading just the centroid and/or extent (common for analytics) does not require loading
- * the vertex table.
+ * <p>The vertex lookup table is placed last because the connectivity writer may add
+ * vertices not present in the tessellated triangles (e.g. for degenerate geometries).
+ * Writing the table after connectivity ensures it includes all vertices. The connectivity
+ * length is written as a fixed 4-byte int (with the actual value patched in after
+ * writing the connectivity data) to avoid buffering. The reader uses the tree length
+ * and connectivity length to skip to the vertex table. Reading just the centroid
+ * and/or extent (common for analytics) does not require loading the vertex table.
  *
  * <p>The {@link #write} method automatically selects the optimal format: point-only
  * geometries (Point, MultiPoint) use the legacy format since vertex ordering is irrelevant
@@ -125,11 +129,18 @@ public class GeometryDocValueWriter {
         final VertexLookupTable.Builder vertexTableBuilder = VertexLookupTable.builder();
         TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
-        // 3. Write vertex lookup table (after tree; reader uses treeLength to skip past the tree)
-        vertexTableBuilder.build().writeTo(out);
-
-        // 4. Write vertex connectivity (geometry structure with ordinals for reconstruction)
+        // 3. Write connectivity (may add vertices to the builder for coordinates in the normalized geometry
+        // that don't appear in any tessellated triangle). We write a dummy length before the data, which we fill in later.
+        long connectivityPosition = out.position();
+        out.writeInt(0); // placeholder for connectivity length
         GeometryConnectivityWriter.writeTo(out, normalizedGeometries, coordinateEncoder, vertexTableBuilder);
+        long vertexTablePosition = out.position();
+        out.seek(connectivityPosition);
+        out.writeInt((int) (vertexTablePosition - connectivityPosition) - 4);
+        out.seek(vertexTablePosition);
+
+        // 5. Write vertex lookup table last (includes all vertices from both tree and connectivity)
+        vertexTableBuilder.build().writeTo(out);
 
         return out.bytes().toBytesRef();
     }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -140,7 +140,7 @@ public class GeometryDocValueWriter {
         out.seek(vertexTablePosition);
 
         // 5. Write vertex lookup table last (includes all vertices from both tree and connectivity)
-        vertexTableBuilder.build().writeTo(out);
+        vertexTableBuilder.writeTo(out);
 
         return out.bytes().toBytesRef();
     }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -127,7 +127,7 @@ public class GeometryDocValueWriter {
 
         // 2. Build and write extent + treeLength + tree (vertex table builder is populated during tree build)
         final VertexLookupTable.Builder vertexTableBuilder = VertexLookupTable.builder();
-        TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
+        V2TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
         // 3. Write connectivity (may add vertices to the builder for coordinates in the normalized geometry
         // that don't appear in any tessellated triangle). We write a dummy length before the data, which we fill in later.
@@ -166,7 +166,7 @@ public class GeometryDocValueWriter {
         out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
 
         // Extent + triangle tree with coordinate deltas
-        TriangleTreeWriter.writeLegacy(out, fields);
+        TriangleTreeWriter.writeTo(out, fields);
 
         return out.bytes().toBytesRef();
     }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -33,12 +33,12 @@ import java.util.List;
  * -----------------------------------------------
  * |   Extent (var-encoding)                     |
  * -----------------------------------------------
- * |   Vertex Lookup Table                       |
- * |   numVertices(VInt) + [x(4),y(4)]...        |
- * -----------------------------------------------
  * |   Triangle Tree Length (VInt)                |
  * -----------------------------------------------
  * |   Triangle Tree (ordinal-based)             |
+ * -----------------------------------------------
+ * |   Vertex Lookup Table                       |
+ * |   numVertices(VInt) + [x(4),y(4)]...        |
  * -----------------------------------------------
  * |   Vertex Connectivity                       |
  * -----------------------------------------------
@@ -61,9 +61,11 @@ import java.util.List;
  * -----------------------------------------------
  * </pre>
  *
- * <p>The vertex lookup table is placed between the extent and the tree so that reading
- * just the centroid and/or extent (common for analytics) does not require loading it,
- * while it is available before both the tree and the connectivity section that need it.
+ * <p>The vertex lookup table is placed after the tree so that the writer can stream
+ * extent, tree length, and tree data directly without buffering. The reader uses the
+ * tree length to skip past the tree to reach the vertex table and connectivity sections.
+ * Reading just the centroid and/or extent (common for analytics) does not require loading
+ * the vertex table.
  *
  * <p>The {@link #write} method automatically selects the optimal format: point-only
  * geometries (Point, MultiPoint) use the legacy format since vertex ordering is irrelevant
@@ -119,24 +121,14 @@ public class GeometryDocValueWriter {
         centroidCalculator.getDimensionalShapeType().writeV2To(out);
         out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
 
-        // 2. Build the triangle tree into a temp buffer, collecting unique vertices
+        // 2. Build and write extent + treeLength + tree (vertex table builder is populated during tree build)
         final VertexLookupTable.Builder vertexTableBuilder = VertexLookupTable.builder();
-        final Extent extent = new Extent();
-        final BytesStreamOutput treeBuffer = new BytesStreamOutput();
-        TriangleTreeWriter.buildExtentAndWriteTree(fields, vertexTableBuilder, extent, treeBuffer);
+        TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
-        // 3. Write extent
-        extent.writeCompressed(out);
-
-        // 4. Write vertex lookup table (before tree, since both tree and connectivity need it)
+        // 3. Write vertex lookup table (after tree; reader uses treeLength to skip past the tree)
         vertexTableBuilder.build().writeTo(out);
 
-        // 5. Write tree length + tree data
-        BytesRef treeBytes = treeBuffer.bytes().toBytesRef();
-        out.writeVInt(treeBytes.length);
-        out.write(treeBytes.bytes, treeBytes.offset, treeBytes.length);
-
-        // 6. Write vertex connectivity (geometry structure with ordinals for reconstruction)
+        // 4. Write vertex connectivity (geometry structure with ordinals for reconstruction)
         GeometryConnectivityWriter.writeTo(out, normalizedGeometries, coordinateEncoder, vertexTableBuilder);
 
         return out.bytes().toBytesRef();

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -86,36 +86,36 @@ public class GeometryDocValueWriter {
      * is irrelevant and the legacy format is more compact. All other geometries use V2 format
      * with vertex table and connectivity for geometry reconstruction.
      *
-     * @param fields               the tessellated triangle fields from the indexer
-     * @param coordinateEncoder    encoder for quantizing coordinates to the integer grid
-     * @param centroidCalculator   calculator with accumulated centroid data
-     * @param normalizedGeometries the normalized geometries whose connectivity to preserve (unused for points)
+     * @param fields             the tessellated triangle fields from the indexer
+     * @param coordinateEncoder  encoder for quantizing coordinates to the integer grid
+     * @param centroidCalculator calculator with accumulated centroid data
+     * @param geometries         the original geometries whose connectivity to preserve (unused for points)
      */
     public static BytesRef write(
         List<IndexableField> fields,
         CoordinateEncoder coordinateEncoder,
         CentroidCalculator centroidCalculator,
-        List<Geometry> normalizedGeometries
+        List<Geometry> geometries
     ) throws IOException {
         if (centroidCalculator.getDimensionalShapeType() == DimensionalShapeType.POINT) {
             return writeLegacy(fields, coordinateEncoder, centroidCalculator);
         }
-        return writeV2(fields, coordinateEncoder, centroidCalculator, normalizedGeometries);
+        return writeV2(fields, coordinateEncoder, centroidCalculator, geometries);
     }
 
     /**
      * Serialize the geometry into a BytesRef in V2 format with vertex table and connectivity.
      *
-     * @param fields               the tessellated triangle fields from the indexer
-     * @param coordinateEncoder    encoder for quantizing coordinates to the integer grid
-     * @param centroidCalculator   calculator with accumulated centroid data
-     * @param normalizedGeometries the normalized geometries whose connectivity to preserve
+     * @param fields             the tessellated triangle fields from the indexer
+     * @param coordinateEncoder  encoder for quantizing coordinates to the integer grid
+     * @param centroidCalculator calculator with accumulated centroid data
+     * @param geometries         the original geometries whose connectivity to preserve
      */
     public static BytesRef writeV2(
         List<IndexableField> fields,
         CoordinateEncoder coordinateEncoder,
         CentroidCalculator centroidCalculator,
-        List<Geometry> normalizedGeometries
+        List<Geometry> geometries
     ) throws IOException {
         final BytesStreamOutput out = new BytesStreamOutput();
 
@@ -129,11 +129,11 @@ public class GeometryDocValueWriter {
         final VertexLookupTable.Builder vertexTableBuilder = VertexLookupTable.builder();
         V2TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
-        // 3. Write connectivity (may add vertices to the builder for coordinates in the normalized geometry
+        // 3. Write connectivity (may add vertices to the builder for coordinates in the original geometry
         // that don't appear in any tessellated triangle). We write a dummy length before the data, which we fill in later.
         long connectivityPosition = out.position();
         out.writeInt(0); // placeholder for connectivity length
-        GeometryConnectivityWriter.writeTo(out, normalizedGeometries, coordinateEncoder, vertexTableBuilder);
+        GeometryConnectivityWriter.writeTo(out, geometries, coordinateEncoder, vertexTableBuilder);
         long vertexTablePosition = out.position();
         out.seek(connectivityPosition);
         out.writeInt((int) (vertexTablePosition - connectivityPosition) - 4);

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -37,7 +37,7 @@ import java.util.List;
  * -----------------------------------------------
  * |   Triangle Tree (ordinal-based)             |
  * -----------------------------------------------
- * |   Connectivity Length (4 bytes)               |
+ * |   Connectivity Length (VInt)                  |
  * -----------------------------------------------
  * |   Vertex Connectivity                       |
  * -----------------------------------------------
@@ -66,10 +66,14 @@ import java.util.List;
  * <p>The vertex lookup table is placed last because the connectivity writer may add
  * vertices not present in the tessellated triangles (e.g. for degenerate geometries).
  * Writing the table after connectivity ensures it includes all vertices. The connectivity
- * length is written as a fixed 4-byte int (with the actual value patched in after
- * writing the connectivity data) to avoid buffering. The reader uses the tree length
- * and connectivity length to skip to the vertex table. Reading just the centroid
- * and/or extent (common for analytics) does not require loading the vertex table.
+ * is buffered first to determine its length, then written with a VInt length prefix.
+ * The reader uses the tree length and connectivity length to skip to the vertex table.
+ * Reading just the centroid and/or extent (common for analytics) does not require
+ * loading the vertex table.
+ *
+ * <p>The vertex lookup table uses adaptive encoding: the writer computes both bit-packed
+ * (extent-relative) and delta-encoded (zigzag VLong) sizes and picks the smaller one.
+ * A flag byte distinguishes the formats. See {@link VertexLookupTable} for details.
  *
  * <p>The {@link #write} method automatically selects the optimal format: point-only
  * geometries (Point, MultiPoint) use the legacy format since vertex ordering is irrelevant
@@ -130,14 +134,12 @@ public class GeometryDocValueWriter {
         V2TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
         // 3. Write connectivity (may add vertices to the builder for coordinates in the original geometry
-        // that don't appear in any tessellated triangle). We write a dummy length before the data, which we fill in later.
-        long connectivityPosition = out.position();
-        out.writeInt(0); // placeholder for connectivity length
-        GeometryConnectivityWriter.writeTo(out, geometries, coordinateEncoder, vertexTableBuilder);
-        long vertexTablePosition = out.position();
-        out.seek(connectivityPosition);
-        out.writeInt((int) (vertexTablePosition - connectivityPosition) - 4);
-        out.seek(vertexTablePosition);
+        // that don't appear in any tessellated triangle). Buffer first to get length, then write VInt length + data.
+        final BytesStreamOutput connectivityBuffer = new BytesStreamOutput();
+        GeometryConnectivityWriter.writeTo(connectivityBuffer, geometries, coordinateEncoder, vertexTableBuilder);
+        BytesRef connectivityBytes = connectivityBuffer.bytes().toBytesRef();
+        out.writeVInt(connectivityBytes.length);
+        out.writeBytes(connectivityBytes.bytes, connectivityBytes.offset, connectivityBytes.length);
 
         // 5. Write vertex lookup table last (includes all vertices from both tree and connectivity)
         vertexTableBuilder.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -37,7 +37,7 @@ import java.util.List;
  * -----------------------------------------------
  * |   Triangle Tree (ordinal-based)             |
  * -----------------------------------------------
- * |   Connectivity Length (VInt)                  |
+ * |   Connectivity Length (4 bytes)               |
  * -----------------------------------------------
  * |   Vertex Connectivity                       |
  * -----------------------------------------------
@@ -66,14 +66,10 @@ import java.util.List;
  * <p>The vertex lookup table is placed last because the connectivity writer may add
  * vertices not present in the tessellated triangles (e.g. for degenerate geometries).
  * Writing the table after connectivity ensures it includes all vertices. The connectivity
- * is buffered first to determine its length, then written with a VInt length prefix.
- * The reader uses the tree length and connectivity length to skip to the vertex table.
- * Reading just the centroid and/or extent (common for analytics) does not require
- * loading the vertex table.
- *
- * <p>The vertex lookup table uses adaptive encoding: the writer computes both bit-packed
- * (extent-relative) and delta-encoded (zigzag VLong) sizes and picks the smaller one.
- * A flag byte distinguishes the formats. See {@link VertexLookupTable} for details.
+ * length is written as a fixed 4-byte int (with the actual value patched in after
+ * writing the connectivity data) to avoid buffering. The reader uses the tree length
+ * and connectivity length to skip to the vertex table. Reading just the centroid
+ * and/or extent (common for analytics) does not require loading the vertex table.
  *
  * <p>The {@link #write} method automatically selects the optimal format: point-only
  * geometries (Point, MultiPoint) use the legacy format since vertex ordering is irrelevant
@@ -134,12 +130,14 @@ public class GeometryDocValueWriter {
         V2TriangleTreeWriter.writeTo(out, fields, vertexTableBuilder);
 
         // 3. Write connectivity (may add vertices to the builder for coordinates in the original geometry
-        // that don't appear in any tessellated triangle). Buffer first to get length, then write VInt length + data.
-        final BytesStreamOutput connectivityBuffer = new BytesStreamOutput();
-        GeometryConnectivityWriter.writeTo(connectivityBuffer, geometries, coordinateEncoder, vertexTableBuilder);
-        BytesRef connectivityBytes = connectivityBuffer.bytes().toBytesRef();
-        out.writeVInt(connectivityBytes.length);
-        out.writeBytes(connectivityBytes.bytes, connectivityBytes.offset, connectivityBytes.length);
+        // that don't appear in any tessellated triangle). We write a dummy length before the data, which we fill in later.
+        long connectivityPosition = out.position();
+        out.writeInt(0); // placeholder for connectivity length
+        GeometryConnectivityWriter.writeTo(out, geometries, coordinateEncoder, vertexTableBuilder);
+        long vertexTablePosition = out.position();
+        out.seek(connectivityPosition);
+        out.writeInt((int) (vertexTablePosition - connectivityPosition) - 4);
+        out.seek(vertexTablePosition);
 
         // 5. Write vertex lookup table last (includes all vertices from both tree and connectivity)
         vertexTableBuilder.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/GeometryDocValueWriter.java
@@ -12,28 +12,131 @@ package org.elasticsearch.lucene.spatial;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
- * This is a tree-writer that serializes a list of {@link IndexableField} as an interval tree
- * into a byte array.
+ * Serializes geometry data into a binary doc-value format.
+ *
+ * <p><b>V2 format</b> (DimensionalShapeType high bit set):
+ * <pre>
+ * -----------------------------------------------
+ * |   centroid-x-coord (4 bytes)                |
+ * -----------------------------------------------
+ * |   centroid-y-coord (4 bytes)                |
+ * -----------------------------------------------
+ * |   DimensionalShapeType (1 byte, V2 bit set) |
+ * -----------------------------------------------
+ * |   Sum of weights (VLong 1-8 bytes)          |
+ * -----------------------------------------------
+ * |   Extent (var-encoding)                     |
+ * -----------------------------------------------
+ * |   Vertex Lookup Table                       |
+ * |   numVertices(VInt) + [x(4),y(4)]...        |
+ * -----------------------------------------------
+ * |   Triangle Tree Length (VInt)                |
+ * -----------------------------------------------
+ * |   Triangle Tree (ordinal-based)             |
+ * -----------------------------------------------
+ * |   Vertex Connectivity                       |
+ * -----------------------------------------------
+ * </pre>
+ *
+ * <p><b>Legacy format</b> (DimensionalShapeType high bit clear):
+ * <pre>
+ * -----------------------------------------------
+ * |   centroid-x-coord (4 bytes)                |
+ * -----------------------------------------------
+ * |   centroid-y-coord (4 bytes)                |
+ * -----------------------------------------------
+ * |   DimensionalShapeType (1 byte)             |
+ * -----------------------------------------------
+ * |   Sum of weights (VLong 1-8 bytes)          |
+ * -----------------------------------------------
+ * |   Extent (var-encoding)                     |
+ * -----------------------------------------------
+ * |   Triangle Tree (coordinate deltas)         |
+ * -----------------------------------------------
+ * </pre>
+ *
+ * <p>The vertex lookup table is placed between the extent and the tree so that reading
+ * just the centroid and/or extent (common for analytics) does not require loading it,
+ * while it is available before both the tree and the connectivity section that need it.
  */
 public class GeometryDocValueWriter {
 
     private GeometryDocValueWriter() {}
 
-    /*** Serialize the triangle tree in a BytesRef */
-    public static BytesRef write(List<IndexableField> fields, CoordinateEncoder coordinateEncoder, CentroidCalculator centroidCalculator)
-        throws IOException {
+    /**
+     * Serialize the geometry into a BytesRef in V2 format with vertex table and connectivity.
+     *
+     * @param fields               the tessellated triangle fields from the indexer
+     * @param coordinateEncoder    encoder for quantizing coordinates to the integer grid
+     * @param centroidCalculator   calculator with accumulated centroid data
+     * @param normalizedGeometries the normalized geometries whose connectivity to preserve
+     */
+    public static BytesRef write(
+        List<IndexableField> fields,
+        CoordinateEncoder coordinateEncoder,
+        CentroidCalculator centroidCalculator,
+        List<Geometry> normalizedGeometries
+    ) throws IOException {
         final BytesStreamOutput out = new BytesStreamOutput();
-        // normalization may be required due to floating point precision errors
+
+        // 1. Centroid header (with V2 format marker in DimensionalShapeType)
+        out.writeInt(coordinateEncoder.encodeX(coordinateEncoder.normalizeX(centroidCalculator.getX())));
+        out.writeInt(coordinateEncoder.encodeY(coordinateEncoder.normalizeY(centroidCalculator.getY())));
+        centroidCalculator.getDimensionalShapeType().writeV2To(out);
+        out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
+
+        // 2. Build the triangle tree into a temp buffer, collecting unique vertices
+        final VertexLookupTable.Builder vertexTableBuilder = VertexLookupTable.builder();
+        final Extent extent = new Extent();
+        final BytesStreamOutput treeBuffer = new BytesStreamOutput();
+        TriangleTreeWriter.buildExtentAndWriteTree(fields, vertexTableBuilder, extent, treeBuffer);
+
+        // 3. Write extent
+        extent.writeCompressed(out);
+
+        // 4. Write vertex lookup table (before tree, since both tree and connectivity need it)
+        vertexTableBuilder.build().writeTo(out);
+
+        // 5. Write tree length + tree data
+        BytesRef treeBytes = treeBuffer.bytes().toBytesRef();
+        out.writeVInt(treeBytes.length);
+        out.write(treeBytes.bytes, treeBytes.offset, treeBytes.length);
+
+        // 6. Write vertex connectivity (geometry structure with ordinals for reconstruction)
+        GeometryConnectivityWriter.writeTo(out, normalizedGeometries, coordinateEncoder, vertexTableBuilder);
+
+        return out.bytes().toBytesRef();
+    }
+
+    /**
+     * Serialize the geometry into a BytesRef in legacy format (no vertex table or connectivity).
+     *
+     * @param fields             the tessellated triangle fields from the indexer
+     * @param coordinateEncoder  encoder for quantizing coordinates to the integer grid
+     * @param centroidCalculator calculator with accumulated centroid data
+     */
+    public static BytesRef writeLegacy(
+        List<IndexableField> fields,
+        CoordinateEncoder coordinateEncoder,
+        CentroidCalculator centroidCalculator
+    ) throws IOException {
+        final BytesStreamOutput out = new BytesStreamOutput();
+
+        // Centroid header (without V2 format marker)
         out.writeInt(coordinateEncoder.encodeX(coordinateEncoder.normalizeX(centroidCalculator.getX())));
         out.writeInt(coordinateEncoder.encodeY(coordinateEncoder.normalizeY(centroidCalculator.getY())));
         centroidCalculator.getDimensionalShapeType().writeTo(out);
         out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
-        TriangleTreeWriter.writeTo(out, fields);
+
+        // Extent + triangle tree with coordinate deltas
+        TriangleTreeWriter.writeLegacy(out, fields);
+
         return out.bytes().toBytesRef();
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
@@ -168,8 +168,7 @@ class TriangleTreeReader {
     /**
      * Visit the legacy triangle tree where coordinates are stored as VLong deltas from parent maxX/maxY.
      */
-    public static void visitLegacy(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY)
-        throws IOException {
+    public static void visitLegacy(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY) throws IOException {
         visitLegacy(input, visitor, true, thisMaxX, thisMaxY, true);
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
@@ -19,24 +19,161 @@ import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.POINT;
 import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.RIGHT;
 
 /**
- * A tree reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
+ * A tree reader for a previously serialized {@link org.elasticsearch.geometry.Geometry} using
  * {@link TriangleTreeWriter}.
  *
- * The tree structure is navigated using a {@link TriangleTreeVisitor}.
+ * <p>Supports two formats:
+ * <ul>
+ *   <li><b>V2 (new)</b>: Triangle components store vertex ordinals referencing a
+ *       {@link VertexLookupTable}. The reader resolves ordinals to coordinates transparently.</li>
+ *   <li><b>Legacy</b>: Triangle components store coordinate values as VLong deltas from the
+ *       parent node's maxX/maxY bounds.</li>
+ * </ul>
  *
+ * <p>The tree structure (bounding box encoding, left/right children) is identical in both formats.
+ * The {@link TriangleTreeVisitor} API receives actual coordinate values in both cases.
  */
 class TriangleTreeReader {
 
     private TriangleTreeReader() {}
 
+    // ---- V2 format: vertex ordinals resolved via VertexLookupTable ----
+
     /**
-     * Visit the Triangle tree using the {@link TriangleTreeVisitor} provided.
+     * Visit the V2 triangle tree. Vertex coordinates are resolved from the lookup table.
      */
-    public static void visit(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY) throws IOException {
-        visit(input, visitor, true, thisMaxX, thisMaxY, true);
+    public static void visit(
+        ByteArrayStreamInput input,
+        TriangleTreeVisitor visitor,
+        int thisMaxX,
+        int thisMaxY,
+        VertexLookupTable vertexTable
+    ) throws IOException {
+        visitV2(input, visitor, true, thisMaxX, thisMaxY, true, vertexTable);
     }
 
-    private static boolean visit(
+    private static boolean visitV2(
+        ByteArrayStreamInput input,
+        TriangleTreeVisitor visitor,
+        boolean splitX,
+        int thisMaxX,
+        int thisMaxY,
+        boolean isRoot,
+        VertexLookupTable vertexTable
+    ) throws IOException {
+        byte metadata = input.readByte();
+        int thisMinX;
+        int thisMinY;
+        if ((metadata & POINT) == POINT) {
+            int ord = input.readVInt();
+            int x = vertexTable.getX(ord);
+            int y = vertexTable.getY(ord);
+            visitor.visitPoint(x, y);
+            if (visitor.push() == false) {
+                return false;
+            }
+            thisMinX = x;
+            thisMinY = y;
+        } else if ((metadata & LINE) == LINE) {
+            int aOrd = input.readVInt();
+            int bOrd = input.readVInt();
+            int aX = vertexTable.getX(aOrd);
+            int aY = vertexTable.getY(aOrd);
+            int bX = vertexTable.getX(bOrd);
+            int bY = vertexTable.getY(bOrd);
+            visitor.visitLine(aX, aY, bX, bY, metadata);
+            if (visitor.push() == false) {
+                return false;
+            }
+            thisMinX = aX;
+            thisMinY = Math.min(aY, bY);
+        } else {
+            int aOrd = input.readVInt();
+            int bOrd = input.readVInt();
+            int cOrd = input.readVInt();
+            int aX = vertexTable.getX(aOrd);
+            int aY = vertexTable.getY(aOrd);
+            int bX = vertexTable.getX(bOrd);
+            int bY = vertexTable.getY(bOrd);
+            int cX = vertexTable.getX(cOrd);
+            int cY = vertexTable.getY(cOrd);
+            visitor.visitTriangle(aX, aY, bX, bY, cX, cY, metadata);
+            if (visitor.push() == false) {
+                return false;
+            }
+            thisMinX = aX;
+            thisMinY = Math.min(Math.min(aY, bY), cY);
+        }
+        if ((metadata & LEFT) == LEFT) {
+            if (pushLeftV2(input, visitor, thisMaxX, thisMaxY, splitX, vertexTable) == false) {
+                return false;
+            }
+        }
+        if ((metadata & RIGHT) == RIGHT) {
+            int rightSize = isRoot ? 0 : input.readVInt();
+            if (pushRightV2(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize, vertexTable) == false) {
+                return false;
+            }
+        }
+        return visitor.push();
+    }
+
+    private static boolean pushLeftV2(
+        ByteArrayStreamInput input,
+        TriangleTreeVisitor visitor,
+        int thisMaxX,
+        int thisMaxY,
+        boolean splitX,
+        VertexLookupTable vertexTable
+    ) throws IOException {
+        int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
+        int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
+        int size = input.readVInt();
+        if (visitor.push(nextMaxX, nextMaxY)) {
+            return visitV2(input, visitor, splitX == false, nextMaxX, nextMaxY, false, vertexTable);
+        } else {
+            input.skipBytes(size);
+            return visitor.push();
+        }
+    }
+
+    private static boolean pushRightV2(
+        ByteArrayStreamInput input,
+        TriangleTreeVisitor visitor,
+        int thisMaxX,
+        int thisMaxY,
+        int thisMinX,
+        int thisMinY,
+        boolean splitX,
+        int rightSize,
+        VertexLookupTable vertexTable
+    ) throws IOException {
+        if ((splitX == false && visitor.pushY(thisMinY)) || (splitX && visitor.pushX(thisMinX))) {
+            int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
+            int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
+            int size = input.readVInt();
+            if (visitor.push(nextMaxX, nextMaxY)) {
+                return visitV2(input, visitor, splitX == false, nextMaxX, nextMaxY, false, vertexTable);
+            } else {
+                input.skipBytes(size);
+            }
+        } else {
+            input.skipBytes(rightSize);
+        }
+        return visitor.push();
+    }
+
+    // ---- Legacy format: inline coordinate deltas ----
+
+    /**
+     * Visit the legacy triangle tree where coordinates are stored as VLong deltas from parent maxX/maxY.
+     */
+    public static void visitLegacy(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY)
+        throws IOException {
+        visitLegacy(input, visitor, true, thisMaxX, thisMaxY, true);
+    }
+
+    private static boolean visitLegacy(
         ByteArrayStreamInput input,
         TriangleTreeVisitor visitor,
         boolean splitX,
@@ -47,7 +184,7 @@ class TriangleTreeReader {
         byte metadata = input.readByte();
         int thisMinX;
         int thisMinY;
-        if ((metadata & POINT) == POINT) { // component in this node is a point
+        if ((metadata & POINT) == POINT) {
             int x = Math.toIntExact(thisMaxX - input.readVLong());
             int y = Math.toIntExact(thisMaxY - input.readVLong());
             visitor.visitPoint(x, y);
@@ -56,7 +193,7 @@ class TriangleTreeReader {
             }
             thisMinX = x;
             thisMinY = y;
-        } else if ((metadata & LINE) == LINE) { // component in this node is a line
+        } else if ((metadata & LINE) == LINE) {
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
@@ -67,7 +204,7 @@ class TriangleTreeReader {
             }
             thisMinX = aX;
             thisMinY = Math.min(aY, bY);
-        } else { // component in this node is a triangle
+        } else {
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
@@ -81,35 +218,39 @@ class TriangleTreeReader {
             thisMinX = aX;
             thisMinY = Math.min(Math.min(aY, bY), cY);
         }
-        if ((metadata & LEFT) == LEFT) { // left != null
-            if (pushLeft(input, visitor, thisMaxX, thisMaxY, splitX) == false) {
+        if ((metadata & LEFT) == LEFT) {
+            if (pushLeftLegacy(input, visitor, thisMaxX, thisMaxY, splitX) == false) {
                 return false;
             }
         }
-        if ((metadata & RIGHT) == RIGHT) { // right != null
-            // root node does not have a size
+        if ((metadata & RIGHT) == RIGHT) {
             int rightSize = isRoot ? 0 : input.readVInt();
-            if (pushRight(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize) == false) {
+            if (pushRightLegacy(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize) == false) {
                 return false;
             }
         }
         return visitor.push();
     }
 
-    private static boolean pushLeft(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY, boolean splitX)
-        throws IOException {
+    private static boolean pushLeftLegacy(
+        ByteArrayStreamInput input,
+        TriangleTreeVisitor visitor,
+        int thisMaxX,
+        int thisMaxY,
+        boolean splitX
+    ) throws IOException {
         int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
         int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
         if (visitor.push(nextMaxX, nextMaxY)) {
-            return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+            return visitLegacy(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
         } else {
             input.skipBytes(size);
             return visitor.push();
         }
     }
 
-    private static boolean pushRight(
+    private static boolean pushRightLegacy(
         ByteArrayStreamInput input,
         TriangleTreeVisitor visitor,
         int thisMaxX,
@@ -124,7 +265,7 @@ class TriangleTreeReader {
             int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
             int size = input.readVInt();
             if (visitor.push(nextMaxX, nextMaxY)) {
-                return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+                return visitLegacy(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
             } else {
                 input.skipBytes(size);
             }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeReader.java
@@ -23,17 +23,20 @@ import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.RIGHT;
  * {@link TriangleTreeWriter}. Reads the legacy format where vertex coordinates are stored as
  * VLong deltas from the parent node's maxX/maxY bounds.
  *
- * @see V2TriangleTreeReader
+ * @see V2TriangleTreeReader for a version that reads the new format
  */
 class TriangleTreeReader {
 
     private TriangleTreeReader() {}
 
-    static void visit(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY) throws IOException {
-        doVisit(input, visitor, true, thisMaxX, thisMaxY, true);
+    /**
+     * Visit the Triangle tree using the {@link TriangleTreeVisitor} provided.
+     */
+    public static void visit(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY) throws IOException {
+        visit(input, visitor, true, thisMaxX, thisMaxY, true);
     }
 
-    private static boolean doVisit(
+    private static boolean visit(
         ByteArrayStreamInput input,
         TriangleTreeVisitor visitor,
         boolean splitX,
@@ -44,7 +47,7 @@ class TriangleTreeReader {
         byte metadata = input.readByte();
         int thisMinX;
         int thisMinY;
-        if ((metadata & POINT) == POINT) {
+        if ((metadata & POINT) == POINT) { // component in this node is a point
             int x = Math.toIntExact(thisMaxX - input.readVLong());
             int y = Math.toIntExact(thisMaxY - input.readVLong());
             visitor.visitPoint(x, y);
@@ -53,7 +56,7 @@ class TriangleTreeReader {
             }
             thisMinX = x;
             thisMinY = y;
-        } else if ((metadata & LINE) == LINE) {
+        } else if ((metadata & LINE) == LINE) { // component in this node is a line
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
@@ -64,7 +67,7 @@ class TriangleTreeReader {
             }
             thisMinX = aX;
             thisMinY = Math.min(aY, bY);
-        } else {
+        } else { // component in this node is a triangle
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
@@ -78,12 +81,13 @@ class TriangleTreeReader {
             thisMinX = aX;
             thisMinY = Math.min(Math.min(aY, bY), cY);
         }
-        if ((metadata & LEFT) == LEFT) {
+        if ((metadata & LEFT) == LEFT) { // left != null
             if (pushLeft(input, visitor, thisMaxX, thisMaxY, splitX) == false) {
                 return false;
             }
         }
-        if ((metadata & RIGHT) == RIGHT) {
+        if ((metadata & RIGHT) == RIGHT) { // right != null
+            // root node does not have a size
             int rightSize = isRoot ? 0 : input.readVInt();
             if (pushRight(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize) == false) {
                 return false;
@@ -92,18 +96,13 @@ class TriangleTreeReader {
         return visitor.push();
     }
 
-    private static boolean pushLeft(
-        ByteArrayStreamInput input,
-        TriangleTreeVisitor visitor,
-        int thisMaxX,
-        int thisMaxY,
-        boolean splitX
-    ) throws IOException {
+    private static boolean pushLeft(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY, boolean splitX)
+        throws IOException {
         int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
         int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
         if (visitor.push(nextMaxX, nextMaxY)) {
-            return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+            return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
         } else {
             input.skipBytes(size);
             return visitor.push();
@@ -125,7 +124,7 @@ class TriangleTreeReader {
             int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
             int size = input.readVInt();
             if (visitor.push(nextMaxX, nextMaxY)) {
-                return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+                return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
             } else {
                 input.skipBytes(size);
             }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeVisitor.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeVisitor.java
@@ -15,6 +15,7 @@ import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.CA_FROM_TRIANG
 
 /** Visitor for triangle interval tree.
  *
+ * @see V2TriangleTreeReader
  * @see TriangleTreeReader
  * */
 public interface TriangleTreeVisitor {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * with common tree traversal logic. Also provides the legacy writer that stores coordinate values as
  * VLong deltas from the node's bounding box maxX/maxY.
  *
- * @see V2TriangleTreeWriter
+ * @see V2TriangleTreeWriter for a version that writes the new format
  */
 public class TriangleTreeWriter {
 
@@ -52,18 +52,6 @@ public class TriangleTreeWriter {
         node.writeTo(out);
     }
 
-    static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
-        final BytesRef bytesRef = field.binaryValue();
-        assert bytesRef.length == 7 * Integer.BYTES;
-        System.arraycopy(bytesRef.bytes, bytesRef.offset, scratch, 0, 7 * Integer.BYTES);
-        final ShapeField.DecodedTriangle decodedTriangle = new ShapeField.DecodedTriangle();
-        ShapeField.decodeTriangle(scratch, decodedTriangle);
-        return decodedTriangle;
-    }
-
-    /**
-     * Builds a tree from the given fields using the provided factory to create format-specific nodes.
-     */
     static TriangleTreeNode build(
         List<IndexableField> fields,
         Extent extent,
@@ -71,9 +59,9 @@ public class TriangleTreeWriter {
     ) {
         final byte[] scratch = new byte[7 * Integer.BYTES];
         if (fields.size() == 1) {
-            final TriangleTreeNode node = nodeFactory.apply(toDecodedTriangle(fields.get(0), scratch));
-            extent.addRectangle(node.minX, node.minY, node.maxX, node.maxY);
-            return node;
+            final TriangleTreeNode triangleTreeNode = nodeFactory.apply(toDecodedTriangle(fields.get(0), scratch));
+            extent.addRectangle(triangleTreeNode.minX, triangleTreeNode.minY, triangleTreeNode.maxX, triangleTreeNode.maxY);
+            return triangleTreeNode;
         }
         final TriangleTreeNode[] nodes = new TriangleTreeNode[fields.size()];
         for (int i = 0; i < fields.size(); i++) {
@@ -81,6 +69,15 @@ public class TriangleTreeWriter {
             extent.addRectangle(nodes[i].minX, nodes[i].minY, nodes[i].maxX, nodes[i].maxY);
         }
         return createTree(nodes, 0, fields.size() - 1, true);
+    }
+
+    private static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
+        final BytesRef bytesRef = field.binaryValue();
+        assert bytesRef.length == 7 * Integer.BYTES;
+        System.arraycopy(bytesRef.bytes, bytesRef.offset, scratch, 0, 7 * Integer.BYTES);
+        final ShapeField.DecodedTriangle decodedTriangle = new ShapeField.DecodedTriangle();
+        ShapeField.decodeTriangle(scratch, decodedTriangle);
+        return decodedTriangle;
     }
 
     /** Creates tree from sorted components (with range low and high inclusive) */
@@ -99,9 +96,11 @@ public class TriangleTreeWriter {
             ArrayUtil.select(components, low, high + 1, mid, comparator);
         }
         TriangleTreeNode newNode = components[mid];
+        // find children
         newNode.left = createTree(components, low, mid - 1, splitX == false);
         newNode.right = createTree(components, mid + 1, high, splitX == false);
 
+        // pull up max values to this node
         if (newNode.left != null) {
             newNode.maxX = Math.max(newNode.maxX, newNode.left.maxX);
             newNode.maxY = Math.max(newNode.maxY, newNode.left.maxY);
@@ -118,12 +117,18 @@ public class TriangleTreeWriter {
      * Subclasses provide format-specific component writing via {@link #writeComponent} and {@link #componentSize}.
      */
     abstract static class TriangleTreeNode {
+        /** minimum latitude of this geometry's bounding box area */
         final int minY;
+        /** maximum latitude of this geometry's bounding box area */
         int maxY;
+        /** minimum longitude of this geometry's bounding box area */
         final int minX;
+        /**  maximum longitude of this geometry's bounding box area */
         int maxX;
+        // child components, or null.
         TriangleTreeNode left;
         TriangleTreeNode right;
+        /** root node of edge tree */
         final ShapeField.DecodedTriangle component;
 
         TriangleTreeNode(ShapeField.DecodedTriangle component) {
@@ -132,26 +137,6 @@ public class TriangleTreeWriter {
             this.minX = Math.min(Math.min(component.aX, component.bX), component.cX);
             this.maxX = Math.max(Math.max(component.aX, component.bX), component.cX);
             this.component = component;
-        }
-
-        abstract void writeComponent(StreamOutput out) throws IOException;
-
-        abstract long componentSize(CountingStreamOutput countingBuffer) throws IOException;
-
-        /**
-         * Computes the total size in bytes of the root node's serialized tree.
-         * Unlike non-root nodes, the root does NOT write a rightSize prefix before the right child.
-         */
-        long totalSize(CountingStreamOutput countingBuffer) throws IOException {
-            long size = 1; // metadata byte
-            size += componentSize(countingBuffer);
-            if (left != null) {
-                size += left.nodeSize(true, maxX, maxY, countingBuffer);
-            }
-            if (right != null) {
-                size += right.nodeSize(true, maxX, maxY, countingBuffer);
-            }
-            return size;
         }
 
         void writeTo(StreamOutput out) throws IOException {
@@ -200,8 +185,26 @@ public class TriangleTreeWriter {
             out.writeByte(metadata);
         }
 
+        abstract void writeComponent(StreamOutput out) throws IOException;
+
+        abstract long componentSize(CountingStreamOutput countingBuffer) throws IOException;
+
+        long totalSize(CountingStreamOutput countingBuffer) throws IOException {
+            long size = 0;
+            size++; // metadata byte
+            size += componentSize(countingBuffer);
+            if (left != null) {
+                size += left.nodeSize(true, maxX, maxY, countingBuffer);
+            }
+            if (right != null) {
+                size += right.nodeSize(true, maxX, maxY, countingBuffer);
+            }
+            return size;
+        }
+
         private long nodeSize(boolean includeBox, int parentMaxX, int parentMaxY, CountingStreamOutput countingBuffer) throws IOException {
-            long size = 1; // metadata
+            long size = 0;
+            size++; // metadata
             size += componentSize(countingBuffer);
             if (left != null) {
                 size += left.nodeSize(true, maxX, maxY, countingBuffer);
@@ -210,7 +213,7 @@ public class TriangleTreeWriter {
                 long rightSize = right.nodeSize(true, maxX, maxY, countingBuffer);
                 countingBuffer.reset();
                 countingBuffer.writeVLong(rightSize);
-                size += countingBuffer.position();
+                size += countingBuffer.position(); // jump size
                 size += rightSize;
             }
             if (includeBox) {
@@ -219,7 +222,7 @@ public class TriangleTreeWriter {
                 countingBuffer.writeVLong((long) parentMaxX - maxX);
                 countingBuffer.writeVLong((long) parentMaxY - maxY);
                 countingBuffer.writeVLong(jumpSize);
-                size += countingBuffer.position();
+                size += countingBuffer.position(); // box size
             }
             return size;
         }
@@ -250,12 +253,17 @@ public class TriangleTreeWriter {
         @Override
         long componentSize(CountingStreamOutput countingBuffer) throws IOException {
             countingBuffer.reset();
-            countingBuffer.writeVLong((long) maxX - component.aX);
-            countingBuffer.writeVLong((long) maxY - component.aY);
-            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+                countingBuffer.writeVLong((long) maxX - component.aX);
+                countingBuffer.writeVLong((long) maxY - component.aY);
+            } else if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                countingBuffer.writeVLong((long) maxX - component.aX);
+                countingBuffer.writeVLong((long) maxY - component.aY);
                 countingBuffer.writeVLong((long) maxX - component.bX);
                 countingBuffer.writeVLong((long) maxY - component.bY);
-            } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
+            } else {
+                countingBuffer.writeVLong((long) maxX - component.aX);
+                countingBuffer.writeVLong((long) maxY - component.aY);
                 countingBuffer.writeVLong((long) maxX - component.bX);
                 countingBuffer.writeVLong((long) maxY - component.bY);
                 countingBuffer.writeVLong((long) maxX - component.cX);

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
@@ -48,30 +48,18 @@ public class TriangleTreeWriter {
 
     /**
      * Builds the triangle tree and extent from the given fields, populating the vertex table builder
-     * with unique vertices, then writes the extent and tree to the output.
+     * with unique vertices, then writes the extent, tree length, and tree to the output.
+     * The tree length prefix allows the reader to skip past the tree to reach subsequent sections
+     * (vertex table, connectivity) without traversing it.
      */
     public static void writeTo(StreamOutput out, List<IndexableField> fields, VertexLookupTable.Builder vertexTableBuilder)
         throws IOException {
         final Extent extent = new Extent();
         final TriangleTreeNode node = build(fields, extent, vertexTableBuilder);
         extent.writeCompressed(out);
+        CountingStreamOutput countingBuffer = new CountingStreamOutput();
+        out.writeVInt(Math.toIntExact(node.totalSize(countingBuffer)));
         node.writeTo(out);
-    }
-
-    /**
-     * Builds the triangle tree from the given fields, populates the vertex table builder and the
-     * provided extent, and writes ONLY the tree (not the extent) to treeOut.
-     * The caller is responsible for writing the extent separately, which allows inserting
-     * other data (like the vertex lookup table) between the extent and the tree in the output.
-     */
-    public static void buildExtentAndWriteTree(
-        List<IndexableField> fields,
-        VertexLookupTable.Builder vertexTableBuilder,
-        Extent outExtent,
-        StreamOutput treeOut
-    ) throws IOException {
-        final TriangleTreeNode node = build(fields, outExtent, vertexTableBuilder);
-        node.writeTo(treeOut);
     }
 
     // ---- Legacy format: coordinate deltas ----
@@ -180,6 +168,24 @@ public class TriangleTreeWriter {
                 this.bOrd = 0;
                 this.cOrd = 0;
             }
+        }
+
+        /**
+         * Computes the total size in bytes of the root node's serialized tree.
+         * This mirrors the structure of {@link #writeTo}: metadata + component + children,
+         * but unlike non-root nodes, the root does NOT write a rightSize prefix before the right child.
+         */
+        private long totalSize(CountingStreamOutput countingBuffer) throws IOException {
+            long size = 0;
+            size++; // metadata byte
+            size += componentSize(countingBuffer);
+            if (left != null) {
+                size += left.nodeSize(true, maxX, maxY, countingBuffer);
+            }
+            if (right != null) {
+                size += right.nodeSize(true, maxX, maxY, countingBuffer);
+            }
+            return size;
         }
 
         private void writeTo(StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
@@ -19,18 +19,15 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * This is a tree-writer that serializes a list of {@link ShapeField.DecodedTriangle} as an interval tree
- * into a byte array.
+ * into a byte array. Contains shared constants, tree building, and the abstract {@link TriangleTreeNode}
+ * with common tree traversal logic. Also provides the legacy writer that stores coordinate values as
+ * VLong deltas from the node's bounding box maxX/maxY.
  *
- * <p>Supports two modes:
- * <ul>
- *   <li><b>V2 (ordinal)</b>: Triangle components reference vertices by ordinal into a
- *       {@link VertexLookupTable}, deduplicating shared vertices across adjacent triangles.</li>
- *   <li><b>Legacy (coordinate deltas)</b>: Triangle components store coordinate values as
- *       VLong deltas from the node's bounding box maxX/maxY. This is the original format.</li>
- * </ul>
+ * @see V2TriangleTreeWriter
  */
 public class TriangleTreeWriter {
 
@@ -42,57 +39,17 @@ public class TriangleTreeWriter {
     static final byte BC_FROM_TRIANGLE = 1 << 5;
     static final byte CA_FROM_TRIANGLE = 1 << 6;
 
-    private TriangleTreeWriter() {}
-
-    // ---- V2 format: vertex ordinals ----
-
-    /**
-     * Builds the triangle tree and extent from the given fields, populating the vertex table builder
-     * with unique vertices, then writes the extent, tree length, and tree to the output.
-     * The tree length prefix allows the reader to skip past the tree to reach subsequent sections
-     * (vertex table, connectivity) without traversing it.
-     */
-    public static void writeTo(StreamOutput out, List<IndexableField> fields, VertexLookupTable.Builder vertexTableBuilder)
-        throws IOException {
-        final Extent extent = new Extent();
-        final TriangleTreeNode node = build(fields, extent, vertexTableBuilder);
-        extent.writeCompressed(out);
-        CountingStreamOutput countingBuffer = new CountingStreamOutput();
-        out.writeVInt(Math.toIntExact(node.totalSize(countingBuffer)));
-        node.writeTo(out);
-    }
-
-    // ---- Legacy format: coordinate deltas ----
+    TriangleTreeWriter() {}
 
     /**
      * Builds the triangle tree and writes it in legacy format (extent + tree with coordinate deltas).
      * No vertex table is used. This is the original format before V2.
      */
-    public static void writeLegacy(StreamOutput out, List<IndexableField> fields) throws IOException {
+    public static void writeTo(StreamOutput out, List<IndexableField> fields) throws IOException {
         final Extent extent = new Extent();
-        final TriangleTreeNode node = build(fields, extent, null);
+        final TriangleTreeNode node = build(fields, extent, LegacyNode::new);
         extent.writeCompressed(out);
         node.writeTo(out);
-    }
-
-    // ---- Shared tree building ----
-
-    /**
-     * @param vertexTableBuilder if non-null, V2 mode (ordinals); if null, legacy mode (coordinate deltas)
-     */
-    private static TriangleTreeNode build(List<IndexableField> fields, Extent extent, VertexLookupTable.Builder vertexTableBuilder) {
-        final byte[] scratch = new byte[7 * Integer.BYTES];
-        if (fields.size() == 1) {
-            final TriangleTreeNode triangleTreeNode = new TriangleTreeNode(toDecodedTriangle(fields.get(0), scratch), vertexTableBuilder);
-            extent.addRectangle(triangleTreeNode.minX, triangleTreeNode.minY, triangleTreeNode.maxX, triangleTreeNode.maxY);
-            return triangleTreeNode;
-        }
-        final TriangleTreeNode[] nodes = new TriangleTreeNode[fields.size()];
-        for (int i = 0; i < fields.size(); i++) {
-            nodes[i] = new TriangleTreeNode(toDecodedTriangle(fields.get(i), scratch), vertexTableBuilder);
-            extent.addRectangle(nodes[i].minX, nodes[i].minY, nodes[i].maxX, nodes[i].maxY);
-        }
-        return createTree(nodes, 0, fields.size() - 1, true);
     }
 
     static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
@@ -102,6 +59,28 @@ public class TriangleTreeWriter {
         final ShapeField.DecodedTriangle decodedTriangle = new ShapeField.DecodedTriangle();
         ShapeField.decodeTriangle(scratch, decodedTriangle);
         return decodedTriangle;
+    }
+
+    /**
+     * Builds a tree from the given fields using the provided factory to create format-specific nodes.
+     */
+    static TriangleTreeNode build(
+        List<IndexableField> fields,
+        Extent extent,
+        Function<ShapeField.DecodedTriangle, ? extends TriangleTreeNode> nodeFactory
+    ) {
+        final byte[] scratch = new byte[7 * Integer.BYTES];
+        if (fields.size() == 1) {
+            final TriangleTreeNode node = nodeFactory.apply(toDecodedTriangle(fields.get(0), scratch));
+            extent.addRectangle(node.minX, node.minY, node.maxX, node.maxY);
+            return node;
+        }
+        final TriangleTreeNode[] nodes = new TriangleTreeNode[fields.size()];
+        for (int i = 0; i < fields.size(); i++) {
+            nodes[i] = nodeFactory.apply(toDecodedTriangle(fields.get(i), scratch));
+            extent.addRectangle(nodes[i].minX, nodes[i].minY, nodes[i].maxX, nodes[i].maxY);
+        }
+        return createTree(nodes, 0, fields.size() - 1, true);
     }
 
     /** Creates tree from sorted components (with range low and high inclusive) */
@@ -120,11 +99,9 @@ public class TriangleTreeWriter {
             ArrayUtil.select(components, low, high + 1, mid, comparator);
         }
         TriangleTreeNode newNode = components[mid];
-        // find children
         newNode.left = createTree(components, low, mid - 1, splitX == false);
         newNode.right = createTree(components, mid + 1, high, splitX == false);
 
-        // pull up max values to this node
         if (newNode.left != null) {
             newNode.maxX = Math.max(newNode.maxX, newNode.left.maxX);
             newNode.maxY = Math.max(newNode.maxY, newNode.left.maxY);
@@ -136,48 +113,37 @@ public class TriangleTreeWriter {
         return newNode;
     }
 
-    /** Represents an inner node of the tree. Supports both V2 and legacy write modes. */
-    private static class TriangleTreeNode {
-        private final int minY;
-        private int maxY;
-        private final int minX;
-        private int maxX;
-        private TriangleTreeNode left;
-        private TriangleTreeNode right;
-        private final ShapeField.DecodedTriangle component;
-        /** True if writing in legacy mode (coordinate deltas). */
-        private final boolean legacyMode;
-        /** Vertex ordinals (V2 only; 0 in legacy mode). */
-        private final int aOrd;
-        private final int bOrd;
-        private final int cOrd;
+    /**
+     * A node in the triangle tree. Contains shared tree traversal and serialization logic.
+     * Subclasses provide format-specific component writing via {@link #writeComponent} and {@link #componentSize}.
+     */
+    abstract static class TriangleTreeNode {
+        final int minY;
+        int maxY;
+        final int minX;
+        int maxX;
+        TriangleTreeNode left;
+        TriangleTreeNode right;
+        final ShapeField.DecodedTriangle component;
 
-        private TriangleTreeNode(ShapeField.DecodedTriangle component, VertexLookupTable.Builder vertexTableBuilder) {
+        TriangleTreeNode(ShapeField.DecodedTriangle component) {
             this.minY = Math.min(Math.min(component.aY, component.bY), component.cY);
             this.maxY = Math.max(Math.max(component.aY, component.bY), component.cY);
             this.minX = Math.min(Math.min(component.aX, component.bX), component.cX);
             this.maxX = Math.max(Math.max(component.aX, component.bX), component.cX);
             this.component = component;
-            this.legacyMode = (vertexTableBuilder == null);
-            if (vertexTableBuilder != null) {
-                this.aOrd = vertexTableBuilder.addVertex(component.aX, component.aY);
-                this.bOrd = vertexTableBuilder.addVertex(component.bX, component.bY);
-                this.cOrd = vertexTableBuilder.addVertex(component.cX, component.cY);
-            } else {
-                this.aOrd = 0;
-                this.bOrd = 0;
-                this.cOrd = 0;
-            }
         }
+
+        abstract void writeComponent(StreamOutput out) throws IOException;
+
+        abstract long componentSize(CountingStreamOutput countingBuffer) throws IOException;
 
         /**
          * Computes the total size in bytes of the root node's serialized tree.
-         * This mirrors the structure of {@link #writeTo}: metadata + component + children,
-         * but unlike non-root nodes, the root does NOT write a rightSize prefix before the right child.
+         * Unlike non-root nodes, the root does NOT write a rightSize prefix before the right child.
          */
-        private long totalSize(CountingStreamOutput countingBuffer) throws IOException {
-            long size = 0;
-            size++; // metadata byte
+        long totalSize(CountingStreamOutput countingBuffer) throws IOException {
+            long size = 1; // metadata byte
             size += componentSize(countingBuffer);
             if (left != null) {
                 size += left.nodeSize(true, maxX, maxY, countingBuffer);
@@ -188,7 +154,7 @@ public class TriangleTreeWriter {
             return size;
         }
 
-        private void writeTo(StreamOutput out) throws IOException {
+        void writeTo(StreamOutput out) throws IOException {
             CountingStreamOutput countingBuffer = new CountingStreamOutput();
             writeMetadata(out);
             writeComponent(out);
@@ -234,40 +200,8 @@ public class TriangleTreeWriter {
             out.writeByte(metadata);
         }
 
-        /**
-         * Writes the triangle component. In V2 mode, writes vertex ordinals.
-         * In legacy mode, writes coordinate deltas from this node's maxX/maxY.
-         */
-        private void writeComponent(StreamOutput out) throws IOException {
-            if (legacyMode) {
-                out.writeVLong((long) maxX - component.aX);
-                out.writeVLong((long) maxY - component.aY);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
-                    return;
-                }
-                out.writeVLong((long) maxX - component.bX);
-                out.writeVLong((long) maxY - component.bY);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                    return;
-                }
-                out.writeVLong((long) maxX - component.cX);
-                out.writeVLong((long) maxY - component.cY);
-            } else {
-                out.writeVInt(aOrd);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
-                    return;
-                }
-                out.writeVInt(bOrd);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                    return;
-                }
-                out.writeVInt(cOrd);
-            }
-        }
-
         private long nodeSize(boolean includeBox, int parentMaxX, int parentMaxY, CountingStreamOutput countingBuffer) throws IOException {
-            long size = 0;
-            size++; // metadata
+            long size = 1; // metadata
             size += componentSize(countingBuffer);
             if (left != null) {
                 size += left.nodeSize(true, maxX, maxY, countingBuffer);
@@ -276,7 +210,7 @@ public class TriangleTreeWriter {
                 long rightSize = right.nodeSize(true, maxX, maxY, countingBuffer);
                 countingBuffer.reset();
                 countingBuffer.writeVLong(rightSize);
-                size += countingBuffer.position(); // jump size
+                size += countingBuffer.position();
                 size += rightSize;
             }
             if (includeBox) {
@@ -285,33 +219,47 @@ public class TriangleTreeWriter {
                 countingBuffer.writeVLong((long) parentMaxX - maxX);
                 countingBuffer.writeVLong((long) parentMaxY - maxY);
                 countingBuffer.writeVLong(jumpSize);
-                size += countingBuffer.position(); // box size
+                size += countingBuffer.position();
             }
             return size;
         }
+    }
 
-        private long componentSize(CountingStreamOutput countingBuffer) throws IOException {
+    /** Legacy node that writes coordinate deltas from the node's bounding box maxX/maxY. */
+    private static class LegacyNode extends TriangleTreeNode {
+        LegacyNode(ShapeField.DecodedTriangle component) {
+            super(component);
+        }
+
+        @Override
+        void writeComponent(StreamOutput out) throws IOException {
+            out.writeVLong((long) maxX - component.aX);
+            out.writeVLong((long) maxY - component.aY);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+                return;
+            }
+            out.writeVLong((long) maxX - component.bX);
+            out.writeVLong((long) maxY - component.bY);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                return;
+            }
+            out.writeVLong((long) maxX - component.cX);
+            out.writeVLong((long) maxY - component.cY);
+        }
+
+        @Override
+        long componentSize(CountingStreamOutput countingBuffer) throws IOException {
             countingBuffer.reset();
-            if (legacyMode) {
-                countingBuffer.writeVLong((long) maxX - component.aX);
-                countingBuffer.writeVLong((long) maxY - component.aY);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                    countingBuffer.writeVLong((long) maxX - component.bX);
-                    countingBuffer.writeVLong((long) maxY - component.bY);
-                } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
-                    countingBuffer.writeVLong((long) maxX - component.bX);
-                    countingBuffer.writeVLong((long) maxY - component.bY);
-                    countingBuffer.writeVLong((long) maxX - component.cX);
-                    countingBuffer.writeVLong((long) maxY - component.cY);
-                }
-            } else {
-                countingBuffer.writeVInt(aOrd);
-                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                    countingBuffer.writeVInt(bOrd);
-                } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
-                    countingBuffer.writeVInt(bOrd);
-                    countingBuffer.writeVInt(cOrd);
-                }
+            countingBuffer.writeVLong((long) maxX - component.aX);
+            countingBuffer.writeVLong((long) maxY - component.aY);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                countingBuffer.writeVLong((long) maxX - component.bX);
+                countingBuffer.writeVLong((long) maxY - component.bY);
+            } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
+                countingBuffer.writeVLong((long) maxX - component.bX);
+                countingBuffer.writeVLong((long) maxY - component.bY);
+                countingBuffer.writeVLong((long) maxX - component.cX);
+                countingBuffer.writeVLong((long) maxY - component.cY);
             }
             return countingBuffer.position();
         }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/TriangleTreeWriter.java
@@ -23,6 +23,14 @@ import java.util.List;
 /**
  * This is a tree-writer that serializes a list of {@link ShapeField.DecodedTriangle} as an interval tree
  * into a byte array.
+ *
+ * <p>Supports two modes:
+ * <ul>
+ *   <li><b>V2 (ordinal)</b>: Triangle components reference vertices by ordinal into a
+ *       {@link VertexLookupTable}, deduplicating shared vertices across adjacent triangles.</li>
+ *   <li><b>Legacy (coordinate deltas)</b>: Triangle components store coordinate values as
+ *       VLong deltas from the node's bounding box maxX/maxY. This is the original format.</li>
+ * </ul>
  */
 public class TriangleTreeWriter {
 
@@ -36,31 +44,70 @@ public class TriangleTreeWriter {
 
     private TriangleTreeWriter() {}
 
-    /*** Serialize the interval tree in the provided data output */
-    public static void writeTo(StreamOutput out, List<IndexableField> fields) throws IOException {
+    // ---- V2 format: vertex ordinals ----
+
+    /**
+     * Builds the triangle tree and extent from the given fields, populating the vertex table builder
+     * with unique vertices, then writes the extent and tree to the output.
+     */
+    public static void writeTo(StreamOutput out, List<IndexableField> fields, VertexLookupTable.Builder vertexTableBuilder)
+        throws IOException {
         final Extent extent = new Extent();
-        final TriangleTreeNode node = build(fields, extent);
-        ;
+        final TriangleTreeNode node = build(fields, extent, vertexTableBuilder);
         extent.writeCompressed(out);
         node.writeTo(out);
     }
 
-    private static TriangleTreeNode build(List<IndexableField> fields, Extent extent) {
+    /**
+     * Builds the triangle tree from the given fields, populates the vertex table builder and the
+     * provided extent, and writes ONLY the tree (not the extent) to treeOut.
+     * The caller is responsible for writing the extent separately, which allows inserting
+     * other data (like the vertex lookup table) between the extent and the tree in the output.
+     */
+    public static void buildExtentAndWriteTree(
+        List<IndexableField> fields,
+        VertexLookupTable.Builder vertexTableBuilder,
+        Extent outExtent,
+        StreamOutput treeOut
+    ) throws IOException {
+        final TriangleTreeNode node = build(fields, outExtent, vertexTableBuilder);
+        node.writeTo(treeOut);
+    }
+
+    // ---- Legacy format: coordinate deltas ----
+
+    /**
+     * Builds the triangle tree and writes it in legacy format (extent + tree with coordinate deltas).
+     * No vertex table is used. This is the original format before V2.
+     */
+    public static void writeLegacy(StreamOutput out, List<IndexableField> fields) throws IOException {
+        final Extent extent = new Extent();
+        final TriangleTreeNode node = build(fields, extent, null);
+        extent.writeCompressed(out);
+        node.writeTo(out);
+    }
+
+    // ---- Shared tree building ----
+
+    /**
+     * @param vertexTableBuilder if non-null, V2 mode (ordinals); if null, legacy mode (coordinate deltas)
+     */
+    private static TriangleTreeNode build(List<IndexableField> fields, Extent extent, VertexLookupTable.Builder vertexTableBuilder) {
         final byte[] scratch = new byte[7 * Integer.BYTES];
         if (fields.size() == 1) {
-            final TriangleTreeNode triangleTreeNode = new TriangleTreeNode(toDecodedTriangle(fields.get(0), scratch));
+            final TriangleTreeNode triangleTreeNode = new TriangleTreeNode(toDecodedTriangle(fields.get(0), scratch), vertexTableBuilder);
             extent.addRectangle(triangleTreeNode.minX, triangleTreeNode.minY, triangleTreeNode.maxX, triangleTreeNode.maxY);
             return triangleTreeNode;
         }
         final TriangleTreeNode[] nodes = new TriangleTreeNode[fields.size()];
         for (int i = 0; i < fields.size(); i++) {
-            nodes[i] = new TriangleTreeNode(toDecodedTriangle(fields.get(i), scratch));
+            nodes[i] = new TriangleTreeNode(toDecodedTriangle(fields.get(i), scratch), vertexTableBuilder);
             extent.addRectangle(nodes[i].minX, nodes[i].minY, nodes[i].maxX, nodes[i].maxY);
         }
         return createTree(nodes, 0, fields.size() - 1, true);
     }
 
-    private static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
+    static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
         final BytesRef bytesRef = field.binaryValue();
         assert bytesRef.length == 7 * Integer.BYTES;
         System.arraycopy(bytesRef.bytes, bytesRef.offset, scratch, 0, 7 * Integer.BYTES);
@@ -101,28 +148,38 @@ public class TriangleTreeWriter {
         return newNode;
     }
 
-    /** Represents an inner node of the tree. */
+    /** Represents an inner node of the tree. Supports both V2 and legacy write modes. */
     private static class TriangleTreeNode {
-        /** minimum latitude of this geometry's bounding box area */
         private final int minY;
-        /** maximum latitude of this geometry's bounding box area */
         private int maxY;
-        /** minimum longitude of this geometry's bounding box area */
         private final int minX;
-        /**  maximum longitude of this geometry's bounding box area */
         private int maxX;
-        // child components, or null.
         private TriangleTreeNode left;
         private TriangleTreeNode right;
-        /** root node of edge tree */
         private final ShapeField.DecodedTriangle component;
+        /** True if writing in legacy mode (coordinate deltas). */
+        private final boolean legacyMode;
+        /** Vertex ordinals (V2 only; 0 in legacy mode). */
+        private final int aOrd;
+        private final int bOrd;
+        private final int cOrd;
 
-        private TriangleTreeNode(ShapeField.DecodedTriangle component) {
+        private TriangleTreeNode(ShapeField.DecodedTriangle component, VertexLookupTable.Builder vertexTableBuilder) {
             this.minY = Math.min(Math.min(component.aY, component.bY), component.cY);
             this.maxY = Math.max(Math.max(component.aY, component.bY), component.cY);
             this.minX = Math.min(Math.min(component.aX, component.bX), component.cX);
             this.maxX = Math.max(Math.max(component.aX, component.bX), component.cX);
             this.component = component;
+            this.legacyMode = (vertexTableBuilder == null);
+            if (vertexTableBuilder != null) {
+                this.aOrd = vertexTableBuilder.addVertex(component.aX, component.aY);
+                this.bOrd = vertexTableBuilder.addVertex(component.bX, component.bY);
+                this.cOrd = vertexTableBuilder.addVertex(component.cX, component.cY);
+            } else {
+                this.aOrd = 0;
+                this.bOrd = 0;
+                this.cOrd = 0;
+            }
         }
 
         private void writeTo(StreamOutput out) throws IOException {
@@ -171,19 +228,35 @@ public class TriangleTreeWriter {
             out.writeByte(metadata);
         }
 
+        /**
+         * Writes the triangle component. In V2 mode, writes vertex ordinals.
+         * In legacy mode, writes coordinate deltas from this node's maxX/maxY.
+         */
         private void writeComponent(StreamOutput out) throws IOException {
-            out.writeVLong((long) maxX - component.aX);
-            out.writeVLong((long) maxY - component.aY);
-            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
-                return;
+            if (legacyMode) {
+                out.writeVLong((long) maxX - component.aX);
+                out.writeVLong((long) maxY - component.aY);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+                    return;
+                }
+                out.writeVLong((long) maxX - component.bX);
+                out.writeVLong((long) maxY - component.bY);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                    return;
+                }
+                out.writeVLong((long) maxX - component.cX);
+                out.writeVLong((long) maxY - component.cY);
+            } else {
+                out.writeVInt(aOrd);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+                    return;
+                }
+                out.writeVInt(bOrd);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                    return;
+                }
+                out.writeVInt(cOrd);
             }
-            out.writeVLong((long) maxX - component.bX);
-            out.writeVLong((long) maxY - component.bY);
-            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                return;
-            }
-            out.writeVLong((long) maxX - component.cX);
-            out.writeVLong((long) maxY - component.cY);
         }
 
         private long nodeSize(boolean includeBox, int parentMaxX, int parentMaxY, CountingStreamOutput countingBuffer) throws IOException {
@@ -213,21 +286,26 @@ public class TriangleTreeWriter {
 
         private long componentSize(CountingStreamOutput countingBuffer) throws IOException {
             countingBuffer.reset();
-            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+            if (legacyMode) {
                 countingBuffer.writeVLong((long) maxX - component.aX);
                 countingBuffer.writeVLong((long) maxY - component.aY);
-            } else if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
-                countingBuffer.writeVLong((long) maxX - component.aX);
-                countingBuffer.writeVLong((long) maxY - component.aY);
-                countingBuffer.writeVLong((long) maxX - component.bX);
-                countingBuffer.writeVLong((long) maxY - component.bY);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                    countingBuffer.writeVLong((long) maxX - component.bX);
+                    countingBuffer.writeVLong((long) maxY - component.bY);
+                } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
+                    countingBuffer.writeVLong((long) maxX - component.bX);
+                    countingBuffer.writeVLong((long) maxY - component.bY);
+                    countingBuffer.writeVLong((long) maxX - component.cX);
+                    countingBuffer.writeVLong((long) maxY - component.cY);
+                }
             } else {
-                countingBuffer.writeVLong((long) maxX - component.aX);
-                countingBuffer.writeVLong((long) maxY - component.aY);
-                countingBuffer.writeVLong((long) maxX - component.bX);
-                countingBuffer.writeVLong((long) maxY - component.bY);
-                countingBuffer.writeVLong((long) maxX - component.cX);
-                countingBuffer.writeVLong((long) maxY - component.cY);
+                countingBuffer.writeVInt(aOrd);
+                if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                    countingBuffer.writeVInt(bOrd);
+                } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
+                    countingBuffer.writeVInt(bOrd);
+                    countingBuffer.writeVInt(cOrd);
+                }
             }
             return countingBuffer.position();
         }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/V2TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/V2TriangleTreeReader.java
@@ -19,18 +19,16 @@ import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.POINT;
 import static org.elasticsearch.lucene.spatial.TriangleTreeWriter.RIGHT;
 
 /**
- * A tree reader for a previously serialized {@link org.elasticsearch.geometry.Geometry} using
- * {@link TriangleTreeWriter}. Reads the legacy format where vertex coordinates are stored as
- * VLong deltas from the parent node's maxX/maxY bounds.
- *
- * @see V2TriangleTreeReader
+ * Reads a V2 triangle tree where vertex coordinates are stored as ordinals referencing a
+ * {@link VertexLookupTable}. The reader resolves ordinals to coordinates transparently.
  */
-class TriangleTreeReader {
+class V2TriangleTreeReader {
 
-    private TriangleTreeReader() {}
+    private V2TriangleTreeReader() {}
 
-    static void visit(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY) throws IOException {
-        doVisit(input, visitor, true, thisMaxX, thisMaxY, true);
+    static void visit(ByteArrayStreamInput input, TriangleTreeVisitor visitor, int thisMaxX, int thisMaxY, VertexLookupTable vertexTable)
+        throws IOException {
+        doVisit(input, visitor, true, thisMaxX, thisMaxY, true, vertexTable);
     }
 
     private static boolean doVisit(
@@ -39,14 +37,16 @@ class TriangleTreeReader {
         boolean splitX,
         int thisMaxX,
         int thisMaxY,
-        boolean isRoot
+        boolean isRoot,
+        VertexLookupTable vertexTable
     ) throws IOException {
         byte metadata = input.readByte();
         int thisMinX;
         int thisMinY;
         if ((metadata & POINT) == POINT) {
-            int x = Math.toIntExact(thisMaxX - input.readVLong());
-            int y = Math.toIntExact(thisMaxY - input.readVLong());
+            int ord = input.readVInt();
+            int x = vertexTable.getX(ord);
+            int y = vertexTable.getY(ord);
             visitor.visitPoint(x, y);
             if (visitor.push() == false) {
                 return false;
@@ -54,10 +54,12 @@ class TriangleTreeReader {
             thisMinX = x;
             thisMinY = y;
         } else if ((metadata & LINE) == LINE) {
-            int aX = Math.toIntExact(thisMaxX - input.readVLong());
-            int aY = Math.toIntExact(thisMaxY - input.readVLong());
-            int bX = Math.toIntExact(thisMaxX - input.readVLong());
-            int bY = Math.toIntExact(thisMaxY - input.readVLong());
+            int aOrd = input.readVInt();
+            int bOrd = input.readVInt();
+            int aX = vertexTable.getX(aOrd);
+            int aY = vertexTable.getY(aOrd);
+            int bX = vertexTable.getX(bOrd);
+            int bY = vertexTable.getY(bOrd);
             visitor.visitLine(aX, aY, bX, bY, metadata);
             if (visitor.push() == false) {
                 return false;
@@ -65,12 +67,15 @@ class TriangleTreeReader {
             thisMinX = aX;
             thisMinY = Math.min(aY, bY);
         } else {
-            int aX = Math.toIntExact(thisMaxX - input.readVLong());
-            int aY = Math.toIntExact(thisMaxY - input.readVLong());
-            int bX = Math.toIntExact(thisMaxX - input.readVLong());
-            int bY = Math.toIntExact(thisMaxY - input.readVLong());
-            int cX = Math.toIntExact(thisMaxX - input.readVLong());
-            int cY = Math.toIntExact(thisMaxY - input.readVLong());
+            int aOrd = input.readVInt();
+            int bOrd = input.readVInt();
+            int cOrd = input.readVInt();
+            int aX = vertexTable.getX(aOrd);
+            int aY = vertexTable.getY(aOrd);
+            int bX = vertexTable.getX(bOrd);
+            int bY = vertexTable.getY(bOrd);
+            int cX = vertexTable.getX(cOrd);
+            int cY = vertexTable.getY(cOrd);
             visitor.visitTriangle(aX, aY, bX, bY, cX, cY, metadata);
             if (visitor.push() == false) {
                 return false;
@@ -79,13 +84,13 @@ class TriangleTreeReader {
             thisMinY = Math.min(Math.min(aY, bY), cY);
         }
         if ((metadata & LEFT) == LEFT) {
-            if (pushLeft(input, visitor, thisMaxX, thisMaxY, splitX) == false) {
+            if (pushLeft(input, visitor, thisMaxX, thisMaxY, splitX, vertexTable) == false) {
                 return false;
             }
         }
         if ((metadata & RIGHT) == RIGHT) {
             int rightSize = isRoot ? 0 : input.readVInt();
-            if (pushRight(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize) == false) {
+            if (pushRight(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize, vertexTable) == false) {
                 return false;
             }
         }
@@ -97,13 +102,14 @@ class TriangleTreeReader {
         TriangleTreeVisitor visitor,
         int thisMaxX,
         int thisMaxY,
-        boolean splitX
+        boolean splitX,
+        VertexLookupTable vertexTable
     ) throws IOException {
         int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
         int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
         if (visitor.push(nextMaxX, nextMaxY)) {
-            return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+            return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false, vertexTable);
         } else {
             input.skipBytes(size);
             return visitor.push();
@@ -118,14 +124,15 @@ class TriangleTreeReader {
         int thisMinX,
         int thisMinY,
         boolean splitX,
-        int rightSize
+        int rightSize,
+        VertexLookupTable vertexTable
     ) throws IOException {
         if ((splitX == false && visitor.pushY(thisMinY)) || (splitX && visitor.pushX(thisMinX))) {
             int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
             int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
             int size = input.readVInt();
             if (visitor.push(nextMaxX, nextMaxY)) {
-                return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
+                return doVisit(input, visitor, splitX == false, nextMaxX, nextMaxY, false, vertexTable);
             } else {
                 input.skipBytes(size);
             }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/V2TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/V2TriangleTreeWriter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.spatial;
+
+import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.io.stream.CountingStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * V2 triangle tree writer where vertex coordinates are stored as ordinals referencing a
+ * {@link VertexLookupTable}, deduplicating shared vertices across adjacent triangles.
+ */
+class V2TriangleTreeWriter extends TriangleTreeWriter {
+
+    private V2TriangleTreeWriter() {}
+
+    /**
+     * Builds the triangle tree and extent from the given fields, populating the vertex table builder
+     * with unique vertices, then writes the extent, tree length, and tree to the output.
+     * The tree length prefix allows the reader to skip past the tree to reach subsequent sections
+     * (vertex table, connectivity) without traversing it.
+     */
+    static void writeTo(StreamOutput out, List<IndexableField> fields, VertexLookupTable.Builder vertexTableBuilder) throws IOException {
+        final Extent extent = new Extent();
+        final TriangleTreeNode node = build(fields, extent, c -> new V2Node(c, vertexTableBuilder));
+        extent.writeCompressed(out);
+        CountingStreamOutput countingBuffer = new CountingStreamOutput();
+        out.writeVInt(Math.toIntExact(node.totalSize(countingBuffer)));
+        node.writeTo(out);
+    }
+
+    static class V2Node extends TriangleTreeNode {
+        private final int aOrd;
+        private final int bOrd;
+        private final int cOrd;
+
+        V2Node(ShapeField.DecodedTriangle component, VertexLookupTable.Builder vertexTableBuilder) {
+            super(component);
+            this.aOrd = vertexTableBuilder.addVertex(component.aX, component.aY);
+            this.bOrd = vertexTableBuilder.addVertex(component.bX, component.bY);
+            this.cOrd = vertexTableBuilder.addVertex(component.cX, component.cY);
+        }
+
+        @Override
+        void writeComponent(StreamOutput out) throws IOException {
+            out.writeVInt(aOrd);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
+                return;
+            }
+            out.writeVInt(bOrd);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                return;
+            }
+            out.writeVInt(cOrd);
+        }
+
+        @Override
+        long componentSize(CountingStreamOutput countingBuffer) throws IOException {
+            countingBuffer.reset();
+            countingBuffer.writeVInt(aOrd);
+            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
+                countingBuffer.writeVInt(bOrd);
+            } else if (component.type == ShapeField.DecodedTriangle.TYPE.TRIANGLE) {
+                countingBuffer.writeVInt(bOrd);
+                countingBuffer.writeVInt(cOrd);
+            }
+            return countingBuffer.position();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
@@ -24,54 +24,65 @@ import java.util.Map;
  * typically appears in ~6 adjacent triangles) and enables compact storage of the connectivity
  * information needed to reconstruct the original geometry.
  *
- * Each entry is fixed-size (4 bytes x + 4 bytes y = 8 bytes), enabling O(1) random access
- * by ordinal during triangle tree traversal.
+ * <p>Each entry is fixed-size (4 bytes x + 4 bytes y = 8 bytes), enabling O(1) random access
+ * by ordinal during triangle tree traversal. The read path avoids allocating separate coordinate
+ * arrays by reading directly from the underlying doc-value byte array.
  */
 public class VertexLookupTable {
 
-    private final int[] xCoords;
-    private final int[] yCoords;
+    private static final int BYTES_PER_VERTEX = 8; // 4 bytes x + 4 bytes y
 
-    private VertexLookupTable(int[] xCoords, int[] yCoords) {
-        assert xCoords.length == yCoords.length;
-        this.xCoords = xCoords;
-        this.yCoords = yCoords;
+    private final byte[] bytes;
+    private final int dataOffset;
+    private final int numVertices;
+
+    private VertexLookupTable(byte[] bytes, int dataOffset, int numVertices) {
+        this.bytes = bytes;
+        this.dataOffset = dataOffset;
+        this.numVertices = numVertices;
     }
 
     /** Returns the encoded x-coordinate for the given vertex ordinal. */
     public int getX(int ordinal) {
-        return xCoords[ordinal];
+        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX);
     }
 
     /** Returns the encoded y-coordinate for the given vertex ordinal. */
     public int getY(int ordinal) {
-        return yCoords[ordinal];
+        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX + 4);
     }
 
     /** Returns the number of unique vertices in the table. */
     public int size() {
-        return xCoords.length;
+        return numVertices;
     }
 
-    /** Serializes the vertex table to the output stream. */
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(xCoords.length);
-        for (int i = 0; i < xCoords.length; i++) {
-            out.writeInt(xCoords[i]);
-            out.writeInt(yCoords[i]);
-        }
-    }
-
-    /** Reads a vertex table from the input stream, loading all vertices into arrays for fast random access. */
-    public static VertexLookupTable readFrom(ByteArrayStreamInput input) throws IOException {
+    /**
+     * Reads a vertex table from the input stream without allocating coordinate arrays.
+     * The returned table reads directly from the underlying byte array on each {@link #getX}/{@link #getY} call.
+     *
+     * @param input the stream positioned at the start of the vertex table
+     * @param bytes the underlying byte array backing the stream (typically {@code BytesRef.bytes})
+     */
+    public static VertexLookupTable readFrom(ByteArrayStreamInput input, byte[] bytes) throws IOException {
         int size = input.readVInt();
-        int[] x = new int[size];
-        int[] y = new int[size];
-        for (int i = 0; i < size; i++) {
-            x[i] = input.readInt();
-            y[i] = input.readInt();
-        }
-        return new VertexLookupTable(x, y);
+        int dataOffset = input.getPosition();
+        input.skipBytes((long) size * BYTES_PER_VERTEX);
+        return new VertexLookupTable(bytes, dataOffset, size);
+    }
+
+    /** Reads a big-endian int from the byte array at the given offset, similar to {@code StreamInput.readInt()}. */
+    static int readIntBE(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8) | (bytes[offset + 3]
+            & 0xFF);
+    }
+
+    /** Writes a big-endian int into the byte array at the given offset, similar to {@code StreamOutput.writeInt()}. */
+    static void writeIntBE(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (value >> 24);
+        bytes[offset + 1] = (byte) (value >> 16);
+        bytes[offset + 2] = (byte) (value >> 8);
+        bytes[offset + 3] = (byte) value;
     }
 
     /** Creates a new builder for constructing a vertex lookup table from triangle vertices. */
@@ -82,12 +93,14 @@ public class VertexLookupTable {
     /**
      * Builder that collects unique vertices and assigns sequential ordinals.
      * Uses a hash map keyed on the packed (x, y) coordinate pair to detect duplicates.
+     * Vertex data is stored in a single packed byte array (x, y pairs in big-endian format)
+     * rather than separate int arrays, matching the on-disk format and enabling efficient
+     * bulk writes.
      */
     public static class Builder {
         private final Map<Long, Integer> coordToOrdinal = new HashMap<>();
         private int nextOrdinal = 0;
-        private int[] xCoords = new int[64];
-        private int[] yCoords = new int[64];
+        private byte[] vertexData = new byte[64 * BYTES_PER_VERTEX];
 
         /**
          * Adds a vertex to the table. If the vertex already exists, returns its existing ordinal.
@@ -100,13 +113,12 @@ public class VertexLookupTable {
                 return existing;
             }
             int ordinal = nextOrdinal++;
-            if (ordinal >= xCoords.length) {
-                int newSize = xCoords.length * 2;
-                xCoords = Arrays.copyOf(xCoords, newSize);
-                yCoords = Arrays.copyOf(yCoords, newSize);
+            int byteOffset = ordinal * BYTES_PER_VERTEX;
+            if (byteOffset + BYTES_PER_VERTEX > vertexData.length) {
+                vertexData = Arrays.copyOf(vertexData, vertexData.length * 2);
             }
-            xCoords[ordinal] = x;
-            yCoords[ordinal] = y;
+            writeIntBE(vertexData, byteOffset, x);
+            writeIntBE(vertexData, byteOffset + 4, y);
             coordToOrdinal.put(key, ordinal);
             return ordinal;
         }
@@ -126,9 +138,10 @@ public class VertexLookupTable {
             return nextOrdinal;
         }
 
-        /** Builds an immutable {@link VertexLookupTable} from the collected vertices. */
-        public VertexLookupTable build() {
-            return new VertexLookupTable(Arrays.copyOf(xCoords, nextOrdinal), Arrays.copyOf(yCoords, nextOrdinal));
+        /** Serializes the vertex table directly to the output stream. */
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(nextOrdinal);
+            out.writeBytes(vertexData, 0, nextOrdinal * BYTES_PER_VERTEX);
         }
 
         private static long packCoordinates(int x, int y) {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
@@ -24,32 +24,41 @@ import java.util.Map;
  * typically appears in ~6 adjacent triangles) and enables compact storage of the connectivity
  * information needed to reconstruct the original geometry.
  *
- * <p>Each entry is fixed-size (4 bytes x + 4 bytes y = 8 bytes), enabling O(1) random access
- * by ordinal during triangle tree traversal. The read path avoids allocating separate coordinate
- * arrays by reading directly from the underlying doc-value byte array.
+ * <p>On-disk format uses bit-packed extent-relative encoding: coordinates are stored as offsets
+ * from the minimum x/y values, using only the bits needed to represent the actual range.
+ * This saves bits proportional to how much smaller the geometry's extent is compared to the
+ * full 32-bit coordinate range (e.g. a geometry spanning 5° saves ~4 bits/axis = ~1 byte/vertex).
+ * On read, the packed data is decoded into int arrays for O(1) random access by ordinal.
+ *
+ * <p>The writer also computes the size of zigzag-VLong delta encoding between consecutive vertices
+ * (which exploits spatial locality from the tessellator) and picks whichever encoding is smaller.
+ * A flag byte distinguishes the two formats.
  */
 public class VertexLookupTable {
 
-    private static final int BYTES_PER_VERTEX = 8; // 4 bytes x + 4 bytes y
+    static final byte ENCODING_BIT_PACKED = 0;
+    static final byte ENCODING_DELTA = 1;
 
-    private final byte[] bytes;
-    private final int dataOffset;
+    private static final int BYTES_PER_VERTEX = 8; // 4 bytes x + 4 bytes y (used by builder)
+
+    private final int[] xs;
+    private final int[] ys;
     private final int numVertices;
 
-    private VertexLookupTable(byte[] bytes, int dataOffset, int numVertices) {
-        this.bytes = bytes;
-        this.dataOffset = dataOffset;
+    private VertexLookupTable(int[] xs, int[] ys, int numVertices) {
+        this.xs = xs;
+        this.ys = ys;
         this.numVertices = numVertices;
     }
 
     /** Returns the encoded x-coordinate for the given vertex ordinal. */
     public int getX(int ordinal) {
-        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX);
+        return xs[ordinal];
     }
 
     /** Returns the encoded y-coordinate for the given vertex ordinal. */
     public int getY(int ordinal) {
-        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX + 4);
+        return ys[ordinal];
     }
 
     /** Returns the number of unique vertices in the table. */
@@ -58,31 +67,67 @@ public class VertexLookupTable {
     }
 
     /**
-     * Reads a vertex table from the input stream without allocating coordinate arrays.
-     * The returned table reads directly from the underlying byte array on each {@link #getX}/{@link #getY} call.
-     *
-     * @param input the stream positioned at the start of the vertex table
-     * @param bytes the underlying byte array backing the stream (typically {@code BytesRef.bytes})
+     * Reads a vertex table, decoding into int arrays for O(1) access.
+     * Supports both bit-packed and delta-encoded formats (distinguished by a flag byte).
      */
-    public static VertexLookupTable readFrom(ByteArrayStreamInput input, byte[] bytes) throws IOException {
+    public static VertexLookupTable readFrom(ByteArrayStreamInput input) throws IOException {
         int size = input.readVInt();
-        int dataOffset = input.getPosition();
-        input.skipBytes((long) size * BYTES_PER_VERTEX);
-        return new VertexLookupTable(bytes, dataOffset, size);
+        if (size == 0) {
+            return new VertexLookupTable(new int[0], new int[0], 0);
+        }
+        byte encoding = input.readByte();
+        return switch (encoding) {
+            case ENCODING_BIT_PACKED -> readBitPacked(input, size);
+            case ENCODING_DELTA -> readDeltaEncoded(input, size);
+            default -> throw new IOException("Unknown vertex table encoding: " + encoding);
+        };
     }
 
-    /** Reads a big-endian int from the byte array at the given offset, similar to {@code StreamInput.readInt()}. */
-    static int readIntBE(byte[] bytes, int offset) {
-        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8) | (bytes[offset + 3]
-            & 0xFF);
+    private static VertexLookupTable readBitPacked(ByteArrayStreamInput input, int size) throws IOException {
+        int minX = input.readInt();
+        int minY = input.readInt();
+        int bitsPerX = input.readByte() & 0xFF;
+        int bitsPerY = input.readByte() & 0xFF;
+
+        int[] xs = new int[size];
+        int[] ys = new int[size];
+
+        long buffer = 0;
+        int bitsInBuffer = 0;
+        for (int i = 0; i < size; i++) {
+            while (bitsInBuffer < bitsPerX) {
+                buffer = (buffer << 8) | (input.readByte() & 0xFFL);
+                bitsInBuffer += 8;
+            }
+            bitsInBuffer -= bitsPerX;
+            xs[i] = minX + (int) ((buffer >>> bitsInBuffer) & mask(bitsPerX));
+
+            while (bitsInBuffer < bitsPerY) {
+                buffer = (buffer << 8) | (input.readByte() & 0xFFL);
+                bitsInBuffer += 8;
+            }
+            bitsInBuffer -= bitsPerY;
+            ys[i] = minY + (int) ((buffer >>> bitsInBuffer) & mask(bitsPerY));
+        }
+        return new VertexLookupTable(xs, ys, size);
     }
 
-    /** Writes a big-endian int into the byte array at the given offset, similar to {@code StreamOutput.writeInt()}. */
-    static void writeIntBE(byte[] bytes, int offset, int value) {
-        bytes[offset] = (byte) (value >> 24);
-        bytes[offset + 1] = (byte) (value >> 16);
-        bytes[offset + 2] = (byte) (value >> 8);
-        bytes[offset + 3] = (byte) value;
+    private static VertexLookupTable readDeltaEncoded(ByteArrayStreamInput input, int size) throws IOException {
+        int[] xs = new int[size];
+        int[] ys = new int[size];
+        int prevX = 0;
+        int prevY = 0;
+        for (int i = 0; i < size; i++) {
+            prevX += (int) input.readZLong();
+            prevY += (int) input.readZLong();
+            xs[i] = prevX;
+            ys[i] = prevY;
+        }
+        return new VertexLookupTable(xs, ys, size);
+    }
+
+    private static long mask(int bits) {
+        return bits == 0 ? 0 : (bits >= 64 ? -1L : (1L << bits) - 1);
     }
 
     /** Creates a new builder for constructing a vertex lookup table from triangle vertices. */
@@ -93,9 +138,7 @@ public class VertexLookupTable {
     /**
      * Builder that collects unique vertices and assigns sequential ordinals.
      * Uses a hash map keyed on the packed (x, y) coordinate pair to detect duplicates.
-     * Vertex data is stored in a single packed byte array (x, y pairs in big-endian format)
-     * rather than separate int arrays, matching the on-disk format and enabling efficient
-     * bulk writes.
+     * On write, both bit-packed and delta-encoded formats are sized; the smaller one is used.
      */
     public static class Builder {
         private final Map<Long, Integer> coordToOrdinal = new HashMap<>();
@@ -138,14 +181,153 @@ public class VertexLookupTable {
             return nextOrdinal;
         }
 
-        /** Serializes the vertex table directly to the output stream. */
+        /**
+         * Serializes the vertex table, automatically choosing the smaller encoding
+         * between bit-packed extent-relative and zigzag-VLong delta encoding.
+         */
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(nextOrdinal);
-            out.writeBytes(vertexData, 0, nextOrdinal * BYTES_PER_VERTEX);
+            if (nextOrdinal == 0) {
+                return;
+            }
+
+            int bitPackedSize = computeBitPackedSize();
+            int deltaSize = computeDeltaSize();
+
+            if (bitPackedSize <= deltaSize) {
+                out.writeByte(ENCODING_BIT_PACKED);
+                writeBitPacked(out);
+            } else {
+                out.writeByte(ENCODING_DELTA);
+                writeDeltaEncoded(out);
+            }
+        }
+
+        private int computeBitPackedSize() {
+            int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
+            int minY = Integer.MAX_VALUE, maxY = Integer.MIN_VALUE;
+            for (int i = 0; i < nextOrdinal; i++) {
+                int x = getBuilderX(i);
+                int y = getBuilderY(i);
+                minX = Math.min(minX, x);
+                maxX = Math.max(maxX, x);
+                minY = Math.min(minY, y);
+                maxY = Math.max(maxY, y);
+            }
+            int bitsPerX = bitsNeeded(Integer.toUnsignedLong(maxX - minX));
+            int bitsPerY = bitsNeeded(Integer.toUnsignedLong(maxY - minY));
+            long totalBits = (long) nextOrdinal * (bitsPerX + bitsPerY);
+            int totalBytes = (int) ((totalBits + 7) >>> 3);
+            return 4 + 4 + 1 + 1 + totalBytes; // minX + minY + bitsPerX + bitsPerY + data
+        }
+
+        private int computeDeltaSize() {
+            int size = 0;
+            int prevX = 0;
+            int prevY = 0;
+            for (int i = 0; i < nextOrdinal; i++) {
+                int x = getBuilderX(i);
+                int y = getBuilderY(i);
+                size += zigzagVLongSize(x - prevX);
+                size += zigzagVLongSize(y - prevY);
+                prevX = x;
+                prevY = y;
+            }
+            return size;
+        }
+
+        private void writeBitPacked(StreamOutput out) throws IOException {
+            int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
+            int minY = Integer.MAX_VALUE, maxY = Integer.MIN_VALUE;
+            for (int i = 0; i < nextOrdinal; i++) {
+                int x = getBuilderX(i);
+                int y = getBuilderY(i);
+                minX = Math.min(minX, x);
+                maxX = Math.max(maxX, x);
+                minY = Math.min(minY, y);
+                maxY = Math.max(maxY, y);
+            }
+
+            int bitsPerX = bitsNeeded(Integer.toUnsignedLong(maxX - minX));
+            int bitsPerY = bitsNeeded(Integer.toUnsignedLong(maxY - minY));
+
+            out.writeInt(minX);
+            out.writeInt(minY);
+            out.writeByte((byte) bitsPerX);
+            out.writeByte((byte) bitsPerY);
+
+            long buffer = 0;
+            int bitsInBuffer = 0;
+            for (int i = 0; i < nextOrdinal; i++) {
+                int relX = getBuilderX(i) - minX;
+                int relY = getBuilderY(i) - minY;
+
+                buffer = (buffer << bitsPerX) | (Integer.toUnsignedLong(relX) & mask(bitsPerX));
+                bitsInBuffer += bitsPerX;
+                while (bitsInBuffer >= 8) {
+                    bitsInBuffer -= 8;
+                    out.writeByte((byte) (buffer >>> bitsInBuffer));
+                }
+
+                buffer = (buffer << bitsPerY) | (Integer.toUnsignedLong(relY) & mask(bitsPerY));
+                bitsInBuffer += bitsPerY;
+                while (bitsInBuffer >= 8) {
+                    bitsInBuffer -= 8;
+                    out.writeByte((byte) (buffer >>> bitsInBuffer));
+                }
+            }
+            if (bitsInBuffer > 0) {
+                out.writeByte((byte) (buffer << (8 - bitsInBuffer)));
+            }
+        }
+
+        private void writeDeltaEncoded(StreamOutput out) throws IOException {
+            int prevX = 0;
+            int prevY = 0;
+            for (int i = 0; i < nextOrdinal; i++) {
+                int x = getBuilderX(i);
+                int y = getBuilderY(i);
+                out.writeZLong(x - prevX);
+                out.writeZLong(y - prevY);
+                prevX = x;
+                prevY = y;
+            }
+        }
+
+        private int getBuilderX(int ordinal) {
+            return readIntBE(vertexData, ordinal * BYTES_PER_VERTEX);
+        }
+
+        private int getBuilderY(int ordinal) {
+            return readIntBE(vertexData, ordinal * BYTES_PER_VERTEX + 4);
         }
 
         private static long packCoordinates(int x, int y) {
             return ((long) x << 32) | (y & 0xFFFFFFFFL);
         }
+    }
+
+    static int bitsNeeded(long unsignedRange) {
+        if (unsignedRange == 0) return 0;
+        return 64 - Long.numberOfLeadingZeros(unsignedRange);
+    }
+
+    static int zigzagVLongSize(int delta) {
+        long zigzag = (((long) delta) << 1) ^ (((long) delta) >> 63);
+        return (70 - Long.numberOfLeadingZeros(zigzag | 1L)) / 7;
+    }
+
+    /** Reads a big-endian int from the byte array at the given offset. */
+    private static int readIntBE(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8) | (bytes[offset + 3]
+            & 0xFF);
+    }
+
+    /** Writes a big-endian int into the byte array at the given offset. */
+    private static void writeIntBE(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (value >> 24);
+        bytes[offset + 1] = (byte) (value >> 16);
+        bytes[offset + 2] = (byte) (value >> 8);
+        bytes[offset + 3] = (byte) value;
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
@@ -24,41 +24,32 @@ import java.util.Map;
  * typically appears in ~6 adjacent triangles) and enables compact storage of the connectivity
  * information needed to reconstruct the original geometry.
  *
- * <p>On-disk format uses bit-packed extent-relative encoding: coordinates are stored as offsets
- * from the minimum x/y values, using only the bits needed to represent the actual range.
- * This saves bits proportional to how much smaller the geometry's extent is compared to the
- * full 32-bit coordinate range (e.g. a geometry spanning 5° saves ~4 bits/axis = ~1 byte/vertex).
- * On read, the packed data is decoded into int arrays for O(1) random access by ordinal.
- *
- * <p>The writer also computes the size of zigzag-VLong delta encoding between consecutive vertices
- * (which exploits spatial locality from the tessellator) and picks whichever encoding is smaller.
- * A flag byte distinguishes the two formats.
+ * <p>Each entry is fixed-size (4 bytes x + 4 bytes y = 8 bytes), enabling O(1) random access
+ * by ordinal during triangle tree traversal. The read path avoids allocating separate coordinate
+ * arrays by reading directly from the underlying doc-value byte array.
  */
 public class VertexLookupTable {
 
-    static final byte ENCODING_BIT_PACKED = 0;
-    static final byte ENCODING_DELTA = 1;
+    private static final int BYTES_PER_VERTEX = 8; // 4 bytes x + 4 bytes y
 
-    private static final int BYTES_PER_VERTEX = 8; // 4 bytes x + 4 bytes y (used by builder)
-
-    private final int[] xs;
-    private final int[] ys;
+    private final byte[] bytes;
+    private final int dataOffset;
     private final int numVertices;
 
-    private VertexLookupTable(int[] xs, int[] ys, int numVertices) {
-        this.xs = xs;
-        this.ys = ys;
+    private VertexLookupTable(byte[] bytes, int dataOffset, int numVertices) {
+        this.bytes = bytes;
+        this.dataOffset = dataOffset;
         this.numVertices = numVertices;
     }
 
     /** Returns the encoded x-coordinate for the given vertex ordinal. */
     public int getX(int ordinal) {
-        return xs[ordinal];
+        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX);
     }
 
     /** Returns the encoded y-coordinate for the given vertex ordinal. */
     public int getY(int ordinal) {
-        return ys[ordinal];
+        return readIntBE(bytes, dataOffset + ordinal * BYTES_PER_VERTEX + 4);
     }
 
     /** Returns the number of unique vertices in the table. */
@@ -67,67 +58,31 @@ public class VertexLookupTable {
     }
 
     /**
-     * Reads a vertex table, decoding into int arrays for O(1) access.
-     * Supports both bit-packed and delta-encoded formats (distinguished by a flag byte).
+     * Reads a vertex table from the input stream without allocating coordinate arrays.
+     * The returned table reads directly from the underlying byte array on each {@link #getX}/{@link #getY} call.
+     *
+     * @param input the stream positioned at the start of the vertex table
+     * @param bytes the underlying byte array backing the stream (typically {@code BytesRef.bytes})
      */
-    public static VertexLookupTable readFrom(ByteArrayStreamInput input) throws IOException {
+    public static VertexLookupTable readFrom(ByteArrayStreamInput input, byte[] bytes) throws IOException {
         int size = input.readVInt();
-        if (size == 0) {
-            return new VertexLookupTable(new int[0], new int[0], 0);
-        }
-        byte encoding = input.readByte();
-        return switch (encoding) {
-            case ENCODING_BIT_PACKED -> readBitPacked(input, size);
-            case ENCODING_DELTA -> readDeltaEncoded(input, size);
-            default -> throw new IOException("Unknown vertex table encoding: " + encoding);
-        };
+        int dataOffset = input.getPosition();
+        input.skipBytes((long) size * BYTES_PER_VERTEX);
+        return new VertexLookupTable(bytes, dataOffset, size);
     }
 
-    private static VertexLookupTable readBitPacked(ByteArrayStreamInput input, int size) throws IOException {
-        int minX = input.readInt();
-        int minY = input.readInt();
-        int bitsPerX = input.readByte() & 0xFF;
-        int bitsPerY = input.readByte() & 0xFF;
-
-        int[] xs = new int[size];
-        int[] ys = new int[size];
-
-        long buffer = 0;
-        int bitsInBuffer = 0;
-        for (int i = 0; i < size; i++) {
-            while (bitsInBuffer < bitsPerX) {
-                buffer = (buffer << 8) | (input.readByte() & 0xFFL);
-                bitsInBuffer += 8;
-            }
-            bitsInBuffer -= bitsPerX;
-            xs[i] = minX + (int) ((buffer >>> bitsInBuffer) & mask(bitsPerX));
-
-            while (bitsInBuffer < bitsPerY) {
-                buffer = (buffer << 8) | (input.readByte() & 0xFFL);
-                bitsInBuffer += 8;
-            }
-            bitsInBuffer -= bitsPerY;
-            ys[i] = minY + (int) ((buffer >>> bitsInBuffer) & mask(bitsPerY));
-        }
-        return new VertexLookupTable(xs, ys, size);
+    /** Reads a big-endian int from the byte array at the given offset, similar to {@code StreamInput.readInt()}. */
+    static int readIntBE(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8) | (bytes[offset + 3]
+            & 0xFF);
     }
 
-    private static VertexLookupTable readDeltaEncoded(ByteArrayStreamInput input, int size) throws IOException {
-        int[] xs = new int[size];
-        int[] ys = new int[size];
-        int prevX = 0;
-        int prevY = 0;
-        for (int i = 0; i < size; i++) {
-            prevX += (int) input.readZLong();
-            prevY += (int) input.readZLong();
-            xs[i] = prevX;
-            ys[i] = prevY;
-        }
-        return new VertexLookupTable(xs, ys, size);
-    }
-
-    private static long mask(int bits) {
-        return bits == 0 ? 0 : (bits >= 64 ? -1L : (1L << bits) - 1);
+    /** Writes a big-endian int into the byte array at the given offset, similar to {@code StreamOutput.writeInt()}. */
+    static void writeIntBE(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (value >> 24);
+        bytes[offset + 1] = (byte) (value >> 16);
+        bytes[offset + 2] = (byte) (value >> 8);
+        bytes[offset + 3] = (byte) value;
     }
 
     /** Creates a new builder for constructing a vertex lookup table from triangle vertices. */
@@ -138,7 +93,9 @@ public class VertexLookupTable {
     /**
      * Builder that collects unique vertices and assigns sequential ordinals.
      * Uses a hash map keyed on the packed (x, y) coordinate pair to detect duplicates.
-     * On write, both bit-packed and delta-encoded formats are sized; the smaller one is used.
+     * Vertex data is stored in a single packed byte array (x, y pairs in big-endian format)
+     * rather than separate int arrays, matching the on-disk format and enabling efficient
+     * bulk writes.
      */
     public static class Builder {
         private final Map<Long, Integer> coordToOrdinal = new HashMap<>();
@@ -181,153 +138,14 @@ public class VertexLookupTable {
             return nextOrdinal;
         }
 
-        /**
-         * Serializes the vertex table, automatically choosing the smaller encoding
-         * between bit-packed extent-relative and zigzag-VLong delta encoding.
-         */
+        /** Serializes the vertex table directly to the output stream. */
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(nextOrdinal);
-            if (nextOrdinal == 0) {
-                return;
-            }
-
-            int bitPackedSize = computeBitPackedSize();
-            int deltaSize = computeDeltaSize();
-
-            if (bitPackedSize <= deltaSize) {
-                out.writeByte(ENCODING_BIT_PACKED);
-                writeBitPacked(out);
-            } else {
-                out.writeByte(ENCODING_DELTA);
-                writeDeltaEncoded(out);
-            }
-        }
-
-        private int computeBitPackedSize() {
-            int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
-            int minY = Integer.MAX_VALUE, maxY = Integer.MIN_VALUE;
-            for (int i = 0; i < nextOrdinal; i++) {
-                int x = getBuilderX(i);
-                int y = getBuilderY(i);
-                minX = Math.min(minX, x);
-                maxX = Math.max(maxX, x);
-                minY = Math.min(minY, y);
-                maxY = Math.max(maxY, y);
-            }
-            int bitsPerX = bitsNeeded(Integer.toUnsignedLong(maxX - minX));
-            int bitsPerY = bitsNeeded(Integer.toUnsignedLong(maxY - minY));
-            long totalBits = (long) nextOrdinal * (bitsPerX + bitsPerY);
-            int totalBytes = (int) ((totalBits + 7) >>> 3);
-            return 4 + 4 + 1 + 1 + totalBytes; // minX + minY + bitsPerX + bitsPerY + data
-        }
-
-        private int computeDeltaSize() {
-            int size = 0;
-            int prevX = 0;
-            int prevY = 0;
-            for (int i = 0; i < nextOrdinal; i++) {
-                int x = getBuilderX(i);
-                int y = getBuilderY(i);
-                size += zigzagVLongSize(x - prevX);
-                size += zigzagVLongSize(y - prevY);
-                prevX = x;
-                prevY = y;
-            }
-            return size;
-        }
-
-        private void writeBitPacked(StreamOutput out) throws IOException {
-            int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
-            int minY = Integer.MAX_VALUE, maxY = Integer.MIN_VALUE;
-            for (int i = 0; i < nextOrdinal; i++) {
-                int x = getBuilderX(i);
-                int y = getBuilderY(i);
-                minX = Math.min(minX, x);
-                maxX = Math.max(maxX, x);
-                minY = Math.min(minY, y);
-                maxY = Math.max(maxY, y);
-            }
-
-            int bitsPerX = bitsNeeded(Integer.toUnsignedLong(maxX - minX));
-            int bitsPerY = bitsNeeded(Integer.toUnsignedLong(maxY - minY));
-
-            out.writeInt(minX);
-            out.writeInt(minY);
-            out.writeByte((byte) bitsPerX);
-            out.writeByte((byte) bitsPerY);
-
-            long buffer = 0;
-            int bitsInBuffer = 0;
-            for (int i = 0; i < nextOrdinal; i++) {
-                int relX = getBuilderX(i) - minX;
-                int relY = getBuilderY(i) - minY;
-
-                buffer = (buffer << bitsPerX) | (Integer.toUnsignedLong(relX) & mask(bitsPerX));
-                bitsInBuffer += bitsPerX;
-                while (bitsInBuffer >= 8) {
-                    bitsInBuffer -= 8;
-                    out.writeByte((byte) (buffer >>> bitsInBuffer));
-                }
-
-                buffer = (buffer << bitsPerY) | (Integer.toUnsignedLong(relY) & mask(bitsPerY));
-                bitsInBuffer += bitsPerY;
-                while (bitsInBuffer >= 8) {
-                    bitsInBuffer -= 8;
-                    out.writeByte((byte) (buffer >>> bitsInBuffer));
-                }
-            }
-            if (bitsInBuffer > 0) {
-                out.writeByte((byte) (buffer << (8 - bitsInBuffer)));
-            }
-        }
-
-        private void writeDeltaEncoded(StreamOutput out) throws IOException {
-            int prevX = 0;
-            int prevY = 0;
-            for (int i = 0; i < nextOrdinal; i++) {
-                int x = getBuilderX(i);
-                int y = getBuilderY(i);
-                out.writeZLong(x - prevX);
-                out.writeZLong(y - prevY);
-                prevX = x;
-                prevY = y;
-            }
-        }
-
-        private int getBuilderX(int ordinal) {
-            return readIntBE(vertexData, ordinal * BYTES_PER_VERTEX);
-        }
-
-        private int getBuilderY(int ordinal) {
-            return readIntBE(vertexData, ordinal * BYTES_PER_VERTEX + 4);
+            out.writeBytes(vertexData, 0, nextOrdinal * BYTES_PER_VERTEX);
         }
 
         private static long packCoordinates(int x, int y) {
             return ((long) x << 32) | (y & 0xFFFFFFFFL);
         }
-    }
-
-    static int bitsNeeded(long unsignedRange) {
-        if (unsignedRange == 0) return 0;
-        return 64 - Long.numberOfLeadingZeros(unsignedRange);
-    }
-
-    static int zigzagVLongSize(int delta) {
-        long zigzag = (((long) delta) << 1) ^ (((long) delta) >> 63);
-        return (70 - Long.numberOfLeadingZeros(zigzag | 1L)) / 7;
-    }
-
-    /** Reads a big-endian int from the byte array at the given offset. */
-    private static int readIntBE(byte[] bytes, int offset) {
-        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8) | (bytes[offset + 3]
-            & 0xFF);
-    }
-
-    /** Writes a big-endian int into the byte array at the given offset. */
-    private static void writeIntBE(byte[] bytes, int offset, int value) {
-        bytes[offset] = (byte) (value >> 24);
-        bytes[offset + 1] = (byte) (value >> 16);
-        bytes[offset + 2] = (byte) (value >> 8);
-        bytes[offset + 3] = (byte) value;
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.spatial;
+
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A lookup table that stores unique vertex coordinates, each assigned a sequential ordinal.
+ * Both the triangle tree and the vertex connectivity structure reference vertices by ordinal
+ * instead of storing coordinate values directly. This deduplicates shared vertices (a vertex
+ * typically appears in ~6 adjacent triangles) and enables compact storage of the connectivity
+ * information needed to reconstruct the original geometry.
+ *
+ * Each entry is fixed-size (4 bytes x + 4 bytes y = 8 bytes), enabling O(1) random access
+ * by ordinal during triangle tree traversal.
+ */
+public class VertexLookupTable {
+
+    private final int[] xCoords;
+    private final int[] yCoords;
+
+    private VertexLookupTable(int[] xCoords, int[] yCoords) {
+        assert xCoords.length == yCoords.length;
+        this.xCoords = xCoords;
+        this.yCoords = yCoords;
+    }
+
+    /** Returns the encoded x-coordinate for the given vertex ordinal. */
+    public int getX(int ordinal) {
+        return xCoords[ordinal];
+    }
+
+    /** Returns the encoded y-coordinate for the given vertex ordinal. */
+    public int getY(int ordinal) {
+        return yCoords[ordinal];
+    }
+
+    /** Returns the number of unique vertices in the table. */
+    public int size() {
+        return xCoords.length;
+    }
+
+    /** Serializes the vertex table to the output stream. */
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(xCoords.length);
+        for (int i = 0; i < xCoords.length; i++) {
+            out.writeInt(xCoords[i]);
+            out.writeInt(yCoords[i]);
+        }
+    }
+
+    /** Reads a vertex table from the input stream, loading all vertices into arrays for fast random access. */
+    public static VertexLookupTable readFrom(ByteArrayStreamInput input) throws IOException {
+        int size = input.readVInt();
+        int[] x = new int[size];
+        int[] y = new int[size];
+        for (int i = 0; i < size; i++) {
+            x[i] = input.readInt();
+            y[i] = input.readInt();
+        }
+        return new VertexLookupTable(x, y);
+    }
+
+    /** Creates a new builder for constructing a vertex lookup table from triangle vertices. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder that collects unique vertices and assigns sequential ordinals.
+     * Uses a hash map keyed on the packed (x, y) coordinate pair to detect duplicates.
+     */
+    public static class Builder {
+        private final Map<Long, Integer> coordToOrdinal = new HashMap<>();
+        private int nextOrdinal = 0;
+        private int[] xCoords = new int[64];
+        private int[] yCoords = new int[64];
+
+        /**
+         * Adds a vertex to the table. If the vertex already exists, returns its existing ordinal.
+         * Otherwise assigns a new sequential ordinal and returns it.
+         */
+        public int addVertex(int x, int y) {
+            long key = packCoordinates(x, y);
+            Integer existing = coordToOrdinal.get(key);
+            if (existing != null) {
+                return existing;
+            }
+            int ordinal = nextOrdinal++;
+            if (ordinal >= xCoords.length) {
+                int newSize = xCoords.length * 2;
+                xCoords = Arrays.copyOf(xCoords, newSize);
+                yCoords = Arrays.copyOf(yCoords, newSize);
+            }
+            xCoords[ordinal] = x;
+            yCoords[ordinal] = y;
+            coordToOrdinal.put(key, ordinal);
+            return ordinal;
+        }
+
+        /**
+         * Looks up the ordinal for a vertex with the given encoded coordinates.
+         * Returns -1 if no such vertex exists in the table.
+         */
+        public int getOrdinal(int x, int y) {
+            long key = packCoordinates(x, y);
+            Integer ordinal = coordToOrdinal.get(key);
+            return ordinal != null ? ordinal : -1;
+        }
+
+        /** Returns the number of unique vertices added so far. */
+        public int size() {
+            return nextOrdinal;
+        }
+
+        /** Builds an immutable {@link VertexLookupTable} from the collected vertices. */
+        public VertexLookupTable build() {
+            return new VertexLookupTable(
+                Arrays.copyOf(xCoords, nextOrdinal),
+                Arrays.copyOf(yCoords, nextOrdinal)
+            );
+        }
+
+        private static long packCoordinates(int x, int y) {
+            return ((long) x << 32) | (y & 0xFFFFFFFFL);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/VertexLookupTable.java
@@ -128,10 +128,7 @@ public class VertexLookupTable {
 
         /** Builds an immutable {@link VertexLookupTable} from the collected vertices. */
         public VertexLookupTable build() {
-            return new VertexLookupTable(
-                Arrays.copyOf(xCoords, nextOrdinal),
-                Arrays.copyOf(yCoords, nextOrdinal)
-            );
+            return new VertexLookupTable(Arrays.copyOf(xCoords, nextOrdinal), Arrays.copyOf(yCoords, nextOrdinal));
         }
 
         private static long packCoordinates(int x, int y) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
@@ -131,7 +131,7 @@ public class AbstractShapeGeometryFieldMapperTests extends ESTestCase {
             try (var iw = new IndexWriter(directory, new IndexWriterConfig(null /* analyzer */))) {
                 for (Geometry geometry : geometries) {
                     var shape = new BinaryShapeDocValuesField("field", encoder);
-                    shape.add(indexerFactory.apply("field").indexShape(geometry), geometry);
+                    shape.add(indexerFactory.apply("field").indexShape(geometry), geometry, geometry);
                     var doc = new Document();
                     doc.add(shape);
                     iw.addDocument(doc);

--- a/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
@@ -131,7 +131,7 @@ public class AbstractShapeGeometryFieldMapperTests extends ESTestCase {
             try (var iw = new IndexWriter(directory, new IndexWriterConfig(null /* analyzer */))) {
                 for (Geometry geometry : geometries) {
                     var shape = new BinaryShapeDocValuesField("field", encoder);
-                    shape.add(indexerFactory.apply("field").indexShape(geometry), geometry, geometry);
+                    shape.add(indexerFactory.apply("field").indexShape(geometry), geometry);
                     var doc = new Document();
                     doc.add(shape);
                     iw.addDocument(doc);

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
@@ -72,7 +72,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
             document.add(field);
         }
         BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.CARTESIAN);
-        docVal.add(fields, geometry);
+        docVal.add(fields, geometry, geometry);
         document.add(docVal);
         w.addDocument(document);
         w.flush();
@@ -117,7 +117,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry);
+            docVal.add(fields, geometry, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }
@@ -159,7 +159,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry);
+            docVal.add(fields, geometry, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
@@ -72,7 +72,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
             document.add(field);
         }
         BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.CARTESIAN);
-        docVal.add(fields, geometry, geometry);
+        docVal.add(fields, geometry);
         document.add(docVal);
         w.addDocument(document);
         w.flush();
@@ -117,7 +117,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry, geometry);
+            docVal.add(fields, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }
@@ -159,7 +159,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry, geometry);
+            docVal.add(fields, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
@@ -72,7 +72,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
             document.add(field);
         }
         BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-        docVal.add(fields, geometry);
+        docVal.add(fields, geometry, geometry);
         document.add(docVal);
         w.addDocument(document);
         w.flush();
@@ -117,7 +117,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry);
+            docVal.add(fields, geometry, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }
@@ -159,7 +159,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry);
+            docVal.add(fields, geometry, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
@@ -72,7 +72,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
             document.add(field);
         }
         BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-        docVal.add(fields, geometry, geometry);
+        docVal.add(fields, geometry);
         document.add(docVal);
         w.addDocument(document);
         w.flush();
@@ -117,7 +117,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry, geometry);
+            docVal.add(fields, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }
@@ -159,7 +159,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
                 doc.add(field);
             }
             BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.GEO);
-            docVal.add(fields, geometry, geometry);
+            docVal.add(fields, geometry);
             doc.add(docVal);
             w.addDocument(doc);
         }

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -95,13 +95,14 @@ public class TriangleTreeTests extends ESTestCase {
     }
 
     public void testExtentDoesNotLoadVertexTable() throws IOException {
-        Point point = new Point(5.0, 10.0);
+        // Use a polygon (not a point) since write() auto-selects legacy for points
+        Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
-        Geometry normalized = indexer.normalize(point);
+        Geometry normalized = indexer.normalize(polygon);
         List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
 
         CentroidCalculator centroidCalculator = new CentroidCalculator();
-        centroidCalculator.add(point);
+        centroidCalculator.add(polygon);
 
         BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
 
@@ -121,6 +122,54 @@ public class TriangleTreeTests extends ESTestCase {
         assertNotNull(extent);
     }
 
+    public void testPointAutoSelectsLegacyFormat() throws IOException {
+        Point point = new Point(5.0, 10.0);
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(point);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(point);
+
+        // write() should auto-select legacy format for points
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(bytesRef);
+
+        assertFalse(reader.isV2Format());
+        assertThat(reader.getDimensionalShapeType(), equalTo(DimensionalShapeType.POINT));
+
+        // Geometry reconstruction should still work via tree traversal
+        Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+        assertNotNull(reconstructed);
+        assertThat(reconstructed.type(), equalTo(normalized.type()));
+    }
+
+    public void testMultiPointAutoSelectsLegacyFormat() throws IOException {
+        MultiPoint multiPoint = new MultiPoint(List.of(new Point(0, 0), new Point(5, 5), new Point(10, 10)));
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(multiPoint);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(multiPoint);
+
+        // write() should auto-select legacy format for multipoints
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(bytesRef);
+
+        assertFalse(reader.isV2Format());
+        assertThat(reader.getDimensionalShapeType(), equalTo(DimensionalShapeType.POINT));
+
+        // Geometry reconstruction should produce a MultiPoint with all 3 points
+        Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+        assertNotNull(reconstructed);
+        assertThat(reconstructed.type(), equalTo(normalized.type()));
+    }
+
     public void testFullDocValueRoundTrip() throws IOException {
         Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
@@ -130,8 +179,8 @@ public class TriangleTreeTests extends ESTestCase {
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(polygon);
 
-        // Write V2 format
-        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        // Write V2 format explicitly (write() also selects V2 for polygons, but be explicit)
+        BytesRef bytesRef = GeometryDocValueWriter.writeV2(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
 
         // Read and verify
         GeometryDocValueReader reader = new GeometryDocValueReader();
@@ -259,8 +308,13 @@ public class TriangleTreeTests extends ESTestCase {
         reader.visit(counter);
         assertThat(counter.counter, equalTo(fieldList.size()));
 
-        // Geometry reconstruction not available for legacy format
-        assertThat(reader.getGeometry(CoordinateEncoder.GEO), nullValue());
+        // Geometry reconstruction: available for POINT type (from tree), null for others
+        Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+        if (reader.getDimensionalShapeType() == DimensionalShapeType.POINT) {
+            assertNotNull(reconstructed);
+        } else {
+            assertThat(reconstructed, nullValue());
+        }
     }
 
     public void testLegacyAndV2ProduceSameTriangles() throws IOException {

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -122,7 +122,7 @@ public class TriangleTreeTests extends ESTestCase {
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(polygon);
 
-        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(polygon));
 
         GeometryDocValueReader reader = new GeometryDocValueReader();
         reader.reset(bytesRef);
@@ -150,7 +150,7 @@ public class TriangleTreeTests extends ESTestCase {
         centroidCalculator.add(point);
 
         // write() should auto-select legacy format for points
-        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(point));
 
         GeometryDocValueReader reader = new GeometryDocValueReader();
         reader.reset(bytesRef);
@@ -174,7 +174,7 @@ public class TriangleTreeTests extends ESTestCase {
         centroidCalculator.add(multiPoint);
 
         // write() should auto-select legacy format for multipoints
-        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(multiPoint));
 
         GeometryDocValueReader reader = new GeometryDocValueReader();
         reader.reset(bytesRef);
@@ -198,7 +198,7 @@ public class TriangleTreeTests extends ESTestCase {
         centroidCalculator.add(polygon);
 
         // Write V2 format explicitly (write() also selects V2 for polygons, but be explicit)
-        BytesRef bytesRef = GeometryDocValueWriter.writeV2(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef bytesRef = GeometryDocValueWriter.writeV2(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(polygon));
 
         // Read and verify
         GeometryDocValueReader reader = new GeometryDocValueReader();
@@ -247,7 +247,7 @@ public class TriangleTreeTests extends ESTestCase {
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
 
-        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(geometry));
 
         GeometryDocValueReader reader = new GeometryDocValueReader();
         reader.reset(bytesRef);
@@ -256,7 +256,7 @@ public class TriangleTreeTests extends ESTestCase {
         assertNotNull(reconstructed);
 
         // Verify the reconstructed geometry has the same type
-        assertThat(reconstructed.type(), equalTo(normalized.type()));
+        assertThat(reconstructed.type(), equalTo(geometry.type()));
     }
 
     // ---- Legacy format backward compatibility tests ----
@@ -346,7 +346,7 @@ public class TriangleTreeTests extends ESTestCase {
 
         // Write both formats
         BytesRef legacyBytes = GeometryDocValueWriter.writeLegacy(fieldList, CoordinateEncoder.GEO, centroidCalculator);
-        BytesRef v2Bytes = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+        BytesRef v2Bytes = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(polygon));
 
         GeometryDocValueReader legacyReader = new GeometryDocValueReader();
         legacyReader.reset(legacyBytes);

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -54,7 +54,7 @@ public class TriangleTreeTests extends ESTestCase {
         int treeLength = input.readVInt();
         int treeStart = input.getPosition();
         input.skipBytes(treeLength);
-        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
 
         input.setPosition(treeStart);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
@@ -105,7 +105,7 @@ public class TriangleTreeTests extends ESTestCase {
         Extent.readFromCompressed(input, extent);
         int treeLength = input.readVInt();
         input.skipBytes(treeLength);
-        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
         assertThat(vertexTable.size(), equalTo(4));
 
         // Should have at least 2 triangles

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -16,6 +16,11 @@ import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
 
@@ -23,25 +28,278 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.nullValue;
 
 public class TriangleTreeTests extends ESTestCase {
 
     public void testVisitAllTriangles() throws IOException {
         Geometry geometry = GeometryTestUtils.randomGeometryWithoutCircle(randomIntBetween(1, 10), false);
-        // write tree
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
-        List<IndexableField> fieldList = indexer.indexShape(geometry);
+        Geometry normalized = indexer.normalize(geometry);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        // Write using V2 format: vertex table + ordinal-based tree
+        VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
         BytesStreamOutput output = new BytesStreamOutput();
-        TriangleTreeWriter.writeTo(output, fieldList);
-        // read tree
+        TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
+        VertexLookupTable vertexTable = vtBuilder.build();
+
+        // Read tree
         ByteArrayStreamInput input = new ByteArrayStreamInput();
         BytesRef bytesRef = output.bytes().toBytesRef();
         input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         Extent extent = new Extent();
         Extent.readFromCompressed(input, extent);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
-        TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY());
+        TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY(), vertexTable);
         assertThat(fieldList.size(), equalTo(visitor.counter));
+    }
+
+    public void testVisitAllTrianglesLegacy() throws IOException {
+        Geometry geometry = GeometryTestUtils.randomGeometryWithoutCircle(randomIntBetween(1, 10), false);
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(geometry);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        // Write using legacy format: coordinate deltas
+        BytesStreamOutput output = new BytesStreamOutput();
+        TriangleTreeWriter.writeLegacy(output, fieldList);
+
+        // Read tree
+        ByteArrayStreamInput input = new ByteArrayStreamInput();
+        BytesRef bytesRef = output.bytes().toBytesRef();
+        input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        Extent extent = new Extent();
+        Extent.readFromCompressed(input, extent);
+        TriangleCounterVisitor visitor = new TriangleCounterVisitor();
+        TriangleTreeReader.visitLegacy(input, visitor, extent.maxX(), extent.maxY());
+        assertThat(fieldList.size(), equalTo(visitor.counter));
+    }
+
+    public void testVertexDeduplication() throws IOException {
+        // A polygon with 4 vertices tessellates into 2 triangles sharing 2 vertices
+        Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 1, 1, 0, 0 }, new double[] { 0, 0, 1, 1, 0 }));
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        List<IndexableField> fieldList = indexer.indexShape(polygon);
+
+        VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
+        BytesStreamOutput output = new BytesStreamOutput();
+        TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
+        VertexLookupTable vertexTable = vtBuilder.build();
+
+        // Square has 4 unique vertices, regardless of how many triangles reference them
+        assertThat(vertexTable.size(), equalTo(4));
+        // Should have at least 2 triangles
+        assertThat(fieldList.size(), greaterThan(1));
+    }
+
+    public void testExtentDoesNotLoadVertexTable() throws IOException {
+        Point point = new Point(5.0, 10.0);
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(point);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(point);
+
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(bytesRef);
+
+        assertTrue(reader.isV2Format());
+
+        // Reading centroid should work without loading anything extra
+        assertNotEquals(0, reader.getCentroidX());
+        assertNotEquals(0, reader.getCentroidY());
+        assertNotNull(reader.getDimensionalShapeType());
+        assertNotEquals(0.0, reader.getSumCentroidWeight());
+
+        // Reading extent should work without loading vertex table
+        Extent extent = reader.getExtent();
+        assertNotNull(extent);
+    }
+
+    public void testFullDocValueRoundTrip() throws IOException {
+        Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(polygon);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(polygon);
+
+        // Write V2 format
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        // Read and verify
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(bytesRef);
+
+        assertTrue(reader.isV2Format());
+
+        // Verify centroid is readable
+        assertNotEquals(0, reader.getCentroidX());
+        assertNotEquals(0, reader.getCentroidY());
+
+        // Verify extent is readable
+        Extent extent = reader.getExtent();
+        assertNotNull(extent);
+
+        // Verify triangle tree is visitable
+        TriangleCounterVisitor counter = new TriangleCounterVisitor();
+        reader.visit(counter);
+        assertThat(counter.counter, equalTo(fieldList.size()));
+
+        // Verify geometry reconstruction
+        Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+        assertNotNull(reconstructed);
+    }
+
+    public void testPointRoundTrip() throws IOException {
+        Point point = new Point(5.0, 10.0);
+        verifyGeometryRoundTrip(point);
+    }
+
+    public void testLineRoundTrip() throws IOException {
+        Line line = new Line(new double[] { 0, 5, 10 }, new double[] { 0, 5, 0 });
+        verifyGeometryRoundTrip(line);
+    }
+
+    public void testMultiPointRoundTrip() throws IOException {
+        MultiPoint multiPoint = new MultiPoint(List.of(new Point(0, 0), new Point(5, 5), new Point(10, 10)));
+        verifyGeometryRoundTrip(multiPoint);
+    }
+
+    private void verifyGeometryRoundTrip(Geometry geometry) throws IOException {
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(geometry);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(geometry);
+
+        BytesRef bytesRef = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(bytesRef);
+
+        Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+        assertNotNull(reconstructed);
+
+        // Verify the reconstructed geometry has the same type
+        assertThat(reconstructed.type(), equalTo(normalized.type()));
+    }
+
+    // ---- Legacy format backward compatibility tests ----
+
+    public void testLegacyFormatBackwardCompatibility() throws IOException {
+        Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(polygon);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(polygon);
+
+        // Write in legacy format
+        BytesRef legacyBytes = GeometryDocValueWriter.writeLegacy(fieldList, CoordinateEncoder.GEO, centroidCalculator);
+
+        // Read with the new reader
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(legacyBytes);
+
+        // Should detect as legacy format
+        assertFalse(reader.isV2Format());
+
+        // Centroid should be readable
+        assertNotEquals(0, reader.getCentroidX());
+        assertNotEquals(0, reader.getCentroidY());
+
+        // DimensionalShapeType should be readable (high bit is stripped)
+        assertThat(reader.getDimensionalShapeType(), equalTo(DimensionalShapeType.POLYGON));
+
+        // Extent should be readable
+        Extent extent = reader.getExtent();
+        assertNotNull(extent);
+
+        // Triangle tree should be visitable using legacy reader path
+        TriangleCounterVisitor counter = new TriangleCounterVisitor();
+        reader.visit(counter);
+        assertThat(counter.counter, equalTo(fieldList.size()));
+
+        // Geometry reconstruction should return null for legacy format
+        assertThat(reader.getGeometry(CoordinateEncoder.GEO), nullValue());
+    }
+
+    public void testLegacyFormatRandomGeometries() throws IOException {
+        Geometry geometry = GeometryTestUtils.randomGeometryWithoutCircle(randomIntBetween(1, 10), false);
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(geometry);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(geometry);
+
+        // Write in legacy format using production code
+        BytesRef legacyBytes = GeometryDocValueWriter.writeLegacy(fieldList, CoordinateEncoder.GEO, centroidCalculator);
+
+        // Read with the new reader
+        GeometryDocValueReader reader = new GeometryDocValueReader();
+        reader.reset(legacyBytes);
+
+        assertFalse(reader.isV2Format());
+
+        // Extent should be readable
+        assertNotNull(reader.getExtent());
+
+        // Tree should be visitable
+        TriangleCounterVisitor counter = new TriangleCounterVisitor();
+        reader.visit(counter);
+        assertThat(counter.counter, equalTo(fieldList.size()));
+
+        // Geometry reconstruction not available for legacy format
+        assertThat(reader.getGeometry(CoordinateEncoder.GEO), nullValue());
+    }
+
+    public void testLegacyAndV2ProduceSameTriangles() throws IOException {
+        Polygon polygon = new Polygon(new LinearRing(new double[] { 0, 10, 10, 0, 0 }, new double[] { 0, 0, 10, 10, 0 }));
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(polygon);
+        List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
+
+        CentroidCalculator centroidCalculator = new CentroidCalculator();
+        centroidCalculator.add(polygon);
+
+        // Write both formats
+        BytesRef legacyBytes = GeometryDocValueWriter.writeLegacy(fieldList, CoordinateEncoder.GEO, centroidCalculator);
+        BytesRef v2Bytes = GeometryDocValueWriter.write(fieldList, CoordinateEncoder.GEO, centroidCalculator, List.of(normalized));
+
+        GeometryDocValueReader legacyReader = new GeometryDocValueReader();
+        legacyReader.reset(legacyBytes);
+
+        GeometryDocValueReader v2Reader = new GeometryDocValueReader();
+        v2Reader.reset(v2Bytes);
+
+        // Both should have same centroid
+        assertThat(legacyReader.getCentroidX(), equalTo(v2Reader.getCentroidX()));
+        assertThat(legacyReader.getCentroidY(), equalTo(v2Reader.getCentroidY()));
+
+        // Both should have same extent
+        Extent legacyExtent = legacyReader.getExtent();
+        Extent v2Extent = v2Reader.getExtent();
+        assertThat(legacyExtent.minX(), equalTo(v2Extent.minX()));
+        assertThat(legacyExtent.maxX(), equalTo(v2Extent.maxX()));
+        assertThat(legacyExtent.minY(), equalTo(v2Extent.minY()));
+        assertThat(legacyExtent.maxY(), equalTo(v2Extent.maxY()));
+
+        // Both should visit the same number of triangles
+        TriangleCounterVisitor legacyCounter = new TriangleCounterVisitor();
+        legacyReader.visit(legacyCounter);
+        TriangleCounterVisitor v2Counter = new TriangleCounterVisitor();
+        v2Reader.visit(v2Counter);
+        assertThat(legacyCounter.counter, equalTo(v2Counter.counter));
     }
 
     private static class TriangleCounterVisitor implements TriangleTreeVisitor {

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -42,7 +42,7 @@ public class TriangleTreeTests extends ESTestCase {
         // Write using V2 format: tree + vertex table
         VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
         BytesStreamOutput output = new BytesStreamOutput();
-        TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
+        V2TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
         vtBuilder.writeTo(output);
 
         // Read tree (extent → treeLength → tree) then vertex table
@@ -58,7 +58,7 @@ public class TriangleTreeTests extends ESTestCase {
 
         input.setPosition(treeStart);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
-        TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY(), vertexTable);
+        V2TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY(), vertexTable);
         assertThat(fieldList.size(), equalTo(visitor.counter));
     }
 
@@ -70,7 +70,7 @@ public class TriangleTreeTests extends ESTestCase {
 
         // Write using legacy format: coordinate deltas
         BytesStreamOutput output = new BytesStreamOutput();
-        TriangleTreeWriter.writeLegacy(output, fieldList);
+        TriangleTreeWriter.writeTo(output, fieldList);
 
         // Read tree
         ByteArrayStreamInput input = new ByteArrayStreamInput();
@@ -79,7 +79,7 @@ public class TriangleTreeTests extends ESTestCase {
         Extent extent = new Extent();
         Extent.readFromCompressed(input, extent);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
-        TriangleTreeReader.visitLegacy(input, visitor, extent.maxX(), extent.maxY());
+        TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY());
         assertThat(fieldList.size(), equalTo(visitor.counter));
     }
 
@@ -91,7 +91,7 @@ public class TriangleTreeTests extends ESTestCase {
 
         VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
         BytesStreamOutput output = new BytesStreamOutput();
-        TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
+        V2TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
 
         // Builder should have 4 unique vertices, regardless of how many triangles reference them
         assertThat(vtBuilder.size(), equalTo(4));

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -39,19 +39,24 @@ public class TriangleTreeTests extends ESTestCase {
         Geometry normalized = indexer.normalize(geometry);
         List<IndexableField> fieldList = indexer.getIndexableFields(normalized);
 
-        // Write using V2 format: vertex table + ordinal-based tree
+        // Write using V2 format: tree + vertex table
         VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
         BytesStreamOutput output = new BytesStreamOutput();
         TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
-        VertexLookupTable vertexTable = vtBuilder.build();
+        vtBuilder.writeTo(output);
 
-        // Read tree (extent → treeLength → tree)
+        // Read tree (extent → treeLength → tree) then vertex table
         ByteArrayStreamInput input = new ByteArrayStreamInput();
         BytesRef bytesRef = output.bytes().toBytesRef();
         input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         Extent extent = new Extent();
         Extent.readFromCompressed(input, extent);
-        input.readVInt(); // skip tree length
+        int treeLength = input.readVInt();
+        int treeStart = input.getPosition();
+        input.skipBytes(treeLength);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
+
+        input.setPosition(treeStart);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
         TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY(), vertexTable);
         assertThat(fieldList.size(), equalTo(visitor.counter));
@@ -87,10 +92,22 @@ public class TriangleTreeTests extends ESTestCase {
         VertexLookupTable.Builder vtBuilder = VertexLookupTable.builder();
         BytesStreamOutput output = new BytesStreamOutput();
         TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
-        VertexLookupTable vertexTable = vtBuilder.build();
 
-        // Square has 4 unique vertices, regardless of how many triangles reference them
+        // Builder should have 4 unique vertices, regardless of how many triangles reference them
+        assertThat(vtBuilder.size(), equalTo(4));
+
+        // Write the vertex table and read it back to verify the round-trip
+        vtBuilder.writeTo(output);
+        ByteArrayStreamInput input = new ByteArrayStreamInput();
+        BytesRef bytesRef = output.bytes().toBytesRef();
+        input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        Extent extent = new Extent();
+        Extent.readFromCompressed(input, extent);
+        int treeLength = input.readVInt();
+        input.skipBytes(treeLength);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
         assertThat(vertexTable.size(), equalTo(4));
+
         // Should have at least 2 triangles
         assertThat(fieldList.size(), greaterThan(1));
     }

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -54,7 +54,7 @@ public class TriangleTreeTests extends ESTestCase {
         int treeLength = input.readVInt();
         int treeStart = input.getPosition();
         input.skipBytes(treeLength);
-        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input);
 
         input.setPosition(treeStart);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
@@ -105,7 +105,7 @@ public class TriangleTreeTests extends ESTestCase {
         Extent.readFromCompressed(input, extent);
         int treeLength = input.readVInt();
         input.skipBytes(treeLength);
-        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input, bytesRef.bytes);
+        VertexLookupTable vertexTable = VertexLookupTable.readFrom(input);
         assertThat(vertexTable.size(), equalTo(4));
 
         // Should have at least 2 triangles

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/TriangleTreeTests.java
@@ -45,12 +45,13 @@ public class TriangleTreeTests extends ESTestCase {
         TriangleTreeWriter.writeTo(output, fieldList, vtBuilder);
         VertexLookupTable vertexTable = vtBuilder.build();
 
-        // Read tree
+        // Read tree (extent → treeLength → tree)
         ByteArrayStreamInput input = new ByteArrayStreamInput();
         BytesRef bytesRef = output.bytes().toBytesRef();
         input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         Extent extent = new Extent();
         Extent.readFromCompressed(input, extent);
+        input.readVInt(); // skip tree length
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
         TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY(), vertexTable);
         assertThat(fieldList.size(), equalTo(visitor.counter));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -421,6 +421,11 @@ public final class EsqlTestUtils {
         }
 
         @Override
+        public boolean supportsGeometryDocValueReconstruction(FieldName name) {
+            return true;
+        }
+
+        @Override
         public Map<ShardId, IndexMetadata> targetShards() {
             return Map.of();
         }
@@ -442,7 +447,8 @@ public final class EsqlTestUtils {
             EXISTS,
             INDEXED,
             DOC_VALUES,
-            EXACT_SUBFIELD
+            EXACT_SUBFIELD,
+            GEOMETRY_DOC_VALUE_RECONSTRUCTION
         }
 
         private final Map<Config, Set<String>> includes = new HashMap<>();
@@ -489,6 +495,11 @@ public final class EsqlTestUtils {
         @Override
         public boolean hasExactSubfield(FieldName field) {
             return isConfigationSet(Config.EXACT_SUBFIELD, field.string());
+        }
+
+        @Override
+        public boolean supportsGeometryDocValueReconstruction(FieldName field) {
+            return isConfigationSet(Config.GEOMETRY_DOC_VALUE_RECONSTRUCTION, field.string());
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-jts.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-jts.csv-spec
@@ -35,23 +35,24 @@ wkt:keyword | simplified:geo_point
 stSimplifyCityBoundaries
 required_capability: st_intersects
 required_capability: st_simplify
+required_capability: st_npoints
 
 // tag::st_simplify_city_boundaries[]
 FROM airport_city_boundaries
 | WHERE ST_INTERSECTS(city_location, TO_GEOSHAPE("POLYGON ((7.998 53.827, 9.470 53.068, 15.754 53.801, 16.523 57.160, 11.162 57.868, 8.064 57.445, 6.219 55.317, 7.998 53.827))"))
-| EVAL o_len = LENGTH(TO_STRING(city_boundary))
+| EVAL o_len = ST_NPOINTS(city_boundary)
 | EVAL city_boundary = ST_SIMPLIFY(city_boundary, 0.05)
-| EVAL s_len = LENGTH(TO_STRING(city_boundary))
+| EVAL s_len = ST_NPOINTS(city_boundary)
 | SORT city
 | KEEP city, o_len, s_len, city_boundary
 // end::st_simplify_city_boundaries[]
 ;
 
 // tag::st_simplify_city_boundaries-result[]
-city:keyword | o_len:i | s_len:i | city_boundary:geo_shape
-Copenhagen   | 265     | 76      | POLYGON ((12.453 55.7122, 12.5332 55.6318, 12.6398 55.7224, 12.453 55.7122))
-Gothenburg   | 112     | 78      | POLYGON ((11.8941 57.6889, 12.0885 57.6823, 12.0541 57.7338, 11.8941 57.6889))
-Norderstedt  | 221     | 75      | POLYGON ((9.9348 53.6785, 10.0729 53.7097, 9.9833 53.7595, 9.9348 53.6785))
+city:keyword | o_len:integer | s_len:integer | city_boundary:geo_shape
+Copenhagen   | 15            | 4             | POLYGON ((12.45299999602139 55.71219999343157, 12.533199973404408 55.63179998192936, 12.639799928292632 55.72239997331053, 12.45299999602139 55.71219999343157))
+Gothenburg   | 6             | 4             | POLYGON ((11.894099973142147 57.68889998551458, 12.088499944657087 57.68229999113828, 12.054099943488836 57.73379999678582, 11.894099973142147 57.68889998551458))
+Norderstedt  | 13            | 4             | POLYGON ((9.934799931943417 53.678499958477914, 10.072899917140603 53.70969995856285, 9.983299970626831 53.759499988518655, 9.934799931943417 53.678499958477914))
 // end::st_simplify_city_boundaries-result[]
 ;
 
@@ -124,8 +125,8 @@ ROW wkt = ["POINT(-97.11 95.53)", "POINT(80.93 72.77)"]
 ;
 
 result:cartesian_point
-POINT (-97.11 95.53)
-POINT (80.93 72.77)
+POINT (-97.11000061035156 95.52999877929688)
+POINT (80.93000030517578 72.7699966430664)
 ;
 
 stSimplifyCartesianShape
@@ -139,7 +140,7 @@ ROW wkt = ["POINT(97.11 75.53)", "POLYGON((0 0, 1 0.1, 2 0, 2 2, 1 1.9, 0 2, 0 0
 ;
 
 result:cartesian_shape
-POINT (97.11 75.53)
+POINT (97.11000061035156 75.52999877929688)
 POLYGON ((0.0 0.0, 2.0 0.0, 2.0 2.0, 0.0 2.0, 0.0 0.0))
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
@@ -64,16 +64,18 @@ abbrev:keyword | name:text    | location:geo_shape                         | cou
 "VLC"          | "Valencia"   | POINT(-0.473474930771676 39.4914597884489) | "Spain"         | "Paterna"    | POINT(-0.4406 39.5028)
 ;
 
-simpleLoadFromCityBoundaries#[skip:-8.13.99, reason:chunked CSV import support added in 8.14]
+simpleLoadFromCityBoundaries
+required_capability: st_npoints
+
 FROM airport_city_boundaries
 | WHERE abbrev == "CPH"
-| EVAL boundary_wkt_length = LENGTH(TO_STRING(city_boundary))
-| KEEP abbrev, region, city_location, airport, boundary_wkt_length
+| EVAL boundary_length = ST_NPOINTS(city_boundary)
+| KEEP abbrev, region, city_location, airport, boundary_length
 | LIMIT 1
 ;
 
-abbrev:keyword  |  region:text         |  city_location:geo_point |  airport:text  |  boundary_wkt_length:integer
-CPH             |  Københavns Kommune  |  POINT(12.5683 55.6761)  |  Copenhagen    |  265
+abbrev:keyword  |  region:text         |  city_location:geo_point |  airport:text  |  boundary_length:integer
+CPH             |  Københavns Kommune  |  POINT(12.5683 55.6761)  |  Copenhagen    |  15
 ;
 
 ###############################################

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownShapeTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownShapeTestCase.java
@@ -544,6 +544,59 @@ public abstract class SpatialPushDownShapeTestCase extends SpatialPushDownTestCa
         }
     }
 
+    /**
+     * Test that ST_SIMPLIFY produces the same results whether reading from doc-values or from source.
+     * When the original field is not in the output (only the simplified result is), the optimizer should
+     * be able to read the geometry from doc-values for indexes that support it.
+     */
+    public void testStSimplifyWithAndWithoutDocValues() {
+        assumeTrue("Test for shapes only", fieldType().contains("shape"));
+        initIndexes();
+
+        String polygon1 = "POLYGON ((-5 -5, -5 5, 5 5, 5 -5, -5 -5))";
+        String polygon2 = "POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))";
+        String line1 = "LINESTRING (0 0, 1 1, 2 0, 3 1, 4 0)";
+
+        addToIndexes(0, "\"" + polygon1 + "\"", ALL_INDEXES);
+        addToIndexes(1, "\"" + polygon2 + "\"", ALL_INDEXES);
+        addToIndexes(2, "\"" + line1 + "\"", ALL_INDEXES);
+        refresh(ALL_INDEXES);
+
+        // Query that drops the original field and only keeps the simplified result.
+        // This allows the optimizer to read from doc-values when available.
+        List<String> queries = getQueries("""
+            FROM index | EVAL simplified = ST_SIMPLIFY(location, 1.0) | KEEP simplified | STATS c = COUNT(*)
+            """);
+        try (TestQueryResponseCollection responses = new TestQueryResponseCollection(queries)) {
+            long indexedCount = (long) responses.getResponse(0, 0);
+            assertThat("Expected 3 results from indexed", indexedCount, equalTo(3L));
+            for (int i = 1; i < ALL_INDEXES.length; i++) {
+                long otherCount = (long) responses.getResponse(i, 0);
+                assertEquals("ST_SIMPLIFY count mismatch for " + ALL_INDEXES[i], indexedCount, otherCount);
+            }
+        }
+
+        // Also verify that reading the actual simplified geometries works across doc-values and source-backed indexes.
+        // We use METADATA _id for deterministic per-document comparison.
+        for (String indexName : ALL_INDEXES) {
+            String query = String.format(Locale.ROOT, """
+                FROM %s METADATA _id | EVAL simplified = ST_SIMPLIFY(location, 1.0) | KEEP _id, simplified
+                """, indexName);
+            try (EsqlQueryResponse response = client().execute(EsqlQueryAction.INSTANCE, syncEsqlQueryRequest(query)).actionGet()) {
+                long rows = 0;
+                var idCol = response.response().column(0).iterator();
+                var simplifiedCol = response.response().column(1).iterator();
+                while (idCol.hasNext()) {
+                    Object id = idCol.next();
+                    Object simplified = simplifiedCol.next();
+                    assertNotNull("ST_SIMPLIFY result should not be null for id=" + id + " in " + indexName, simplified);
+                    rows++;
+                }
+                assertThat("Expected 3 rows from " + indexName, rows, equalTo(3L));
+            }
+        }
+    }
+
     @Override
     protected Geometry quantize(Geometry shape) {
         TestQuantizedGeometryVisitor visitor = new TestQuantizedGeometryVisitor();

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator.java
@@ -21,8 +21,8 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link StSimplify}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator implements EvalOperator.ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator.class);
+public final class StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator implements EvalOperator.ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator.class);
 
   private final Source source;
 
@@ -34,7 +34,7 @@ public final class StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator im
 
   private Warnings warnings;
 
-  public StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator(Source source,
+  public StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator(Source source,
       EvalOperator.ExpressionEvaluator geometry, double tolerance, DriverContext driverContext) {
     this.source = source;
     this.geometry = geometry;
@@ -68,7 +68,7 @@ public final class StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator im
           continue position;
         }
         try {
-          StSimplify.processNonFoldableGeometryAndConstantTolerance(result, p, geometryBlock, this.tolerance);
+          StSimplify.processCartesianShapeAndConstantTolerance(result, p, geometryBlock, this.tolerance);
         } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
@@ -80,7 +80,7 @@ public final class StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator im
 
   @Override
   public String toString() {
-    return "StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
+    return "StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
   }
 
   @Override
@@ -110,13 +110,14 @@ public final class StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator im
     }
 
     @Override
-    public StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator get(DriverContext context) {
-      return new StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator(source, geometry.get(context), tolerance, context);
+    public StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator get(
+        DriverContext context) {
+      return new StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator(source, geometry.get(context), tolerance, context);
     }
 
     @Override
     public String toString() {
-      return "StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
+      return "StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator.java
@@ -1,0 +1,122 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link StSimplify}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator implements EvalOperator.ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator.class);
+
+  private final Source source;
+
+  private final EvalOperator.ExpressionEvaluator geometry;
+
+  private final double tolerance;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator(Source source,
+      EvalOperator.ExpressionEvaluator geometry, double tolerance, DriverContext driverContext) {
+    this.source = source;
+    this.geometry = geometry;
+    this.tolerance = tolerance;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (BytesRefBlock geometryBlock = (BytesRefBlock) geometry.eval(page)) {
+      return eval(page.getPositionCount(), geometryBlock);
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += geometry.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BytesRefBlock eval(int positionCount, BytesRefBlock geometryBlock) {
+    try(BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        boolean allBlocksAreNulls = true;
+        if (!geometryBlock.isNull(p)) {
+          allBlocksAreNulls = false;
+        }
+        if (allBlocksAreNulls) {
+          result.appendNull();
+          continue position;
+        }
+        try {
+          StSimplify.processGeoShapeAndConstantTolerance(result, p, geometryBlock, this.tolerance);
+        } catch (IllegalArgumentException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(geometry);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory geometry;
+
+    private final double tolerance;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory geometry,
+        double tolerance) {
+      this.source = source;
+      this.geometry = geometry;
+      this.tolerance = tolerance;
+    }
+
+    @Override
+    public StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator get(DriverContext context) {
+      return new StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator(source, geometry.get(context), tolerance, context);
+    }
+
+    @Override
+    public String toString() {
+      return "StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator[" + "geometry=" + geometry + ", tolerance=" + tolerance + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
@@ -143,9 +143,7 @@ public class SpatialRelatesUtils {
             throw new IllegalArgumentException(ShapeType.CIRCLE + " geometry is not supported");
         }
         centroidCalculator.add(geometry);
-        reader.reset(
-            GeometryDocValueWriter.write(shapeIndexer.indexShape(geometry), encoder, centroidCalculator, List.of(geometry))
-        );
+        reader.reset(GeometryDocValueWriter.write(shapeIndexer.indexShape(geometry), encoder, centroidCalculator, List.of(geometry)));
         return reader;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
@@ -143,7 +143,9 @@ public class SpatialRelatesUtils {
             throw new IllegalArgumentException(ShapeType.CIRCLE + " geometry is not supported");
         }
         centroidCalculator.add(geometry);
-        reader.reset(GeometryDocValueWriter.write(shapeIndexer.indexShape(geometry), encoder, centroidCalculator));
+        reader.reset(
+            GeometryDocValueWriter.write(shapeIndexer.indexShape(geometry), encoder, centroidCalculator, List.of(geometry))
+        );
         return reader;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelope.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelope.java
@@ -122,12 +122,11 @@ public class StEnvelope extends SpatialUnaryDocValuesFunction {
             ? new SpatialEnvelopeResults.Factory<BytesRefBlock.Builder>(GEO, () -> new GeoPointVisitor(WRAP))
             : new SpatialEnvelopeResults.Factory<BytesRefBlock.Builder>(CARTESIAN, CartesianPointVisitor::new);
         var spatial = toEvaluator.apply(spatialField());
-        if (spatialDocValues) {
-            if (isSpatialPoint(spatialField().dataType())) {
-                return new StEnvelopeFromDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
-            }
-            throw new IllegalArgumentException("Cannot use doc values for type " + spatialField().dataType());
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
+            // Spatial points are converted to encoded longs
+            return new StEnvelopeFromDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
         }
+        // Spatial shapes from doc-values are extracted as re-constructed geometries, so we use the same evaluator as reading from source
         return new StEnvelopeFromWKBEvaluator.Factory(source(), spatial, resultsBuilder::get);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StNPoints.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StNPoints.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isSpatialPoint;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.UNSPECIFIED;
 
 /**
@@ -81,11 +82,11 @@ public class StNPoints extends SpatialUnaryDocValuesFunction {
 
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        if (spatialDocValues) {
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
             return new StNPointsFromPointDocValuesEvaluator.Factory(source(), toEvaluator.apply(spatialField()));
-        } else {
-            return new StNPointsFromWKBEvaluator.Factory(source(), toEvaluator.apply(spatialField()));
         }
+        // spatialDocValues for shapes is provided as WKB
+        return new StNPointsFromWKBEvaluator.Factory(source(), toEvaluator.apply(spatialField()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplify.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplify.java
@@ -156,7 +156,10 @@ public class StSimplify extends SpatialDocValuesFunction {
                 inputTolerance
             );
         }
-        return new StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator.Factory(source(), geometryEvaluator, inputTolerance);
+        // For WKB, we need to know if it is Geo or Cartesian to quantize the results to match Lucene grids
+        return DataType.isSpatialGeo(geometry.dataType())
+            ? new StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator.Factory(source(), geometryEvaluator, inputTolerance)
+            : new StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator.Factory(source(), geometryEvaluator, inputTolerance);
     }
 
     @Override
@@ -178,14 +181,24 @@ public class StSimplify extends SpatialDocValuesFunction {
         }
     }
 
-    @Evaluator(extraName = "NonFoldableGeometryAndFoldableTolerance", warnExceptions = { IllegalArgumentException.class })
-    static void processNonFoldableGeometryAndConstantTolerance(
+    @Evaluator(extraName = "NonFoldableGeoShapeAndFoldableTolerance", warnExceptions = { IllegalArgumentException.class })
+    static void processGeoShapeAndConstantTolerance(
         BytesRefBlock.Builder builder,
         @Position int p,
         BytesRefBlock geometry,
         @Fixed double tolerance
     ) {
-        processor.processGeometries(builder, p, geometry, tolerance);
+        geoProcessor.processGeometries(builder, p, geometry, tolerance);
+    }
+
+    @Evaluator(extraName = "NonFoldableCartesianShapeAndFoldableTolerance", warnExceptions = { IllegalArgumentException.class })
+    static void processCartesianShapeAndConstantTolerance(
+        BytesRefBlock.Builder builder,
+        @Position int p,
+        BytesRefBlock geometry,
+        @Fixed double tolerance
+    ) {
+        cartesianProcessor.processGeometries(builder, p, geometry, tolerance);
     }
 
     @Evaluator(
@@ -268,8 +281,20 @@ public class StSimplify extends SpatialDocValuesFunction {
                 builder.appendNull();
             } else {
                 final Geometry jtsGeometry = asJtsGeometry(left, p);
+                quantizeCoordinates(jtsGeometry);
                 Geometry simplifiedGeometry = DouglasPeuckerSimplifier.simplify(jtsGeometry, tolerance);
                 builder.appendBytesRef(UNSPECIFIED.jtsGeometryToWkb(simplifiedGeometry));
+            }
+        }
+
+        private void quantizeCoordinates(Geometry jtsGeometry) {
+            if (spatialCoordinateType != UNSPECIFIED) {
+                jtsGeometry.apply((org.locationtech.jts.geom.CoordinateFilter) coord -> {
+                    long encoded = spatialCoordinateType.pointAsLong(coord.x, coord.y);
+                    coord.x = spatialCoordinateType.decodeX(encoded);
+                    coord.y = spatialCoordinateType.decodeY(encoded);
+                });
+                jtsGeometry.geometryChanged();
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMax.java
@@ -96,15 +96,13 @@ public class StXMax extends SpatialUnaryDocValuesFunction {
             ? new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(GEO, () -> new GeoPointVisitor(WRAP))
             : new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(CARTESIAN, CartesianPointVisitor::new);
         var spatial = toEvaluator.apply(spatialField());
-        if (spatialDocValues) {
-            if (isSpatialPoint(spatialField().dataType())) {
-                // Cartesian: use linear optimization; Geo: use envelope visitor for longitude wrapping
-                return isSpatialGeo(spatialField().dataType())
-                    ? new StXMaxFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
-                    : new StXMaxFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
-            }
-            throw new IllegalArgumentException("Cannot use doc values for type " + spatialField().dataType());
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
+            // Cartesian: use linear optimization; Geo: use envelope visitor for longitude wrapping
+            return isSpatialGeo(spatialField().dataType())
+                ? new StXMaxFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
+                : new StXMaxFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
         }
+        // spatialDocValues for shapes is provided as WKB
         return new StXMaxFromWKBEvaluator.Factory(source(), spatial, resultsBuilder::get);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMin.java
@@ -96,15 +96,13 @@ public class StXMin extends SpatialUnaryDocValuesFunction {
             ? new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(GEO, () -> new GeoPointVisitor(WRAP))
             : new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(CARTESIAN, CartesianPointVisitor::new);
         var spatial = toEvaluator.apply(spatialField());
-        if (spatialDocValues) {
-            if (isSpatialPoint(spatialField().dataType())) {
-                // Cartesian: use linear optimization; Geo: use envelope visitor for longitude wrapping
-                return isSpatialGeo(spatialField().dataType())
-                    ? new StXMinFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
-                    : new StXMinFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
-            }
-            throw new IllegalArgumentException("Cannot use doc values for type " + spatialField().dataType());
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
+            // Cartesian: use linear optimization; Geo: use envelope visitor for longitude wrapping
+            return isSpatialGeo(spatialField().dataType())
+                ? new StXMinFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
+                : new StXMinFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
         }
+        // spatialDocValues for shapes is provided as WKB
         return new StXMinFromWKBEvaluator.Factory(source(), spatial, resultsBuilder::get);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMax.java
@@ -96,15 +96,13 @@ public class StYMax extends SpatialUnaryDocValuesFunction {
             ? new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(GEO, () -> new GeoPointVisitor(WRAP))
             : new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(CARTESIAN, CartesianPointVisitor::new);
         var spatial = toEvaluator.apply(spatialField());
-        if (spatialDocValues) {
-            if (isSpatialPoint(spatialField().dataType())) {
-                // Both use linear optimization with different decode functions
-                return isSpatialGeo(spatialField().dataType())
-                    ? new StYMaxFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
-                    : new StYMaxFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
-            }
-            throw new IllegalArgumentException("Cannot use doc values for type " + spatialField().dataType());
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
+            // Both use linear optimization with different decode functions
+            return isSpatialGeo(spatialField().dataType())
+                ? new StYMaxFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
+                : new StYMaxFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
         }
+        // spatialDocValues for shapes is provided as WKB
         return new StYMaxFromWKBEvaluator.Factory(source(), spatial, resultsBuilder::get);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMin.java
@@ -96,15 +96,13 @@ public class StYMin extends SpatialUnaryDocValuesFunction {
             ? new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(GEO, () -> new GeoPointVisitor(WRAP))
             : new SpatialEnvelopeResults.Factory<DoubleBlock.Builder>(CARTESIAN, CartesianPointVisitor::new);
         var spatial = toEvaluator.apply(spatialField());
-        if (spatialDocValues) {
-            if (isSpatialPoint(spatialField().dataType())) {
-                // Both use linear optimization with different decode functions
-                return isSpatialGeo(spatialField().dataType())
-                    ? new StYMinFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
-                    : new StYMinFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
-            }
-            throw new IllegalArgumentException("Cannot use doc values for type " + spatialField().dataType());
+        if (spatialDocValues && isSpatialPoint(spatialField().dataType())) {
+            // Both use linear optimization with different decode functions
+            return isSpatialGeo(spatialField().dataType())
+                ? new StYMinFromGeoDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get)
+                : new StYMinFromCartesianDocValuesEvaluator.Factory(source(), spatial, resultsBuilder::get);
         }
+        // spatialDocValues for shapes is provided as WKB
         return new StYMinFromWKBEvaluator.Factory(source(), spatial, resultsBuilder::get);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
@@ -78,6 +78,7 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Parameter
         if (foundAttributes.isEmpty()) {
             return planNode;
         }
+        log.debug("Updating plan to mark [{}] for doc-values field extraction", foundAttributes);
 
         return planNode.transformDown(UnaryExec.class, exec -> {
             if (exec instanceof AggregateExec agg) {
@@ -146,25 +147,38 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Parameter
 
     private Set<FieldAttribute> findAttributesFromAggregatesAndEvals(UnaryExec exec, LocalPhysicalOptimizerContext ctx) {
         var foundAttributes = new HashSet<FieldAttribute>();
-        // Search for STATS with spatial aggregations
+        // Search for STATS with spatial aggregations (shapes not allowed here; handled by SpatialShapeBoundsExtraction)
         exec.forEachDown(AggregateExec.class, agg -> {
             for (NamedExpression aggExpr : agg.aggregates()) {
                 if (aggExpr instanceof Alias as && as.child() instanceof SpatialAggregateFunction af) {
+                    log.debug("Checking spatial aggregation [{}] for applicable attributes", af);
                     if (af.field() instanceof FieldAttribute fieldAttribute
-                        && allowedForDocValues(fieldAttribute, ctx.searchStats(), agg, foundAttributes)) {
+                        && allowedForDocValues(fieldAttribute, ctx.searchStats(), agg, foundAttributes, false)) {
                         foundAttributes.add(fieldAttribute);
+                        log.debug(
+                            "Found attribute [{}] in spatial aggregation [{}] for doc-values extraction consideration",
+                            fieldAttribute,
+                            af
+                        );
                     }
                 }
             }
         });
-        // Search in EVALs for functions that can take doc values, namely St_Simplify, St_Geotile, St_Geohex, St_Geohash
+        // Search in EVALs for functions that can take doc values, namely St_Simplify, St_Geotile, St_Geohex, St_Geohash.
+        // Shapes are allowed here when the field supports geometry reconstruction from doc-values.
         exec.forEachDown(EvalExec.class, evalExec -> {
             for (Alias field : evalExec.fields()) {
                 field.forEachDown(SpatialDocValuesFunction.class, spatialFunction -> {
+                    log.debug("Checking spatial function [{}] for applicable attributes", spatialFunction);
                     if (spatialFunction.spatialField() instanceof FieldAttribute fieldAttribute
                         && spatialFunction.prefersDocValuesExtraction()
-                        && allowedForDocValues(fieldAttribute, ctx.searchStats(), exec, foundAttributes)) {
+                        && allowedForDocValues(fieldAttribute, ctx.searchStats(), exec, foundAttributes, true)) {
                         foundAttributes.add(fieldAttribute);
+                        log.debug(
+                            "Found attribute [{}] in spatial function [{}] for doc-values extraction consideration",
+                            fieldAttribute,
+                            spatialFunction
+                        );
                     }
                 });
             }
@@ -173,7 +187,10 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Parameter
         exec.output().forEach(attribute -> {
             if (attribute instanceof FieldAttribute fieldAttribute) {
                 // Any field that will be returned to the coordinator cannot be loaded from doc-values
-                foundAttributes.remove(fieldAttribute);
+                if (foundAttributes.contains(fieldAttribute)) {
+                    foundAttributes.remove(fieldAttribute);
+                    log.debug("Removed output table attribute [{}] from doc-values extraction consideration", fieldAttribute);
+                }
             }
         });
         return foundAttributes;
@@ -203,21 +220,26 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Parameter
     /**
      * This function disallows the use of more than one field for doc-values extraction in the same spatial relation function.
      * This is because comparing two doc-values fields is not supported in the current implementation.
-     * This also rejects fields that do not have doc-values in the field mapping, as well as rejecting geo_shape and cartesian_shape
-     * because we do not yet support full doc-values extraction for non-point geometries. We do have aggregations that support
-     * shapes, and to prevent them triggering this rule on non-point geometries we have to explicitly disallow them here.
+     * For point geometries, doc-values are always allowed. For shape geometries (geo_shape, cartesian_shape),
+     * doc-values are only allowed when {@code allowShapes} is true and the field's index supports geometry
+     * reconstruction from doc-values (V2 format).
      */
     private boolean allowedForDocValues(
         FieldAttribute fieldAttribute,
         SearchStats stats,
         UnaryExec exec,
-        Set<FieldAttribute> foundAttributes
+        Set<FieldAttribute> foundAttributes,
+        boolean allowShapes
     ) {
+        log.debug("Considering [{}]", fieldAttribute);
         if (stats.hasDocValues(fieldAttribute.fieldName()) == false) {
             return false;
         }
         if (fieldAttribute.dataType() == DataType.GEO_SHAPE || fieldAttribute.dataType() == DataType.CARTESIAN_SHAPE) {
-            return false;
+            if (allowShapes == false || stats.supportsGeometryDocValueReconstruction(fieldAttribute.fieldName()) == false) {
+                log.debug("Attribute [{}] does not support geometry reconstruction from doc-values", fieldAttribute);
+                return false;
+            }
         }
         var candidateDocValuesAttributes = new HashSet<>(foundAttributes);
         candidateDocValuesAttributes.add(fieldAttribute);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialShapeBoundsExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialShapeBoundsExtraction.java
@@ -54,6 +54,7 @@ public class SpatialShapeBoundsExtraction extends ParameterizedOptimizerRule<Agg
         if (foundAttributes.isEmpty()) {
             return aggregate;
         }
+        log.debug("Updating plan to mark [{}] for doc-values bounds extraction", foundAttributes);
         return aggregate.transformDown(PhysicalPlan.class, exec -> switch (exec) {
             case AggregateExec agg -> transformAggregateExec(agg, foundAttributes);
             case FieldExtractExec fieldExtractExec -> transformFieldExtractExec(fieldExtractExec, foundAttributes);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
 import org.elasticsearch.index.mapper.ConstantFieldType;
 import org.elasticsearch.index.mapper.DocCountFieldMapper.DocCountFieldType;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -456,6 +457,15 @@ public class SearchContextStats implements SearchStats {
     @Override
     public MappedFieldType fieldType(FieldName field) {
         return cache.computeIfAbsent(field.string(), this::makeFieldStats).config.fieldType;
+    }
+
+    @Override
+    public boolean supportsGeometryDocValueReconstruction(FieldName field) {
+        MappedFieldType type = fieldType(field);
+        if (type instanceof AbstractGeometryFieldMapper.AbstractGeometryFieldType<?> geoFieldType) {
+            return geoFieldType.supportsGeometryDocValueReconstruction();
+        }
+        return false;
     }
 
     private interface DocCountTester {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -66,6 +66,14 @@ public interface SearchStats {
     }
 
     /**
+     * Returns true if the field's doc-values support full geometry reconstruction. This is used by the
+     * optimizer to decide whether shape fields can be read from doc-values instead of source.
+     */
+    default boolean supportsGeometryDocValueReconstruction(FieldName name) {
+        return false;
+    }
+
+    /**
      * Returns the target shards and their index metadata.
      */
     Map<ShardId, IndexMetadata> targetShards();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyTests.java
@@ -152,10 +152,6 @@ public class StSimplifyTests extends AbstractScalarFunctionTestCase {
         // The evaluator quantizes coordinates for indexed fields, but fold() handles literals
         // where quantization doesn't apply. Recompute without quantization for the fold test.
         var data = testCase.getData();
-        if (testCase.getExpectedTypeError() != null || data.size() < 2) {
-            super.testFold();
-            return;
-        }
         Object geomData = data.get(0).data();
         Object tolData = data.get(1).data();
         if (geomData instanceof BytesRef wkb && tolData instanceof Number tol) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StSimplifyTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
@@ -30,6 +31,8 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
+import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
+import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.UNSPECIFIED;
 
 @FunctionName("st_simplify")
@@ -98,6 +101,7 @@ public class StSimplifyTests extends AbstractScalarFunctionTestCase {
         TestCaseSupplier.TypedDataSupplier geometrySupplier
     ) {
         String testName = spatialType.typeName() + " with tolerance.";
+        String evaluatorPrefix = evaluatorPrefix(spatialType);
 
         suppliers.add(new TestCaseSupplier(testName, List.of(spatialType, DOUBLE), () -> {
             TestCaseSupplier.TypedData geoTypedData = geometrySupplier.get();
@@ -105,10 +109,8 @@ public class StSimplifyTests extends AbstractScalarFunctionTestCase {
             double tolerance = randomDoubleBetween(0, 100, true);
             TestCaseSupplier.TypedData toleranceData = new TestCaseSupplier.TypedData(tolerance, DOUBLE, "tolerance");
             toleranceData = toleranceData.forceLiteral();
-            String evaluatorName = "StSimplifyNonFoldableGeometryAndFoldableToleranceEvaluator[geometry=Attribute[channel=0], tolerance="
-                + tolerance
-                + "]";
-            var expectedResult = valueOf(geometry, tolerance);
+            String evaluatorName = evaluatorPrefix + "[geometry=Attribute[channel=0], tolerance=" + tolerance + "]";
+            var expectedResult = valueOf(geometry, tolerance, spatialType);
 
             return new TestCaseSupplier.TestCase(
                 List.of(geoTypedData, toleranceData),
@@ -119,16 +121,64 @@ public class StSimplifyTests extends AbstractScalarFunctionTestCase {
         }));
     }
 
-    private static BytesRef valueOf(BytesRef wkb, double tolerance) {
+    private static String evaluatorPrefix(DataType spatialType) {
+        return DataType.isSpatialGeo(spatialType)
+            ? "StSimplifyNonFoldableGeoShapeAndFoldableToleranceEvaluator"
+            : "StSimplifyNonFoldableCartesianShapeAndFoldableToleranceEvaluator";
+    }
+
+    private static BytesRef valueOf(BytesRef wkb, double tolerance, DataType spatialType) {
         if (wkb == null) {
             return null;
         }
         try {
             org.locationtech.jts.geom.Geometry jtsGeometry = UNSPECIFIED.wkbToJtsGeometry(wkb);
+            SpatialCoordinateTypes coordType = DataType.isSpatialGeo(spatialType) ? GEO : CARTESIAN;
+            jtsGeometry.apply((org.locationtech.jts.geom.CoordinateFilter) coord -> {
+                long encoded = coordType.pointAsLong(coord.x, coord.y);
+                coord.x = coordType.decodeX(encoded);
+                coord.y = coordType.decodeY(encoded);
+            });
+            jtsGeometry.geometryChanged();
             org.locationtech.jts.geom.Geometry simplifiedGeometry = DouglasPeuckerSimplifier.simplify(jtsGeometry, tolerance);
             return UNSPECIFIED.jtsGeometryToWkb(simplifiedGeometry);
         } catch (Exception e) {
             throw new AssumptionViolatedException("Skipping invalid test case");
+        }
+    }
+
+    @Override
+    public void testFold() {
+        // The evaluator quantizes coordinates for indexed fields, but fold() handles literals
+        // where quantization doesn't apply. Recompute without quantization for the fold test.
+        var data = testCase.getData();
+        if (testCase.getExpectedTypeError() != null || data.size() < 2) {
+            super.testFold();
+            return;
+        }
+        Object geomData = data.get(0).data();
+        Object tolData = data.get(1).data();
+        if (geomData instanceof BytesRef wkb && tolData instanceof Number tol) {
+            BytesRef nonQuantized = valueOfNoQuantize(wkb, tol.doubleValue());
+            if (nonQuantized != null) {
+                testCase = new TestCaseSupplier.TestCase(
+                    data,
+                    testCase.evaluatorToString().toString(),
+                    testCase.expectedType(),
+                    Matchers.equalTo(nonQuantized)
+                );
+            }
+        }
+        super.testFold();
+    }
+
+    private static BytesRef valueOfNoQuantize(BytesRef wkb, double tolerance) {
+        try {
+            org.locationtech.jts.geom.Geometry jtsGeometry = UNSPECIFIED.wkbToJtsGeometry(wkb);
+            org.locationtech.jts.geom.Geometry simplifiedGeometry = DouglasPeuckerSimplifier.simplify(jtsGeometry, tolerance);
+            return UNSPECIFIED.jtsGeometryToWkb(simplifiedGeometry);
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -4511,6 +4511,103 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
+     * Test that ST_SIMPLIFY on a geo_shape field uses doc-values when available and the original field is not in the output.
+     * When the field IS in the output, doc-values cannot be used because the coordinator needs the original precision.
+     */
+    public void testSpatialSimplifyGeoShapeUsesDocValues() {
+        for (boolean keepShape : new boolean[] { false, true }) {
+            String query = """
+                FROM airport_city_boundaries
+                | EVAL simplified = ST_SIMPLIFY(city_boundary, 0.05)
+                | SORT airport
+                """ + (keepShape ? "| KEEP airport, simplified, city_boundary" : "| KEEP airport, simplified");
+            for (boolean withDocValues : new boolean[] { true, false }) {
+                withDocValues &= keepShape == false;
+                var fieldExtractPreference = withDocValues ? FieldExtractPreference.DOC_VALUES : FieldExtractPreference.NONE;
+                var testData = withDocValues ? airportsCityBoundaries : airportsCityBoundariesNoShapeDocValues;
+                var plan = physicalPlan(query.replace("airport_city_boundaries", testData.index.name()), testData);
+                var optimized = optimizedPlan(plan, testData.stats);
+                var project = as(optimized, ProjectExec.class);
+                var topNExec = as(project.child(), TopNExec.class);
+                var exchange = as(topNExec.child(), ExchangeExec.class);
+                project = as(exchange.child(), ProjectExec.class);
+                if (keepShape) {
+                    assertThat(Expressions.names(project.projections()), hasItems("airport", "simplified", "city_boundary"));
+                } else {
+                    assertThat(
+                        Expressions.names(project.projections()),
+                        allOf(hasItems("airport", "simplified"), not(hasItems("city_boundary")))
+                    );
+                }
+
+                var topNExecDataNode = as(project.child(), TopNExec.class);
+                var fieldExtract = as(topNExecDataNode.child(), FieldExtractExec.class);
+                assertThat(
+                    Expressions.names(fieldExtract.attributesToExtract()),
+                    allOf(hasItems("airport"), not(hasItems("city_boundary")))
+                );
+                var evalExec = as(fieldExtract.child(), EvalExec.class);
+                var alias = as(evalExec.fields().getLast(), Alias.class);
+                assertThat(alias.name(), equalTo("simplified"));
+                var stSimplifyFunction = as(alias.child(), StSimplify.class);
+                assertThat(stSimplifyFunction.spatialDocValues(), equalTo(withDocValues));
+                var spatialField = as(stSimplifyFunction.spatialField(), FieldAttribute.class);
+                assertThat(spatialField.name(), equalTo("city_boundary"));
+                assertThat(spatialField.dataType(), equalTo(GEO_SHAPE));
+                fieldExtract = as(evalExec.child(), FieldExtractExec.class);
+                assertThat(Expressions.names(fieldExtract.attributesToExtract()), is(List.of("city_boundary")));
+                assertChildIsExtractedAs(evalExec, fieldExtractPreference, GEO_SHAPE);
+            }
+        }
+    }
+
+    /**
+     * Test that ST_SIMPLIFY on a cartesian_shape field uses doc-values when available and the original field is not in the output.
+     * The SORT pushes the EVAL down to the data node where the SpatialDocValuesExtraction rule can optimize it.
+     * Note: for Cartesian, the SORT is pushed into EsQueryExec directly (no TopNExec in data node plan).
+     */
+    public void testSpatialSimplifyCartesianShapeUsesDocValues() {
+        for (boolean keepShape : new boolean[] { false, true }) {
+            String query = """
+                FROM cartesian_multipolygons
+                | EVAL simplified = ST_SIMPLIFY(shape, 0.05)
+                | SORT name
+                """ + (keepShape ? "| KEEP name, simplified, shape" : "| KEEP name, simplified");
+            for (boolean withDocValues : new boolean[] { true, false }) {
+                withDocValues &= keepShape == false;
+                var fieldExtractPreference = withDocValues ? FieldExtractPreference.DOC_VALUES : FieldExtractPreference.NONE;
+                var testData = withDocValues ? cartesianMultipolygons : cartesianMultipolygonsNoDocValues;
+                var plan = physicalPlan(query.replace("cartesian_multipolygons", testData.index.name()), testData);
+                var optimized = optimizedPlan(plan, testData.stats);
+                var project = as(optimized, ProjectExec.class);
+                var topNExec = as(project.child(), TopNExec.class);
+                var exchange = as(topNExec.child(), ExchangeExec.class);
+                project = as(exchange.child(), ProjectExec.class);
+                if (keepShape) {
+                    assertThat(Expressions.names(project.projections()), hasItems("name", "simplified", "shape"));
+                } else {
+                    assertThat(Expressions.names(project.projections()), allOf(hasItems("name", "simplified"), not(hasItems("shape"))));
+                }
+
+                // The data node plan has FieldExtractExec → EvalExec → FieldExtractExec → EsQueryExec
+                var fieldExtract = as(project.child(), FieldExtractExec.class);
+                assertThat(Expressions.names(fieldExtract.attributesToExtract()), allOf(hasItems("name"), not(hasItems("shape"))));
+                var evalExec = as(fieldExtract.child(), EvalExec.class);
+                var alias = as(evalExec.fields().getLast(), Alias.class);
+                assertThat(alias.name(), equalTo("simplified"));
+                var stSimplifyFunction = as(alias.child(), StSimplify.class);
+                assertThat(stSimplifyFunction.spatialDocValues(), equalTo(withDocValues));
+                var spatialField = as(stSimplifyFunction.spatialField(), FieldAttribute.class);
+                assertThat(spatialField.name(), equalTo("shape"));
+                assertThat(spatialField.dataType(), equalTo(CARTESIAN_SHAPE));
+                fieldExtract = as(evalExec.child(), FieldExtractExec.class);
+                assertThat(Expressions.names(fieldExtract.attributesToExtract()), is(List.of("shape")));
+                assertChildIsExtractedAs(evalExec, fieldExtractPreference, CARTESIAN_SHAPE);
+            }
+        }
+    }
+
+    /**
      * The combination of spatial grid functions and SORT will lead to doc-values being extracted for points.
      * We test that all nine spatial functions get correctly notified that they will receive doc value points.
      */

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeScriptDocValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeScriptDocValues.java
@@ -55,7 +55,9 @@ public final class GeoShapeScriptDocValues extends GeoShapeValues {
         final List<IndexableField> fields = indexer.getIndexableFields(geometry);
         final CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
-        geoShapeValue.reset(GeometryDocValueWriter.write(fields, CoordinateEncoder.GEO, centroidCalculator));
+        geoShapeValue.reset(
+            GeometryDocValueWriter.write(fields, CoordinateEncoder.GEO, centroidCalculator, List.of(geometry))
+        );
         return geoShapeValue;
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeScriptDocValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeScriptDocValues.java
@@ -55,9 +55,7 @@ public final class GeoShapeScriptDocValues extends GeoShapeValues {
         final List<IndexableField> fields = indexer.getIndexableFields(geometry);
         final CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
-        geoShapeValue.reset(
-            GeometryDocValueWriter.write(fields, CoordinateEncoder.GEO, centroidCalculator, List.of(geometry))
-        );
+        geoShapeValue.reset(GeometryDocValueWriter.write(fields, CoordinateEncoder.GEO, centroidCalculator, List.of(geometry)));
         return geoShapeValue;
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -90,7 +90,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         try {
             final Geometry geometry = WellKnownText.fromWKT(geometryValidator(), true, missing);
             final BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("missing", encoder);
-            field.add(missingShapeIndexer.indexShape(geometry), geometry);
+            field.add(missingShapeIndexer.indexShape(geometry), geometry, geometry);
             final T value = supplier.get();
             value.reset(field.binaryValue());
             return value;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -90,7 +90,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         try {
             final Geometry geometry = WellKnownText.fromWKT(geometryValidator(), true, missing);
             final BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("missing", encoder);
-            field.add(missingShapeIndexer.indexShape(geometry), geometry, geometry);
+            field.add(missingShapeIndexer.indexShape(geometry), geometry);
             final T value = supplier.get();
             value.reset(field.binaryValue());
             return value;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -214,6 +214,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
                 scriptValues(),
                 geoFormatterFactory,
                 context.isSourceSynthetic(),
+                version,
                 meta.get()
             );
             hasScript = script.get() != null;
@@ -245,9 +246,10 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
             FieldValues<Geometry> scriptValues,
             GeoFormatterFactory<Geometry> geoFormatterFactory,
             boolean isSyntheticSource,
+            IndexVersion indexCreatedVersion,
             Map<String, String> meta
         ) {
-            super(name, IndexType.points(indexed, hasDocValues), isStored, parser, orientation, meta);
+            super(name, IndexType.points(indexed, hasDocValues), isStored, parser, orientation, indexCreatedVersion, meta);
             this.scriptValues = scriptValues;
             this.geoFormatterFactory = geoFormatterFactory;
             this.isSyntheticSource = isSyntheticSource;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -438,7 +438,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
                 context.doc().addWithKey(name, docValuesField);
             }
             // we need to pass the original geometry to compute more precisely the centroid, e.g if lon > 180
-            docValuesField.add(fields, geometry);
+            docValuesField.add(fields, geometry, normalizedGeometry);
         } else if (indexed) {
             context.addToFieldNames(fieldType().name());
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -439,8 +439,8 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
                 docValuesField = new BinaryShapeDocValuesField(name, CoordinateEncoder.GEO);
                 context.doc().addWithKey(name, docValuesField);
             }
-            // we need to pass the original geometry to compute more precisely the centroid, e.g if lon > 180
-            docValuesField.add(fields, geometry, normalizedGeometry);
+            // we pass the original geometry for both precise centroid calculation, and persisted geometry topology
+            docValuesField.add(fields, geometry);
         } else if (indexed) {
             context.addToFieldNames(fieldType().name());
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -331,6 +331,11 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
             if (blContext.fieldExtractPreference() == FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS) {
                 return new GeoBoundsBlockLoader(name());
             }
+            if (blContext.fieldExtractPreference() == FieldExtractPreference.DOC_VALUES
+                && hasDocValues()
+                && supportsGeometryDocValueReconstruction()) {
+                return new GeoGeometryBlockLoader(name());
+            }
             // Multi fields don't have fallback synthetic source.
             if (isSyntheticSource && blContext.parentField(name()) == null) {
                 return blockLoaderFromFallbackSyntheticSource(blContext);
@@ -343,6 +348,12 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
 
             GeoBoundsBlockLoader(String fieldName) {
                 super(fieldName);
+            }
+        }
+
+        static class GeoGeometryBlockLoader extends AbstractShapeGeometryFieldMapper.AbstractShapeGeometryFieldType.GeometryBlockLoader {
+            GeoGeometryBlockLoader(String fieldName) {
+                super(fieldName, CoordinateEncoder.GEO);
             }
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -208,6 +208,11 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
             if (blContext.fieldExtractPreference() == FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS) {
                 return new CartesianBoundsBlockLoader(name());
             }
+            if (blContext.fieldExtractPreference() == FieldExtractPreference.DOC_VALUES
+                && hasDocValues()
+                && supportsGeometryDocValueReconstruction()) {
+                return new CartesianGeometryBlockLoader(name());
+            }
 
             // Multi fields don't have fallback synthetic source.
             if (isSyntheticSource && blContext.parentField(name()) == null) {
@@ -230,6 +235,12 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
                 builder.appendInt(extent.top);
                 builder.appendInt(extent.bottom);
                 builder.endPositionEntry();
+            }
+        }
+
+        static class CartesianGeometryBlockLoader extends GeometryBlockLoader {
+            CartesianGeometryBlockLoader(String fieldName) {
+                super(fieldName, CoordinateEncoder.CARTESIAN);
             }
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -133,6 +133,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
                 orientation.get().value(),
                 parser,
                 context.isSourceSynthetic(),
+                version,
                 meta.get()
             );
             return new ShapeFieldMapper(leafName(), ft, builderParams(this, context), parser, this);
@@ -158,9 +159,10 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
             Orientation orientation,
             Parser<Geometry> parser,
             boolean isSyntheticSource,
+            IndexVersion indexCreatedVersion,
             Map<String, String> meta
         ) {
-            super(name, IndexType.points(indexed, hasDocValues), false, parser, orientation, meta);
+            super(name, IndexType.points(indexed, hasDocValues), false, parser, orientation, indexCreatedVersion, meta);
             this.isSyntheticSource = isSyntheticSource;
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -274,7 +274,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
                 docValuesField = new BinaryShapeDocValuesField(name, CoordinateEncoder.CARTESIAN);
                 context.doc().addWithKey(name, docValuesField);
             }
-            docValuesField.add(fields, geometry);
+            docValuesField.add(fields, geometry, geometry);
         } else if (indexed) {
             context.addToFieldNames(fieldType().name());
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -276,7 +276,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
                 docValuesField = new BinaryShapeDocValuesField(name, CoordinateEncoder.CARTESIAN);
                 context.doc().addWithKey(name, docValuesField);
             }
-            docValuesField.add(fields, geometry, geometry);
+            docValuesField.add(fields, geometry);
         } else if (indexed) {
             context.addToFieldNames(fieldType().name());
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/runtime/GeoShapeScriptFieldGeoShapeQuery.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/runtime/GeoShapeScriptFieldGeoShapeQuery.java
@@ -23,9 +23,9 @@ import org.elasticsearch.script.GeometryFieldScript;
 import org.elasticsearch.script.Script;
 
 import java.io.IOException;
-import java.util.List;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 public class GeoShapeScriptFieldGeoShapeQuery extends AbstractGeoShapeScriptFieldQuery {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/runtime/GeoShapeScriptFieldGeoShapeQuery.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/runtime/GeoShapeScriptFieldGeoShapeQuery.java
@@ -23,6 +23,7 @@ import org.elasticsearch.script.GeometryFieldScript;
 import org.elasticsearch.script.Script;
 
 import java.io.IOException;
+import java.util.List;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Objects;
@@ -67,7 +68,12 @@ public class GeoShapeScriptFieldGeoShapeQuery extends AbstractGeoShapeScriptFiel
     private BytesRef encodeGeometry(Geometry geometry) throws IOException {
         final CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
-        return GeometryDocValueWriter.write(indexer.getIndexableFields(geometry), CoordinateEncoder.GEO, centroidCalculator);
+        return GeometryDocValueWriter.write(
+            indexer.getIndexableFields(geometry),
+            CoordinateEncoder.GEO,
+            centroidCalculator,
+            List.of(geometry)
+        );
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -7,14 +7,18 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.geo.Circle;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeometryNormalizer;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.GeometryVisitor;
+import org.elasticsearch.geometry.Line;
 import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
@@ -28,7 +32,9 @@ import org.elasticsearch.lucene.spatial.Extent;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.io.BufferedReader;
@@ -143,6 +149,9 @@ public class GeometryDocValueTests extends ESTestCase {
             double labelY = ((double) minY + maxY) / 2;
             assertEquals(labelX, labelPosition.getX(), 0.0000001);
             assertEquals(labelY, labelPosition.getY(), 0.0000001);
+
+            // Assert that we can extract the original geometry from the doc-values
+            assertThat("Expect equivalent geometry", reader.getGeometry(CoordinateEncoder.GEO), equivalentTo(rectangle));
         }
     }
 
@@ -166,6 +175,9 @@ public class GeometryDocValueTests extends ESTestCase {
             new GeoPoint(labelPosition),
             isRectangleLabelPosition(r1, r2)
         );
+
+        Geometry extracted = reader.getGeometry(CoordinateEncoder.GEO);
+        assertThat("Expect equivalent geometry", extracted, equivalentTo(geometry));
     }
 
     public void testAntarcticaLabelPosition() throws Exception {
@@ -187,8 +199,11 @@ public class GeometryDocValueTests extends ESTestCase {
         double centroidY = CoordinateEncoder.GEO.decodeY(reader.getCentroidY());
         assertEquals(centroidX, labelPosition.getX(), 0.0000001);
         assertEquals(centroidY, labelPosition.getY(), 0.0000001);
-        Circle tolerance = new Circle(centroidY, centroidX, 1);
+        org.apache.lucene.geo.Circle tolerance = new org.apache.lucene.geo.Circle(centroidY, centroidX, 1);
         assertTrue("Expect label position to be within the geometry", shapeValue.relate(tolerance) != GeoRelation.QUERY_DISJOINT);
+
+        // Assert that we can extract the original geometry from the doc-values
+        assertThat("Expect equivalent geometry", reader.getGeometry(CoordinateEncoder.GEO), equivalentTo(geometry));
     }
 
     public void testFranceLabelPosition() throws Exception {
@@ -202,8 +217,11 @@ public class GeometryDocValueTests extends ESTestCase {
         double centroidY = CoordinateEncoder.GEO.decodeY(reader.getCentroidY());
         assertEquals(centroidX, labelPosition.getX(), 0.0000001);
         assertEquals(centroidY, labelPosition.getY(), 0.0000001);
-        Circle tolerance = new Circle(centroidY, centroidX, 1);
+        org.apache.lucene.geo.Circle tolerance = new org.apache.lucene.geo.Circle(centroidY, centroidX, 1);
         assertTrue("Expect label position to be within the geometry", shapeValue.relate(tolerance) != GeoRelation.QUERY_DISJOINT);
+
+        // Assert that we can extract the original geometry from the doc-values
+        assertThat("Expect equivalent geometry", reader.getGeometry(CoordinateEncoder.GEO), equivalentTo(geometry));
     }
 
     private Geometry loadResourceAsGeometry(String filename) throws IOException, ParseException {
@@ -282,5 +300,219 @@ public class GeometryDocValueTests extends ESTestCase {
     private static void assertDimensionalShapeType(Geometry geometry, DimensionalShapeType expected) throws IOException {
         GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         assertThat(reader.getDimensionalShapeType(), equalTo(expected));
+    }
+
+    private Matcher<? super Geometry> equivalentTo(Geometry geometry) {
+        return new TestGeometryEquivalence(geometry, CoordinateEncoder.GEO);
+    }
+
+    /**
+     * Hamcrest matcher that checks two geometries are structurally identical (same topology)
+     * with coordinates equivalent within the Lucene quantization tolerance. Coordinates are
+     * compared by encoding both sides to the integer grid and checking equality, so any
+     * difference smaller than one quantization step is accepted.
+     */
+    private static class TestGeometryEquivalence extends BaseMatcher<Geometry> {
+
+        private final Geometry expected;
+        private final CoordinateEncoder encoder;
+        private String mismatch;
+
+        private TestGeometryEquivalence(Geometry expected, CoordinateEncoder encoder) {
+            this.expected = expected;
+            this.encoder = encoder;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (o instanceof Geometry actual) {
+                mismatch = checkEquivalent(expected, actual, "");
+                return mismatch == null;
+            }
+            mismatch = "not a Geometry: " + (o == null ? "null" : o.getClass().getName());
+            return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("geometry equivalent (within quantization) to ").appendValue(WellKnownText.toWKT(expected));
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description description) {
+            if (mismatch != null) {
+                description.appendText(mismatch);
+            }
+        }
+
+        private String checkEquivalent(Geometry expected, Geometry actual, String path) {
+            return expected.visit(new EquivalenceVisitor(actual, path));
+        }
+
+        private class EquivalenceVisitor implements GeometryVisitor<String, RuntimeException> {
+            private final Geometry actual;
+            private final String path;
+
+            EquivalenceVisitor(Geometry actual, String path) {
+                this.actual = actual;
+                this.path = path;
+            }
+
+            @Override
+            public String visit(Circle circle) {
+                return path + ": Circle comparison not supported";
+            }
+
+            @Override
+            public String visit(GeometryCollection<?> expected) {
+                if (actual instanceof GeometryCollection<?> a) {
+                    if (expected.size() != a.size()) return sizeMismatch(expected.size(), a.size());
+                    for (int i = 0; i < expected.size(); i++) {
+                        String r = checkEquivalent(expected.get(i), a.get(i), path + "[" + i + "]");
+                        if (r != null) return r;
+                    }
+                    return null;
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(Line expected) {
+                if (actual instanceof Line a) {
+                    return compareLineCoords(path, expected, a);
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(LinearRing expected) {
+                if (actual instanceof LinearRing a) {
+                    return compareLineCoords(path, expected, a);
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(MultiLine expected) {
+                if (actual instanceof MultiLine a) {
+                    if (expected.size() != a.size()) return sizeMismatch(expected.size(), a.size());
+                    for (int i = 0; i < expected.size(); i++) {
+                        String r = checkEquivalent(expected.get(i), a.get(i), path + "[" + i + "]");
+                        if (r != null) return r;
+                    }
+                    return null;
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(MultiPoint expected) {
+                if (actual instanceof MultiPoint a) {
+                    if (expected.size() != a.size()) return sizeMismatch(expected.size(), a.size());
+                    for (int i = 0; i < expected.size(); i++) {
+                        String r = checkEquivalent(expected.get(i), a.get(i), path + "[" + i + "]");
+                        if (r != null) return r;
+                    }
+                    return null;
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(MultiPolygon expected) {
+                if (actual instanceof MultiPolygon a) {
+                    if (expected.size() != a.size()) return sizeMismatch(expected.size(), a.size());
+                    for (int i = 0; i < expected.size(); i++) {
+                        String r = checkEquivalent(expected.get(i), a.get(i), path + "[" + i + "]");
+                        if (r != null) return r;
+                    }
+                    return null;
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(Point expected) {
+                if (actual instanceof Point a) {
+                    return compareCoord(path, expected.getX(), expected.getY(), a.getX(), a.getY());
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(Polygon expected) {
+                if (actual instanceof Polygon a) {
+                    if (expected.getNumberOfHoles() != a.getNumberOfHoles()) {
+                        return path + ": expected " + expected.getNumberOfHoles() + " holes but got " + a.getNumberOfHoles();
+                    }
+                    String r = compareLineCoords(path + ".shell", expected.getPolygon(), a.getPolygon());
+                    if (r != null) return r;
+                    for (int i = 0; i < expected.getNumberOfHoles(); i++) {
+                        r = compareLineCoords(path + ".hole[" + i + "]", expected.getHole(i), a.getHole(i));
+                        if (r != null) return r;
+                    }
+                    return null;
+                }
+                return typeMismatch(expected);
+            }
+
+            @Override
+            public String visit(Rectangle expected) {
+                // Reconstructed geometries produce Polygons, not Rectangles
+                if (actual instanceof Polygon a) {
+                    Polygon poly = new Polygon(
+                        new LinearRing(
+                            new double[] {
+                                expected.getMinX(),
+                                expected.getMaxX(),
+                                expected.getMaxX(),
+                                expected.getMinX(),
+                                expected.getMinX() },
+                            new double[] {
+                                expected.getMinY(),
+                                expected.getMinY(),
+                                expected.getMaxY(),
+                                expected.getMaxY(),
+                                expected.getMinY() }
+                        )
+                    );
+                    return checkEquivalent(poly, a, path);
+                }
+                return typeMismatch(expected);
+            }
+
+            private String typeMismatch(Geometry expectedNode) {
+                return path + ": expected type " + expectedNode.type() + " but got " + actual.type();
+            }
+
+            private String sizeMismatch(int expectedSize, int actualSize) {
+                return path + ": expected " + expectedSize + " elements but got " + actualSize;
+            }
+        }
+
+        private String compareLineCoords(String path, Line expected, Line actual) {
+            if (expected.length() != actual.length()) {
+                return path + ": expected " + expected.length() + " vertices but got " + actual.length();
+            }
+            for (int i = 0; i < expected.length(); i++) {
+                String r = compareCoord(path + "[" + i + "]", expected.getX(i), expected.getY(i), actual.getX(i), actual.getY(i));
+                if (r != null) return r;
+            }
+            return null;
+        }
+
+        private String compareCoord(String path, double expectedX, double expectedY, double actualX, double actualY) {
+            int ex = encoder.encodeX(encoder.normalizeX(expectedX));
+            int ax = encoder.encodeX(actualX);
+            if (ex != ax) {
+                return path + ".x: " + expectedX + " (enc:" + ex + ") != " + actualX + " (enc:" + ax + ")";
+            }
+            int ey = encoder.encodeY(encoder.normalizeY(expectedY));
+            int ay = encoder.encodeY(actualY);
+            if (ey != ay) {
+                return path + ".y: " + expectedY + " (enc:" + ey + ") != " + actualY + " (enc:" + ay + ")";
+            }
+            return null;
+        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
-import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.DimensionalShapeType;
 import org.elasticsearch.lucene.spatial.Extent;
@@ -226,7 +225,6 @@ public class GeometryDocValueTests extends ESTestCase {
     }
 
     public void testRandomGeometryReconstruction() throws IOException {
-        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
         for (int i = 0; i < 100; i++) {
             Geometry geometry = switch (i % 7) {
                 case 0 -> randomPoint(false);
@@ -243,11 +241,10 @@ public class GeometryDocValueTests extends ESTestCase {
                 );
                 default -> throw new AssertionError();
             };
-            Geometry normalized = indexer.normalize(geometry);
             GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(geometry, CoordinateEncoder.GEO);
             Geometry extracted = reader.getGeometry(CoordinateEncoder.GEO);
             assertNotNull("Iteration " + i + ": expected non-null geometry for " + geometry.type(), extracted);
-            assertThat("Iteration " + i + ": equivalent geometry for " + normalized.type(), extracted, equivalentTo(normalized));
+            assertThat("Iteration " + i + ": equivalent geometry for " + geometry.type(), extracted, equivalentTo(geometry));
         }
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -498,25 +498,10 @@ public class GeometryDocValueTests extends ESTestCase {
 
             @Override
             public String visit(Rectangle expected) {
-                // Reconstructed geometries produce Polygons, not Rectangles
-                if (actual instanceof Polygon a) {
-                    Polygon poly = new Polygon(
-                        new LinearRing(
-                            new double[] {
-                                expected.getMinX(),
-                                expected.getMaxX(),
-                                expected.getMaxX(),
-                                expected.getMinX(),
-                                expected.getMinX() },
-                            new double[] {
-                                expected.getMinY(),
-                                expected.getMinY(),
-                                expected.getMaxY(),
-                                expected.getMaxY(),
-                                expected.getMinY() }
-                        )
-                    );
-                    return checkEquivalent(poly, a, path);
+                if (actual instanceof Rectangle a) {
+                    String r = compareCoord(path + ".min", expected.getMinX(), expected.getMinY(), a.getMinX(), a.getMinY());
+                    if (r != null) return r;
+                    return compareCoord(path + ".max", expected.getMaxX(), expected.getMaxY(), a.getMaxX(), a.getMaxY());
                 }
                 return typeMismatch(expected);
             }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.DimensionalShapeType;
 import org.elasticsearch.lucene.spatial.Extent;
@@ -224,6 +225,32 @@ public class GeometryDocValueTests extends ESTestCase {
         assertThat("Expect equivalent geometry", reader.getGeometry(CoordinateEncoder.GEO), equivalentTo(geometry));
     }
 
+    public void testRandomGeometryReconstruction() throws IOException {
+        GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        for (int i = 0; i < 100; i++) {
+            Geometry geometry = switch (i % 7) {
+                case 0 -> randomPoint(false);
+                case 1 -> randomMultiPoint(false);
+                case 2 -> randomLine(false);
+                case 3 -> randomMultiLine(false);
+                case 4 -> randomPolygon(false);
+                case 5 -> randomMultiPolygon(false);
+                case 6 -> new Rectangle(
+                    randomIntBetween(-179, -1),
+                    randomIntBetween(1, 179),
+                    randomIntBetween(1, 89),
+                    randomIntBetween(-89, -1)
+                );
+                default -> throw new AssertionError();
+            };
+            Geometry normalized = indexer.normalize(geometry);
+            GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(geometry, CoordinateEncoder.GEO);
+            Geometry extracted = reader.getGeometry(CoordinateEncoder.GEO);
+            assertNotNull("Iteration " + i + ": expected non-null geometry for " + geometry.type(), extracted);
+            assertThat("Iteration " + i + ": equivalent geometry for " + normalized.type(), extracted, equivalentTo(normalized));
+        }
+    }
+
     private Geometry loadResourceAsGeometry(String filename) throws IOException, ParseException {
         GZIPInputStream is = new GZIPInputStream(getClass().getResourceAsStream(filename));
         final BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
@@ -409,9 +436,25 @@ public class GeometryDocValueTests extends ESTestCase {
             public String visit(MultiPoint expected) {
                 if (actual instanceof MultiPoint a) {
                     if (expected.size() != a.size()) return sizeMismatch(expected.size(), a.size());
+                    // Point ordering in MultiPoint is semantically meaningless and is not
+                    // preserved by the triangle tree (legacy format), so match greedily.
+                    boolean[] used = new boolean[a.size()];
                     for (int i = 0; i < expected.size(); i++) {
-                        String r = checkEquivalent(expected.get(i), a.get(i), path + "[" + i + "]");
-                        if (r != null) return r;
+                        Point ep = expected.get(i);
+                        boolean found = false;
+                        for (int j = 0; j < a.size(); j++) {
+                            if (used[j] == false) {
+                                Point ap = a.get(j);
+                                if (compareCoord("", ep.getX(), ep.getY(), ap.getX(), ap.getY()) == null) {
+                                    used[j] = true;
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (found == false) {
+                            return path + ": no matching point for expected[" + i + "] (" + ep.getX() + ", " + ep.getY() + ") in " + a;
+                        }
                     }
                     return null;
                 }
@@ -503,7 +546,7 @@ public class GeometryDocValueTests extends ESTestCase {
 
         private String compareCoord(String path, double expectedX, double expectedY, double actualX, double actualY) {
             int ex = encoder.encodeX(encoder.normalizeX(expectedX));
-            int ax = encoder.encodeX(actualX);
+            int ax = encoder.encodeX(encoder.normalizeX(actualX));
             if (ex != ax) {
                 return path + ".x: " + expectedX + " (enc:" + ex + ") != " + actualX + " (enc:" + ax + ")";
             }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
@@ -17,6 +17,11 @@ import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.lucene.spatial.BinaryShapeDocValuesField;
+import org.elasticsearch.lucene.spatial.CoordinateEncoder;
+import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentType;
@@ -24,6 +29,7 @@ import org.elasticsearch.xcontent.support.MapXContentParser;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.datageneration.GeoShapeDataSourceHandler;
 
+import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,12 +50,17 @@ public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     @Override
     @SuppressWarnings("unchecked")
     protected Object expected(Map<String, Object> fieldMapping, Object value, TestContext testContext) {
+        boolean docValuesMode = params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES
+            && (Boolean) fieldMapping.getOrDefault("doc_values", true);
+
+        if (docValuesMode) {
+            return expectedFromDocValues(value);
+        }
+
         if (value instanceof List<?> == false) {
             return convert(value);
         }
 
-        // TODO FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS is currently not covered, it needs special logic
-        // As a result we always load from source (stored or fallback synthetic) and they should work the same.
         var resultList = ((List<Object>) value).stream().map(this::convert).filter(Objects::nonNull).toList();
         return maybeFoldList(resultList);
     }
@@ -67,6 +78,51 @@ public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
         return null;
     }
 
+    /**
+     * Compute expected value for DOC_VALUES mode by round-tripping through the doc-values format.
+     * Doc-values combine multiple field values into a single binary value, reconstructing the
+     * original (non-normalized) geometry with quantized coordinates.
+     */
+    @SuppressWarnings("unchecked")
+    private Object expectedFromDocValues(Object value) {
+        List<Object> values = value instanceof List<?> ? (List<Object>) value : List.of(value);
+        List<Geometry> geometries = values.stream().map(this::parseGeometry).filter(Objects::nonNull).toList();
+        if (geometries.isEmpty()) {
+            return null;
+        }
+        try {
+            GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+            BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("test", CoordinateEncoder.GEO);
+            for (Geometry geometry : geometries) {
+                Geometry normalized = indexer.normalize(geometry);
+                field.add(indexer.getIndexableFields(normalized), geometry);
+            }
+            GeometryDocValueReader reader = new GeometryDocValueReader();
+            reader.reset(field.binaryValue());
+            Geometry reconstructed = reader.getGeometry(CoordinateEncoder.GEO);
+            if (reconstructed == null) {
+                return null;
+            }
+            return toWKB(reconstructed);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Geometry parseGeometry(Object value) {
+        try {
+            if (value instanceof String s) {
+                return WellKnownText.fromWKT(GeographyValidator.instance(true), false, s);
+            }
+            if (value instanceof Map<?, ?> m) {
+                return parseGeoJson(m);
+            }
+        } catch (Exception e) {
+            // Malformed value
+        }
+        return null;
+    }
+
     private Geometry fromWKT(String s) {
         try {
             var geometry = WellKnownText.fromWKT(GeographyValidator.instance(true), false, s);
@@ -79,6 +135,16 @@ public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     @SuppressWarnings("unchecked")
     private Geometry fromGeoJson(Map<?, ?> map) {
         try {
+            var geometry = parseGeoJson(map);
+            return normalize(geometry);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Geometry parseGeoJson(Map<?, ?> map) {
+        try {
             var parser = new MapXContentParser(
                 xContentRegistry(),
                 LoggingDeprecationHandler.INSTANCE,
@@ -86,9 +152,7 @@ public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
                 XContentType.JSON
             );
             parser.nextToken();
-
-            var geometry = GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser);
-            return normalize(geometry);
+            return GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
@@ -103,9 +103,7 @@ public class GeoShapeScriptMapperTests extends MapperScriptTestCase<GeometryFiel
         assertBinaryDocValue(
             fields.get(2),
             centroidCalculator,
-            List.of(
-                new org.elasticsearch.geometry.GeometryCollection<>(List.of(new Point(-1, 1), new Point(-2, 2)))
-            ),
+            List.of(new org.elasticsearch.geometry.GeometryCollection<>(List.of(new Point(-1, 1), new Point(-2, 2)))),
             fields.get(0),
             fields.get(1)
         );

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
@@ -100,7 +100,15 @@ public class GeoShapeScriptMapperTests extends MapperScriptTestCase<GeometryFiel
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(new Point(-1, 1));
         centroidCalculator.add(new Point(-2, 2));
-        assertBinaryDocValue(fields.get(2), centroidCalculator, fields.get(0), fields.get(1));
+        assertBinaryDocValue(
+            fields.get(2),
+            centroidCalculator,
+            List.of(
+                new org.elasticsearch.geometry.GeometryCollection<>(List.of(new Point(-1, 1), new Point(-2, 2)))
+            ),
+            fields.get(0),
+            fields.get(1)
+        );
     }
 
     @Override
@@ -115,7 +123,7 @@ public class GeoShapeScriptMapperTests extends MapperScriptTestCase<GeometryFiel
         Field[] f = LatLonShape.createIndexableFields("test", 1, -1);
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(new Point(-1, 1));
-        assertBinaryDocValue(fields.get(0), centroidCalculator, f);
+        assertBinaryDocValue(fields.get(0), centroidCalculator, List.of(new Point(-1, 1)), f);
     }
 
     private void assertPoint(IndexableField indexableField, double lon, double lat) {
@@ -129,9 +137,19 @@ public class GeoShapeScriptMapperTests extends MapperScriptTestCase<GeometryFiel
         assertEquals(triangle.aY, GeoEncodingUtils.encodeLatitude(lat), 0.0);
     }
 
-    private void assertBinaryDocValue(IndexableField binaryDocValue, CentroidCalculator calculator, IndexableField... values) {
+    private void assertBinaryDocValue(
+        IndexableField binaryDocValue,
+        CentroidCalculator calculator,
+        List<org.elasticsearch.geometry.Geometry> normalizedGeometries,
+        IndexableField... values
+    ) {
         try {
-            BytesRef bytesRef = GeometryDocValueWriter.write(Arrays.stream(values).toList(), CoordinateEncoder.GEO, calculator);
+            BytesRef bytesRef = GeometryDocValueWriter.write(
+                Arrays.stream(values).toList(),
+                CoordinateEncoder.GEO,
+                calculator,
+                normalizedGeometries
+            );
             assertEquals(bytesRef, binaryDocValue.binaryValue());
         } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeScriptMapperTests.java
@@ -138,16 +138,11 @@ public class GeoShapeScriptMapperTests extends MapperScriptTestCase<GeometryFiel
     private void assertBinaryDocValue(
         IndexableField binaryDocValue,
         CentroidCalculator calculator,
-        List<org.elasticsearch.geometry.Geometry> normalizedGeometries,
+        List<org.elasticsearch.geometry.Geometry> geometries,
         IndexableField... values
     ) {
         try {
-            BytesRef bytesRef = GeometryDocValueWriter.write(
-                Arrays.stream(values).toList(),
-                CoordinateEncoder.GEO,
-                calculator,
-                normalizedGeometries
-            );
+            BytesRef bytesRef = GeometryDocValueWriter.write(Arrays.stream(values).toList(), CoordinateEncoder.GEO, calculator, geometries);
             assertEquals(bytesRef, binaryDocValue.binaryValue());
         } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -208,6 +208,7 @@ public class CircleProcessorTests extends ESTestCase {
             null,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/UnsupportedAggregationsTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/UnsupportedAggregationsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.spatial.search.aggregations;
 import org.apache.lucene.document.Document;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.lucene.spatial.BinaryShapeDocValuesField;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -44,6 +45,7 @@ public class UnsupportedAggregationsTests extends AggregatorTestCase {
             null,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         BinaryShapeDocValuesField field = GeoTestUtils.binaryGeoShapeDocValuesField("geometry", new Point(0, 0));
@@ -64,6 +66,7 @@ public class UnsupportedAggregationsTests extends AggregatorTestCase {
             Orientation.RIGHT,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         BinaryShapeDocValuesField field = GeoTestUtils.binaryCartesianShapeDocValuesField("geometry", new Point(0, 0));
@@ -87,6 +90,7 @@ public class UnsupportedAggregationsTests extends AggregatorTestCase {
             null,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         BinaryShapeDocValuesField field = GeoTestUtils.binaryGeoShapeDocValuesField("geometry", new Point(0, 0));
@@ -107,6 +111,7 @@ public class UnsupportedAggregationsTests extends AggregatorTestCase {
             Orientation.RIGHT,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         BinaryShapeDocValuesField field = GeoTestUtils.binaryCartesianShapeDocValuesField("geometry", new Point(0, 0));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.lucene.spatial.BinaryShapeDocValuesField;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -260,6 +261,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
             null,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         testCase(

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeBoundsAggregatorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -72,6 +73,7 @@ public class CartesianShapeBoundsAggregatorTests extends AggregatorTestCase {
                 Orientation.RIGHT,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {
@@ -102,6 +104,7 @@ public class CartesianShapeBoundsAggregatorTests extends AggregatorTestCase {
                 Orientation.RIGHT,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {
@@ -128,6 +131,7 @@ public class CartesianShapeBoundsAggregatorTests extends AggregatorTestCase {
                 Orientation.RIGHT,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
 
@@ -162,6 +166,7 @@ public class CartesianShapeBoundsAggregatorTests extends AggregatorTestCase {
                 Orientation.RIGHT,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
 
@@ -253,6 +258,7 @@ public class CartesianShapeBoundsAggregatorTests extends AggregatorTestCase {
             Orientation.RIGHT,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         try (IndexReader reader = w.getReader()) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.lucene.spatial.CentroidCalculator;
 import org.elasticsearch.lucene.spatial.DimensionalShapeType;
@@ -59,6 +60,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                 Orientation.RIGHT,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {
@@ -84,6 +86,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                     Orientation.RIGHT,
                     null,
                     false,
+                    IndexVersion.current(),
                     Collections.emptyMap()
                 );
                 InternalCartesianCentroid result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -96,6 +99,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                     Orientation.RIGHT,
                     null,
                     false,
+                    IndexVersion.current(),
                     Collections.emptyMap()
                 );
                 result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -123,6 +127,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                     Orientation.RIGHT,
                     null,
                     false,
+                    IndexVersion.current(),
                     Collections.emptyMap()
                 );
                 InternalCartesianCentroid result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -197,6 +202,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
             Orientation.RIGHT,
             null,
             false,
+            IndexVersion.current(),
             Collections.emptyMap()
         );
         CartesianCentroidAggregationBuilder aggBuilder = new CartesianCentroidAggregationBuilder("my_agg").field("field");

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -63,6 +64,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {
@@ -98,6 +100,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {
@@ -129,6 +132,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
 
@@ -169,6 +173,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
 
@@ -235,6 +240,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Collections.emptyMap()
             );
             try (IndexReader reader = w.getReader()) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.lucene.spatial.CentroidCalculator;
 import org.elasticsearch.lucene.spatial.DimensionalShapeType;
@@ -68,6 +69,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                 null,
                 null,
                 false,
+                IndexVersion.current(),
                 Map.of()
             );
             try (IndexReader reader = w.getReader()) {
@@ -96,6 +98,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                     null,
                     null,
                     false,
+                    IndexVersion.current(),
                     Map.of()
                 );
                 InternalGeoCentroid result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -111,6 +114,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                     null,
                     null,
                     false,
+                    IndexVersion.current(),
                     Map.of()
                 );
                 result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -142,6 +146,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                     null,
                     null,
                     false,
+                    IndexVersion.current(),
                     Map.of()
                 );
                 InternalGeoCentroid result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
@@ -219,6 +224,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
             null,
             null,
             false,
+            IndexVersion.current(),
             Map.of()
         );
         GeoCentroidAggregationBuilder aggBuilder = new GeoCentroidAggregationBuilder("my_agg").field("field");

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
@@ -48,9 +48,7 @@ public class GeoTestUtils {
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
         GeometryDocValueReader reader = new GeometryDocValueReader();
-        reader.reset(
-            GeometryDocValueWriter.write(indexer.getIndexableFields(normalized), encoder, centroidCalculator, List.of(normalized))
-        );
+        reader.reset(GeometryDocValueWriter.write(indexer.getIndexableFields(normalized), encoder, centroidCalculator, List.of(geometry)));
         return reader;
     }
 
@@ -58,7 +56,7 @@ public class GeoTestUtils {
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, name);
         Geometry normalized = indexer.normalize(geometry);
         BinaryShapeDocValuesField field = new BinaryShapeDocValuesField(name, CoordinateEncoder.GEO);
-        field.add(indexer.getIndexableFields(normalized), geometry, normalized);
+        field.add(indexer.getIndexableFields(normalized), geometry);
         return field;
     }
 
@@ -66,7 +64,7 @@ public class GeoTestUtils {
     public static BinaryShapeDocValuesField binaryCartesianShapeDocValuesField(String name, Geometry geometry) {
         CartesianShapeIndexer indexer = new CartesianShapeIndexer(name);
         BinaryShapeDocValuesField field = new BinaryShapeDocValuesField(name, CoordinateEncoder.CARTESIAN);
-        field.add(indexer.indexShape(geometry), geometry, geometry);
+        field.add(indexer.indexShape(geometry), geometry);
         return field;
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
@@ -38,22 +38,27 @@ import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
+import java.util.List;
 
 public class GeoTestUtils {
 
     public static GeometryDocValueReader geometryDocValueReader(Geometry geometry, CoordinateEncoder encoder) throws IOException {
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, "test");
+        Geometry normalized = indexer.normalize(geometry);
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         centroidCalculator.add(geometry);
         GeometryDocValueReader reader = new GeometryDocValueReader();
-        reader.reset(GeometryDocValueWriter.write(indexer.indexShape(geometry), encoder, centroidCalculator));
+        reader.reset(
+            GeometryDocValueWriter.write(indexer.getIndexableFields(normalized), encoder, centroidCalculator, List.of(normalized))
+        );
         return reader;
     }
 
     public static BinaryShapeDocValuesField binaryGeoShapeDocValuesField(String name, Geometry geometry) {
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, name);
+        Geometry normalized = indexer.normalize(geometry);
         BinaryShapeDocValuesField field = new BinaryShapeDocValuesField(name, CoordinateEncoder.GEO);
-        field.add(indexer.indexShape(geometry), geometry);
+        field.add(indexer.getIndexableFields(normalized), geometry, normalized);
         return field;
     }
 
@@ -61,7 +66,7 @@ public class GeoTestUtils {
     public static BinaryShapeDocValuesField binaryCartesianShapeDocValuesField(String name, Geometry geometry) {
         CartesianShapeIndexer indexer = new CartesianShapeIndexer(name);
         BinaryShapeDocValuesField field = new BinaryShapeDocValuesField(name, CoordinateEncoder.CARTESIAN);
-        field.add(indexer.indexShape(geometry), geometry);
+        field.add(indexer.indexShape(geometry), geometry, geometry);
         return field;
     }
 


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/142561 expands the doc-values format for `geo_shape` and `shape` to include topology information enabling the reconstruction of the original geometry. This can be used in ST_SIMPLIFY to improve the performance of ES|QL by reading from doc-values instead of source.

Initial benchmark runs on the WIP commit show some improvements:

| query | not using doc-values | using doc-values | improvement |
| --- | --- | --- | --- |
|        st-envelope-esql  |       2.54785      |       1.13575      | 55.43% |
|  st-envelope-count-esql  |   75979.8          |    9542.87         | 87.45% |
|        st-simplify-esql  |       2.15192      |       1.08471      | 49.6% |
|  st-simplify-count-esql  |  141663            |  121791            | 14.03% |

While there are some nice improvements, it is clear that the counts query for ST_SIMPLIFY could be improved much more. In particular, this PR does not (YET) push the function down to the block-loader, which should help.
