### PR TITLE
ESQL: Fix license dependency mappings

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-tasks.named("dependencyLicenses").configure {
+tasks.withType(org.elasticsearch.gradle.internal.AbstractDependenciesTask).configureEach {
   mapping from: /lucene-.*/, to: 'lucene'
   mapping from: /orc-.*/, to: 'orc'
   mapping from: /hadoop-.*/, to: 'hadoop'


### PR DESCRIPTION
Fix mapping for dependency org.apache.hive:hive-storage-api in esql-datasource-orc plugin.