### PR TITLE
ESQL: Make datasources plugins lazy

### DIFF
--- a/docs/changelog/142815.yaml
+++ b/docs/changelog/142815.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 142815
+summary: Make datasources plugins lazy
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Data source plugin that provides CSV format support for ESQL external data sources.
@@ -35,6 +36,16 @@ import java.util.Map;
  * the core ESQL plugin free of third-party format libraries.
  */
 public class CsvDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedFormats() {
+        return Set.of("csv");
+    }
+
+    @Override
+    public Set<String> supportedExtensions() {
+        return Set.of(".csv", ".tsv");
+    }
 
     @Override
     public Map<String, FormatReaderFactory> formatReaders(Settings settings) {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Data source plugin providing Google Cloud Storage support for ESQL.
@@ -27,6 +28,11 @@ import java.util.Objects;
  * </pre>
  */
 public class GcsDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedSchemes() {
+        return Set.of("gs");
+    }
 
     @Override
     public Map<String, StorageProviderFactory> storageProviders(Settings settings) {

--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/GrpcDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/GrpcDataSourcePlugin.java
@@ -13,12 +13,18 @@ import org.elasticsearch.xpack.esql.datasources.spi.ConnectorFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Registers the Arrow Flight connector for ESQL.
  * Handles {@code flight://} and {@code grpc://} URIs for columnar data streaming via gRPC.
  */
 public class GrpcDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedConnectorSchemes() {
+        return Set.of("flight", "grpc");
+    }
 
     @Override
     public Map<String, ConnectorFactory> connectors(Settings settings) {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -34,6 +35,11 @@ import java.util.concurrent.ExecutorService;
  * backed by the ES GENERIC thread pool.
  */
 public class HttpDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedSchemes() {
+        return Set.of("http", "https", "file");
+    }
 
     @Override
     public Map<String, StorageProviderFactory> storageProviders(Settings settings, ExecutorService executor) {

--- a/x-pack/plugin/esql-datasource-iceberg/src/main/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-iceberg/src/main/java/org/elasticsearch/xpack/esql/datasource/iceberg/IcebergDataSourcePlugin.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.TableCatalogFactory;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Data source plugin that provides Iceberg table catalog support for ESQL external data sources.
@@ -36,6 +37,11 @@ import java.util.Map;
  * to avoid jar hell issues in the core ESQL plugin.
  */
 public class IcebergDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedCatalogs() {
+        return Set.of("iceberg");
+    }
 
     @Override
     public Map<String, TableCatalogFactory> tableCatalogs(Settings settings) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Data source plugin that provides Parquet format support for ESQL external data sources.
@@ -35,6 +36,16 @@ import java.util.Map;
  * to avoid jar hell issues in the core ESQL plugin.
  */
 public class ParquetDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedFormats() {
+        return Set.of("parquet");
+    }
+
+    @Override
+    public Set<String> supportedExtensions() {
+        return Set.of(".parquet");
+    }
 
     @Override
     public Map<String, FormatReaderFactory> formatReaders(Settings settings) {

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
@@ -14,12 +14,18 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Data source plugin providing S3 storage support for ESQL.
  * Supports s3://, s3a://, and s3n:// URI schemes.
  */
 public class S3DataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    @Override
+    public Set<String> supportedSchemes() {
+        return Set.of("s3", "s3a", "s3n");
+    }
 
     @Override
     public Map<String, StorageProviderFactory> storageProviders(Settings settings) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceCapabilities.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Aggregated capability declarations from all registered {@link DataSourcePlugin} instances.
+ * Built once at startup from cheap SPI calls; does not store plugin references.
+ */
+public record DataSourceCapabilities(Set<String> schemes, Set<String> formats, Set<String> extensions, Set<String> catalogs) {
+
+    public boolean supportsScheme(String s) {
+        return s != null && schemes.contains(s.toLowerCase(Locale.ROOT));
+    }
+
+    public boolean supportsFormat(String f) {
+        return f != null && formats.contains(f.toLowerCase(Locale.ROOT));
+    }
+
+    public boolean supportsExtension(String ext) {
+        if (ext == null) {
+            return false;
+        }
+        String normalized = ext.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith(".") == false) {
+            normalized = "." + normalized;
+        }
+        return extensions.contains(normalized);
+    }
+
+    public boolean supportsCatalog(String c) {
+        return c != null && catalogs.contains(c.toLowerCase(Locale.ROOT));
+    }
+
+    public String supportedSchemesString() {
+        return String.join(", ", schemes);
+    }
+
+    public static DataSourceCapabilities build(List<DataSourcePlugin> plugins) {
+        Set<String> allSchemes = new LinkedHashSet<>();
+        Set<String> allFormats = new LinkedHashSet<>();
+        Set<String> allExtensions = new LinkedHashSet<>();
+        Set<String> allCatalogs = new LinkedHashSet<>();
+
+        for (DataSourcePlugin plugin : plugins) {
+            for (String scheme : plugin.supportedSchemes()) {
+                allSchemes.add(scheme.toLowerCase(Locale.ROOT));
+            }
+            for (String scheme : plugin.supportedConnectorSchemes()) {
+                allSchemes.add(scheme.toLowerCase(Locale.ROOT));
+            }
+            for (String format : plugin.supportedFormats()) {
+                String lower = format.toLowerCase(Locale.ROOT);
+                if (allFormats.contains(lower)) {
+                    throw new IllegalArgumentException("Format reader for [" + format + "] is already registered");
+                }
+                allFormats.add(lower);
+            }
+            for (String ext : plugin.supportedExtensions()) {
+                String normalized = ext.toLowerCase(Locale.ROOT);
+                if (normalized.startsWith(".") == false) {
+                    normalized = "." + normalized;
+                }
+                allExtensions.add(normalized);
+            }
+            for (String catalog : plugin.supportedCatalogs()) {
+                String lower = catalog.toLowerCase(Locale.ROOT);
+                if (allCatalogs.contains(lower)) {
+                    throw new IllegalArgumentException("Source factory for type [" + catalog + "] is already registered");
+                }
+                allCatalogs.add(lower);
+            }
+        }
+
+        return new DataSourceCapabilities(
+            Collections.unmodifiableSet(allSchemes),
+            Collections.unmodifiableSet(allFormats),
+            Collections.unmodifiableSet(allExtensions),
+            Collections.unmodifiableSet(allCatalogs)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -15,7 +15,9 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.TableCatalog;
 import org.elasticsearch.xpack.esql.datasources.spi.TableCatalogFactory;
@@ -26,27 +28,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
  * Module that collects all data source implementations from plugins.
- * Follows the same pattern as RepositoriesModule in Elasticsearch core.
  *
- * <p>This module:
- * <ul>
- *   <li>Discovers all plugins implementing {@link DataSourcePlugin}</li>
- *   <li>Collects storage providers, format readers, and external source factories</li>
- *   <li>Populates registries for runtime lookup</li>
- *   <li>Validates that no duplicate registrations occur</li>
- *   <li>Creates an {@link OperatorFactoryRegistry} for unified operator factory lookup</li>
- * </ul>
- *
- * <p>This module implements Closeable to properly release resources held by storage providers
- * (such as HttpClient connections) and managed TableCatalog instances.
- *
- * <p>Note: Method names follow the project convention of omitting the "get" prefix.
+ * <p>This module registers lazy delegating factories per-plugin so that heavy dependencies
+ * (AWS SDK, Parquet, Arrow) are only loaded when a query targets that backend.
+ * Capability declarations ({@link DataSourceCapabilities}) are used for cheap routing
+ * and early validation without triggering classloading.
  */
 public final class DataSourceModule implements Closeable {
 
@@ -59,90 +53,142 @@ public final class DataSourceModule implements Closeable {
     private final FilterPushdownRegistry filterPushdownRegistry;
     private final List<Closeable> managedCloseables;
     private final Settings settings;
+    private final DataSourceCapabilities capabilities;
 
     public DataSourceModule(
         List<DataSourcePlugin> dataSourcePlugins,
+        DataSourceCapabilities capabilities,
         Settings settings,
         BlockFactory blockFactory,
         ExecutorService executor
     ) {
         this.settings = settings;
+        this.capabilities = capabilities;
         this.storageProviderRegistry = new StorageProviderRegistry(settings);
         this.formatReaderRegistry = new FormatReaderRegistry();
 
-        Map<String, StorageProviderFactory> storageFactories = new HashMap<>();
-        Map<String, FormatReaderFactory> formatFactories = new HashMap<>();
         Map<String, ExternalSourceFactory> sourceFactoryMap = new LinkedHashMap<>();
-        // FIXME: pluginFactories is a backward-compat bridge for DataSourcePlugin.operatorFactories().
-        // Once plugins migrate to ExternalSourceFactory.operatorFactory(), remove this field.
         Map<String, SourceOperatorFactoryProvider> operatorFactoryProviders = new HashMap<>();
         List<Closeable> closeables = new ArrayList<>();
+        Map<String, String> registeredSchemes = new HashMap<>();
 
         for (DataSourcePlugin plugin : dataSourcePlugins) {
+            LazyPluginState state = new LazyPluginState(plugin, settings, executor);
 
-            Map<String, StorageProviderFactory> newStorageTypes = plugin.storageProviders(settings, executor);
-            for (Map.Entry<String, StorageProviderFactory> entry : newStorageTypes.entrySet()) {
-                String scheme = entry.getKey();
-                if (storageFactories.put(scheme, entry.getValue()) != null) {
+            // Storage providers: register a delegating factory per declared scheme
+            for (String scheme : plugin.supportedSchemes()) {
+                String existing = registeredSchemes.put(scheme, plugin.getClass().getName());
+                if (existing != null) {
                     throw new IllegalArgumentException("Storage provider for scheme [" + scheme + "] is already registered");
                 }
+                StorageProviderFactory delegating = new StorageProviderFactory() {
+                    @Override
+                    public org.elasticsearch.xpack.esql.datasources.spi.StorageProvider create(Settings s) {
+                        Map<String, StorageProviderFactory> factories = state.storageFactories();
+                        StorageProviderFactory real = factories.get(scheme);
+                        if (real == null) {
+                            throw new IllegalArgumentException(
+                                "Plugin "
+                                    + plugin.getClass().getName()
+                                    + " declared scheme ["
+                                    + scheme
+                                    + "] but storageProviders() did not return it"
+                            );
+                        }
+                        return real.create(s);
+                    }
+
+                    @Override
+                    public org.elasticsearch.xpack.esql.datasources.spi.StorageProvider create(Settings s, Map<String, Object> config) {
+                        Map<String, StorageProviderFactory> factories = state.storageFactories();
+                        StorageProviderFactory real = factories.get(scheme);
+                        if (real == null) {
+                            throw new IllegalArgumentException(
+                                "Plugin "
+                                    + plugin.getClass().getName()
+                                    + " declared scheme ["
+                                    + scheme
+                                    + "] but storageProviders() did not return it"
+                            );
+                        }
+                        return real.create(s, config);
+                    }
+                };
+                storageProviderRegistry.registerFactory(scheme, delegating);
             }
 
-            Map<String, FormatReaderFactory> newFormatTypes = plugin.formatReaders(settings);
-            for (Map.Entry<String, FormatReaderFactory> entry : newFormatTypes.entrySet()) {
-                String format = entry.getKey();
-                if (formatFactories.put(format, entry.getValue()) != null) {
-                    throw new IllegalArgumentException("Format reader for [" + format + "] is already registered");
+            // Format readers: register a delegating factory per declared format
+            for (String format : plugin.supportedFormats()) {
+                FormatReaderFactory delegating = (s, bf) -> {
+                    Map<String, FormatReaderFactory> factories = state.formatFactories();
+                    FormatReaderFactory real = factories.get(format);
+                    if (real == null) {
+                        throw new IllegalArgumentException(
+                            "Plugin "
+                                + plugin.getClass().getName()
+                                + " declared format ["
+                                + format
+                                + "] but formatReaders() did not return it"
+                        );
+                    }
+                    return real.create(s, bf);
+                };
+                formatReaderRegistry.registerLazy(format, delegating, settings, blockFactory);
+            }
+
+            // Pre-register extensions from capabilities so hasExtension() works without triggering lazy init.
+            // Each extension maps to a single format; cross-product with multiple formats is not supported.
+            Set<String> pluginFormats = plugin.supportedFormats();
+            Set<String> pluginExtensions = plugin.supportedExtensions();
+            if (pluginFormats.size() > 1 && pluginExtensions.isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "Plugin "
+                        + plugin.getClass().getName()
+                        + " declares multiple formats "
+                        + pluginFormats
+                        + " with extensions "
+                        + pluginExtensions
+                        + "; each plugin must declare at most one format when extensions are present"
+                );
+            }
+            for (String ext : pluginExtensions) {
+                for (String format : pluginFormats) {
+                    formatReaderRegistry.registerExtension(ext, format);
                 }
             }
 
-            // New unified path: sourceFactories()
-            Map<String, ExternalSourceFactory> newSourceFactories = plugin.sourceFactories(settings);
-            for (Map.Entry<String, ExternalSourceFactory> entry : newSourceFactories.entrySet()) {
-                String sourceType = entry.getKey();
-                if (sourceFactoryMap.put(sourceType, entry.getValue()) != null) {
-                    throw new IllegalArgumentException("Source factory for type [" + sourceType + "] is already registered");
+            // Connectors: register lazy wrappers only for explicitly declared connector schemes
+            Set<String> connectorSchemes = plugin.supportedConnectorSchemes();
+            if (connectorSchemes.isEmpty() == false) {
+                LazyConnectorFactory lazyConnector = new LazyConnectorFactory(state, connectorSchemes, plugin.getClass().getName());
+                for (String scheme : connectorSchemes) {
+                    sourceFactoryMap.putIfAbsent(scheme, lazyConnector);
                 }
             }
 
-            // Bridge: connectors() → sourceFactoryMap (ConnectorFactory is ExternalSourceFactory)
-            Map<String, ConnectorFactory> newConnectors = plugin.connectors(settings);
-            for (Map.Entry<String, ConnectorFactory> entry : newConnectors.entrySet()) {
-                String connectorType = entry.getKey();
-                if (sourceFactoryMap.put(connectorType, entry.getValue()) != null) {
-                    throw new IllegalArgumentException("Source factory for type [" + connectorType + "] is already registered");
-                }
-            }
-
-            // Bridge: tableCatalogs() → create TableCatalog, add to sourceFactoryMap + closeables
-            Map<String, TableCatalogFactory> newCatalogTypes = plugin.tableCatalogs(settings);
-            for (Map.Entry<String, TableCatalogFactory> entry : newCatalogTypes.entrySet()) {
-                String catalogType = entry.getKey();
-                TableCatalog catalog = entry.getValue().create(settings);
-                closeables.add(catalog);
-                if (sourceFactoryMap.put(catalogType, catalog) != null) {
+            // Table catalogs: register lazy wrappers
+            for (String catalogType : plugin.supportedCatalogs()) {
+                LazyTableCatalogWrapper lazyCatalog = new LazyTableCatalogWrapper(state, catalogType, closeables, settings);
+                if (sourceFactoryMap.put(catalogType, lazyCatalog) != null) {
                     throw new IllegalArgumentException("Source factory for type [" + catalogType + "] is already registered");
                 }
             }
 
-            // FIXME: standalone operatorFactories() and filterPushdownSupport() on DataSourcePlugin
-            // are unused by all production plugins; remove bridge once confirmed.
+            // FIXME: operatorFactories() is a backward-compat bridge for plugins that haven't migrated
+            // to ExternalSourceFactory.operatorFactory(). Currently no production plugin overrides it,
+            // so this call is effectively a no-op. It remains eager intentionally — once migration
+            // is complete, remove this block and the pluginFactories field.
             Map<String, SourceOperatorFactoryProvider> newOperatorFactories = plugin.operatorFactories(settings);
-            for (Map.Entry<String, SourceOperatorFactoryProvider> entry : newOperatorFactories.entrySet()) {
-                String sourceType = entry.getKey();
-                if (operatorFactoryProviders.put(sourceType, entry.getValue()) != null) {
-                    throw new IllegalArgumentException("Operator factory for source type [" + sourceType + "] is already registered");
+            if (newOperatorFactories.isEmpty() == false) {
+                for (Map.Entry<String, SourceOperatorFactoryProvider> entry : newOperatorFactories.entrySet()) {
+                    String sourceType = entry.getKey();
+                    if (operatorFactoryProviders.put(sourceType, entry.getValue()) != null) {
+                        throw new IllegalArgumentException(
+                            "Operator factory for source type [" + sourceType + "] is already registered"
+                        );
+                    }
                 }
             }
-        }
-
-        // Register factories lazily -- providers and readers are created on first access
-        for (Map.Entry<String, StorageProviderFactory> entry : storageFactories.entrySet()) {
-            storageProviderRegistry.registerFactory(entry.getKey(), entry.getValue());
-        }
-
-        for (Map.Entry<String, FormatReaderFactory> entry : formatFactories.entrySet()) {
-            formatReaderRegistry.registerLazy(entry.getKey(), entry.getValue(), settings, blockFactory);
         }
 
         // Register the framework-internal FileSourceFactory as a catch-all fallback.
@@ -151,23 +197,30 @@ public final class DataSourceModule implements Closeable {
         sourceFactoryMap.put("file", fileFallback);
         // Also register under each format name so OperatorFactoryRegistry can look up
         // by the sourceType returned from FormatReader.formatName() (e.g. "parquet", "csv").
-        for (String formatName : formatFactories.keySet()) {
+        for (String formatName : capabilities.formats()) {
             sourceFactoryMap.putIfAbsent(formatName, fileFallback);
         }
 
         this.sourceFactories = Map.copyOf(sourceFactoryMap);
         this.pluginFactories = Map.copyOf(operatorFactoryProviders);
-        this.managedCloseables = List.copyOf(closeables);
+        this.managedCloseables = closeables;
 
-        // Build FilterPushdownRegistry from ExternalSourceFactory capabilities
+        // Build FilterPushdownRegistry -- only from non-lazy factories to avoid triggering loading.
+        // Lazy wrappers (LazyConnectorFactory, LazyTableCatalogWrapper) return null from
+        // filterPushdownSupport() by default, which is correct since the real support
+        // is only available after loading.
         Map<String, FilterPushdownSupport> filterPushdownProviders = new HashMap<>();
         for (Map.Entry<String, ExternalSourceFactory> entry : this.sourceFactories.entrySet()) {
-            FilterPushdownSupport fps = entry.getValue().filterPushdownSupport();
+            ExternalSourceFactory factory = entry.getValue();
+            // Skip lazy wrappers to avoid triggering classloading
+            if (factory instanceof LazyConnectorFactory || factory instanceof LazyTableCatalogWrapper) {
+                continue;
+            }
+            FilterPushdownSupport fps = factory.filterPushdownSupport();
             if (fps != null) {
                 filterPushdownProviders.put(entry.getKey(), fps);
             }
         }
-        // FIXME: standalone filterPushdownSupport() bridge omitted — no production plugin uses it.
         this.filterPushdownRegistry = new FilterPushdownRegistry(filterPushdownProviders);
     }
 
@@ -177,6 +230,10 @@ public final class DataSourceModule implements Closeable {
         all.add(storageProviderRegistry);
         all.addAll(managedCloseables);
         IOUtils.close(all);
+    }
+
+    public DataSourceCapabilities capabilities() {
+        return capabilities;
     }
 
     public StorageProviderRegistry storageProviderRegistry() {
@@ -197,5 +254,241 @@ public final class DataSourceModule implements Closeable {
 
     public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor) {
         return new OperatorFactoryRegistry(sourceFactories, pluginFactories, executor);
+    }
+
+    /**
+     * Per-plugin lazy state that caches the results of each factory method.
+     * Factory methods are only called when first needed, deferring heavy classloading.
+     */
+    static class LazyPluginState {
+        private final DataSourcePlugin plugin;
+        private final Settings settings;
+        private final ExecutorService executor;
+        private volatile Map<String, StorageProviderFactory> storageFactoriesCache;
+        private volatile Map<String, FormatReaderFactory> formatFactoriesCache;
+        private volatile Map<String, ConnectorFactory> connectorFactoriesCache;
+        private volatile Map<String, TableCatalogFactory> catalogFactoriesCache;
+
+        LazyPluginState(DataSourcePlugin plugin, Settings settings, ExecutorService executor) {
+            this.plugin = plugin;
+            this.settings = settings;
+            this.executor = executor;
+        }
+
+        Map<String, StorageProviderFactory> storageFactories() {
+            if (storageFactoriesCache == null) {
+                synchronized (this) {
+                    if (storageFactoriesCache == null) {
+                        storageFactoriesCache = plugin.storageProviders(settings, executor);
+                    }
+                }
+            }
+            return storageFactoriesCache;
+        }
+
+        Map<String, FormatReaderFactory> formatFactories() {
+            if (formatFactoriesCache == null) {
+                synchronized (this) {
+                    if (formatFactoriesCache == null) {
+                        formatFactoriesCache = plugin.formatReaders(settings);
+                    }
+                }
+            }
+            return formatFactoriesCache;
+        }
+
+        Map<String, ConnectorFactory> connectorFactories() {
+            if (connectorFactoriesCache == null) {
+                synchronized (this) {
+                    if (connectorFactoriesCache == null) {
+                        connectorFactoriesCache = plugin.connectors(settings);
+                    }
+                }
+            }
+            return connectorFactoriesCache;
+        }
+
+        Map<String, TableCatalogFactory> catalogFactories() {
+            if (catalogFactoriesCache == null) {
+                synchronized (this) {
+                    if (catalogFactoriesCache == null) {
+                        catalogFactoriesCache = plugin.tableCatalogs(settings);
+                    }
+                }
+            }
+            return catalogFactoriesCache;
+        }
+    }
+
+    /**
+     * Lazy connector wrapper whose canHandle() checks declared schemes without loading the plugin.
+     */
+    static class LazyConnectorFactory implements ExternalSourceFactory {
+        private final LazyPluginState state;
+        private final Set<String> declaredSchemes;
+        private final String pluginName;
+        private volatile ConnectorFactory delegate;
+
+        LazyConnectorFactory(LazyPluginState state, Set<String> declaredSchemes, String pluginName) {
+            this.state = state;
+            this.declaredSchemes = declaredSchemes;
+            this.pluginName = pluginName;
+        }
+
+        @Override
+        public String type() {
+            return resolveDelegate().type();
+        }
+
+        @Override
+        public boolean canHandle(String location) {
+            if (location == null) {
+                return false;
+            }
+            try {
+                String scheme = extractScheme(location);
+                return declaredSchemes.contains(scheme);
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public SourceMetadata resolveMetadata(String location, Map<String, Object> config) {
+            return resolveDelegate().resolveMetadata(location, config);
+        }
+
+        @Override
+        public FilterPushdownSupport filterPushdownSupport() {
+            if (delegate == null) {
+                return null;
+            }
+            return delegate.filterPushdownSupport();
+        }
+
+        @Override
+        public SourceOperatorFactoryProvider operatorFactory() {
+            return resolveDelegate().operatorFactory();
+        }
+
+        private ConnectorFactory resolveDelegate() {
+            if (delegate == null) {
+                synchronized (this) {
+                    if (delegate == null) {
+                        Map<String, ConnectorFactory> connectors = state.connectorFactories();
+                        if (connectors.isEmpty()) {
+                            throw new IllegalStateException("Plugin " + pluginName + " declared schemes but connectors() returned empty");
+                        }
+                        if (connectors.size() > 1) {
+                            throw new IllegalStateException(
+                                "Plugin "
+                                    + pluginName
+                                    + " returned multiple connectors "
+                                    + connectors.keySet()
+                                    + "; lazy mode supports a single connector per plugin"
+                            );
+                        }
+                        delegate = connectors.values().iterator().next();
+                    }
+                }
+            }
+            return delegate;
+        }
+
+        private static String extractScheme(String location) {
+            int colonIdx = location.indexOf("://");
+            if (colonIdx <= 0) {
+                throw new IllegalArgumentException("No scheme in location: " + location);
+            }
+            return location.substring(0, colonIdx).toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /**
+     * Lazy table catalog wrapper whose canHandle() uses heuristics (S3 scheme + no file extension)
+     * without loading Iceberg classes.
+     */
+    static class LazyTableCatalogWrapper implements ExternalSourceFactory {
+        private final LazyPluginState state;
+        private final String catalogType;
+        private final List<Closeable> managedCloseables;
+        private final Settings settings;
+        private volatile TableCatalog delegate;
+
+        LazyTableCatalogWrapper(LazyPluginState state, String catalogType, List<Closeable> managedCloseables, Settings settings) {
+            this.state = state;
+            this.catalogType = catalogType;
+            this.managedCloseables = managedCloseables;
+            this.settings = settings;
+        }
+
+        @Override
+        public String type() {
+            return catalogType;
+        }
+
+        @Override
+        public boolean canHandle(String path) {
+            if (path == null) {
+                return false;
+            }
+            try {
+                StoragePath sp = StoragePath.of(path);
+                String scheme = sp.scheme();
+                if (Set.of("s3", "s3a", "s3n").contains(scheme) == false) {
+                    return false;
+                }
+                String obj = sp.objectName();
+                if (obj != null) {
+                    int dot = obj.lastIndexOf('.');
+                    if (dot >= 0 && dot < obj.length() - 1) {
+                        return false;
+                    }
+                }
+                return true;
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public SourceMetadata resolveMetadata(String location, Map<String, Object> config) {
+            return resolveDelegate().resolveMetadata(location, config);
+        }
+
+        @Override
+        public FilterPushdownSupport filterPushdownSupport() {
+            if (delegate == null) {
+                return null;
+            }
+            return delegate.filterPushdownSupport();
+        }
+
+        @Override
+        public SourceOperatorFactoryProvider operatorFactory() {
+            return resolveDelegate().operatorFactory();
+        }
+
+        private TableCatalog resolveDelegate() {
+            if (delegate == null) {
+                synchronized (this) {
+                    if (delegate == null) {
+                        Map<String, TableCatalogFactory> factories = state.catalogFactories();
+                        TableCatalogFactory factory = factories.get(catalogType);
+                        if (factory == null) {
+                            throw new IllegalStateException(
+                                "Plugin declared catalog [" + catalogType + "] but tableCatalogs() did not return it"
+                            );
+                        }
+                        TableCatalog catalog = factory.create(settings);
+                        synchronized (managedCloseables) {
+                            managedCloseables.add(catalog);
+                        }
+                        delegate = catalog;
+                    }
+                }
+            }
+            return delegate;
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.TableCatalog;
 import org.elasticsearch.xpack.esql.datasources.spi.TableCatalogFactory;
@@ -48,8 +49,7 @@ public final class DataSourceModule implements Closeable {
     private final StorageProviderRegistry storageProviderRegistry;
     private final FormatReaderRegistry formatReaderRegistry;
     private final Map<String, ExternalSourceFactory> sourceFactories;
-    // FIXME: pluginFactories is a backward-compat bridge for DataSourcePlugin.operatorFactories().
-    // Once plugins migrate to ExternalSourceFactory.operatorFactory(), remove this field.
+    // TODO(#142815): backward-compat bridge — remove once table functions land.
     private final Map<String, SourceOperatorFactoryProvider> pluginFactories;
     private final FilterPushdownRegistry filterPushdownRegistry;
     private final List<Closeable> managedCloseables;
@@ -84,7 +84,7 @@ public final class DataSourceModule implements Closeable {
                 }
                 StorageProviderFactory delegating = new StorageProviderFactory() {
                     @Override
-                    public org.elasticsearch.xpack.esql.datasources.spi.StorageProvider create(Settings s) {
+                    public StorageProvider create(Settings s) {
                         Map<String, StorageProviderFactory> factories = state.storageFactories();
                         StorageProviderFactory real = factories.get(scheme);
                         if (real == null) {
@@ -100,7 +100,7 @@ public final class DataSourceModule implements Closeable {
                     }
 
                     @Override
-                    public org.elasticsearch.xpack.esql.datasources.spi.StorageProvider create(Settings s, Map<String, Object> config) {
+                    public StorageProvider create(Settings s, Map<String, Object> config) {
                         Map<String, StorageProviderFactory> factories = state.storageFactories();
                         StorageProviderFactory real = factories.get(scheme);
                         if (real == null) {
@@ -175,10 +175,8 @@ public final class DataSourceModule implements Closeable {
                 }
             }
 
-            // FIXME: operatorFactories() is a backward-compat bridge for plugins that haven't migrated
-            // to ExternalSourceFactory.operatorFactory(). Currently no production plugin overrides it,
-            // so this call is effectively a no-op. It remains eager intentionally — once migration
-            // is complete, remove this block and the pluginFactories field.
+            // TODO(#142815): operatorFactories() is a backward-compat bridge for plugins that haven't
+            // migrated to ExternalSourceFactory.operatorFactory(). Remove once table functions land.
             Map<String, SourceOperatorFactoryProvider> newOperatorFactories = plugin.operatorFactories(settings);
             if (newOperatorFactories.isEmpty() == false) {
                 for (Map.Entry<String, SourceOperatorFactoryProvider> entry : newOperatorFactories.entrySet()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.xpack.esql.datasources.spi.Connector;
 import org.elasticsearch.xpack.esql.datasources.spi.ConnectorFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
@@ -321,7 +322,7 @@ public final class DataSourceModule implements Closeable {
     /**
      * Lazy connector wrapper whose canHandle() checks declared schemes without loading the plugin.
      */
-    static class LazyConnectorFactory implements ExternalSourceFactory {
+    static class LazyConnectorFactory implements ConnectorFactory {
         private final LazyPluginState state;
         private final Set<String> declaredSchemes;
         private final String pluginName;
@@ -354,6 +355,11 @@ public final class DataSourceModule implements Closeable {
         @Override
         public SourceMetadata resolveMetadata(String location, Map<String, Object> config) {
             return resolveDelegate().resolveMetadata(location, config);
+        }
+
+        @Override
+        public Connector open(Map<String, Object> config) {
+            return resolveDelegate().open(config);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -183,9 +183,7 @@ public final class DataSourceModule implements Closeable {
                 for (Map.Entry<String, SourceOperatorFactoryProvider> entry : newOperatorFactories.entrySet()) {
                     String sourceType = entry.getKey();
                     if (operatorFactoryProviders.put(sourceType, entry.getValue()) != null) {
-                        throw new IllegalArgumentException(
-                            "Operator factory for source type [" + sourceType + "] is already registered"
-                        );
+                        throw new IllegalArgumentException("Operator factory for source type [" + sourceType + "] is already registered");
                     }
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -146,6 +146,21 @@ public class ExternalSourceResolver {
     }
 
     private SourceMetadata resolveSingleSource(String path, Map<String, Object> config) {
+        // Early scheme validation: reject unsupported schemes without loading any plugin factories
+        try {
+            StoragePath parsed = StoragePath.of(path);
+            DataSourceCapabilities capabilities = dataSourceModule.capabilities();
+            if (capabilities != null && capabilities.supportsScheme(parsed.scheme()) == false) {
+                throw new UnsupportedSchemeException(
+                    "Unsupported storage scheme [" + parsed.scheme() + "]. Supported: " + capabilities.supportedSchemesString()
+                );
+            }
+        } catch (UnsupportedSchemeException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            // Path parsing failed -- let the factory iteration handle it
+        }
+
         Exception lastFailure = null;
         for (ExternalSourceFactory factory : dataSourceModule.sourceFactories().values()) {
             if (factory.canHandle(path)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -70,10 +70,8 @@ final class FileSourceFactory implements ExternalSourceFactory {
             if (storageRegistry.hasProvider(scheme) == false) {
                 return false;
             }
-            // byExtension triggers lazy init of format readers, so it correctly
-            // discovers extensions even on first call (unlike hasExtension).
-            formatRegistry.byExtension(objectName);
-            return true;
+            String ext = objectName.substring(objectName.lastIndexOf('.'));
+            return formatRegistry.hasExtension(ext);
         } catch (IllegalArgumentException e) {
             return false;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
@@ -83,6 +83,20 @@ public class FormatReaderRegistry {
         return supplier.get();
     }
 
+    public void registerExtension(String extension, String formatName) {
+        String normalizedExt = extension.toLowerCase(Locale.ROOT);
+        if (normalizedExt.startsWith(".") == false) {
+            normalizedExt = "." + normalizedExt;
+        }
+        Supplier<FormatReader> supplier = byName.get(formatName.toLowerCase(Locale.ROOT));
+        if (supplier == null) {
+            throw new IllegalArgumentException(
+                "Cannot register extension [" + extension + "] -- format [" + formatName + "] not registered"
+            );
+        }
+        byExtension.put(normalizedExt, supplier);
+    }
+
     public FormatReader byExtension(String objectName) {
         if (Strings.isNullOrEmpty(objectName)) {
             throw new IllegalArgumentException("Object name cannot be null or empty");
@@ -96,14 +110,9 @@ public class FormatReaderRegistry {
         String extension = objectName.substring(lastDot).toLowerCase(Locale.ROOT);
         Supplier<FormatReader> supplier = byExtension.get(extension);
         if (supplier == null) {
-            // Extension not yet registered -- try triggering lazy init of all registered formats
-            for (Supplier<FormatReader> s : byName.values()) {
-                s.get();
-            }
-            supplier = byExtension.get(extension);
-            if (supplier == null) {
-                throw new IllegalArgumentException("No format reader registered for extension: " + extension);
-            }
+            throw new IllegalArgumentException(
+                "No format reader registered for extension: " + extension + ". Supported: " + byExtension.keySet()
+            );
         }
         return supplier.get();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/UnsupportedSchemeException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/UnsupportedSchemeException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+/**
+ * Thrown when a URI scheme is not supported by any registered data source plugin.
+ */
+class UnsupportedSchemeException extends IllegalArgumentException {
+    UnsupportedSchemeException(String message) {
+        super(message);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourcePlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourcePlugin.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -35,6 +36,46 @@ import java.util.concurrent.ExecutorService;
  * since there are no corresponding setters.
  */
 public interface DataSourcePlugin {
+
+    /**
+     * URI schemes whose storage providers this plugin supplies (e.g. "s3", "gs", "http").
+     * Called once at registration time; must be cheap (no I/O, no heavy deps).
+     * Connector plugins should use {@link #supportedConnectorSchemes()} instead.
+     */
+    default Set<String> supportedSchemes() {
+        return Set.of();
+    }
+
+    /**
+     * URI schemes handled by this plugin's connectors (e.g. "flight", "grpc").
+     * Separate from {@link #supportedSchemes()} which is for storage providers.
+     */
+    default Set<String> supportedConnectorSchemes() {
+        return Set.of();
+    }
+
+    /**
+     * Format names this plugin provides (e.g. "csv", "parquet").
+     * Keys must match {@link #formatReaders(Settings)} keys.
+     */
+    default Set<String> supportedFormats() {
+        return Set.of();
+    }
+
+    /**
+     * File extensions this plugin's format readers handle (with leading dot, e.g. ".csv", ".parquet").
+     */
+    default Set<String> supportedExtensions() {
+        return Set.of();
+    }
+
+    /**
+     * Catalog types this plugin provides (e.g. "iceberg").
+     * Keys must match {@link #tableCatalogs(Settings)} keys.
+     */
+    default Set<String> supportedCatalogs() {
+        return Set.of();
+    }
 
     default Map<String, StorageProviderFactory> storageProviders(Settings settings) {
         return Map.of();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -75,6 +75,7 @@ import org.elasticsearch.xpack.esql.action.RestEsqlStopAsyncAction;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
 import org.elasticsearch.xpack.esql.analysis.PlanCheckerProvider;
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.datasources.DataSourceCapabilities;
 import org.elasticsearch.xpack.esql.datasources.DataSourceModule;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
@@ -221,10 +222,14 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
             }
         }
 
+        // Build capabilities from plugin declarations (cheap -- no I/O, no heavy deps)
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(allDataSourcePlugins);
+
         // Create DataSourceModule with all discovered plugins
         // Pass GENERIC executor for plugins that need async I/O (e.g. HTTP storage provider)
         DataSourceModule dataSourceModule = new DataSourceModule(
             allDataSourcePlugins,
+            capabilities,
             settings,
             blockFactoryProvider.blockFactory(),
             services.threadPool().executor(ThreadPool.Names.GENERIC)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ConnectorFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests verifying per-plugin lazy loading behavior in DataSourceModule.
+ * Uses spy plugins with AtomicBoolean flags to track when factory methods are called.
+ */
+public class DataSourceModuleLazyLoadingTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    private static final AtomicBoolean SPY_STORAGE_FACTORY_CALLED = new AtomicBoolean(false);
+    private static final AtomicBoolean SPY_FORMAT_FACTORY_CALLED = new AtomicBoolean(false);
+    private static final AtomicBoolean OTHER_FORMAT_FACTORY_CALLED = new AtomicBoolean(false);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = new BlockFactory(new NoopCircuitBreaker("test"), BigArrays.NON_RECYCLING_INSTANCE);
+        SPY_STORAGE_FACTORY_CALLED.set(false);
+        SPY_FORMAT_FACTORY_CALLED.set(false);
+        OTHER_FORMAT_FACTORY_CALLED.set(false);
+    }
+
+    public void testFactoryMethodsNotCalledAtConstruction() {
+        List<DataSourcePlugin> plugins = List.of(new SpyStoragePlugin(), new SpyFormatPlugin(), new OtherFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        new DataSourceModule(plugins, capabilities, Settings.EMPTY, blockFactory, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+
+        assertFalse("Storage factory should not be called at construction", SPY_STORAGE_FACTORY_CALLED.get());
+        assertFalse("Spy format factory should not be called at construction", SPY_FORMAT_FACTORY_CALLED.get());
+        assertFalse("Other format factory should not be called at construction", OTHER_FORMAT_FACTORY_CALLED.get());
+    }
+
+    public void testAccessingOneFormatDoesNotLoadOther() {
+        List<DataSourcePlugin> plugins = List.of(new SpyFormatPlugin(), new OtherFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        module.formatReaderRegistry().byName("spy");
+
+        assertTrue("Spy format factory should be called", SPY_FORMAT_FACTORY_CALLED.get());
+        assertFalse("Other format factory should NOT be called", OTHER_FORMAT_FACTORY_CALLED.get());
+    }
+
+    public void testByExtensionOnlyLoadsRelevantPlugin() {
+        List<DataSourcePlugin> plugins = List.of(new SpyFormatPlugin(), new OtherFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        module.formatReaderRegistry().byExtension("data.spy");
+
+        assertTrue("Spy format factory should be called for .spy extension", SPY_FORMAT_FACTORY_CALLED.get());
+        assertFalse("Other format factory should NOT be called for .spy extension", OTHER_FORMAT_FACTORY_CALLED.get());
+    }
+
+    public void testStorageProviderCreatedOnlyOnAccess() {
+        List<DataSourcePlugin> plugins = List.of(new SpyStoragePlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        assertFalse("Storage factory should not be called yet", SPY_STORAGE_FACTORY_CALLED.get());
+
+        module.storageProviderRegistry().provider(StoragePath.of("spy://bucket/file.txt"));
+
+        assertTrue("Storage factory should be called after provider access", SPY_STORAGE_FACTORY_CALLED.get());
+    }
+
+    public void testCapabilitiesAvailableWithoutAnyFactoryLoading() {
+        List<DataSourcePlugin> plugins = List.of(new SpyStoragePlugin(), new SpyFormatPlugin(), new OtherFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        DataSourceCapabilities caps = module.capabilities();
+        assertTrue("Should support spy scheme", caps.supportsScheme("spy"));
+        assertTrue("Should support spy format", caps.supportsFormat("spy"));
+        assertTrue("Should support other format", caps.supportsFormat("other"));
+        assertTrue("Should support .spy extension", caps.supportsExtension(".spy"));
+        assertTrue("Should support .other extension", caps.supportsExtension(".other"));
+
+        assertFalse("Storage factory should not be called", SPY_STORAGE_FACTORY_CALLED.get());
+        assertFalse("Spy format factory should not be called", SPY_FORMAT_FACTORY_CALLED.get());
+        assertFalse("Other format factory should not be called", OTHER_FORMAT_FACTORY_CALLED.get());
+    }
+
+    public void testUnsupportedSchemeRejectedWithoutFactoryLoading() {
+        List<DataSourcePlugin> plugins = List.of(new SpyStoragePlugin(), new SpyFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        assertFalse("ftp scheme should not be supported", module.capabilities().supportsScheme("ftp"));
+        assertFalse("hdfs scheme should not be supported", module.capabilities().supportsScheme("hdfs"));
+
+        assertFalse("Storage factory should not be called", SPY_STORAGE_FACTORY_CALLED.get());
+        assertFalse("Format factory should not be called", SPY_FORMAT_FACTORY_CALLED.get());
+    }
+
+    public void testStorageOnlyPluginNotRegisteredAsConnector() {
+        List<DataSourcePlugin> plugins = List.of(new SpyStoragePlugin(), new SpyFormatPlugin());
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        // Storage-only plugin should NOT produce a LazyConnectorFactory entry
+        for (Map.Entry<String, ExternalSourceFactory> entry : module.sourceFactories().entrySet()) {
+            assertFalse(
+                "sourceFactories should not contain LazyConnectorFactory for storage-only plugin, but found one at key [" + entry.getKey()
+                    + "]",
+                entry.getValue() instanceof DataSourceModule.LazyConnectorFactory
+            );
+        }
+
+        // But the storage provider should still be accessible
+        assertTrue("spy scheme should have a storage provider", module.storageProviderRegistry().hasProvider("spy"));
+        assertFalse("Storage factory should not be called yet", SPY_STORAGE_FACTORY_CALLED.get());
+    }
+
+    public void testConnectorSchemesInCapabilities() {
+        DataSourcePlugin connectorPlugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedConnectorSchemes() {
+                return Set.of("flight", "grpc");
+            }
+
+            @Override
+            public Map<String, ConnectorFactory> connectors(Settings settings) {
+                return Map.of();
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(connectorPlugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        assertTrue("flight should be in capabilities", capabilities.supportsScheme("flight"));
+        assertTrue("grpc should be in capabilities", capabilities.supportsScheme("grpc"));
+    }
+
+    public void testMultiFormatWithExtensionsRejected() {
+        DataSourcePlugin badPlugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedFormats() {
+                return Set.of("fmt1", "fmt2");
+            }
+
+            @Override
+            public Set<String> supportedExtensions() {
+                return Set.of(".ext1");
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of(
+                    "fmt1",
+                    (s, bf) -> new StubFormatReader("fmt1", List.of(".ext1")),
+                    "fmt2",
+                    (s, bf) -> new StubFormatReader("fmt2", List.of(".ext1"))
+                );
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(badPlugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new DataSourceModule(plugins, capabilities, Settings.EMPTY, blockFactory, EsExecutors.DIRECT_EXECUTOR_SERVICE)
+        );
+        assertTrue(e.getMessage().contains("multiple formats"));
+    }
+
+    // ===== Spy plugin implementations =====
+
+    private static class SpyStoragePlugin implements DataSourcePlugin {
+        @Override
+        public Set<String> supportedSchemes() {
+            return Set.of("spy");
+        }
+
+        @Override
+        public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+            SPY_STORAGE_FACTORY_CALLED.set(true);
+            return Map.of("spy", s -> new StubStorageProvider());
+        }
+    }
+
+    private static class SpyFormatPlugin implements DataSourcePlugin {
+        @Override
+        public Set<String> supportedFormats() {
+            return Set.of("spy");
+        }
+
+        @Override
+        public Set<String> supportedExtensions() {
+            return Set.of(".spy");
+        }
+
+        @Override
+        public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+            SPY_FORMAT_FACTORY_CALLED.set(true);
+            return Map.of("spy", (s, bf) -> new StubFormatReader("spy", List.of(".spy")));
+        }
+    }
+
+    private static class OtherFormatPlugin implements DataSourcePlugin {
+        @Override
+        public Set<String> supportedFormats() {
+            return Set.of("other");
+        }
+
+        @Override
+        public Set<String> supportedExtensions() {
+            return Set.of(".other");
+        }
+
+        @Override
+        public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+            OTHER_FORMAT_FACTORY_CALLED.set(true);
+            return Map.of("other", (s, bf) -> new StubFormatReader("other", List.of(".other")));
+        }
+    }
+
+    // ===== Stub implementations =====
+
+    private static class StubStorageProvider implements StorageProvider {
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("spy");
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return false;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class StubFormatReader implements FormatReader {
+        private final String name;
+        private final List<String> extensions;
+
+        StubFormatReader(String name, List<String> extensions) {
+            this.name = name;
+            this.extensions = extensions;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize) {
+            throw new UnsupportedOperationException("Stub");
+        }
+
+        @Override
+        public String formatName() {
+            return name;
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return extensions;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
@@ -176,7 +176,8 @@ public class DataSourceModuleLazyLoadingTests extends ESTestCase {
         // Storage-only plugin should NOT produce a LazyConnectorFactory entry
         for (Map.Entry<String, ExternalSourceFactory> entry : module.sourceFactories().entrySet()) {
             assertFalse(
-                "sourceFactories should not contain LazyConnectorFactory for storage-only plugin, but found one at key [" + entry.getKey()
+                "sourceFactories should not contain LazyConnectorFactory for storage-only plugin, but found one at key ["
+                    + entry.getKey()
                     + "]",
                 entry.getValue() instanceof DataSourceModule.LazyConnectorFactory
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlResolveFieldsAction;
 import org.elasticsearch.xpack.esql.action.EsqlResolveFieldsResponse;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
+import org.elasticsearch.xpack.esql.datasources.DataSourceCapabilities;
 import org.elasticsearch.xpack.esql.datasources.DataSourceModule;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
@@ -140,9 +141,11 @@ public class PlanExecutorMetricsTests extends ESTestCase {
 
         // Create a minimal DataSourceModule for testing
         BlockFactory blockFactory = new BlockFactory(new NoopCircuitBreaker("test"), BigArrays.NON_RECYCLING_INSTANCE);
+        List<DataSourcePlugin> plugins = List.of(new DataSourcePlugin() {});
         try (
             DataSourceModule dataSourceModule = new DataSourceModule(
-                List.of(new DataSourcePlugin() {}),
+                plugins,
+                DataSourceCapabilities.build(plugins),
                 Settings.EMPTY,
                 blockFactory,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE


### PR DESCRIPTION
Defer heavy plugin factory methods (storageProviders, formatReaders,
connectors, tableCatalogs) until first query access so that AWS SDK,
Parquet, and Arrow classes are not loaded at node startup.

- DataSourcePlugin: added supportedSchemes/Formats/Extensions/Catalogs
  and supportedConnectorSchemes for cheap capability declarations
- DataSourceCapabilities: new record aggregating all plugin capabilities
  at startup without triggering classloading
- DataSourceModule: lazy delegating factories per-plugin via
  LazyPluginState, LazyConnectorFactory, LazyTableCatalogWrapper
- FormatReaderRegistry: added registerExtension for pre-registration
  without lazy init; removed fallback init-all-formats path
- ExternalSourceResolver: early scheme validation via capabilities;
  introduced UnsupportedSchemeException replacing string matching
- FileSourceFactory: canHandle uses hasExtension instead of byExtension
- GrpcDataSourcePlugin: migrated to supportedConnectorSchemes
- DataSourceModuleLazyLoadingTests: spy-based tests verifying per-plugin
  isolation and lazy loading guarantees

 Developed using AI-assisted tooling