### PR TITLE
[ML] Fix latest transform skipping documents at checkpoint boundaries

### DIFF
--- a/docs/changelog/142853.yaml
+++ b/docs/changelog/142853.yaml
@@ -1,0 +1,6 @@
+area: Transform
+issues:
+ - 106363
+pr: 142853
+summary: Fix latest transform skipping documents at checkpoint boundaries
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeSyncConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeSyncConfig.java
@@ -131,13 +131,13 @@ public class TimeSyncConfig implements SyncConfig {
 
     @Override
     public QueryBuilder getRangeQuery(TransformCheckpoint newCheckpoint) {
-        return new RangeQueryBuilder(field).lt(newCheckpoint.getTimeUpperBound()).format("epoch_millis");
+        return new RangeQueryBuilder(field).lte(newCheckpoint.getTimeUpperBound()).format("epoch_millis");
     }
 
     @Override
     public QueryBuilder getRangeQuery(TransformCheckpoint oldCheckpoint, TransformCheckpoint newCheckpoint) {
-        return new RangeQueryBuilder(field).gte(oldCheckpoint.getTimeUpperBound())
-            .lt(newCheckpoint.getTimeUpperBound())
+        return new RangeQueryBuilder(field).gt(oldCheckpoint.getTimeUpperBound())
+            .lte(newCheckpoint.getTimeUpperBound())
             .format("epoch_millis");
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeSyncConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeSyncConfigTests.java
@@ -9,12 +9,15 @@ package org.elasticsearch.xpack.core.transform.transforms;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class TimeSyncConfigTests extends AbstractXContentSerializingTestCase<TimeSyncConfig> {
 
@@ -45,5 +48,37 @@ public class TimeSyncConfigTests extends AbstractXContentSerializingTestCase<Tim
     public void testDefaultDelay() {
         TimeSyncConfig config = new TimeSyncConfig(randomAlphaOfLength(10), null);
         assertThat(config.getDelay(), equalTo(TimeSyncConfig.DEFAULT_DELAY));
+    }
+
+    public void testGetRangeQueryWithSingleCheckpoint() {
+        TimeSyncConfig config = new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(60));
+        TransformCheckpoint checkpoint = new TransformCheckpoint("t_id", 123456789L, 1L, Collections.emptyMap(), 100000L);
+
+        assertThat(
+            config.getRangeQuery(checkpoint),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").lte(100000L).format("epoch_millis")))
+        );
+    }
+
+    public void testGetRangeQueryWithTwoCheckpoints() {
+        TimeSyncConfig config = new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(60));
+        TransformCheckpoint oldCheckpoint = new TransformCheckpoint("t_id", 100000000L, 1L, Collections.emptyMap(), 100000L);
+        TransformCheckpoint newCheckpoint = new TransformCheckpoint("t_id", 123456789L, 2L, Collections.emptyMap(), 200000L);
+
+        assertThat(
+            config.getRangeQuery(oldCheckpoint, newCheckpoint),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gt(100000L).lte(200000L).format("epoch_millis")))
+        );
+    }
+
+    public void testGetRangeQueryWithIdenticalCheckpointBounds() {
+        TimeSyncConfig config = new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(60));
+        TransformCheckpoint oldCheckpoint = new TransformCheckpoint("t_id", 100000000L, 1L, Collections.emptyMap(), 100000L);
+        TransformCheckpoint newCheckpoint = new TransformCheckpoint("t_id", 100000001L, 2L, Collections.emptyMap(), 100000L);
+
+        assertThat(
+            config.getRangeQuery(oldCheckpoint, newCheckpoint),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gt(100000L).lte(100000L).format("epoch_millis")))
+        );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -64,8 +64,8 @@ class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
 
         BoolQueryBuilder queryBuilder = new BoolQueryBuilder().filter(transformConfig.getSource().getQueryConfig().getQuery())
             .filter(
-                new RangeQueryBuilder(timeSyncConfig.getField()).gte(lastCheckpoint.getTimeUpperBound())
-                    .lt(timeUpperBound)
+                new RangeQueryBuilder(timeSyncConfig.getField()).gt(lastCheckpoint.getTimeUpperBound())
+                    .lte(timeUpperBound)
                     .format("epoch_millis")
             );
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0)

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollector.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollector.java
@@ -45,9 +45,12 @@ class LatestChangeCollector implements Function.ChangeCollector {
     public QueryBuilder buildFilterQuery(TransformCheckpoint lastCheckpoint, TransformCheckpoint nextCheckpoint) {
         // We are only interested in documents that were created in the timeline of the current checkpoint.
         // Older documents cannot influence the transform results as we require the sort field values to change monotonically over time.
+        if (lastCheckpoint.getTimeUpperBound() == 0L) {
+            return QueryBuilders.rangeQuery(synchronizationField).lte(nextCheckpoint.getTimeUpperBound()).format("epoch_millis");
+        }
         return QueryBuilders.rangeQuery(synchronizationField)
-            .gte(lastCheckpoint.getTimeUpperBound())
-            .lt(nextCheckpoint.getTimeUpperBound())
+            .gt(lastCheckpoint.getTimeUpperBound())
+            .lte(nextCheckpoint.getTimeUpperBound())
             .format("epoch_millis");
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -168,6 +168,21 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
         );
     }
 
+    public void testSourceHasChanged_UsesExclusiveLowerBound() throws InterruptedException {
+        testSourceHasChangedWithExclusivity(
+            0,
+            false,
+            new TransformCheckpoint("", 100000000L, 7, emptyMap(), 120000000L),
+            TransformConfigVersion.CURRENT,
+            TIMESTAMP_FIELD,
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            tuple(120000000L, 123000000L),
+            false,
+            true
+        );
+    }
+
     private void testSourceHasChanged(
         long totalHits,
         boolean expectedHasChangedValue,
@@ -177,6 +192,32 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
         TimeValue dateHistogramInterval,
         TimeValue delay,
         Tuple<Long, Long> expectedRangeQueryBounds
+    ) throws InterruptedException {
+        testSourceHasChangedWithExclusivity(
+            totalHits,
+            expectedHasChangedValue,
+            lastCheckpoint,
+            transformVersion,
+            dateHistogramField,
+            dateHistogramInterval,
+            delay,
+            expectedRangeQueryBounds,
+            false,
+            true
+        );
+    }
+
+    private void testSourceHasChangedWithExclusivity(
+        long totalHits,
+        boolean expectedHasChangedValue,
+        TransformCheckpoint lastCheckpoint,
+        TransformConfigVersion transformVersion,
+        String dateHistogramField,
+        TimeValue dateHistogramInterval,
+        TimeValue delay,
+        Tuple<Long, Long> expectedRangeQueryBounds,
+        boolean expectInclusiveLower,
+        boolean expectInclusiveUpper
     ) throws InterruptedException {
         final SearchResponse searchResponse = newSearchResponse(totalHits);
         try {
@@ -207,6 +248,8 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
             RangeQueryBuilder rangeQuery = (RangeQueryBuilder) boolQuery.filter().get(1);
             assertThat(rangeQuery.from(), is(equalTo(expectedRangeQueryBounds.v1())));
             assertThat(rangeQuery.to(), is(equalTo(expectedRangeQueryBounds.v2())));
+            assertThat(rangeQuery.includeLower(), is(equalTo(expectInclusiveLower)));
+            assertThat(rangeQuery.includeUpper(), is(equalTo(expectInclusiveUpper)));
 
             assertThat(hasChangedHolder.get(), is(equalTo(expectedHasChangedValue)));
             assertThat(exceptionHolder.get(), is(nullValue()));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
@@ -28,7 +28,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                 new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 0L),
                 new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 123456789L)
             ),
-            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(0L).lt(123456789L).format("epoch_millis")))
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").lte(123456789L).format("epoch_millis")))
         );
 
         assertThat(
@@ -36,7 +36,31 @@ public class LatestChangeCollectorTests extends ESTestCase {
                 new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 123456789L),
                 new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 234567890L)
             ),
-            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(123456789L).lt(234567890L).format("epoch_millis")))
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gt(123456789L).lte(234567890L).format("epoch_millis")))
+        );
+    }
+
+    public void testBuildFilterQueryWithEmptyLastCheckpoint() {
+        LatestChangeCollector changeCollector = new LatestChangeCollector("timestamp");
+
+        assertThat(
+            changeCollector.buildFilterQuery(
+                TransformCheckpoint.EMPTY,
+                new TransformCheckpoint("t_id", 42L, 1L, Collections.emptyMap(), 1000L)
+            ),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").lte(1000L).format("epoch_millis")))
+        );
+    }
+
+    public void testBuildFilterQueryWithSameTimestampBoundary() {
+        LatestChangeCollector changeCollector = new LatestChangeCollector("timestamp");
+
+        assertThat(
+            changeCollector.buildFilterQuery(
+                new TransformCheckpoint("t_id", 100L, 1L, Collections.emptyMap(), 1000L),
+                new TransformCheckpoint("t_id", 200L, 2L, Collections.emptyMap(), 1000L)
+            ),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gt(1000L).lte(1000L).format("epoch_millis")))
         );
     }
 


### PR DESCRIPTION
The `latest` transform was skipping source documents when multiple documents shared the same `@timestamp` value at checkpoint boundaries. This occurred because range queries used exclusive upper bounds (`lt`) instead of inclusive ones (`lte`), creating gaps where documents at exact checkpoint boundaries were excluded from processing. The issue was systemic across the transform time-based synchronization infrastructure, affecting `LatestChangeCollector`, `TimeSyncConfig`, and `TimeBasedCheckpointProvider`.

## Solution

Change the range query logic to use:

- **Lower bound**: `gt` (strictly greater than) for subsequent checkpoints to avoid reprocessing boundary documents
- **Upper bound**: `lte` (less than or equal) to include all documents up to and including the checkpoint boundary
- **First checkpoint**: Use `gte(0)` or no lower bound since there's no previous checkpoint

This creates clean windows: `(T1, T2]`, `(T2, T3]`, etc. with no gaps and no overlaps.
Excellent question! The key is understanding what happens when **checkpoint boundaries don't advance** (when they "stall").

## Why is this the solution? 

Both approaches use semi-open intervals, but they differ in **which window owns the boundary point**:

### Old Approach: `[T_prev, T_next)` - Inclusive Lower, Exclusive Upper

```
Window 1: [0, 1000)    → processes timestamps 0-999
Window 2: [1000, 2000) → processes timestamps 1000-1999
```

This looks fine for **advancing checkpoints**. But when checkpoints stall:

```
Window 1: [0, 1000)    → processes timestamps 0-999
Window 2: [1000, 1000) → EMPTY INTERVAL (no documents match timestamp >= 1000 AND < 1000)

Document with timestamp = 1000:
- NOT in Window 1 (excluded by "lt 1000")
- NOT in Window 2 (impossible to satisfy [1000, 1000))
- Result: LOST FOREVER
```

### New Approach: `(T_prev, T_next]` - Exclusive Lower, Inclusive Upper

```
Window 1: (-, 1000]    → processes timestamps up to and INCLUDING 1000
Window 2: (1000, 2000] → processes timestamps 1001-2000
```

When checkpoints stall:

```
Window 1: (-, 1000]    → processes timestamps up to and INCLUDING 1000
Window 2: (1000, 1000] → EMPTY INTERVAL (still empty, but that's OK!)

Document with timestamp = 1000:
- IN Window 1 (included by "lte 1000")
- Already processed, so empty Window 2 is fine
- Result: SAFELY PROCESSED
```

Closes #106363