### PR TITLE
Cancel reindex body always has status

### DIFF
--- a/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_cancel_reindex.yml
+++ b/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_cancel_reindex.yml
@@ -53,8 +53,7 @@ setup:
   - match: { cancelled: true }
   - match: { status.canceled: "by user request" }
   - gte: { status.total: 0 }
-  # different from `GET _reindex`
-  - not_exists: response
+  - exists: error
 
   - do:
       reindex_get:

--- a/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_cancel_reindex.yml
+++ b/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_cancel_reindex.yml
@@ -53,7 +53,7 @@ setup:
   - match: { cancelled: true }
   - match: { status.canceled: "by user request" }
   - gte: { status.total: 0 }
-  - exists: error
+  # depending on how quickly we cancel, we might either get an error (shard failure) or response, so not asserting
 
   - do:
       reindex_get:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -335,9 +335,6 @@ tests:
 - class: org.elasticsearch.xpack.gpu.GPUPluginInitializationWithGPUIT
   method: testAutoModeSupportedVectorType
   issue: https://github.com/elastic/elasticsearch/issues/142072
-- class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
-  method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
-  issue: https://github.com/elastic/elasticsearch/issues/142079
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077


### PR DESCRIPTION
- There seems to be a race where by the time we cancel the task with `wait_for_completion=true`, the status isn't yet set, leading to failure asserting `status.cancelled` in yaml rest tests
- So let's cancel the task asynchronously, and wait for it's completion (local node operation so no hops) and get the normal full and completed`GET _reindex` response
  * This was originally the approach i was going to go with, but seemed simpler to do the current approach, but knowing this, sways my thinking towards this

Closes #142079