### PR TITLE
[ML] Add missing job_id filter to Anomaly Detection data deleter

### DIFF
--- a/docs/changelog/138160.yaml
+++ b/docs/changelog/138160.yaml
@@ -1,0 +1,5 @@
+pr: 138160
+summary: Add missing `job_id` filter to Anomaly Detection data deleter
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -287,6 +287,28 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
         });
     }
 
+    protected void assertThatNumberOfAnnotationsIsEqualTo(String jobId, int expectedNumberOfAnnotations) throws Exception {
+        // Refresh the annotations index so that recently indexed annotation docs are visible.
+        indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
+            .get();
+
+        SearchRequest searchRequest = client().prepareSearch(AnnotationIndex.READ_ALIAS_NAME)
+            .setQuery(QueryBuilders.termQuery("job_id", jobId))
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
+            .request();
+
+        assertCheckedResponse(client().search(searchRequest), searchResponse -> {
+            List<Annotation> annotations = new ArrayList<>();
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                try (XContentParser parser = createParser(jsonXContent, hit.getSourceRef())) {
+                    annotations.add(Annotation.fromXContent(parser, null));
+                }
+            }
+            assertThat("Annotations were: " + annotations, annotations, hasSize(expectedNumberOfAnnotations));
+        });
+    }
+
     protected List<Annotation> getAnnotations() throws Exception {
         List<Annotation> annotations = new ArrayList<>();
         // Refresh the annotations index so that recently indexed annotation docs are visible.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -250,6 +250,7 @@ public class JobDataDeleter {
      */
     public void deleteResultsFromTime(long cutoffEpochMs, ActionListener<Boolean> listener) {
         QueryBuilder query = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
             .filter(
                 QueryBuilders.termsQuery(
                     Result.RESULT_TYPE.getPreferredName(),
@@ -261,6 +262,7 @@ public class JobDataDeleter {
                 )
             )
             .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).gte(cutoffEpochMs));
+
         String[] indicesToQuery = removeReadOnlyIndices(
             List.of(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)),
             listener,


### PR DESCRIPTION
When reverting to a previous model snapshot intervening results are removed. A bug in the delete-by-query query meant that results were deleted for all jobs in this period not just the job being deleted. The fix here reinstates the job_id filter.
