### PR TITLE
Fix lookup join nullify

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
@@ -95,6 +95,25 @@ FROM partial_mapping_sample_data
 2024-10-23T13:52:55.015Z | 173.21.3.15  | 8268152             | Connection error?      | 1                     | English
 ;
 
+
+// https://github.com/elastic/elasticsearch/issues/141978
+lookupJoinWithMissingAttributeInKeep
+required_capability: optional_fields_nullify_tech_preview
+required_capability: join_lookup_v12
+
+SET unmapped_fields="load"\;
+FROM languages
+| LOOKUP JOIN languages_lookup ON language_code 
+| KEEP language_code, language_name, foobar
+;
+
+language_code:integer | language_name:keyword | foobar:keyword
+1                     | English               | null
+2                     | French                | null
+3                     | Spanish               | null
+4                     | German                | null
+;
+
 ######################
 # Single index tests #
 ######################

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -469,6 +469,24 @@ x:integer      |does_not_exist:null |language_code:integer |language_name:keywor
 1              |null                |null                  |null
 ;
 
+// https://github.com/elastic/elasticsearch/issues/141978
+lookupJoinWithMissingAttributeInKeep
+required_capability: optional_fields_nullify_tech_preview
+required_capability: join_lookup_v12
+
+SET unmapped_fields="nullify"\;
+FROM languages
+| LOOKUP JOIN languages_lookup ON language_code 
+| KEEP language_code, language_name, foobar
+;
+
+language_code:integer | language_name:keyword | foobar:null
+1                     | English               | null
+2                     | French                | null
+3                     | Spanish               | null
+4                     | German                | null
+;
+
 enrich
 required_capability: optional_fields_nullify_tech_preview
 required_capability: enrich_load

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -205,12 +205,16 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
     }
 
     /**
-     * Inserts an Eval atop each child of the given {@code nAry}, if the child is a LeafPlan.
+     * Inserts an Eval atop each child of the given {@code nAry}, if the child is a LeafPlan. Skips LOOKUP EsRelations.
      */
     private static LogicalPlan evalUnresolvedAtopNary(LogicalPlan nAry, List<Alias> nullAliases) {
         List<LogicalPlan> newChildren = new ArrayList<>(nAry.children().size());
         boolean changed = false;
         for (var child : nAry.children()) {
+            if (child instanceof EsRelation esr && esr.indexMode() == IndexMode.LOOKUP) {
+                newChildren.add(child);
+                continue;
+            }
             if (child instanceof LeafPlan source) {
                 assertSourceType(source);
                 child = new Eval(source.source(), source, nullAliases);


### PR DESCRIPTION
This change fixes lookup queries with unknown fields executed with `SET unmapped_fields="nullify";`.
Such queries produced the following plan:
```
Optimized logicalPlan plan:
    Project[[language_code{f}#8, language_name{f}#11, foobar{r}#12]]
    \_Limit[1000[INTEGER],true,false]
      \_Join[LEFT,[language_code{f}#8],[language_code{f}#10],null]
        |_Eval[[null[NULL] AS foobar#12]]
        | \_Limit[1000[INTEGER],false,false]
        |   \_EsRelation[languages][language_code{f}#8, language_name{f}#9]
        \_Eval[[null[NULL] AS foobar#12]]                                              <------------------------------
          \_EsRelation[languages_lookup][LOOKUP][language_code{f}#10, language_name{f}#11]
```
and could not be mapped to a physical plan.

The fix is to avoid inserting eval on top of lookup sources.
Alternatively we should consider setting eval on top of `Join` instead of individual `EsRelations`.

Fixes: #141978