### PR TITLE
Add support for steps to change the target index name for later steps

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -64,6 +64,7 @@ import org.elasticsearch.datastreams.lifecycle.rest.RestExplainDataStreamLifecyc
 import org.elasticsearch.datastreams.lifecycle.rest.RestGetDataStreamLifecycleAction;
 import org.elasticsearch.datastreams.lifecycle.rest.RestPutDataStreamLifecycleAction;
 import org.elasticsearch.datastreams.lifecycle.transitions.DlmAction;
+import org.elasticsearch.datastreams.lifecycle.transitions.DlmStep;
 import org.elasticsearch.datastreams.options.action.DeleteDataStreamOptionsAction;
 import org.elasticsearch.datastreams.options.action.GetDataStreamOptionsAction;
 import org.elasticsearch.datastreams.options.action.TransportDeleteDataStreamOptionsAction;
@@ -214,6 +215,8 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, HealthPlu
         // Register DLM actions here. Order matters - they will be executed in the order they are listed for a given index.
         List<DlmAction> dlmActions = List.of();
 
+        verifyActions(dlmActions);
+
         dataLifecycleInitialisationService.set(
             new DataStreamLifecycleService(
                 settings,
@@ -236,6 +239,26 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, HealthPlu
         components.add(dataLifecycleInitialisationService.get());
         components.add(dataStreamLifecycleErrorsPublisher.get());
         return components;
+    }
+
+    // visible for testing
+    static void verifyActions(List<DlmAction> dlmActions) {
+        for (DlmAction action : dlmActions) {
+            if (action.steps().isEmpty()) {
+                throw new IllegalStateException("DLM action [" + action.name() + "] must have at least one step");
+            }
+            for (DlmStep step : action.steps()) {
+                if (step.possibleOutputIndexNamePatterns().isEmpty()) {
+                    throw new IllegalStateException(
+                        "DLM step ["
+                            + step.stepName()
+                            + "] in action ["
+                            + action.name()
+                            + "] must have at least one possible output index name pattern"
+                    );
+                }
+            }
+        }
     }
 
     @Override

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -568,7 +568,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
 
             for (Index index : indicesEligibleForAction) {
                 long findStepStartTime = nowSupplier.getAsLong();
-                DlmStep stepToExecute = findFirstIncompleteStep(projectState, dataStream, action, index);
+                int stepToExecuteIndex = findFirstIncompleteStepIndex(projectState, dataStream, action, index);
                 if (logger.isTraceEnabled()) {
                     long findStepDuration = nowSupplier.getAsLong() - findStepStartTime;
                     logger.trace(
@@ -580,7 +580,8 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                     );
                 }
 
-                if (stepToExecute != null) {
+                if (stepToExecuteIndex >= 0) {
+                    DlmStep stepToExecute = action.steps().get(stepToExecuteIndex);
                     try {
                         logger.trace(
                             "Executing step [{}] for action [{}] on datastream [{}] index [{}]",
@@ -590,7 +591,8 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                             index.getName()
                         );
                         long stepStartTime = nowSupplier.getAsLong();
-                        DlmStepContext dlmStepContext = actionContext.stepContextFor(index);
+                        Index indexForExecution = resolveIndexForStepExecution(stepToExecuteIndex, index, action, projectState);
+                        DlmStepContext dlmStepContext = actionContext.stepContextFor(indexForExecution);
                         stepToExecute.execute(dlmStepContext);
                         if (logger.isTraceEnabled()) {
                             long stepDuration = nowSupplier.getAsLong() - stepStartTime;
@@ -633,13 +635,14 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
         return indicesProcessed;
     }
 
-    private DlmStep findFirstIncompleteStep(ProjectState projectState, DataStream dataStream, DlmAction action, Index index) {
-        DlmStep stepToExecute = null;
-        for (DlmStep step : action.steps().reversed()) {
+    private int findFirstIncompleteStepIndex(ProjectState projectState, DataStream dataStream, DlmAction action, Index index) {
+        int stepToExecute = -1;
+        for (int i = action.steps().size() - 1; i >= 0; i--) {
+            DlmStep step = action.steps().get(i);
             try {
                 long checkStartTime = nowSupplier.getAsLong();
                 if (step.stepCompleted(index, projectState) == false) {
-                    stepToExecute = step;
+                    stepToExecute = i;
                     if (logger.isTraceEnabled()) {
                         logger.trace(
                             "Step [{}] for action [{}] on datastream [{}] index [{}] is not complete, checked in [{}]",
@@ -678,6 +681,32 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
             }
         }
         return stepToExecute;
+    }
+
+    // visible for testing
+    Index resolveIndexForStepExecution(int stepToExecuteIndex, Index index, DlmAction action, ProjectState projectState) {
+        if (stepToExecuteIndex < 1) {
+            return index;
+        }
+
+        DlmStep previousStep = action.steps().get(stepToExecuteIndex - 1);
+        List<Function<String, String>> possibleOutputIndexNamePatterns = previousStep.possibleOutputIndexNamePatterns();
+
+        for (Function<String, String> possibleOutputIndexNamePattern : possibleOutputIndexNamePatterns) {
+            String candidateIndexName = possibleOutputIndexNamePattern.apply(index.getName());
+            if (projectState.metadata().hasIndex(candidateIndexName)) {
+                return projectState.metadata().index(candidateIndexName).getIndex();
+            }
+        }
+
+        logger.warn(
+            "Unable to resolve index name for executing step [{}] for action [{}] with index [{}], defaulting to original index name",
+            action.steps().get(stepToExecuteIndex).stepName(),
+            action.name(),
+            index.getName()
+        );
+
+        return index;
     }
 
     // visible for testing

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/DlmStep.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/DlmStep.java
@@ -12,6 +12,9 @@ package org.elasticsearch.datastreams.lifecycle.transitions;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.index.Index;
 
+import java.util.List;
+import java.util.function.Function;
+
 /**
  * A step within a Data Lifecycle Management action. Each step is responsible for determining if it has been completed for a given index
  * and executing the necessary operations to complete the step.
@@ -42,4 +45,17 @@ public interface DlmStep {
      */
     String stepName();
 
+    /**
+     * A list of functions that can be used to generate possible output index name patterns for this step based input index name.
+     * This is used when a step might change the index that is targeted for later steps in the action such as cloning.
+     * <br>
+     * The list is ordered and the first function that generates an index name that exists in the cluster will be used by later steps.
+     * <br>
+     * If not overridden, this method simply returns a list with the identity function, meaning that by default steps will target
+     * the same index as the input index.
+     * @return A list of functions that take an index name and return a possible output index name pattern.
+     */
+    default List<Function<String, String>> possibleOutputIndexNamePatterns() {
+        return List.of(Function.identity());
+    }
 }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsPluginTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsPluginTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.datastreams;
+
+import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.datastreams.lifecycle.transitions.DlmAction;
+import org.elasticsearch.datastreams.lifecycle.transitions.DlmActionContext;
+import org.elasticsearch.datastreams.lifecycle.transitions.DlmStep;
+import org.elasticsearch.datastreams.lifecycle.transitions.DlmStepContext;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class DataStreamsPluginTests extends ESTestCase {
+
+    public void testVerifyActionsWithEmptyList() {
+        DataStreamsPlugin.verifyActions(List.of());
+    }
+
+    public void testVerifyActionsWithDefaultOutputPatterns() {
+        TestDlmStep step = new TestDlmStep("step-1");
+        DlmAction action = new TestDlmAction("valid-action", List.of(step));
+        DataStreamsPlugin.verifyActions(List.of(action));
+    }
+
+    public void testVerifyActionsWithSingleCustomOutputPattern() {
+        TestDlmStep step = new TestDlmStep("step-1");
+        step.outputIndexNamePatterns = List.of(name -> "cloned-" + name);
+        DlmAction action = new TestDlmAction("valid-action", List.of(step));
+        DataStreamsPlugin.verifyActions(List.of(action));
+    }
+
+    public void testVerifyActionsWithMultipleCustomOutputPatterns() {
+        TestDlmStep step = new TestDlmStep("step-1");
+        step.outputIndexNamePatterns = List.of(name -> "partial-" + name, name -> "full-" + name);
+        DlmAction action = new TestDlmAction("valid-action", List.of(step));
+        DataStreamsPlugin.verifyActions(List.of(action));
+    }
+
+    public void testVerifyActionsWithMixOfDefaultAndCustomOutputPatterns() {
+        TestDlmStep defaultStep = new TestDlmStep("default-step");
+        TestDlmStep customStep = new TestDlmStep("custom-step");
+        customStep.outputIndexNamePatterns = List.of(name -> "cloned-" + name);
+        DlmAction action = new TestDlmAction("valid-action", List.of(defaultStep, customStep));
+        DataStreamsPlugin.verifyActions(List.of(action));
+    }
+
+    public void testVerifyActionsWithMultipleValidActions() {
+        TestDlmStep step1 = new TestDlmStep("step-1");
+        step1.outputIndexNamePatterns = List.of(name -> "cloned-" + name);
+        DlmAction action1 = new TestDlmAction("action-1", List.of(step1, new TestDlmStep("step-2")));
+        DlmAction action2 = new TestDlmAction("action-2", List.of(new TestDlmStep("step-3")));
+        DataStreamsPlugin.verifyActions(List.of(action1, action2));
+    }
+
+    public void testVerifyActionsThrowsOnActionWithNoSteps() {
+        DlmAction action = new TestDlmAction("empty-action", List.of());
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> DataStreamsPlugin.verifyActions(List.of(action)));
+        assertThat(e.getMessage(), containsString("DLM action [empty-action] must have at least one step"));
+    }
+
+    public void testVerifyActionsThrowsOnStepWithEmptyOutputPatterns() {
+        TestDlmStep step = new TestDlmStep("bad-step");
+        step.outputIndexNamePatterns = List.of();
+        DlmAction action = new TestDlmAction("my-action", List.of(step));
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> DataStreamsPlugin.verifyActions(List.of(action)));
+        assertThat(e.getMessage(), containsString("DLM step [bad-step] in action [my-action]"));
+        assertThat(e.getMessage(), containsString("must have at least one possible output index name pattern"));
+    }
+
+    public void testVerifyActionsThrowsOnSecondActionWithNoSteps() {
+        DlmAction validAction = new TestDlmAction("valid-action", List.of(new TestDlmStep("step-1")));
+        DlmAction emptyAction = new TestDlmAction("broken-action", List.of());
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> DataStreamsPlugin.verifyActions(List.of(validAction, emptyAction))
+        );
+        assertThat(e.getMessage(), containsString("DLM action [broken-action] must have at least one step"));
+    }
+
+    public void testVerifyActionsThrowsOnSecondStepWithEmptyOutputPatterns() {
+        TestDlmStep goodStep = new TestDlmStep("good-step");
+        TestDlmStep badStep = new TestDlmStep("bad-step");
+        badStep.outputIndexNamePatterns = List.of();
+        DlmAction action = new TestDlmAction("my-action", List.of(goodStep, badStep));
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> DataStreamsPlugin.verifyActions(List.of(action)));
+        assertThat(e.getMessage(), containsString("DLM step [bad-step] in action [my-action]"));
+    }
+
+    private static class TestDlmStep implements DlmStep {
+        private final String name;
+        List<Function<String, String>> outputIndexNamePatterns = null;
+
+        TestDlmStep(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean stepCompleted(Index index, ProjectState projectState) {
+            return false;
+        }
+
+        @Override
+        public void execute(DlmStepContext dlmStepContext) {}
+
+        @Override
+        public String stepName() {
+            return name;
+        }
+
+        @Override
+        public List<Function<String, String>> possibleOutputIndexNamePatterns() {
+            if (outputIndexNamePatterns != null) {
+                return outputIndexNamePatterns;
+            }
+            return DlmStep.super.possibleOutputIndexNamePatterns();
+        }
+    }
+
+    private static class TestDlmAction implements DlmAction {
+        private final String name;
+        private final List<DlmStep> steps;
+
+        TestDlmAction(String name, List<DlmStep> steps) {
+            this.name = name;
+            this.steps = steps;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Function<DataStreamLifecycle, TimeValue> applyAfterTime() {
+            return dsl -> null;
+        }
+
+        @Override
+        public List<DlmStep> steps() {
+            return steps;
+        }
+
+        @Override
+        public boolean canRunOnProject(DlmActionContext dlmActionContext) {
+            return true;
+        }
+    }
+}

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -1841,6 +1841,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         int completedCheckCount = 0;
         int executeCount = 0;
         final Set<String> executedIndices = new HashSet<>();
+        List<Function<String, String>> outputIndexNamePatterns = null;
 
         @Override
         public boolean stepCompleted(Index index, ProjectState projectState) {
@@ -1860,6 +1861,14 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         @Override
         public String stepName() {
             return "Test Step";
+        }
+
+        @Override
+        public List<Function<String, String>> possibleOutputIndexNamePatterns() {
+            if (outputIndexNamePatterns != null) {
+                return outputIndexNamePatterns;
+            }
+            return DlmStep.super.possibleOutputIndexNamePatterns();
         }
     }
 
@@ -2317,6 +2326,148 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         // Action should NOT be executed, so step1.executeCount should be 0
         assertThat(step1.executeCount, equalTo(0));
         assertThat(processedIndices, empty());
+    }
+
+    public void testResolveIndexForStepExecutionFirstStep() {
+        TestDlmStep step1 = new TestDlmStep();
+        TestDlmStep step2 = new TestDlmStep();
+        TestDlmAction action = new TestDlmAction(TimeValue.timeValueMillis(1), step1, step2);
+
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        IndexMetadata indexMetadata = IndexMetadata.builder("original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        builder.put(indexMetadata, false);
+        ProjectState projectState = projectStateFromProject(builder);
+
+        Index originalIndex = indexMetadata.getIndex();
+        Index result = dataStreamLifecycleService.resolveIndexForStepExecution(0, originalIndex, action, projectState);
+        assertThat(result, is(originalIndex));
+    }
+
+    public void testResolveIndexForStepExecutionPreviousStepOutputMatchesExistingIndex() {
+        TestDlmStep step1 = new TestDlmStep();
+        step1.outputIndexNamePatterns = List.of(name -> "cloned-" + name);
+        TestDlmStep step2 = new TestDlmStep();
+        TestDlmAction action = new TestDlmAction(TimeValue.timeValueMillis(1), step1, step2);
+
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        IndexMetadata originalMeta = IndexMetadata.builder("original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexMetadata clonedMeta = IndexMetadata.builder("cloned-original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        builder.put(originalMeta, false);
+        builder.put(clonedMeta, false);
+        ProjectState projectState = projectStateFromProject(builder);
+
+        Index result = dataStreamLifecycleService.resolveIndexForStepExecution(1, originalMeta.getIndex(), action, projectState);
+        assertThat(result, is(clonedMeta.getIndex()));
+    }
+
+    public void testResolveIndexForStepExecutionNoMatchReturnsOriginalIndex() {
+        TestDlmStep step1 = new TestDlmStep();
+        step1.outputIndexNamePatterns = List.of(name -> "nonexistent-" + name);
+        TestDlmStep step2 = new TestDlmStep();
+        TestDlmAction action = new TestDlmAction(TimeValue.timeValueMillis(1), step1, step2);
+
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        IndexMetadata originalMeta = IndexMetadata.builder("original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        builder.put(originalMeta, false);
+        ProjectState projectState = projectStateFromProject(builder);
+
+        Index originalIndex = originalMeta.getIndex();
+        try (var mockLog = MockLog.capture(DataStreamLifecycleService.class)) {
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "resolve index warning",
+                    DataStreamLifecycleService.class.getCanonicalName(),
+                    Level.WARN,
+                    "Unable to resolve index name for executing step [Test Step] for action [Test DLM Action] with index ["
+                        + originalIndex.getName()
+                        + "], defaulting to original index name"
+                )
+            );
+
+            Index result = dataStreamLifecycleService.resolveIndexForStepExecution(1, originalIndex, action, projectState);
+            assertThat(result, is(originalIndex));
+            mockLog.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testResolveIndexForStepExecutionMultiplePatternsFirstMatchWins() {
+        TestDlmStep step1 = new TestDlmStep();
+        step1.outputIndexNamePatterns = List.of(name -> "first-" + name, name -> "second-" + name);
+        TestDlmStep step2 = new TestDlmStep();
+        TestDlmAction action = new TestDlmAction(TimeValue.timeValueMillis(1), step1, step2);
+
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        IndexMetadata originalMeta = IndexMetadata.builder("original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexMetadata firstMeta = IndexMetadata.builder("first-original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexMetadata secondMeta = IndexMetadata.builder("second-original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        builder.put(originalMeta, false);
+        builder.put(firstMeta, false);
+        builder.put(secondMeta, false);
+        ProjectState projectState = projectStateFromProject(builder);
+
+        Index result = dataStreamLifecycleService.resolveIndexForStepExecution(1, originalMeta.getIndex(), action, projectState);
+        assertThat(result, is(firstMeta.getIndex()));
+    }
+
+    public void testResolveIndexForStepExecutionSkipsNonMatchingPatternsUsesSecond() {
+        TestDlmStep step1 = new TestDlmStep();
+        step1.outputIndexNamePatterns = List.of(name -> "nonexistent-" + name, name -> "second-" + name);
+        TestDlmStep step2 = new TestDlmStep();
+        TestDlmAction action = new TestDlmAction(TimeValue.timeValueMillis(1), step1, step2);
+
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        IndexMetadata originalMeta = IndexMetadata.builder("original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexMetadata secondMeta = IndexMetadata.builder("second-original-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        builder.put(originalMeta, false);
+        builder.put(secondMeta, false);
+        ProjectState projectState = projectStateFromProject(builder);
+
+        Index result = dataStreamLifecycleService.resolveIndexForStepExecution(1, originalMeta.getIndex(), action, projectState);
+        assertThat(result, is(secondMeta.getIndex()));
+    }
+
+    public void testDlmStepDefaultPossibleOutputIndexNamePatterns() {
+        TestDlmStep step = new TestDlmStep();
+        List<Function<String, String>> patterns = step.possibleOutputIndexNamePatterns();
+        assertThat(patterns, hasSize(1));
+        String testName = randomAlphaOfLength(10);
+        assertThat(patterns.get(0).apply(testName), is(testName));
     }
 
     public void testFormatExecutionTimeMilliseconds() {


### PR DESCRIPTION
This PR adds a few functions:

* The ability for a step to specify a number of index name patterns that it indicate the name future steps should use instead of the actual backing index name
  * For example a clone step might output "my-index-clone" or "my-index" depending on if the clone is needed and actually happens
  * In this case, the next step after the clone would look to see which index was actually created (if any) and target that
* It adds a default implementation that just assumes the output is the original backing index name
* It adds validation to ensure that when actions are registered in the plugin, no steps give an empty list for the possible index patterns