### PR TITLE
Fix SearchableSnapshotsTSDBSyntheticIdIntegTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -431,9 +431,6 @@ tests:
 - class: org.elasticsearch.compute.operator.exchange.BatchDriverTests
   method: testSinglePageSingleBatch
   issue: https://github.com/elastic/elasticsearch/issues/142895
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsTSDBSyntheticIdIntegTests
-  method: testSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/142918
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/to_aggregate_metric_double with multi_values}
   issue: https://github.com/elastic/elasticsearch/issues/142964


### PR DESCRIPTION
Previously, the test would try to create a synthetic_id index in setUp even if the feature flag was disabled. This would cause the test to fail on unrecognized setting.

Closes https://github.com/elastic/elasticsearch/issues/142918