### PR TITLE
ES|QL: fix Generative tests for commands that don't change the output schema

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -425,9 +425,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrTimeSeriesDataStreamsIT
   method: testCrossClusterReplicationForTSDB
   issue: https://github.com/elastic/elasticsearch/issues/142797
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/142426
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackSubqueryIT
   method: testManyRandomKeywordFieldsInSubqueryIntermediateResultsWithSortOneField
   issue: https://github.com/elastic/elasticsearch/issues/141202
@@ -443,9 +440,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/142426
 - class: org.elasticsearch.xpack.search.AsyncSearchTaskTests
   method: testWithFailure
   issue: https://github.com/elastic/elasticsearch/issues/142821

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/CommandGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/CommandGenerator.java
@@ -130,9 +130,9 @@ public interface CommandGenerator {
             return VALIDATION_OK;
         }
 
-        if (previousColumns.stream().anyMatch(x -> x.name().contains("<all-fields-projected>"))) {
-            return VALIDATION_OK; // known bug
-        }
+        // known bug https://github.com/elastic/elasticsearch/issues/121741
+        previousColumns = previousColumns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
+        columns = columns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
 
         if (previousColumns.size() != columns.size()) {
             return new ValidationResult(false, "Expecting [" + previousColumns.size() + "] columns, got [" + columns.size() + "]");
@@ -154,9 +154,10 @@ public interface CommandGenerator {
      * The command doesn't have to produce LESS columns than the previous query
      */
     static ValidationResult expectAtLeastSameNumberOfColumns(List<Column> previousColumns, List<Column> columns) {
-        if (previousColumns.stream().anyMatch(x -> x.name().contains("<all-fields-projected>"))) {
-            return VALIDATION_OK; // known bug
-        }
+        // known bug https://github.com/elastic/elasticsearch/issues/121741
+        previousColumns = previousColumns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
+        columns = columns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
+
 
         if (previousColumns.size() > columns.size()) {
             return new ValidationResult(false, "Expecting at least [" + previousColumns.size() + "] columns, got [" + columns.size() + "]");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/CommandGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/CommandGenerator.java
@@ -158,7 +158,6 @@ public interface CommandGenerator {
         previousColumns = previousColumns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
         columns = columns.stream().filter(x -> x.name().contains("<all-fields-projected>") == false).toList();
 
-
         if (previousColumns.size() > columns.size()) {
             return new ValidationResult(false, "Expecting at least [" + previousColumns.size() + "] columns, got [" + columns.size() + "]");
         }


### PR DESCRIPTION
Some commands, depending how the query get optimized, could produce an `<all-fields-projected>` column. 
That's a [known bug](https://github.com/elastic/elasticsearch/issues/121741) and it created some problems in the output schema validation. 
With this change we just ignore that column for now.

I'm tentatively unmuting the tests, but I'm not sure this is the only failure, so there is a chance that they'll get muted again