### PR TITLE
Fix intermittent failures in CrossClusterAsyncSearchIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -144,9 +144,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
   method: testInvalidToken
   issue: https://github.com/elastic/elasticsearch/issues/133328
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
-  issue: https://github.com/elastic/elasticsearch/issues/127302
 - class: org.elasticsearch.xpack.ml.integration.InferenceIT
   method: testInferClassificationModel
   issue: https://github.com/elastic/elasticsearch/issues/133448
@@ -165,9 +162,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
-  issue: https://github.com/elastic/elasticsearch/issues/136894
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/117208


### PR DESCRIPTION
Possible cause for the failures:
- When creating the cluster, we wait for YELLOW status
- However, YELLOW can be there for two reasons - either there are not enough nodes for all replicas (which could happen due to random settings) or some shards did not finish initializing yet
- The second part could cause the shard be in RECOVERING status when we are querying it and lead to failure

Waiting until there is no initializing shards should avoid this problem. 

Closes https://github.com/elastic/elasticsearch/issues/127302 
Closes https://github.com/elastic/elasticsearch/issues/136894