### PR TITLE
Fix serialization of NodeGpuStatsResponse when no GPU is present

### DIFF
--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
@@ -29,7 +29,7 @@ public class GPUSupport {
     private static final AtomicLong GPU_USAGE_COUNT = new AtomicLong();
 
     private record GpuInfo(long totalMemory, String name) {
-        static final GpuInfo UNSUPPORTED = new GpuInfo(-1L, null);
+        static final GpuInfo UNSUPPORTED = new GpuInfo(0L, null);
     }
 
     private static class Holder {
@@ -136,7 +136,7 @@ public class GPUSupport {
     /**
      * Returns the total device memory in bytes of the first available compatible GPU.
      *
-     * @return total device memory in bytes, or -1 if GPU is not available or supported
+     * @return total device memory in bytes, or 0 if GPU is not available or supported
      */
     public static long getTotalGpuMemory() {
         return Holder.GPU_INFO.totalMemory();

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
@@ -29,7 +29,19 @@ public class GPUSupport {
     private static final AtomicLong GPU_USAGE_COUNT = new AtomicLong();
 
     private record GpuInfo(long totalMemory, String name) {
+
         static final GpuInfo UNSUPPORTED = new GpuInfo(0L, null);
+
+        GpuInfo {
+            checkNonNegative(totalMemory, "totalMemory");
+        }
+    }
+
+    static long checkNonNegative(long value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must be non-negative, got [" + value + "]");
+        }
+        return value;
     }
 
     private static class Holder {

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
@@ -33,8 +33,8 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
         super(node);
         this.gpuSupported = gpuSupported;
         this.gpuSettingEnabled = gpuSettingEnabled;
-        this.gpuUsageCount = gpuUsageCount;
-        this.totalGpuMemoryInBytes = totalGpuMemoryInBytes;
+        this.gpuUsageCount = checkNonNegative(gpuUsageCount, "gpuUsageCount");
+        this.totalGpuMemoryInBytes = checkNonNegative(totalGpuMemoryInBytes, "totalGpuMemoryInBytes");
         this.gpuName = gpuName;
     }
 
@@ -80,5 +80,12 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
 
     public String getGpuName() {
         return gpuName;
+    }
+
+    private static long checkNonNegative(long value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must be non-negative, got [" + value + "]");
+        }
+        return value;
     }
 }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
@@ -43,7 +43,7 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
         this.gpuSupported = in.readBoolean();
         this.gpuSettingEnabled = in.readBoolean();
         this.gpuUsageCount = in.readVLong();
-        this.totalGpuMemoryInBytes = in.readLong();
+        this.totalGpuMemoryInBytes = in.readVLong();
         this.gpuName = in.readOptionalString();
     }
 
@@ -53,7 +53,7 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
         out.writeBoolean(gpuSupported);
         out.writeBoolean(gpuSettingEnabled);
         out.writeVLong(gpuUsageCount);
-        out.writeLong(totalGpuMemoryInBytes);
+        out.writeVLong(totalGpuMemoryInBytes);
         out.writeOptionalString(gpuName);
     }
 

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponse.java
@@ -43,7 +43,7 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
         this.gpuSupported = in.readBoolean();
         this.gpuSettingEnabled = in.readBoolean();
         this.gpuUsageCount = in.readVLong();
-        this.totalGpuMemoryInBytes = in.readVLong();
+        this.totalGpuMemoryInBytes = in.readLong();
         this.gpuName = in.readOptionalString();
     }
 
@@ -53,7 +53,7 @@ public class NodeGpuStatsResponse extends BaseNodeResponse {
         out.writeBoolean(gpuSupported);
         out.writeBoolean(gpuSettingEnabled);
         out.writeVLong(gpuUsageCount);
-        out.writeVLong(totalGpuMemoryInBytes);
+        out.writeLong(totalGpuMemoryInBytes);
         out.writeOptionalString(gpuName);
     }
 

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GpuUsageTransportActionTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GpuUsageTransportActionTests.java
@@ -33,7 +33,7 @@ public class GpuUsageTransportActionTests extends ESTestCase {
         var nodeResponses = List.of(
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), true, true, 5, 24_000_000_000L, "NVIDIA L4"),
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), true, false, 0, 24_000_000_000L, "NVIDIA L4"),
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node3"), false, false, 0, -1L, null),
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node3"), false, false, 0, 0L, null),
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node4"), true, true, 3, 80_000_000_000L, "NVIDIA A100")
         );
 
@@ -65,8 +65,8 @@ public class GpuUsageTransportActionTests extends ESTestCase {
 
     public void testAggregation_noGpuNodes() throws Exception {
         var nodeResponses = List.of(
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), false, false, 0, -1L, null),
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), false, false, 0, -1L, null)
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), false, false, 0, 0L, null),
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), false, false, 0, 0L, null)
         );
 
         var usage = GpuUsageTransportAction.buildUsage(new GpuStatsResponse(CLUSTER_NAME, nodeResponses, Collections.emptyList()), false);

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
@@ -13,10 +13,11 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class NodeGpuStatsResponseTests extends ESTestCase {
 
-    // Reproduces #142936: GPUSupport previously returned -1 for totalGpuMemoryInBytes when no GPU
-    // is present, and writeVLong does not support negative values, causing an IllegalStateException.
+    // GPUSupport returns 0L for totalGpuMemoryInBytes when no GPU is present.
     public void testSerializationWithNoGpu() throws IOException {
         var node = DiscoveryNodeUtils.create("node1");
         var response = new NodeGpuStatsResponse(node, false, false, 0, 0L, null);
@@ -51,5 +52,19 @@ public class NodeGpuStatsResponseTests extends ESTestCase {
             assertEquals(24_000_000_000L, deserialized.getTotalGpuMemoryInBytes());
             assertEquals("NVIDIA L4", deserialized.getGpuName());
         }
+    }
+
+    // Verifies that negative gpuUsageCount is rejected at construction time.
+    public void testNegativeGpuUsageCountRejected() {
+        var node = DiscoveryNodeUtils.create("node1");
+        var e = expectThrows(IllegalArgumentException.class, () -> new NodeGpuStatsResponse(node, true, true, -1, 24_000_000_000L, "GPU"));
+        assertThat(e.getMessage(), containsString("gpuUsageCount must be non-negative"));
+    }
+
+    // Verifies that negative totalGpuMemoryInBytes is rejected at construction time.
+    public void testNegativeTotalGpuMemoryRejected() {
+        var node = DiscoveryNodeUtils.create("node1");
+        var e = expectThrows(IllegalArgumentException.class, () -> new NodeGpuStatsResponse(node, true, true, 0, -1L, "GPU"));
+        assertThat(e.getMessage(), containsString("totalGpuMemoryInBytes must be non-negative"));
     }
 }

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
@@ -15,11 +15,11 @@ import java.io.IOException;
 
 public class NodeGpuStatsResponseTests extends ESTestCase {
 
-    // GPUSupport returns -1 for totalGpuMemoryInBytes when no GPU is present,
-    // and writeVLong does not support negative values, causing an IllegalStateException.
+    // Reproduces #142936: GPUSupport previously returned -1 for totalGpuMemoryInBytes when no GPU
+    // is present, and writeVLong does not support negative values, causing an IllegalStateException.
     public void testSerializationWithNoGpu() throws IOException {
         var node = DiscoveryNodeUtils.create("node1");
-        var response = new NodeGpuStatsResponse(node, false, false, 0, -1L, null);
+        var response = new NodeGpuStatsResponse(node, false, false, 0, 0L, null);
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             response.writeTo(out);
@@ -29,7 +29,7 @@ public class NodeGpuStatsResponseTests extends ESTestCase {
             assertFalse(deserialized.isGpuSupported());
             assertFalse(deserialized.isGpuSettingEnabled());
             assertEquals(0, deserialized.getGpuUsageCount());
-            assertEquals(-1L, deserialized.getTotalGpuMemoryInBytes());
+            assertEquals(0L, deserialized.getTotalGpuMemoryInBytes());
             assertNull(deserialized.getGpuName());
         }
     }

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/NodeGpuStatsResponseTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.gpu;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class NodeGpuStatsResponseTests extends ESTestCase {
+
+    // GPUSupport returns -1 for totalGpuMemoryInBytes when no GPU is present,
+    // and writeVLong does not support negative values, causing an IllegalStateException.
+    public void testSerializationWithNoGpu() throws IOException {
+        var node = DiscoveryNodeUtils.create("node1");
+        var response = new NodeGpuStatsResponse(node, false, false, 0, -1L, null);
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            response.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            var deserialized = new NodeGpuStatsResponse(in);
+            assertFalse(deserialized.isGpuSupported());
+            assertFalse(deserialized.isGpuSettingEnabled());
+            assertEquals(0, deserialized.getGpuUsageCount());
+            assertEquals(-1L, deserialized.getTotalGpuMemoryInBytes());
+            assertNull(deserialized.getGpuName());
+        }
+    }
+
+    // Verifies that a response from a node with a working GPU can be
+    // round-tripped through stream serialization with all fields preserved.
+    public void testSerializationWithGpu() throws IOException {
+        var node = DiscoveryNodeUtils.create("node1");
+        var response = new NodeGpuStatsResponse(node, true, true, 42, 24_000_000_000L, "NVIDIA L4");
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            response.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            var deserialized = new NodeGpuStatsResponse(in);
+            assertTrue(deserialized.isGpuSupported());
+            assertTrue(deserialized.isGpuSettingEnabled());
+            assertEquals(42, deserialized.getGpuUsageCount());
+            assertEquals(24_000_000_000L, deserialized.getTotalGpuMemoryInBytes());
+            assertEquals("NVIDIA L4", deserialized.getGpuName());
+        }
+    }
+}


### PR DESCRIPTION
`NodeGpuStatsResponse` uses `writeVLong` for `totalGpuMemoryInBytes`, which throws IllegalStateException on the sentinel value `-1` returned by `GPUSupport.getTotalGpuMemory()` when no compatible GPU is available. The fix is to replace `-1` with `0L` (which does not change the semantics), and add a serialization round-trip test that reproduces the original failure and validates fix.

No transport version change is needed since the serial-form is not in any shipping release.

resolves #142936