### PR TITLE
Activity logging improvements

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchLoggingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchLoggingIT.java
@@ -117,7 +117,12 @@ public class SearchLoggingIT extends AbstractSearchCancellationTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return CollectionUtils.concatLists(
-            List.of(TestSystemIndexPlugin.class, DataStreamsPlugin.class, TestSystemDataStreamPlugin.class),
+            List.of(
+                TestSystemIndexPlugin.class,
+                DataStreamsPlugin.class,
+                TestSystemDataStreamPlugin.class,
+                SearchTimeoutIT.SearchTimeoutPlugin.class
+            ),
             super.nodePlugins()
         );
     }
@@ -136,6 +141,7 @@ public class SearchLoggingIT extends AbstractSearchCancellationTestCase {
             assertMessageSuccess(message, "search", "fox");
             assertThat(message.get(ES_FIELDS_PREFIX + "hits"), equalTo("1"));
             assertThat(message.get(ES_FIELDS_PREFIX + "indices"), equalTo(""));
+            assertNull(message.get(ES_FIELDS_PREFIX + "timed_out"));
         }
 
         // Match
@@ -146,6 +152,7 @@ public class SearchLoggingIT extends AbstractSearchCancellationTestCase {
             assertMessageSuccess(message, "search", "quick");
             assertThat(message.get(ES_FIELDS_PREFIX + "hits"), equalTo("3"));
             assertThat(message.get(ES_FIELDS_PREFIX + "indices"), equalTo(INDEX_NAME));
+            assertNull(message.get(ES_FIELDS_PREFIX + "timed_out"));
         }
     }
 
@@ -330,6 +337,30 @@ public class SearchLoggingIT extends AbstractSearchCancellationTestCase {
         assertMessageSuccess(messageWithAgg, "search", "match_all");
         assertThat(messageNoAgg.get(ES_FIELDS_PREFIX + "hits"), equalTo("3"));
         assertThat(messageWithAgg.get(SearchLogProducer.SEARCH_HAS_AGGREGATIONS_FIELD), equalTo("true"));
+    }
+
+    public void testSearchTimedOutLog() {
+        setupIndex();
+        final String timedOutField = ES_FIELDS_PREFIX + "timed_out";
+
+        // Search that times out (using plugin that throws TimeExceededException): timed_out must be true
+        SearchResponse timedOutResponse = null;
+        try {
+            timedOutResponse = client().prepareSearch(INDEX_NAME)
+                .setQuery(new SearchTimeoutIT.BulkScorerTimeoutQuery(false))
+                .setTimeout(TimeValue.timeValueSeconds(10))
+                .setAllowPartialSearchResults(true)
+                .get();
+            assertThat(timedOutResponse.isTimedOut(), equalTo(true));
+        } finally {
+            if (timedOutResponse != null) {
+                timedOutResponse.decRef();
+            }
+        }
+        var eventTimedOut = appender.getLastEventAndReset();
+        Map<String, String> messageTimedOut = getMessageData(eventTimedOut);
+        assertMessageSuccess(messageTimedOut, "search", "timeout");
+        assertThat(messageTimedOut.get(timedOutField), equalTo("true"));
     }
 
     private void setupIndex() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchLoggingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchLoggingIT.java
@@ -62,9 +62,11 @@ import java.util.Map;
 
 import static org.elasticsearch.common.logging.activity.ActivityLogProducer.ES_FIELDS_PREFIX;
 import static org.elasticsearch.common.logging.activity.ActivityLogProducer.EVENT_OUTCOME_FIELD;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.test.AbstractSearchCancellationTestCase.ScriptedBlockPlugin.SEARCH_BLOCK_SCRIPT_NAME;
 import static org.elasticsearch.test.ActivityLoggingUtils.assertMessageFailure;
 import static org.elasticsearch.test.ActivityLoggingUtils.assertMessageSuccess;
@@ -306,6 +308,28 @@ public class SearchLoggingIT extends AbstractSearchCancellationTestCase {
                 new DeleteDataStreamAction.Request(TEST_REQUEST_TIMEOUT, TestSystemDataStreamPlugin.SYSTEM_DATA_STREAM_NAME)
             ).actionGet();
         }
+    }
+
+    public void testSearchHasAggregationsLog() {
+        setupIndex();
+
+        // Search without aggregations: search.has_aggregations must not be present
+        assertSearchHitsWithoutFailures(prepareSearch(INDEX_NAME).setQuery(matchQuery("field1", "quick")), "1", "2", "3");
+        var eventNoAgg = appender.getLastEventAndReset();
+        Map<String, String> messageNoAgg = getMessageData(eventNoAgg);
+        assertMessageSuccess(messageNoAgg, "search", "quick");
+        assertNull(messageNoAgg.get(SearchLogProducer.SEARCH_HAS_AGGREGATIONS_FIELD));
+
+        // Search with aggregations: search.has_aggregations must be true
+        assertResponse(
+            prepareSearch(INDEX_NAME).setSize(0).setQuery(matchAllQuery()).addAggregation(filter("agg_filter", matchAllQuery())),
+            ElasticsearchAssertions::assertNoFailures
+        );
+        var eventWithAgg = appender.getLastEventAndReset();
+        Map<String, String> messageWithAgg = getMessageData(eventWithAgg);
+        assertMessageSuccess(messageWithAgg, "search", "match_all");
+        assertThat(messageNoAgg.get(ES_FIELDS_PREFIX + "hits"), equalTo("3"));
+        assertThat(messageWithAgg.get(SearchLogProducer.SEARCH_HAS_AGGREGATIONS_FIELD), equalTo("true"));
     }
 
     private void setupIndex() {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class SearchLogContext extends ActivityLoggerContext {
@@ -95,7 +96,16 @@ public class SearchLogContext extends ActivityLoggerContext {
         return isSystemSearch;
     }
 
+    @Override
+    public boolean isTimedOut() {
+        return response != null && response.isTimedOut();
+    }
+
     public String getIndices() {
         return Strings.join(getIndexNames(), ",");
+    }
+
+    public boolean hasAggregations() {
+        return response != null && response.hasAggregations();
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchLogContext.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 public class SearchLogContext extends ActivityLoggerContext {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchLogProducer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchLogProducer.java
@@ -30,7 +30,7 @@ public class SearchLogProducer implements ActivityLogProducer<SearchLogContext> 
     private final Predicate<String> systemChecker;
 
     public static final Setting<Boolean> SEARCH_LOGGER_LOG_SYSTEM = Setting.boolSetting(
-        ACTIVITY_LOGGER_SETTINGS_PREFIX + "search.include_system_indices",
+        ACTIVITY_LOGGER_SETTINGS_PREFIX + "search.include.system_indices",
         false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
@@ -58,6 +58,9 @@ public class SearchLogProducer implements ActivityLogProducer<SearchLogContext> 
         msg.field(ES_FIELDS_PREFIX + "hits", context.getHits());
         if (context.isSystemSearch(systemChecker)) {
             msg.field(ES_FIELDS_PREFIX + "is_system", true);
+        }
+        if (context.hasAggregations()) {
+            msg.field(ES_FIELDS_PREFIX + "search.has_aggregations", true);
         }
         return Optional.of(msg);
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchLogProducer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchLogProducer.java
@@ -25,6 +25,7 @@ public class SearchLogProducer implements ActivityLogProducer<SearchLogContext> 
 
     public static final String LOGGER_NAME = "search.activitylog";
     public static final String[] NEVER_MATCH = new String[] { "*", "-*" };
+    public static final String SEARCH_HAS_AGGREGATIONS_FIELD = ES_FIELDS_PREFIX + "search.has_aggregations";
 
     private boolean logSystemSearches = false;
     private final Predicate<String> systemChecker;
@@ -60,7 +61,7 @@ public class SearchLogProducer implements ActivityLogProducer<SearchLogContext> 
             msg.field(ES_FIELDS_PREFIX + "is_system", true);
         }
         if (context.hasAggregations()) {
-            msg.field(ES_FIELDS_PREFIX + "search.has_aggregations", true);
+            msg.field(SEARCH_HAS_AGGREGATIONS_FIELD, true);
         }
         return Optional.of(msg);
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLogProducer.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLogProducer.java
@@ -53,6 +53,9 @@ public interface ActivityLogProducer<Context extends ActivityLoggerContext> {
             fields.field("error.type", context.getErrorType());
             fields.field("error.message", context.getErrorMessage());
         }
+        if (context.isTimedOut()) {
+            fields.field(ES_FIELDS_PREFIX + "timed_out", true);
+        }
         return fields;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLoggerContext.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLoggerContext.java
@@ -12,6 +12,8 @@ package org.elasticsearch.common.logging.activity;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.tasks.Task;
 
+import java.util.Optional;
+
 /**
  * Context for {@link ActivityLogger}.
  * This class contains the information needed to log the query and is extended by specific logging contexts for each action.
@@ -40,6 +42,10 @@ public abstract class ActivityLoggerContext {
 
     public boolean isSuccess() {
         return error == null;
+    }
+
+    public boolean isTimedOut() {
+        return false;
     }
 
     public String getType() {

--- a/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLoggerContext.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/activity/ActivityLoggerContext.java
@@ -12,8 +12,6 @@ package org.elasticsearch.common.logging.activity;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.tasks.Task;
 
-import java.util.Optional;
-
 /**
  * Context for {@link ActivityLogger}.
  * This class contains the information needed to log the query and is extended by specific logging contexts for each action.

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
@@ -9,11 +9,14 @@ package org.elasticsearch.xpack.eql.logging;
 
 import joptsimple.internal.Strings;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.logging.activity.ActivityLoggerContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class EqlLogContext extends ActivityLoggerContext {
@@ -41,10 +44,17 @@ public class EqlLogContext extends ActivityLoggerContext {
         return Strings.join(request.indices(), ",");
     }
 
+    @Override
+    public boolean isTimedOut() {
+        return response != null && response.isTimeout();
+    }
+
     long getHits() {
         if (response == null || response.hits() == null || response.hits().totalHits() == null) {
             return 0;
         }
         return response.hits().totalHits().value();
     }
+
+
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/logging/EqlLogContext.java
@@ -9,14 +9,11 @@ package org.elasticsearch.xpack.eql.logging;
 
 import joptsimple.internal.Strings;
 
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.logging.activity.ActivityLoggerContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
 
-import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class EqlLogContext extends ActivityLoggerContext {
@@ -55,6 +52,5 @@ public class EqlLogContext extends ActivityLoggerContext {
         }
         return response.hits().totalHits().value();
     }
-
 
 }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLoggingIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLoggingIT.java
@@ -84,7 +84,7 @@ public class SqlLoggingIT extends AbstractSqlIntegTestCase {
         assertThat(appender.events.size(), equalTo(1));
         var message = getMessageData(appender.getLastEventAndReset());
         assertMessageSuccess(message, "sql", query);
-        assertThat(message.get(ES_FIELDS_PREFIX + "rows"), equalTo("2"));
+        assertThat(message.get(ES_FIELDS_PREFIX + "hits"), equalTo("2"));
     }
 
     public void testSqlFailureLogging() {
@@ -93,6 +93,6 @@ public class SqlLoggingIT extends AbstractSqlIntegTestCase {
         assertThat(appender.events.size(), equalTo(1));
         var message = getMessageData(appender.getLastEventAndReset());
         assertMessageFailure(message, "sql", query, VerificationException.class, "Unknown index [test]");
-        assertThat(message.get(ES_FIELDS_PREFIX + "rows"), equalTo("0"));
+        assertThat(message.get(ES_FIELDS_PREFIX + "hits"), equalTo("0"));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogProducer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/logging/SqlLogProducer.java
@@ -20,7 +20,7 @@ public class SqlLogProducer implements ActivityLogProducer<SqlLogContext> {
     @Override
     public Optional<ESLogMessage> produce(SqlLogContext context, ActionLoggingFields additionalFields) {
         ESLogMessage msg = produceCommon(context, additionalFields);
-        return Optional.of(msg.field(ES_FIELDS_PREFIX + "query", context.getQuery()).field(ES_FIELDS_PREFIX + "rows", context.getRows()));
+        return Optional.of(msg.field(ES_FIELDS_PREFIX + "query", context.getQuery()).field(ES_FIELDS_PREFIX + "hits", context.getRows()));
     }
 
     @Override


### PR DESCRIPTION
- Rename `rows` to `hits` for SQL
- Add `timed_out` flag
- Add `search.has_aggregations` field
- Rename `search.include.system_indices` setting

See: https://github.com/elastic/elasticsearch/issues/142619