### PR TITLE
Move tsdb doc values format larger numeric block variant to its own doc values format

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -458,6 +458,7 @@ module org.elasticsearch.server {
         with
             org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat,
             org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat,
+            org.elasticsearch.index.codec.tsdb.es819.ES819TSDBLargerNumericBlocksDocValuesFormat,
             org.elasticsearch.index.codec.bloomfilter.ES94BloomFilterDocValuesFormat;
     provides org.apache.lucene.codecs.KnnVectorsFormat
         with

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -222,6 +222,7 @@ public class IndexVersions {
     public static final IndexVersion DISK_BBQ_QUANTIZE_BITS = def(9_069_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion ID_FIELD_USE_ES812_POSTINGS_FORMAT = def(9_070_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_94 = def(9_071_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion TIME_SERIES_DOC_VALUE_FORMAT_USE_LARGE_BLOCK = def(9_072_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 
 import static org.apache.lucene.util.hnsw.HnswGraphBuilder.DEFAULT_BEAM_WIDTH;
 import static org.apache.lucene.util.hnsw.HnswGraphBuilder.DEFAULT_MAX_CONN;
+import static org.elasticsearch.index.IndexVersions.TIME_SERIES_DOC_VALUE_FORMAT_USE_LARGE_BLOCK;
 
 /**
  * Class that encapsulates the logic of figuring out the most appropriate file format for a given field, across postings, doc values and
@@ -68,8 +69,6 @@ public class PerFieldFormatSupplier {
 
     private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private final KnnVectorsFormat knnVectorsFormat;
-    private static final DocValuesFormat tsdbDocValuesFormat = new ES819TSDBDocValuesFormat();
-    private static final DocValuesFormat tsdbDocValuesFormatLargeNumericBlock = new ES819TSDBLargerNumericBlocksDocValuesFormat();
     private static final ES812PostingsFormat es812PostingsFormat = new ES812PostingsFormat();
     private static final PostingsFormat completionPostingsFormat = PostingsFormat.forName("Completion101");
 
@@ -199,8 +198,9 @@ public class PerFieldFormatSupplier {
 
         if (useTSDBDocValuesFormat(field)) {
             return (mapperService != null && mapperService.getIndexSettings().isUseTimeSeriesDocValuesFormatLargeBlockSize())
-                ? tsdbDocValuesFormatLargeNumericBlock
-                : tsdbDocValuesFormat;
+                && TIME_SERIES_DOC_VALUE_FORMAT_USE_LARGE_BLOCK.onOrAfter(mapperService.getIndexSettings().getIndexVersionCreated())
+                    ? new ES819TSDBLargerNumericBlocksDocValuesFormat()
+                    : new ES819TSDBDocValuesFormat();
         }
 
         return docValuesFormat;

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.codec.bloomfilter.ES94BloomFilterDocValuesFormat;
 import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBLargerNumericBlocksDocValuesFormat;
 import org.elasticsearch.index.codec.vectors.es93.ES93HnswVectorsFormat;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -67,8 +68,8 @@ public class PerFieldFormatSupplier {
 
     private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private final KnnVectorsFormat knnVectorsFormat;
-    private static final ES819TSDBDocValuesFormat tsdbDocValuesFormat = ES819TSDBDocValuesFormat.getInstance(false);
-    private static final ES819TSDBDocValuesFormat tsdbDocValuesFormatLargeNumericBlock = ES819TSDBDocValuesFormat.getInstance(true);
+    private static final DocValuesFormat tsdbDocValuesFormat = new ES819TSDBDocValuesFormat();
+    private static final DocValuesFormat tsdbDocValuesFormatLargeNumericBlock = new ES819TSDBLargerNumericBlocksDocValuesFormat();
     private static final ES812PostingsFormat es812PostingsFormat = new ES812PostingsFormat();
     private static final PostingsFormat completionPostingsFormat = PostingsFormat.forName("Completion101");
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
@@ -41,9 +41,9 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
     static final int NUMERIC_LARGE_BLOCK_SHIFT = 9;
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
     static final String CODEC_NAME = "ES819TSDB";
-    static final String DATA_CODEC = "ES819TSDBDocValuesData";
+    static final String DATA_CODEC = CODEC_NAME + "DocValuesData";
     static final String DATA_EXTENSION = "dvd";
-    static final String META_CODEC = "ES819TSDBDocValuesMetadata";
+    static final String META_CODEC = CODEC_NAME + "DocValuesMetadata";
     static final String META_EXTENSION = "dvm";
     static final byte NUMERIC = 0;
     static final byte BINARY = 1;
@@ -140,10 +140,6 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
     final BinaryDVCompressionMode binaryDVCompressionMode;
     final boolean enablePerBlockCompression;
 
-    public static ES819TSDBDocValuesFormat getInstance(boolean useLargeNumericBlock) {
-        return useLargeNumericBlock ? new ES819TSDBDocValuesFormat(NUMERIC_LARGE_BLOCK_SHIFT) : new ES819TSDBDocValuesFormat();
-    }
-
     public ES819TSDBDocValuesFormat() {
         this(NUMERIC_BLOCK_SHIFT);
     }
@@ -217,6 +213,17 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
         this.enableOptimizedMerge = enableOptimizedMerge;
         this.binaryDVCompressionMode = binaryDVCompressionMode;
         this.enablePerBlockCompression = enablePerBlockCompression;
+        this.numericBlockShift = numericBlockShift;
+    }
+
+    protected ES819TSDBDocValuesFormat(String codecName, int numericBlockShift) {
+        super(codecName);
+        assert numericBlockShift == NUMERIC_BLOCK_SHIFT || numericBlockShift == NUMERIC_LARGE_BLOCK_SHIFT : numericBlockShift;
+        this.skipIndexIntervalSize = DEFAULT_SKIP_INDEX_INTERVAL_SIZE;
+        this.minDocsPerOrdinalForRangeEncoding = ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL;
+        this.enableOptimizedMerge = OPTIMIZED_MERGE_ENABLE_DEFAULT;
+        this.binaryDVCompressionMode = BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1;
+        this.enablePerBlockCompression = true;
         this.numericBlockShift = numericBlockShift;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBLargerNumericBlocksDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBLargerNumericBlocksDocValuesFormat.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+public class ES819TSDBLargerNumericBlocksDocValuesFormat extends ES819TSDBDocValuesFormat {
+
+    static final String CODEC_NAME = "ES819TSDBLargerNumericBlocks";
+
+    public ES819TSDBLargerNumericBlocksDocValuesFormat() {
+        super(CODEC_NAME, NUMERIC_LARGE_BLOCK_SHIFT);
+    }
+}

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
@@ -1,3 +1,4 @@
 org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat
 org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat
+org.elasticsearch.index.codec.tsdb.es819.ES819TSDBLargerNumericBlocksDocValuesFormat
 org.elasticsearch.index.codec.bloomfilter.ES94BloomFilterDocValuesFormat

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.codec.perfield.XPerFieldDocValuesFormat;
 import org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormatTests.TestES87TSDBDocValuesFormat;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBLargerNumericBlocksDocValuesFormat;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
@@ -64,6 +65,12 @@ public class TsdbDocValueBwcTests extends ESTestCase {
         var compressionMode = ES819TSDBDocValuesFormatTests.randomBinaryCompressionMode();
         var newCodec = TestUtil.alwaysDocValuesFormat(new ES819TSDBDocValuesFormat(compressionMode));
         testMixedIndex(oldCodec, newCodec);
+    }
+
+    public void testMixedIndexFromDefaultBlocksToLargerBlocks() throws Exception {
+        var oldCodec = TestUtil.alwaysDocValuesFormat(new ES819TSDBDocValuesFormat());
+        var newCodec = TestUtil.alwaysDocValuesFormat(new ES819TSDBLargerNumericBlocksDocValuesFormat());
+        testMixedIndex(oldCodec, newCodec, this::assertVersion819, this::assertVersion819LargerNumericBlocks);
     }
 
     public void testMixedIndexDocValueVersion0ToVersion1() throws Exception {
@@ -135,6 +142,12 @@ public class TsdbDocValueBwcTests extends ESTestCase {
     void assertVersion819(DirectoryReader reader) throws IOException, NoSuchFieldException, ClassNotFoundException, IllegalAccessException {
         assert819DocValuesFormatVersion(reader);
         assertFieldInfoDocValuesFormat(reader, "0", "ES819TSDB");
+    }
+
+    void assertVersion819LargerNumericBlocks(DirectoryReader reader) throws IOException, NoSuchFieldException, ClassNotFoundException,
+        IllegalAccessException {
+        assert819DLargerNumericBlocksValuesFormatVersion(reader);
+        assertFieldInfoDocValuesFormat(reader, "0", "ES819TSDBLargerNumericBlocks");
     }
 
     void testMixedIndex(Codec oldCodec, Codec newCodec) throws IOException, NoSuchFieldException, IllegalAccessException,
@@ -499,6 +512,48 @@ public class TsdbDocValueBwcTests extends ESTestCase {
                 assertThat(
                     tsdbDvReader,
                     Matchers.instanceOf(Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer"))
+                );
+            }
+        }
+    }
+
+    private void assert819DLargerNumericBlocksValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException,
+        IllegalAccessException, IOException, ClassNotFoundException {
+
+        for (var leafReaderContext : reader.leaves()) {
+            var leaf = (SegmentReader) leafReaderContext.reader();
+            var dvReader = leaf.getDocValuesReader();
+            dvReader.checkIntegrity();
+
+            if (dvReader instanceof XPerFieldDocValuesFormat.FieldsReader perFieldDvReader) {
+                var formats = perFieldDvReader.getFormats();
+                assertThat(formats, Matchers.aMapWithSize(1));
+                var tsdbDvReader = formats.get("ES819TSDBLargerNumericBlocks_0");
+                tsdbDvReader.checkIntegrity();
+                assertThat(
+                    tsdbDvReader,
+                    Matchers.instanceOf(
+                        Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer")
+                    )
+                );
+            } else {
+                if (System.getSecurityManager() != null) {
+                    // With jvm version 24 entitlements are used and security manager is nog longer used.
+                    // Making this assertion work with security manager requires granting the entire test codebase privileges to use
+                    // suppressAccessChecks and suppressAccessChecks. This is undesired from a security manager perspective.
+                    logger.info("not asserting doc values format version, because security manager is used");
+                    continue;
+                }
+                var field = getFormatsFieldFromPerFieldFieldsReader(dvReader.getClass());
+                Map<?, ?> formats = (Map<?, ?>) field.get(dvReader);
+                assertThat(formats, Matchers.aMapWithSize(1));
+                var tsdbDvReader = (DocValuesProducer) formats.get("ES819TSDBLargerNumericBlocks_0");
+                tsdbDvReader.checkIntegrity();
+                assertThat(
+                    tsdbDvReader,
+                    Matchers.instanceOf(
+                        Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer")
+                    )
                 );
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
@@ -532,9 +532,7 @@ public class TsdbDocValueBwcTests extends ESTestCase {
                 tsdbDvReader.checkIntegrity();
                 assertThat(
                     tsdbDvReader,
-                    Matchers.instanceOf(
-                        Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer")
-                    )
+                    Matchers.instanceOf(Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer"))
                 );
             } else {
                 if (System.getSecurityManager() != null) {
@@ -551,9 +549,7 @@ public class TsdbDocValueBwcTests extends ESTestCase {
                 tsdbDvReader.checkIntegrity();
                 assertThat(
                     tsdbDvReader,
-                    Matchers.instanceOf(
-                        Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer")
-                    )
+                    Matchers.instanceOf(Class.forName("org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer"))
                 );
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -100,6 +100,16 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         }
     };
 
+    protected final Codec codecLargerBlocks = new Elasticsearch92Lucene103Codec() {
+
+        final ES819TSDBDocValuesFormat docValuesFormat = new ES819TSDBLargerNumericBlocksDocValuesFormat();
+
+        @Override
+        public DocValuesFormat getDocValuesFormatForField(String field) {
+            return docValuesFormat;
+        }
+    };
+
     public static class TestES819TSDBDocValuesFormatVersion0 extends ES819TSDBDocValuesFormat {
 
         public TestES819TSDBDocValuesFormatVersion0() {
@@ -124,7 +134,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
     @Override
     protected Codec getCodec() {
-        return codec;
+        return random().nextBoolean() ? codec : codecLargerBlocks;
     }
 
     public void testBinaryCompressionEnabled() {


### PR DESCRIPTION
This to make sure the larger numeric block size is always used when in time series mode. Previously, if the codec was constructed via SPI then we would still use the smaller numeric block size.