### PR TITLE
Fix TSDBSyntheticIdUpgradeIT exception assertion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -437,12 +437,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexResumeIT
   method: testLocalResumeReindexFromScroll_slicedAuto
   issue: https://github.com/elastic/elasticsearch/issues/142749
-- class: org.elasticsearch.upgrades.TSDBSyntheticIdUpgradeIT
-  method: testRollingUpgrade {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/141734
-- class: org.elasticsearch.upgrades.TSDBSyntheticIdUpgradeIT
-  method: testRollingUpgrade {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/141749
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
   method: testResolveExternalRelationPassesFileSet
   issue: https://github.com/elastic/elasticsearch/issues/142795

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TSDBSyntheticIdUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TSDBSyntheticIdUpgradeIT.java
@@ -140,7 +140,7 @@ public class TSDBSyntheticIdUpgradeIT extends AbstractRollingUpgradeTestCase {
             """, timestamp, randomByte()));
     }
 
-    private static void assertNoWriteIndex(String indexName, IndexVersion oldClusterIndexVersion) {
+    private static void assertNoWriteIndex(String indexName, IndexVersion oldClusterIndexVersion) throws IOException {
         String setting = IndexSettings.SYNTHETIC_ID.getKey();
         String unknownSetting = "unknown setting [" + setting + "]";
         String versionTooLow = String.format(
@@ -152,7 +152,9 @@ public class TSDBSyntheticIdUpgradeIT extends AbstractRollingUpgradeTestCase {
         );
 
         ResponseException e = assertThrows(ResponseException.class, () -> createSyntheticIdIndex(indexName));
-        assertThat(e.getMessage(), Matchers.either(Matchers.containsString(unknownSetting)).or(Matchers.containsString(versionTooLow)));
+        String reason = ObjectPath.createFromResponse(e.getResponse()).evaluate("error.reason");
+
+        assertThat(reason, Matchers.either(Matchers.containsString(unknownSetting)).or(Matchers.containsString(versionTooLow)));
         assertThat(e.getMessage(), Matchers.containsString("illegal_argument_exception"));
     }
 


### PR DESCRIPTION
When creating an index with ESRestTestCase.createIndex a random xContentType will be used. If the type is YAML, the exception message will be split into multiple lines if the lines are long. This will break the format of the expected string and the test fails.

This is fixed by getting the actual Response object from the exception and evaluate error.reason which will give the original exception message without the line breaks.

Fix https://github.com/elastic/elasticsearch/issues/141734, https://github.com/elastic/elasticsearch/issues/141749