### PR TITLE
[Docs] Add info about the defaults values of index.sort.* settings

### DIFF
--- a/docs/reference/elasticsearch/index-settings/sorting.md
+++ b/docs/reference/elasticsearch/index-settings/sorting.md
@@ -80,8 +80,10 @@ $$$index-sort-order$$$
 `index.sort.order` {applies_to}`serverless: all`
 :   The sort order to use for each field. The order option can have the following values:
 
-    * `asc`:  For ascending order
+    * `asc`:  For ascending order.
     * `desc`: For descending order.
+
+    When `index.sort.field` is set but `index.sort.order` is not explicitly provided, each field defaults to `asc`.
 
 $$$index-sort-mode$$$
 `index.sort.mode` {applies_to}`serverless: all`
@@ -90,6 +92,8 @@ $$$index-sort-mode$$$
     * `min`: 	Pick the lowest value.
     * `max`: 	Pick the highest value.
 
+    When `index.sort.order` is set to `asc`, `index.sort.mode` defaults to `min`. If you set the order to `desc`, the mode defaults to `max`.
+
 
 $$$index-sort-missing$$$
 `index.sort.missing` {applies_to}`serverless: all`
@@ -97,6 +101,8 @@ $$$index-sort-missing$$$
 
     * `_last`: Documents without value for the field are sorted last.
     * `_first`: Documents without value for the field are sorted first.
+
+    Documents missing the sort field are always sorted last by default, regardless of sort order.
 
 
 ::::{warning}


### PR DESCRIPTION
Fixes [#56](https://github.com/elastic/docs-content-internal/issues/56)

The info added in this PR can be summarised as follows: 

| Setting | Default | Source |
|---|---|---|
| `index.sort.field` | None (no index sorting by default) | [`IndexSortConfig.java` L122](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java#L122) |
| `index.sort.order` | `asc` | [`IndexSortConfig.java` L220-L226](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java#L220-L226) |
| `index.sort.mode` | `min` when order is `asc`, `max` when order is `desc` | [`IndexSortConfig.java` L228-L245](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java#L228-L245) |
| `index.sort.missing` | `_last` | [`IndexSortConfig.java` L247-L259](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java#L247-L259) |
