### PR TITLE
[ES|QL] Support integer type in the second parameter of FIRST/LAST aggs.

### DIFF
--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -497,13 +497,18 @@ tasks.named('stringTemplates').configure {
    * Generates pairwise states. We generate the ones that we need at the moment,
    * but add more if you need more.
    */
-  def generateTwoStateFiles = { inputFile, includeBoolean, prefix = "" ->
+  def generateTwoStateFiles = { inputFile, includeBoolean = false, includeInteger = false, prefix = "" ->
     def v1Props = [longProperties]
     def v2Props = [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties]
 
     if (includeBoolean) {
       // Generate the two-state class for the boolean type
       v2Props << booleanProperties
+    }
+
+    if (includeInteger) {
+      // Generate the two-state classes for the boolean type
+      v1Props << intProperties
     }
 
     v1Props.forEach { v1 ->
@@ -520,8 +525,8 @@ tasks.named('stringTemplates').configure {
     }
   }
 
-  generateTwoStateFiles(file("src/main/java/org/elasticsearch/compute/aggregation/X-2State.java.st"), false)
-  generateTwoStateFiles(file("src/main/java/org/elasticsearch/compute/aggregation/X-All2State.java.st"), true, "All")
+  generateTwoStateFiles(file("src/main/java/org/elasticsearch/compute/aggregation/X-2State.java.st"))
+  generateTwoStateFiles(file("src/main/java/org/elasticsearch/compute/aggregation/X-All2State.java.st"), true, true, "All")
 
   File irateAggregatorInputFile = file("src/main/java/org/elasticsearch/compute/aggregation/X-IrateAggregator.java.st")
   template {
@@ -974,48 +979,41 @@ tasks.named('stringTemplates').configure {
   }
 
   // TODO: add {value}_over_time for other types: boolean, bytes_refs
-  def generateTimestampAggregatorClasses = { inputFilename, includeBoolean, prefix = "" ->
+  def generateTimestampAggregatorClasses = { inputFilename, includeBoolean = false, prefix = "" ->
     def inputFile = file(inputFilename)
+
+    def v1Props = [intProperties, longProperties, floatProperties, doubleProperties, bytesRefProperties]
+    def v2Props = [longProperties]
+
+    if (includeBoolean) {
+      // Generate aggregators for the boolean type
+      v1Props << booleanProperties
+    }
+
     ["First", "Last"].forEach { Occurrence ->
       {
-        template {
-          it.properties = addOccurrence(intProperties, Occurrence) + [Prefix: prefix]
-          it.inputFile = inputFile
-          it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}IntByTimestampAggregator.java"
-        }
-        template {
-          it.properties = addOccurrence(longProperties, Occurrence) + [Prefix: prefix]
-          it.inputFile = inputFile
-          it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}LongByTimestampAggregator.java"
-        }
-        template {
-          it.properties = addOccurrence(floatProperties, Occurrence) + [Prefix: prefix]
-          it.inputFile = inputFile
-          it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}FloatByTimestampAggregator.java"
-        }
-        template {
-          it.properties = addOccurrence(doubleProperties, Occurrence) + [Prefix: prefix]
-          it.inputFile = inputFile
-          it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}DoubleByTimestampAggregator.java"
-        }
-        template {
-          it.properties = addOccurrence(bytesRefProperties, Occurrence) + [Prefix: prefix]
-          it.inputFile = inputFile
-          it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}BytesRefByTimestampAggregator.java"
-        }
-        if (includeBoolean) {
-          // Generate an aggregator for the boolean type
-          template {
-            it.properties = addOccurrence(booleanProperties, Occurrence) + [Prefix: prefix]
-            it.inputFile = inputFile
-            it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}BooleanByTimestampAggregator.java"
+        v1Props.forEach { v1 ->
+          v2Props.forEach { v2 ->
+            def properties = [:]
+            if (prefix == "") {
+              v1.forEach { k, v -> properties[k] = v }
+            } else {
+              v1.forEach { k, v -> properties["v1_" + k] = v }
+            }
+            v2.forEach { k, v -> properties["v2_" + k] = v }
+
+            template {
+              it.properties = addOccurrence(properties, Occurrence) + [Prefix: prefix]
+              it.inputFile = inputFile
+              it.outputFile = "org/elasticsearch/compute/aggregation/${prefix}${Occurrence}${v1.Type}ByTimestampAggregator.java"
+            }
           }
         }
       }
     }
   }
 
-  generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-ValueByTimestampAggregator.java.st", false)
+  generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-ValueByTimestampAggregator.java.st")
   generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st", true, "All")
 
   File rateAggregatorInputFile = file("src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st")

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBooleanState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBooleanState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code boolean}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntBooleanState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private ByteArray v2;
+
+    public AllIntBooleanState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    ByteArray v2() {
+        return v2;
+    }
+
+    void v2(ByteArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        boolean[] values = new boolean[size];
+        for (int i = 0; i < size; ++i) {
+            values[i] = v2.get(i) == 1;
+        }
+        return driverContext.blockFactory().newBooleanArrayBlock(values, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBytesRefState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBytesRefState.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code BytesRef}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntBytesRefState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private BytesRefArray v2;
+
+    public AllIntBytesRefState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    BytesRefArray v2() {
+        return v2;
+    }
+
+    void v2(BytesRefArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        var result = driverContext.blockFactory().newBytesRefArrayBlock(v2, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+        v2 = null; // transfer the ownership of v2 to the block
+        return result;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntDoubleState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntDoubleState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code double}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntDoubleState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private DoubleArray v2;
+
+    public AllIntDoubleState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    DoubleArray v2() {
+        return v2;
+    }
+
+    void v2(DoubleArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        double[] values = new double[size];
+        for (int i = 0; i < size; ++i) {
+            values[i] = v2.get(i);
+        }
+        return driverContext.blockFactory().newDoubleArrayBlock(values, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntFloatState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntFloatState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code float}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntFloatState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private FloatArray v2;
+
+    public AllIntFloatState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    FloatArray v2() {
+        return v2;
+    }
+
+    void v2(FloatArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        float[] values = new float[size];
+        for (int i = 0; i < size; ++i) {
+            values[i] = v2.get(i);
+        }
+        return driverContext.blockFactory().newFloatArrayBlock(values, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntIntState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntIntState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code int}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntIntState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private IntArray v2;
+
+    public AllIntIntState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    IntArray v2() {
+        return v2;
+    }
+
+    void v2(IntArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        int[] values = new int[size];
+        for (int i = 0; i < size; ++i) {
+            values[i] = v2.get(i);
+        }
+        return driverContext.blockFactory().newIntArrayBlock(values, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntLongState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntLongState.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+// begin generated imports
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+// end generated imports
+
+/**
+ * Aggregator state for a single {@code int} and a single {@code long}, with support for null v2 values.
+ * This class is generated. Edit {@code X-All2State.java.st} instead.
+ */
+final class AllIntLongState implements AggregatorState {
+
+    private BigArrays bigArrays;
+
+    /**
+     * Whether an observation was recorded in this state
+     */
+    private boolean observed;
+
+    /**
+     * The timestamp
+     */
+    private int v1;
+
+    /**
+     * Whether the observed timestamp was null
+     */
+    private boolean v1Seen;
+
+    /**
+     * The value can be null, single valued of multivalued.
+     */
+    private LongArray v2;
+
+    public AllIntLongState(BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+    }
+
+    BigArrays bigArrays() {
+        return bigArrays;
+    }
+
+    boolean observed() {
+        return observed;
+    }
+
+    void observed(boolean observed) {
+        this.observed = observed;
+    }
+
+    int v1() {
+        return v1;
+    }
+
+    void v1(int v1) {
+        this.v1 = v1;
+    }
+
+    boolean v1Seen() {
+        return v1Seen;
+    }
+
+    void v1Seen(boolean v1Seen) {
+        this.v1Seen = v1Seen;
+    }
+
+    LongArray v2() {
+        return v2;
+    }
+
+    void v2(LongArray v2) {
+        this.v2 = v2;
+    }
+
+    /** Extracts an intermediate view of the contents of this state.  */
+    @Override
+    public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        assert blocks.length >= offset + 4;
+        blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
+        blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
+        blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
+        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+    }
+
+    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+        if (v2 == null) {
+            return driverContext.blockFactory().newConstantNullBlock(1);
+        }
+
+        int size = (int) v2.size();
+        long[] values = new long[size];
+        for (int i = 0; i < size; ++i) {
+            values[i] = v2.get(i);
+        }
+        return driverContext.blockFactory().newLongArrayBlock(values, 1, new int[] { 0, size }, null, Block.MvOrdering.UNORDERED);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(v2);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
@@ -13,8 +13,8 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!boolean)$
-import org.elasticsearch.common.util.$Type$Array;
+$if(!v1_boolean)$
+import org.elasticsearch.common.util.$v1_Type$Array;
 $endif$
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
@@ -23,7 +23,7 @@ import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$Type$Block;
+import org.elasticsearch.compute.data.$v1_Type$Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -41,36 +41,36 @@ import java.util.BitSet;
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
         @IntermediateState(name = "timestamp", type = "LONG"),
-        @IntermediateState(name = "values", type = "$TYPE$_BLOCK") }
+        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestamps", type = "LONG_BLOCK"),
-        @IntermediateState(name = "values", type = "$TYPE$_BLOCK") }
+        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
 )
-public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
+public class $Prefix$$Occurrence$$v1_Type$ByTimestampAggregator {
     public static String describe() {
-        $if(BytesRef)$
+        $if(v1_BytesRef)$
         return "all_$occurrence$_bytesref_by_timestamp";
         $else$
-        return "all_$occurrence$_$type$_by_timestamp";
+        return "all_$occurrence$_$v1_type$_by_timestamp";
         $endif$
     }
 
-    public static $Prefix$Long$Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$Long$Type$State(driverContext.bigArrays());
+    public static $Prefix$Long$v1_Type$State initSingle(DriverContext driverContext) {
+        return new $Prefix$Long$v1_Type$State(driverContext.bigArrays());
     }
 
-    $if(long || int)$
-    private static void overrideState($Prefix$Long$Type$State current, boolean timestampPresent, long timestamp, $Type$Block values, int position) {
+    $if(v1_long || v1_int)$
+    private static void overrideState($Prefix$Long$v1_Type$State current, boolean timestampPresent, long timestamp, $v1_Type$Block values, int position) {
     $else$
     private static void overrideState(
-        $Prefix$Long$Type$State current,
+        $Prefix$Long$v1_Type$State current,
         boolean timestampPresent,
         long timestamp,
-        $Type$Block values,
+        $v1_Type$Block values,
         int position
     ) {
     $endif$
@@ -83,31 +83,31 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(BytesRef)$
+            $if(v1_BytesRef)$
             BytesRefArray a = null;
-            $elseif(boolean)$
+            $elseif(v1_boolean)$
             ByteArray a = null;
             $else$
-            $Type$Array a = null;
+            $v1_Type$Array a = null;
             $endif$
             boolean success = false;
             try {
-                $if(BytesRef)$
+                $if(v1_BytesRef)$
                 a = new BytesRefArray(0, current.bigArrays());
-                $elseif(boolean)$
+                $elseif(v1_boolean)$
                 a = current.bigArrays().newByteArray(count);
                 $else$
-                a = current.bigArrays().new$Type$Array(count);
+                a = current.bigArrays().new$v1_Type$Array(count);
                 $endif$
                 for (int i = 0; i < count; ++i) {
-                    $if(BytesRef)$
+                    $if(v1_BytesRef)$
                     BytesRef bytesScratch = new BytesRef();
                     values.getBytesRef(offset + i, bytesScratch);
                     a.append(bytesScratch);
-                    $elseif(boolean)$
-                    a.set(i, (byte) (values.get$Type$(offset + i) ? 1 : 0));
+                    $elseif(v1_boolean)$
+                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
                     $else$
-                    a.set(i, values.get$Type$(offset + i));
+                    a.set(i, values.get$v1_Type$(offset + i));
                     $endif$
                 }
                 success = true;
@@ -138,7 +138,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         return result;
     }
 
-    public static void combine($Prefix$Long$Type$State current, @Position int position, $Type$Block values, LongBlock timestamps) {
+    public static void combine($Prefix$Long$v1_Type$State current, @Position int position, $v1_Type$Block values, LongBlock timestamps) {
         long timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
@@ -152,11 +152,11 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
     }
 
     public static void combineIntermediate(
-        $Prefix$Long$Type$State current,
+        $Prefix$Long$v1_Type$State current,
         boolean observed,
         boolean timestampPresent,
         long timestamp,
-        $Type$Block values
+        $v1_Type$Block values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -178,7 +178,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$Long$Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal($Prefix$Long$v1_Type$State current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -186,7 +186,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $Type$Block values, LongBlock timestamps) {
+    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, LongBlock timestamps) {
         long timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
@@ -197,7 +197,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         BooleanBlock observed,
         BooleanBlock timestampPresent,
         LongBlock timestamps,
-        $Type$Block values,
+        $v1_Type$Block values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
@@ -234,7 +234,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(BytesRef)$BytesRefArray$elseif(boolean)$ByteArray$else$$Type$Array$endif$> values;
+        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
 
         private int maxGroupId = -1;
 
@@ -262,7 +262,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(BytesRef)$
+                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
                 $else$
                 this.values = bigArrays.newObjectArray(1);
@@ -285,7 +285,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, long timestamp, int position, $Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, long timestamp, int position, $v1_Type$Block valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
@@ -309,7 +309,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(BytesRef)$
+                $if(v1_BytesRef)$
                 BytesRefArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
@@ -330,20 +330,20 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
                     }
                 }
                 $else$
-                $if(boolean)$ByteArray$else$$Type$Array$endif$ groupValues = null;
+                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(boolean)$
+                        $if(v1_boolean)$
                         groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$Type$(i + offset) ? 1 : 0));
+                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
                         }
                         $else$
-                        groupValues = bigArrays.new$Type$Array(count);
+                        groupValues = bigArrays.new$v1_Type$Array(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$Type$(i + offset));
+                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
                         }
                         $endif$
                     }
@@ -408,7 +408,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -417,31 +417,31 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(BytesRef)$
+                        $if(v1_BytesRef)$
                         case 1 -> {
                             BytesRef bytesScratch = new BytesRef();
                             values.get(group).get(0, bytesScratch);
                             valuesBuilder.appendBytesRef(bytesScratch);
                         }
                         $else$
-                        $if(boolean)$
-                        case 1 -> valuesBuilder.append$Type$(values.get(group).get(0) == 1);
+                        $if(v1_boolean)$
+                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
                         $else$
-                        case 1 -> valuesBuilder.append$Type$(values.get(group).get(0));
+                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
                         $endif$
                         $endif$
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(BytesRef)$
+                                $if(v1_BytesRef)$
                                 BytesRef bytesScratch = new BytesRef();
                                 values.get(group).get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
                                 $else$
-                                $if(boolean)$
-                                valuesBuilder.append$Type$(values.get(group).get(i) == 1);
+                                $if(v1_boolean)$
+                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
                                 $else$
-                                valuesBuilder.append$Type$(values.get(group).get(i));
+                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
                                 $endif$
                                 $endif$
                             }


### PR DESCRIPTION
This PR is just a refactoring. Yes, it adds two-state classes for the int type, but these aren't used anywhere yet. The changes in Gradle and the agg template, when executed, don't change any existing generated code and that's what we want.

- Minor Gradle refactoring to allow parameterization of the type being aggregated on, when generate First/Last aggregators.
- Generate two-state classes for int type
- Introduce the `v1_` prefix in the template. `v2_` is coming up later to replace things like `ByTimestamp` to `ByLong`.
