### PR TITLE
Add JDK22+ heap-backed native vector scorer suppliers

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
@@ -61,6 +61,21 @@ public interface VectorScorerFactory {
     );
 
     /**
+     * Returns an optional containing a float vector score supplier for array-backed vectors,
+     * or an empty optional if a scorer is not supported.
+     *
+     * @param similarityType the similarity type
+     * @param values the random access vector values
+     * @return an optional containing the vector scorer supplier, or empty
+     */
+    default Optional<RandomVectorScorerSupplier> getFloatVectorScorerSupplier(
+        VectorSimilarityType similarityType,
+        FloatVectorValues values
+    ) {
+        return Optional.empty();
+    }
+
+    /**
      * Returns an optional containing a byte vector score supplier
      * for the given parameters, or an empty optional if a scorer is not supported.
      *
@@ -76,6 +91,18 @@ public interface VectorScorerFactory {
         IndexInput input,
         ByteVectorValues values
     );
+
+    /**
+     * Returns an optional containing a byte vector score supplier for array-backed vectors,
+     * or an empty optional if a scorer is not supported.
+     *
+     * @param similarityType the similarity type
+     * @param values the random access vector values
+     * @return an optional containing the vector scorer supplier, or empty
+     */
+    default Optional<RandomVectorScorerSupplier> getByteVectorScorerSupplier(VectorSimilarityType similarityType, ByteVectorValues values) {
+        return Optional.empty();
+    }
 
     /**
      * Returns an optional containing a float vector scorer for

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
@@ -25,6 +25,8 @@ import org.elasticsearch.simdvec.internal.ByteVectorScorer;
 import org.elasticsearch.simdvec.internal.ByteVectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.FloatVectorScorer;
 import org.elasticsearch.simdvec.internal.FloatVectorScorerSupplier;
+import org.elasticsearch.simdvec.internal.HeapByteVectorScorerSupplier;
+import org.elasticsearch.simdvec.internal.HeapFloatVectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int4VectorScorer;
 import org.elasticsearch.simdvec.internal.Int4VectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int7SQVectorScorer;
@@ -102,6 +104,19 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
             };
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<RandomVectorScorerSupplier> getFloatVectorScorerSupplier(
+        VectorSimilarityType similarityType,
+        FloatVectorValues values
+    ) {
+        return HeapFloatVectorScorerSupplier.create(similarityType, values);
+    }
+
+    @Override
+    public Optional<RandomVectorScorerSupplier> getByteVectorScorerSupplier(VectorSimilarityType similarityType, ByteVectorValues values) {
+        return HeapByteVectorScorerSupplier.create(similarityType, values);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapByteVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapByteVectorScorerSupplier.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.elasticsearch.simdvec.VectorSimilarityType;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.util.Optional;
+
+/**
+ * Array-backed scorer supplier used when vectors do not expose an index slice.
+ * This is only enabled on JDK22+ where passing heap-backed memory segments to native code is supported.
+ */
+public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorerSupplier {
+
+    private static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
+
+    protected final ByteVectorValues values;
+    protected final int maxOrd;
+    protected final int dims;
+
+    HeapByteVectorScorerSupplier(ByteVectorValues values) {
+        this.values = values;
+        this.maxOrd = values.size();
+        this.dims = values.dimension();
+    }
+
+    public static Optional<RandomVectorScorerSupplier> create(VectorSimilarityType similarityType, ByteVectorValues values) {
+        if (SUPPORTS_HEAP_SEGMENTS == false) {
+            return Optional.empty();
+        }
+        return switch (similarityType) {
+            case COSINE -> Optional.of(new CosineSupplier(values));
+            case DOT_PRODUCT -> Optional.of(new DotProductSupplier(values));
+            case EUCLIDEAN -> Optional.of(new EuclideanSupplier(values));
+            case MAXIMUM_INNER_PRODUCT -> Optional.of(new MaxInnerProductSupplier(values));
+        };
+    }
+
+    @Override
+    public UpdateableRandomVectorScorer scorer() {
+        return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
+            private int firstOrd = -1;
+            private MemorySegment firstSegment;
+
+            @Override
+            public float score(int node) throws IOException {
+                checkOrdinal(node);
+                final byte[] secondVector = values.vectorValue(node);
+                return scoreFromSegments(firstSegment, MemorySegment.ofArray(secondVector));
+            }
+
+            @Override
+            public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                float max = Float.NEGATIVE_INFINITY;
+                for (int i = 0; i < numNodes; i++) {
+                    scores[i] = score(nodes[i]);
+                    max = Math.max(max, scores[i]);
+                }
+                return max;
+            }
+
+            @Override
+            public void setScoringOrdinal(int node) throws IOException {
+                checkOrdinal(node);
+                this.firstOrd = node;
+                this.firstSegment = MemorySegment.ofArray(values.vectorValue(firstOrd));
+            }
+        };
+    }
+
+    private void checkOrdinal(int ord) {
+        if (ord < 0 || ord >= maxOrd) {
+            throw new IllegalArgumentException("illegal ordinal: " + ord);
+        }
+    }
+
+    abstract float scoreFromSegments(MemorySegment a, MemorySegment b);
+
+    abstract HeapByteVectorScorerSupplier copyInternal();
+
+    @Override
+    public HeapByteVectorScorerSupplier copy() {
+        return copyInternal();
+    }
+
+    static final class CosineSupplier extends HeapByteVectorScorerSupplier {
+        CosineSupplier(ByteVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return (1 + Similarities.cosineI8(a, b, dims)) / 2;
+        }
+
+        @Override
+        HeapByteVectorScorerSupplier copyInternal() {
+            return new CosineSupplier(values);
+        }
+    }
+
+    static final class DotProductSupplier extends HeapByteVectorScorerSupplier {
+        private final float denom = (float) (dims * (1 << 15));
+
+        DotProductSupplier(ByteVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return 0.5f + Similarities.dotProductI8(a, b, dims) / denom;
+        }
+
+        @Override
+        HeapByteVectorScorerSupplier copyInternal() {
+            return new DotProductSupplier(values);
+        }
+    }
+
+    static final class EuclideanSupplier extends HeapByteVectorScorerSupplier {
+        EuclideanSupplier(ByteVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceI8(a, b, dims));
+        }
+
+        @Override
+        HeapByteVectorScorerSupplier copyInternal() {
+            return new EuclideanSupplier(values);
+        }
+    }
+
+    static final class MaxInnerProductSupplier extends HeapByteVectorScorerSupplier {
+        MaxInnerProductSupplier(ByteVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductI8(a, b, dims));
+        }
+
+        @Override
+        HeapByteVectorScorerSupplier copyInternal() {
+            return new MaxInnerProductSupplier(values);
+        }
+    }
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapByteVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapByteVectorScorerSupplier.java
@@ -28,12 +28,10 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
     private static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
 
     protected final ByteVectorValues values;
-    protected final int maxOrd;
     protected final int dims;
 
     HeapByteVectorScorerSupplier(ByteVectorValues values) {
         this.values = values;
-        this.maxOrd = values.size();
         this.dims = values.dimension();
     }
 
@@ -52,8 +50,9 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
     @Override
     public UpdateableRandomVectorScorer scorer() {
         return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
-            private int firstOrd = -1;
             private MemorySegment firstSegment;
+            private byte[] packedVectors = new byte[0];
+            private MemorySegment packedVectorsSegment = MemorySegment.ofArray(packedVectors);
 
             @Override
             public float score(int node) throws IOException {
@@ -64,9 +63,15 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
 
             @Override
             public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                if (numNodes == 0) {
+                    return Float.NEGATIVE_INFINITY;
+                }
+                final MemorySegment vectorsSegment = packVectors(nodes, numNodes);
+                final MemorySegment scoresSegment = MemorySegment.ofArray(scores);
+                bulkScoreFromSegments(vectorsSegment, firstSegment, numNodes, scoresSegment);
+                normalizeBulkScores(scores, numNodes);
                 float max = Float.NEGATIVE_INFINITY;
                 for (int i = 0; i < numNodes; i++) {
-                    scores[i] = score(nodes[i]);
                     max = Math.max(max, scores[i]);
                 }
                 return max;
@@ -75,13 +80,29 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
             @Override
             public void setScoringOrdinal(int node) throws IOException {
                 checkOrdinal(node);
-                this.firstOrd = node;
-                this.firstSegment = MemorySegment.ofArray(values.vectorValue(firstOrd));
+                this.firstSegment = MemorySegment.ofArray(values.vectorValue(node));
+            }
+
+            private MemorySegment packVectors(int[] nodes, int numNodes) throws IOException {
+                final int requiredValues = Math.multiplyExact(numNodes, dims);
+                if (packedVectors.length < requiredValues) {
+                    packedVectors = new byte[requiredValues];
+                    packedVectorsSegment = MemorySegment.ofArray(packedVectors);
+                }
+
+                for (int i = 0; i < numNodes; i++) {
+                    final int node = nodes[i];
+                    checkOrdinal(node);
+                    final byte[] vector = values.vectorValue(node);
+                    System.arraycopy(vector, 0, packedVectors, i * dims, dims);
+                }
+                return packedVectorsSegment;
             }
         };
     }
 
     private void checkOrdinal(int ord) {
+        final int maxOrd = values.size();
         if (ord < 0 || ord >= maxOrd) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
@@ -89,12 +110,9 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
 
     abstract float scoreFromSegments(MemorySegment a, MemorySegment b);
 
-    abstract HeapByteVectorScorerSupplier copyInternal();
+    abstract void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores);
 
-    @Override
-    public HeapByteVectorScorerSupplier copy() {
-        return copyInternal();
-    }
+    abstract void normalizeBulkScores(float[] scores, int count);
 
     static final class CosineSupplier extends HeapByteVectorScorerSupplier {
         CosineSupplier(ByteVectorValues values) {
@@ -107,7 +125,19 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
         }
 
         @Override
-        HeapByteVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.cosineI8Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = (1 + scores[i]) / 2;
+            }
+        }
+
+        @Override
+        public HeapByteVectorScorerSupplier copy() {
             return new CosineSupplier(values);
         }
     }
@@ -125,7 +155,19 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
         }
 
         @Override
-        HeapByteVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.dotProductI8Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = 0.5f + scores[i] / denom;
+            }
+        }
+
+        @Override
+        public HeapByteVectorScorerSupplier copy() {
             return new DotProductSupplier(values);
         }
     }
@@ -141,7 +183,19 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
         }
 
         @Override
-        HeapByteVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.squareDistanceI8Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = VectorUtil.normalizeDistanceToUnitInterval(scores[i]);
+            }
+        }
+
+        @Override
+        public HeapByteVectorScorerSupplier copy() {
             return new EuclideanSupplier(values);
         }
     }
@@ -157,7 +211,19 @@ public abstract class HeapByteVectorScorerSupplier implements RandomVectorScorer
         }
 
         @Override
-        HeapByteVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.dotProductI8Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = VectorUtil.scaleMaxInnerProductScore(scores[i]);
+            }
+        }
+
+        @Override
+        public HeapByteVectorScorerSupplier copy() {
             return new MaxInnerProductSupplier(values);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapFloatVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapFloatVectorScorerSupplier.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.elasticsearch.simdvec.VectorSimilarityType;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.util.Optional;
+
+/**
+ * Array-backed scorer supplier used when vectors do not expose an index slice.
+ * This is only enabled on JDK22+ where passing heap-backed memory segments to native code is supported.
+ */
+public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScorerSupplier {
+
+    private static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
+
+    protected final FloatVectorValues values;
+    protected final int maxOrd;
+    protected final int dims;
+
+    HeapFloatVectorScorerSupplier(FloatVectorValues values) {
+        this.values = values;
+        this.maxOrd = values.size();
+        this.dims = values.dimension();
+    }
+
+    public static Optional<RandomVectorScorerSupplier> create(VectorSimilarityType similarityType, FloatVectorValues values) {
+        if (SUPPORTS_HEAP_SEGMENTS == false) {
+            return Optional.empty();
+        }
+        return switch (similarityType) {
+            case COSINE, DOT_PRODUCT -> Optional.of(new DotProductSupplier(values));
+            case EUCLIDEAN -> Optional.of(new EuclideanSupplier(values));
+            case MAXIMUM_INNER_PRODUCT -> Optional.of(new MaxInnerProductSupplier(values));
+        };
+    }
+
+    @Override
+    public UpdateableRandomVectorScorer scorer() {
+        return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
+            private int firstOrd = -1;
+            private MemorySegment firstSegment;
+
+            @Override
+            public float score(int node) throws IOException {
+                checkOrdinal(node);
+                final float[] secondVector = values.vectorValue(node);
+                return scoreFromSegments(firstSegment, MemorySegment.ofArray(secondVector));
+            }
+
+            @Override
+            public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                float max = Float.NEGATIVE_INFINITY;
+                for (int i = 0; i < numNodes; i++) {
+                    scores[i] = score(nodes[i]);
+                    max = Math.max(max, scores[i]);
+                }
+                return max;
+            }
+
+            @Override
+            public void setScoringOrdinal(int node) throws IOException {
+                checkOrdinal(node);
+                this.firstOrd = node;
+                this.firstSegment = MemorySegment.ofArray(values.vectorValue(firstOrd));
+            }
+        };
+    }
+
+    private void checkOrdinal(int ord) {
+        if (ord < 0 || ord >= maxOrd) {
+            throw new IllegalArgumentException("illegal ordinal: " + ord);
+        }
+    }
+
+    abstract float scoreFromSegments(MemorySegment a, MemorySegment b);
+
+    abstract HeapFloatVectorScorerSupplier copyInternal();
+
+    @Override
+    public HeapFloatVectorScorerSupplier copy() {
+        return copyInternal();
+    }
+
+    static final class DotProductSupplier extends HeapFloatVectorScorerSupplier {
+        DotProductSupplier(FloatVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.normalizeToUnitInterval(Similarities.dotProductF32(a, b, dims));
+        }
+
+        @Override
+        HeapFloatVectorScorerSupplier copyInternal() {
+            return new DotProductSupplier(values);
+        }
+    }
+
+    static final class EuclideanSupplier extends HeapFloatVectorScorerSupplier {
+        EuclideanSupplier(FloatVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceF32(a, b, dims));
+        }
+
+        @Override
+        HeapFloatVectorScorerSupplier copyInternal() {
+            return new EuclideanSupplier(values);
+        }
+    }
+
+    static final class MaxInnerProductSupplier extends HeapFloatVectorScorerSupplier {
+        MaxInnerProductSupplier(FloatVectorValues values) {
+            super(values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductF32(a, b, dims));
+        }
+
+        @Override
+        HeapFloatVectorScorerSupplier copyInternal() {
+            return new MaxInnerProductSupplier(values);
+        }
+    }
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapFloatVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/HeapFloatVectorScorerSupplier.java
@@ -28,12 +28,10 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
     private static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
 
     protected final FloatVectorValues values;
-    protected final int maxOrd;
     protected final int dims;
 
     HeapFloatVectorScorerSupplier(FloatVectorValues values) {
         this.values = values;
-        this.maxOrd = values.size();
         this.dims = values.dimension();
     }
 
@@ -51,8 +49,9 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
     @Override
     public UpdateableRandomVectorScorer scorer() {
         return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
-            private int firstOrd = -1;
             private MemorySegment firstSegment;
+            private float[] packedVectors = new float[0];
+            private MemorySegment packedVectorsSegment = MemorySegment.ofArray(packedVectors);
 
             @Override
             public float score(int node) throws IOException {
@@ -63,9 +62,15 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
 
             @Override
             public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                if (numNodes == 0) {
+                    return Float.NEGATIVE_INFINITY;
+                }
+                final MemorySegment vectorsSegment = packVectors(nodes, numNodes);
+                final MemorySegment scoresSegment = MemorySegment.ofArray(scores);
+                bulkScoreFromSegments(vectorsSegment, firstSegment, numNodes, scoresSegment);
+                normalizeBulkScores(scores, numNodes);
                 float max = Float.NEGATIVE_INFINITY;
                 for (int i = 0; i < numNodes; i++) {
-                    scores[i] = score(nodes[i]);
                     max = Math.max(max, scores[i]);
                 }
                 return max;
@@ -74,13 +79,29 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
             @Override
             public void setScoringOrdinal(int node) throws IOException {
                 checkOrdinal(node);
-                this.firstOrd = node;
-                this.firstSegment = MemorySegment.ofArray(values.vectorValue(firstOrd));
+                this.firstSegment = MemorySegment.ofArray(values.vectorValue(node));
+            }
+
+            private MemorySegment packVectors(int[] nodes, int numNodes) throws IOException {
+                final int requiredValues = Math.multiplyExact(numNodes, dims);
+                if (packedVectors.length < requiredValues) {
+                    packedVectors = new float[requiredValues];
+                    packedVectorsSegment = MemorySegment.ofArray(packedVectors);
+                }
+
+                for (int i = 0; i < numNodes; i++) {
+                    final int node = nodes[i];
+                    checkOrdinal(node);
+                    final float[] vector = values.vectorValue(node);
+                    System.arraycopy(vector, 0, packedVectors, i * dims, dims);
+                }
+                return packedVectorsSegment;
             }
         };
     }
 
     private void checkOrdinal(int ord) {
+        final int maxOrd = values.size();
         if (ord < 0 || ord >= maxOrd) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
@@ -88,12 +109,9 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
 
     abstract float scoreFromSegments(MemorySegment a, MemorySegment b);
 
-    abstract HeapFloatVectorScorerSupplier copyInternal();
+    abstract void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores);
 
-    @Override
-    public HeapFloatVectorScorerSupplier copy() {
-        return copyInternal();
-    }
+    abstract void normalizeBulkScores(float[] scores, int count);
 
     static final class DotProductSupplier extends HeapFloatVectorScorerSupplier {
         DotProductSupplier(FloatVectorValues values) {
@@ -106,7 +124,19 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
         }
 
         @Override
-        HeapFloatVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.dotProductF32Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = VectorUtil.normalizeToUnitInterval(scores[i]);
+            }
+        }
+
+        @Override
+        public HeapFloatVectorScorerSupplier copy() {
             return new DotProductSupplier(values);
         }
     }
@@ -122,7 +152,19 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
         }
 
         @Override
-        HeapFloatVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.squareDistanceF32Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = VectorUtil.normalizeDistanceToUnitInterval(scores[i]);
+            }
+        }
+
+        @Override
+        public HeapFloatVectorScorerSupplier copy() {
             return new EuclideanSupplier(values);
         }
     }
@@ -138,7 +180,19 @@ public abstract class HeapFloatVectorScorerSupplier implements RandomVectorScore
         }
 
         @Override
-        HeapFloatVectorScorerSupplier copyInternal() {
+        void bulkScoreFromSegments(MemorySegment a, MemorySegment b, int count, MemorySegment scores) {
+            Similarities.dotProductF32Bulk(a, b, dims, count, scores);
+        }
+
+        @Override
+        void normalizeBulkScores(float[] scores, int count) {
+            for (int i = 0; i < count; i++) {
+                scores[i] = VectorUtil.scaleMaxInnerProductScore(scores[i]);
+            }
+        }
+
+        @Override
+        public HeapFloatVectorScorerSupplier copy() {
             return new MaxInnerProductSupplier(values);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Similarities.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Similarities.java
@@ -178,6 +178,12 @@ public class Similarities {
     );
 
     static final MethodHandle DOT_PRODUCT_F32 = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.FLOAT32, Operation.SINGLE);
+    static final MethodHandle DOT_PRODUCT_F32_BULK = DISTANCE_FUNCS.getHandle(Function.DOT_PRODUCT, DataType.FLOAT32, Operation.BULK);
+    static final MethodHandle DOT_PRODUCT_F32_BULK_WITH_OFFSETS = DISTANCE_FUNCS.getHandle(
+        Function.DOT_PRODUCT,
+        DataType.FLOAT32,
+        Operation.BULK_OFFSETS
+    );
     static final MethodHandle DOT_PRODUCT_F32_BULK_SPARSE = DISTANCE_FUNCS.getHandle(
         Function.DOT_PRODUCT,
         DataType.FLOAT32,
@@ -185,6 +191,16 @@ public class Similarities {
     );
 
     static final MethodHandle SQUARE_DISTANCE_F32 = DISTANCE_FUNCS.getHandle(Function.SQUARE_DISTANCE, DataType.FLOAT32, Operation.SINGLE);
+    static final MethodHandle SQUARE_DISTANCE_F32_BULK = DISTANCE_FUNCS.getHandle(
+        Function.SQUARE_DISTANCE,
+        DataType.FLOAT32,
+        Operation.BULK
+    );
+    static final MethodHandle SQUARE_DISTANCE_F32_BULK_WITH_OFFSETS = DISTANCE_FUNCS.getHandle(
+        Function.SQUARE_DISTANCE,
+        DataType.FLOAT32,
+        Operation.BULK_OFFSETS
+    );
     static final MethodHandle SQUARE_DISTANCE_F32_BULK_SPARSE = DISTANCE_FUNCS.getHandle(
         Function.SQUARE_DISTANCE,
         DataType.FLOAT32,
@@ -654,6 +670,30 @@ public class Similarities {
         }
     }
 
+    static void dotProductF32Bulk(MemorySegment a, MemorySegment b, int dimensions, int count, MemorySegment scores) {
+        try {
+            DOT_PRODUCT_F32_BULK.invokeExact(a, b, dimensions, count, scores);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    static void dotProductF32BulkWithOffsets(
+        MemorySegment a,
+        MemorySegment b,
+        int dimensions,
+        int pitch,
+        MemorySegment offsets,
+        int count,
+        MemorySegment scores
+    ) {
+        try {
+            DOT_PRODUCT_F32_BULK_WITH_OFFSETS.invokeExact(a, b, dimensions, pitch, offsets, count, scores);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
     static void dotProductF32BulkSparse(MemorySegment addresses, MemorySegment query, int dimensions, int count, MemorySegment scores) {
         try {
             DOT_PRODUCT_F32_BULK_SPARSE.invokeExact(addresses, query, dimensions, count, scores);
@@ -665,6 +705,30 @@ public class Similarities {
     public static float squareDistanceF32(MemorySegment a, MemorySegment b, int length) {
         try {
             return (float) SQUARE_DISTANCE_F32.invokeExact(a, b, length);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    static void squareDistanceF32Bulk(MemorySegment a, MemorySegment b, int dimensions, int count, MemorySegment scores) {
+        try {
+            SQUARE_DISTANCE_F32_BULK.invokeExact(a, b, dimensions, count, scores);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    static void squareDistanceF32BulkWithOffsets(
+        MemorySegment a,
+        MemorySegment b,
+        int dimensions,
+        int pitch,
+        MemorySegment offsets,
+        int count,
+        MemorySegment scores
+    ) {
+        try {
+            SQUARE_DISTANCE_F32_BULK_WITH_OFFSETS.invokeExact(a, b, dimensions, pitch, offsets, count, scores);
         } catch (Throwable e) {
             throw rethrow(e);
         }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ByteVectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ByteVectorScorerFactoryTests.java
@@ -33,6 +33,7 @@ import static org.elasticsearch.simdvec.VectorSimilarityType.COSINE;
 import static org.elasticsearch.simdvec.VectorSimilarityType.DOT_PRODUCT;
 import static org.elasticsearch.simdvec.VectorSimilarityType.EUCLIDEAN;
 import static org.elasticsearch.simdvec.VectorSimilarityType.MAXIMUM_INNER_PRODUCT;
+import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 import static org.hamcrest.Matchers.closeTo;
 
 public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
@@ -59,6 +60,35 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
         testRandomSupplier(maxChunkSize, ESTestCase::randomByteArrayOfLength, VectorSimilarityType.values());
+    }
+
+    public void testArrayBackedRandomSupplier() throws IOException {
+        assumeTrue(notSupportedMsg(), supported());
+        assumeTrue("Not supported on current JDK", SUPPORTS_HEAP_SEGMENTS);
+        var factory = AbstractVectorTestCase.factory.get();
+
+        final int dims = randomIntBetween(1, 1024);
+        final int size = randomIntBetween(2, 100);
+        final byte[][] vectors = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            vectors[i] = randomByteArrayOfLength(dims);
+        }
+        final ByteVectorValues values = arrayBackedVectorValues(vectors);
+
+        for (int times = 0; times < TIMES; times++) {
+            int idx0 = randomIntBetween(0, size - 1);
+            int idx1 = randomIntBetween(0, size - 1);
+            for (var sim : VectorSimilarityType.values()) {
+                float expected = luceneScore(sim, vectors[idx0], vectors[idx1]);
+                var scorerSupplier = factory.getByteVectorScorerSupplier(sim, values);
+                assertTrue(scorerSupplier.isPresent());
+                var scorer = scorerSupplier.get().scorer();
+                scorer.setScoringOrdinal(idx0);
+
+                double expectedDelta = expected * DELTA;
+                assertThat(sim.toString(), (double) scorer.score(idx1), closeTo(expected, expectedDelta));
+            }
+        }
     }
 
     void testRandomSupplier(long maxChunkSize, IntFunction<byte[]> bytesSupplier, VectorSimilarityType... types) throws IOException {
@@ -351,4 +381,28 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
     }
 
     static final int TIMES = 100; // a loop iteration times
+
+    static ByteVectorValues arrayBackedVectorValues(byte[][] vectors) {
+        return new ByteVectorValues() {
+            @Override
+            public int dimension() {
+                return vectors[0].length;
+            }
+
+            @Override
+            public int size() {
+                return vectors.length;
+            }
+
+            @Override
+            public byte[] vectorValue(int targetOrd) {
+                return vectors[targetOrd];
+            }
+
+            @Override
+            public ByteVectorValues copy() {
+                return this;
+            }
+        };
+    }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ByteVectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ByteVectorScorerFactoryTests.java
@@ -91,6 +91,45 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    public void testArrayBackedRandomSupplierBulkScore() throws IOException {
+        assumeTrue(notSupportedMsg(), supported());
+        assumeTrue("Not supported on current JDK", SUPPORTS_HEAP_SEGMENTS);
+        var factory = AbstractVectorTestCase.factory.get();
+
+        final int dims = randomIntBetween(1, 1024);
+        final int size = randomIntBetween(2, 100);
+        final byte[][] vectors = new byte[size][];
+        for (int i = 0; i < size; i++) {
+            vectors[i] = randomByteArrayOfLength(dims);
+        }
+        final ByteVectorValues values = arrayBackedVectorValues(vectors);
+
+        for (int times = 0; times < TIMES; times++) {
+            final int queryOrd = randomIntBetween(0, size - 1);
+            final int numNodes = randomIntBetween(1, size);
+            final int[] nodes = new int[numNodes];
+            for (int i = 0; i < numNodes; i++) {
+                nodes[i] = randomIntBetween(0, size - 1);
+            }
+
+            for (var sim : VectorSimilarityType.values()) {
+                final var scorerSupplier = factory.getByteVectorScorerSupplier(sim, values);
+                assertTrue(scorerSupplier.isPresent());
+                final var scorer = scorerSupplier.get().scorer();
+                scorer.setScoringOrdinal(queryOrd);
+
+                final float[] scores = new float[numNodes];
+                scorer.bulkScore(nodes, scores, numNodes);
+
+                for (int i = 0; i < numNodes; i++) {
+                    float expected = luceneScore(sim, vectors[queryOrd], vectors[nodes[i]]);
+                    double expectedDelta = expected * DELTA;
+                    assertThat(sim.toString(), (double) scores[i], closeTo(expected, expectedDelta));
+                }
+            }
+        }
+    }
+
     void testRandomSupplier(long maxChunkSize, IntFunction<byte[]> bytesSupplier, VectorSimilarityType... types) throws IOException {
         var factory = AbstractVectorTestCase.factory.get();
 

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/FloatVectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/FloatVectorScorerFactoryTests.java
@@ -108,6 +108,35 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    public void testArrayBackedRandomSupplier() throws IOException {
+        assumeTrue(notSupportedMsg(), supported());
+        assumeTrue("Not supported on current JDK", SUPPORTS_HEAP_SEGMENTS);
+        var factory = AbstractVectorTestCase.factory.get();
+
+        final int dims = randomIntBetween(1, 1024);
+        final int size = randomIntBetween(2, 100);
+        final float[][] vectors = new float[size][];
+        for (int i = 0; i < size; i++) {
+            vectors[i] = randomVector(dims);
+        }
+        final FloatVectorValues values = arrayBackedVectorValues(vectors);
+
+        for (int times = 0; times < TIMES; times++) {
+            int idx0 = randomIntBetween(0, size - 1);
+            int idx1 = randomIntBetween(0, size - 1);
+            for (var sim : List.of(DOT_PRODUCT, EUCLIDEAN, MAXIMUM_INNER_PRODUCT)) {
+                float expected = luceneScore(sim, vectors[idx0], vectors[idx1]);
+                var scorerSupplier = factory.getFloatVectorScorerSupplier(sim, values);
+                assertTrue(scorerSupplier.isPresent());
+                var scorer = scorerSupplier.get().scorer();
+                scorer.setScoringOrdinal(idx0);
+
+                double expectedDelta = expected * DELTA;
+                assertThat(sim.toString(), (double) scorer.score(idx1), closeTo(expected, expectedDelta));
+            }
+        }
+    }
+
     void testRandomSupplier(Directory dir, IntFunction<float[]> floatsSupplier) throws IOException {
         var factory = AbstractVectorTestCase.factory.get();
 
@@ -301,5 +330,29 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
                 vectors[i] = vec;
             }
         }
+    }
+
+    static FloatVectorValues arrayBackedVectorValues(float[][] vectors) {
+        return new FloatVectorValues() {
+            @Override
+            public int dimension() {
+                return vectors[0].length;
+            }
+
+            @Override
+            public int size() {
+                return vectors.length;
+            }
+
+            @Override
+            public float[] vectorValue(int targetOrd) {
+                return vectors[targetOrd];
+            }
+
+            @Override
+            public FloatVectorValues copy() {
+                return this;
+            }
+        };
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/FloatVectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/FloatVectorScorerFactoryTests.java
@@ -137,6 +137,45 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    public void testArrayBackedRandomSupplierBulkScore() throws IOException {
+        assumeTrue(notSupportedMsg(), supported());
+        assumeTrue("Not supported on current JDK", SUPPORTS_HEAP_SEGMENTS);
+        var factory = AbstractVectorTestCase.factory.get();
+
+        final int dims = randomIntBetween(1, 1024);
+        final int size = randomIntBetween(2, 100);
+        final float[][] vectors = new float[size][];
+        for (int i = 0; i < size; i++) {
+            vectors[i] = randomVector(dims);
+        }
+        final FloatVectorValues values = arrayBackedVectorValues(vectors);
+
+        for (int times = 0; times < TIMES; times++) {
+            final int queryOrd = randomIntBetween(0, size - 1);
+            final int numNodes = randomIntBetween(1, size);
+            final int[] nodes = new int[numNodes];
+            for (int i = 0; i < numNodes; i++) {
+                nodes[i] = randomIntBetween(0, size - 1);
+            }
+
+            for (var sim : List.of(DOT_PRODUCT, EUCLIDEAN, MAXIMUM_INNER_PRODUCT)) {
+                final var scorerSupplier = factory.getFloatVectorScorerSupplier(sim, values);
+                assertTrue(scorerSupplier.isPresent());
+                final var scorer = scorerSupplier.get().scorer();
+                scorer.setScoringOrdinal(queryOrd);
+
+                final float[] scores = new float[numNodes];
+                scorer.bulkScore(nodes, scores, numNodes);
+
+                for (int i = 0; i < numNodes; i++) {
+                    float expected = luceneScore(sim, vectors[queryOrd], vectors[nodes[i]]);
+                    double expectedDelta = expected * DELTA;
+                    assertThat(sim.toString(), (double) scores[i], closeTo(expected, expectedDelta));
+                }
+            }
+        }
+    }
+
     void testRandomSupplier(Directory dir, IntFunction<float[]> floatsSupplier) throws IOException {
         var factory = AbstractVectorTestCase.factory.get();
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93GenericFlatVectorScorer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93GenericFlatVectorScorer.java
@@ -57,19 +57,15 @@ public class ES93GenericFlatVectorScorer implements FlatVectorsScorer {
             }
             return DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
         }
-
-        if (FACTORY != null && vectorValues instanceof HasIndexSlice sl) {
+        if (FACTORY != null) {
+            final var similarityType = VectorSimilarityType.of(similarityFunction);
             Optional<RandomVectorScorerSupplier> scorer = switch (vectorValues.getEncoding()) {
-                case BYTE -> FACTORY.getByteVectorScorerSupplier(
-                    VectorSimilarityType.of(similarityFunction),
-                    sl.getSlice(),
-                    (ByteVectorValues) vectorValues
-                );
-                case FLOAT32 -> FACTORY.getFloatVectorScorerSupplier(
-                    VectorSimilarityType.of(similarityFunction),
-                    sl.getSlice(),
-                    (FloatVectorValues) vectorValues
-                );
+                case BYTE -> vectorValues instanceof HasIndexSlice sl
+                    ? FACTORY.getByteVectorScorerSupplier(similarityType, sl.getSlice(), (ByteVectorValues) vectorValues)
+                    : FACTORY.getByteVectorScorerSupplier(similarityType, (ByteVectorValues) vectorValues);
+                case FLOAT32 -> vectorValues instanceof HasIndexSlice sl
+                    ? FACTORY.getFloatVectorScorerSupplier(similarityType, sl.getSlice(), (FloatVectorValues) vectorValues)
+                    : FACTORY.getFloatVectorScorerSupplier(similarityType, (FloatVectorValues) vectorValues);
             };
             if (scorer.isPresent()) {
                 return scorer.get();


### PR DESCRIPTION
### Description

This PR implements an Elasticsearch-first fix for #142379 by enabling native vector scorer suppliers during the array-backed phase of HNSW graph building (JDK 22+), while preserving existing off-heap paths and Lucene fallback behavior.

  Context from issue discussion:
  - During initial HNSW build, vectors may come from heap arrays (`vectorValue`), so the existing index-slice/off-heap native supplier path is not always used.
  - We add a JDK22+ heap-backed `MemorySegment` supplier path in Elasticsearch first, as requested in the issue thread.

### Changes

  1. Extended `VectorScorerFactory` API for array-backed suppliers:
  - `getFloatVectorScorerSupplier(VectorSimilarityType, FloatVectorValues)`
  - `getByteVectorScorerSupplier(VectorSimilarityType, ByteVectorValues)`

  2. Implemented array-backed native suppliers in `simdvec`:
  - Heap float supplier
  - Heap byte supplier

  3. Wired factory implementation:
  - `VectorScorerFactoryImpl` now returns heap-backed suppliers for array-backed values.

  4. Updated ES scorer selection path:
  - `ES93FlatVectorScorer` now tries:
    - index-slice native supplier (existing behavior)
    - array-backed native supplier (new behavior)
    - Lucene fallback supplier

  5. Added test coverage for the new array-backed path:
  - `FloatVectorScorerFactoryTests.testArrayBackedRandomSupplier`
  - `ByteVectorScorerFactoryTests.testArrayBackedRandomSupplier`

  ### Behavior / Safety

  - New array-backed native supplier path is explicitly gated to JDK 22+ (`Runtime.version().feature() >= 22`).
  - If unsupported/incompatible, behavior falls back to existing Lucene scorer path.
  - Existing off-heap/index-slice path remains unchanged.

  ### Validation

  Ran with runtime JDK 25 (JDK22+ path active):

  ```bash
  ./gradlew :libs:simdvec:compileMain21Java :server:compileJava
  ./gradlew :libs:simdvec:test \
    --tests org.elasticsearch.simdvec.FloatVectorScorerFactoryTests.testArrayBackedRandomSupplier \
    --tests org.elasticsearch.simdvec.ByteVectorScorerFactoryTests.testArrayBackedRandomSupplier
  ./gradlew :server:test \
    --tests org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTests.testKnnQuantizedFlatVectorsFormat \
    --tests org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTests.testKnnQuantizedHNSWVectorsFormat
  ./gradlew :libs:simdvec:spotlessApply
  ./gradlew :libs:simdvec:spotlessJavaCheck :server:spotlessJavaCheck
  ```

  All above commands completed successfully.
