### PR TITLE
[9.3] Fix built-in roles sync losing updates (#142433)

### DIFF
--- a/docs/changelog/142433.yaml
+++ b/docs/changelog/142433.yaml
@@ -1,0 +1,6 @@
+area: Security
+issues: []
+pr: 142433
+summary: Fix built-in roles sync to retry on lock contention instead of silently discarding
+  pending updates
+type: bug


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix built-in roles sync losing updates (#142433)