### PR TITLE
ESQL: Fix Parquet reader on missing projected columns

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -115,6 +115,8 @@ public class ParquetFormatReader implements FormatReader {
                 Attribute attr = attributeMap.get(columnName);
                 if (attr != null) {
                     projectedAttributes.add(attr);
+                } else {
+                    projectedAttributes.add(new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL));
                 }
             }
         }


### PR DESCRIPTION
For projected column names that are not in the file schema, add a `ReferenceAttribute` with `DataType.NULL` instead of omitting them. This keeps the projected attribute list aligned with the requested columns and returns null blocks for missing columns.

