### PR TITLE
Fix return_intermediate_results query param on get async search results

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestGetAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestGetAsyncSearchAction.java
@@ -44,8 +44,8 @@ public class RestGetAsyncSearchAction extends BaseRestHandler {
         if (request.hasParam("keep_alive")) {
             get.setKeepAlive(request.paramAsTime("keep_alive", get.getKeepAlive()));
         }
-        if (request.hasParam("partial_results")) {
-            get.setReturnIntermediateResults(request.paramAsBoolean("partial_results", get.getReturnIntermediateResults()));
+        if (request.hasParam("return_intermediate_results")) {
+            get.setReturnIntermediateResults(request.paramAsBoolean("return_intermediate_results", get.getReturnIntermediateResults()));
         }
         return channel -> client.execute(GetAsyncSearchAction.INSTANCE, get, new RestRefCountedChunkedToXContentListener<>(channel) {
             @Override


### PR DESCRIPTION
Change from `partial_results` to `return_intermediate_results` 

https://github.com/elastic/elasticsearch/pull/141073 introduced a new query parameter to allow clients to decide whether or not intermediate results should be returned when getting async search results if the query is not complete. The initial Github issue asked for a `partial_results` query parameter but it was decided to change it to `return_intermediate_results`. That change was made in the PR in all places except for `RestGetAsyncSearchAction`. This PR corrects that oversight. 
