### PR TITLE
Fix GPU stats serialization for unsupported GPUs

### DIFF
--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/GPUSupport.java
@@ -29,7 +29,7 @@ public class GPUSupport {
     private static final AtomicLong GPU_USAGE_COUNT = new AtomicLong();
 
     private record GpuInfo(long totalMemory, String name) {
-        static final GpuInfo UNSUPPORTED = new GpuInfo(-1L, null);
+        static final GpuInfo UNSUPPORTED = new GpuInfo(0L, null);
     }
 
     private static class Holder {
@@ -136,7 +136,7 @@ public class GPUSupport {
     /**
      * Returns the total device memory in bytes of the first available compatible GPU.
      *
-     * @return total device memory in bytes, or -1 if GPU is not available or supported
+     * @return total device memory in bytes, or 0 if GPU is not available or supported
      */
     public static long getTotalGpuMemory() {
         return Holder.GPU_INFO.totalMemory();

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GpuUsageTransportActionTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GpuUsageTransportActionTests.java
@@ -33,7 +33,7 @@ public class GpuUsageTransportActionTests extends ESTestCase {
         var nodeResponses = List.of(
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), true, true, 5, 24_000_000_000L, "NVIDIA L4"),
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), true, false, 0, 24_000_000_000L, "NVIDIA L4"),
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node3"), false, false, 0, -1L, null),
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node3"), false, false, 0, 0L, null),
             new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node4"), true, true, 3, 80_000_000_000L, "NVIDIA A100")
         );
 
@@ -65,8 +65,8 @@ public class GpuUsageTransportActionTests extends ESTestCase {
 
     public void testAggregation_noGpuNodes() throws Exception {
         var nodeResponses = List.of(
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), false, false, 0, -1L, null),
-            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), false, false, 0, -1L, null)
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node1"), false, false, 0, 0L, null),
+            new NodeGpuStatsResponse(DiscoveryNodeUtils.create("node2"), false, false, 0, 0L, null)
         );
 
         var usage = GpuUsageTransportAction.buildUsage(new GpuStatsResponse(CLUSTER_NAME, nodeResponses, Collections.emptyList()), false);


### PR DESCRIPTION
Use 0 instead of -1 for totalGpuMemory when GPU is unsupported. 
This fixes writeVLong serialization which doesn't support negative values.