### PR TITLE
ESQL: Fix DECAY number parameters

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/decay.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/decay.csv-spec
@@ -155,6 +155,17 @@ decay_result:double
 0.75
 ;
 
+intOffsetAsDouble
+required_capability: decay_function_parameter_conversion
+
+ROW value = 5
+| EVAL decay_result = decay(value, 10, 10, {"offset": 0.1, "decay": 0.5, "type": "linear"})
+| KEEP decay_result;
+
+decay_result:double
+0.75
+;
+
 doubleLinear
 required_capability: decay_function
 
@@ -188,6 +199,17 @@ decay_result:double
 0.8408964
 ;
 
+doubleOffsetAsInt
+required_capability: decay_function_parameter_conversion
+
+ROW value = 5.0
+| EVAL decay_result = round(decay(value, 10.0, 10.0, {"offset": 0, "decay": 0.5, "type": "gauss"}), 7)
+| KEEP decay_result;
+
+decay_result:double
+0.8408964
+;
+
 longLinear
 required_capability: decay_function
 
@@ -197,6 +219,17 @@ ROW value = 15::long
 
 decay_result:double
 1.0
+;
+
+longOffsetAsDouble
+required_capability: decay_function_parameter_conversion
+
+ROW value = 15::long
+| EVAL decay_result = decay(value, 10::long, 10::long, {"offset": 0.2, "decay": 0.5, "type": "linear"})
+| KEEP decay_result;
+
+decay_result:double
+0.75
 ;
 
 cartesianPointLinear1

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1494,9 +1494,14 @@ public class EsqlCapabilities {
         CATEGORIZE_OPTIONS,
 
         /**
-         * Decay function for custom scoring
+         * Decay function for custom scoring.
          */
         DECAY_FUNCTION,
+
+        /**
+         * Fix conversions for parameters for {@code DECAY}.
+         */
+        DECAY_FUNCTION_PARAMETER_CONVERSION,
 
         /**
          * Support correct counting of skipped shards.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
@@ -366,27 +366,27 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
             case INTEGER -> new DecayIntEvaluator.Factory(
                 source(),
                 valueFactory,
-                (Integer) originFolded,
-                (Integer) scaleFolded,
-                (Integer) offsetFolded,
+                ((Number) originFolded).intValue(),
+                ((Number) scaleFolded).intValue(),
+                ((Number) offsetFolded).intValue(),
                 decayFolded,
                 decayFunction
             );
             case DOUBLE -> new DecayDoubleEvaluator.Factory(
                 source(),
                 valueFactory,
-                (Double) originFolded,
-                (Double) scaleFolded,
-                (Double) offsetFolded,
+                ((Number) originFolded).doubleValue(),
+                ((Number) scaleFolded).doubleValue(),
+                ((Number) offsetFolded).doubleValue(),
                 decayFolded,
                 decayFunction
             );
             case LONG -> new DecayLongEvaluator.Factory(
                 source(),
                 valueFactory,
-                (Long) originFolded,
-                (Long) scaleFolded,
-                (Long) offsetFolded,
+                ((Number) originFolded).longValue(),
+                ((Number) scaleFolded).longValue(),
+                ((Number) offsetFolded).longValue(),
                 decayFolded,
                 decayFunction
             );


### PR DESCRIPTION
When the first parameter to `DECAY` as a number we validate the types of `offset` and `scale` are any number. But then we cast them to precisely the same type as the first parameter. This fixes that - now we accept any number and convert them.

Closes #142628
