### PR TITLE
Refactor query rewrite async actions for knn and sparse_vector queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -440,7 +440,7 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         }
         if (queryVectorBuilder != null) {
             SetOnce<float[]> toSet = new SetOnce<>();
-            QueryVectorBuilderAsyncAction.registerAction(ctx, queryVectorBuilder, toSet);
+            ctx.registerUniqueAsyncAction(new QueryVectorBuilderAsyncAction(queryVectorBuilder), toSet::set);
             return new KnnVectorQueryBuilder(
                 fieldName,
                 queryVector,

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -16,8 +16,6 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -31,7 +29,6 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryRewriteAsyncAction;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.ToChildBlockJoinQueryBuilder;
@@ -443,18 +440,7 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         }
         if (queryVectorBuilder != null) {
             SetOnce<float[]> toSet = new SetOnce<>();
-            ctx.registerUniqueAsyncAction(new QueryVectorBuilderAsyncAction(queryVectorBuilder), v -> {
-                toSet.set(v);
-                if (v == null) {
-                    throw new IllegalArgumentException(
-                        format(
-                            "[%s] with name [%s] returned null query_vector",
-                            QUERY_VECTOR_BUILDER_FIELD.getPreferredName(),
-                            queryVectorBuilder.getWriteableName()
-                        )
-                    );
-                }
-            });
+            QueryVectorBuilderAsyncAction.registerAction(ctx, queryVectorBuilder, toSet);
             return new KnnVectorQueryBuilder(
                 fieldName,
                 queryVector,
@@ -678,28 +664,5 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
     public KnnVectorQueryBuilder setAutoPrefilteringEnabled(boolean isAutoPrefilteringEnabled) {
         this.isAutoPrefilteringEnabled = isAutoPrefilteringEnabled;
         return this;
-    }
-
-    private static final class QueryVectorBuilderAsyncAction extends QueryRewriteAsyncAction<float[], QueryVectorBuilderAsyncAction> {
-        private final QueryVectorBuilder queryVectorBuilder;
-
-        private QueryVectorBuilderAsyncAction(QueryVectorBuilder queryVectorBuilder) {
-            this.queryVectorBuilder = Objects.requireNonNull(queryVectorBuilder);
-        }
-
-        @Override
-        protected void execute(Client client, ActionListener<float[]> listener) {
-            queryVectorBuilder.buildVector(client, listener);
-        }
-
-        @Override
-        public int doHashCode() {
-            return Objects.hash(queryVectorBuilder);
-        }
-
-        @Override
-        public boolean doEquals(QueryVectorBuilderAsyncAction other) {
-            return Objects.equals(queryVectorBuilder, other.queryVectorBuilder);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilderAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilderAsyncAction.java
@@ -9,11 +9,9 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.query.QueryRewriteAsyncAction;
-import org.elasticsearch.index.query.QueryRewriteContext;
 
 import java.util.Objects;
 
@@ -29,7 +27,18 @@ public final class QueryVectorBuilderAsyncAction extends QueryRewriteAsyncAction
 
     @Override
     protected void execute(Client client, ActionListener<float[]> listener) {
-        queryVectorBuilder.buildVector(client, listener);
+        queryVectorBuilder.buildVector(client, listener.delegateFailureAndWrap((l, v) -> {
+            if (v == null) {
+                throw new IllegalArgumentException(
+                    format(
+                        "[%s] with name [%s] returned null query_vector",
+                        QUERY_VECTOR_BUILDER_FIELD.getPreferredName(),
+                        queryVectorBuilder.getWriteableName()
+                    )
+                );
+            }
+            l.onResponse(v);
+        }));
     }
 
     @Override
@@ -40,24 +49,5 @@ public final class QueryVectorBuilderAsyncAction extends QueryRewriteAsyncAction
     @Override
     public boolean doEquals(QueryVectorBuilderAsyncAction other) {
         return Objects.equals(queryVectorBuilder, other.queryVectorBuilder);
-    }
-
-    public static void registerAction(
-        QueryRewriteContext queryRewriteContext,
-        QueryVectorBuilder queryVectorBuilder,
-        SetOnce<float[]> supplier
-    ) {
-        queryRewriteContext.registerUniqueAsyncAction(new QueryVectorBuilderAsyncAction(queryVectorBuilder), v -> {
-            supplier.set(v);
-            if (v == null) {
-                throw new IllegalArgumentException(
-                    format(
-                        "[%s] with name [%s] returned null query_vector",
-                        QUERY_VECTOR_BUILDER_FIELD.getPreferredName(),
-                        queryVectorBuilder.getWriteableName()
-                    )
-                );
-            }
-        });
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilderAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilderAsyncAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.query.QueryRewriteAsyncAction;
+import org.elasticsearch.index.query.QueryRewriteContext;
+
+import java.util.Objects;
+
+import static org.elasticsearch.common.Strings.format;
+import static org.elasticsearch.search.vectors.KnnVectorQueryBuilder.QUERY_VECTOR_BUILDER_FIELD;
+
+public final class QueryVectorBuilderAsyncAction extends QueryRewriteAsyncAction<float[], QueryVectorBuilderAsyncAction> {
+    private final QueryVectorBuilder queryVectorBuilder;
+
+    public QueryVectorBuilderAsyncAction(QueryVectorBuilder queryVectorBuilder) {
+        this.queryVectorBuilder = Objects.requireNonNull(queryVectorBuilder);
+    }
+
+    @Override
+    protected void execute(Client client, ActionListener<float[]> listener) {
+        queryVectorBuilder.buildVector(client, listener);
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(queryVectorBuilder);
+    }
+
+    @Override
+    public boolean doEquals(QueryVectorBuilderAsyncAction other) {
+        return Objects.equals(queryVectorBuilder, other.queryVectorBuilder);
+    }
+
+    public static void registerAction(
+        QueryRewriteContext queryRewriteContext,
+        QueryVectorBuilder queryVectorBuilder,
+        SetOnce<float[]> supplier
+    ) {
+        queryRewriteContext.registerUniqueAsyncAction(new QueryVectorBuilderAsyncAction(queryVectorBuilder), v -> {
+            supplier.set(v);
+            if (v == null) {
+                throw new IllegalArgumentException(
+                    format(
+                        "[%s] with name [%s] returned null query_vector",
+                        QUERY_VECTOR_BUILDER_FIELD.getPreferredName(),
+                        queryVectorBuilder.getWriteableName()
+                    )
+                );
+            }
+        });
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseInferenceRewriteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseInferenceRewriteAction.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.search;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.query.QueryRewriteAsyncAction;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.xpack.core.ml.action.CoordinatedInferenceAction;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelPrefixStrings;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfigUpdate;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class SparseInferenceRewriteAction extends QueryRewriteAsyncAction<TextExpansionResults, SparseInferenceRewriteAction> {
+    private final String inferenceId;
+    private final String query;
+
+    SparseInferenceRewriteAction(String inferenceId, String query) {
+        this.inferenceId = inferenceId;
+        this.query = query;
+    }
+
+    @Override
+    protected void execute(Client client, ActionListener<TextExpansionResults> responseListener) {
+        // TODO: Move this class to `server` and update to use InferenceAction.Request
+        CoordinatedInferenceAction.Request inferRequest = CoordinatedInferenceAction.Request.forTextInput(
+            inferenceId,
+            List.of(query),
+            TextExpansionConfigUpdate.EMPTY_UPDATE,
+            false,
+            null
+        );
+
+        inferRequest.setHighPriority(true);
+        inferRequest.setPrefixType(TrainedModelPrefixStrings.PrefixType.SEARCH);
+
+        executeAsyncWithOrigin(
+            client,
+            ML_ORIGIN,
+            CoordinatedInferenceAction.INSTANCE,
+            inferRequest,
+            responseListener.delegateFailureAndWrap((listener, inferenceResponse) -> {
+                List<InferenceResults> inferenceResults = inferenceResponse.getInferenceResults();
+                if (inferenceResults.isEmpty()) {
+                    listener.onFailure(new IllegalStateException("inference response contain no results"));
+                    return;
+                }
+                if (inferenceResults.size() > 1) {
+                    listener.onFailure(new IllegalStateException("inference response should contain only one result"));
+                    return;
+                }
+
+                if (inferenceResults.getFirst() instanceof TextExpansionResults textExpansionResults) {
+                    listener.onResponse(textExpansionResults);
+                } else if (inferenceResults.getFirst() instanceof WarningInferenceResults warning) {
+                    listener.onFailure(new IllegalStateException(warning.getWarning()));
+                } else {
+                    listener.onFailure(
+                        new IllegalArgumentException(
+                            "expected a result of type ["
+                                + TextExpansionResults.NAME
+                                + "] received ["
+                                + inferenceResults.getFirst().getWriteableName()
+                                + "]. Is ["
+                                + inferenceId
+                                + "] a compatible model?"
+                        )
+                    );
+                }
+            })
+        );
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(inferenceId, query);
+    }
+
+    @Override
+    public boolean doEquals(SparseInferenceRewriteAction other) {
+        return Objects.equals(inferenceId, other.inferenceId) && Objects.equals(query, other.query);
+    }
+}


### PR DESCRIPTION
Refactors the `QueryRewriteAsyncAction`s for the `knn` and `sparse_vector` queries to move them to dedicated files. This is a prerequisite for https://github.com/elastic/elasticsearch/pull/142254, so that we can use these actions in intercepted `knn` and `sparse_vector` queries.