### PR TITLE
Add DRA Version Bump

### DIFF
--- a/.buildkite/pipelines/version-bump-pipeline.yml
+++ b/.buildkite/pipelines/version-bump-pipeline.yml
@@ -1,0 +1,61 @@
+notify:
+  - slack:
+      channels:
+        - "#test-channel-for-plugin"
+    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
+  - slack:
+      channels:
+        - "#test-channel-for-plugin"
+      message: |
+        🚦 Pipeline waiting for approval 🚦
+        Repo: `${REPO}`
+
+        Ready to fetch DRA artifacts - please unblock when ready.
+        New version: `${NEW_VERSION}`
+        Branch: `${BRANCH}`
+        Workflow: `${WORKFLOW}`
+        ${BUILDKITE_BUILD_URL}
+    if: build.state == "blocked"
+
+steps:
+  # TODO: replace this block step by real version bump logic
+  - block: "Ready to fetch for DRA artifacts?"
+    prompt: |
+      Unblock when your team is ready to proceed.
+
+      Trigger parameters:
+      - NEW_VERSION: ${NEW_VERSION}
+      - BRANCH: ${BRANCH}
+      - WORKFLOW: ${WORKFLOW}
+    key: block-get-dra-artifacts
+    blocked_state: running
+
+  - label: "Fetch DRA Artifacts"
+    key: fetch-dra-artifacts
+    depends_on: block-get-dra-artifacts
+    agents:
+      image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
+      cpu: 2
+      memory: 4G
+      ephemeralStorage: 10G
+    command:
+      - echo "Starting DRA artifacts retrieval..."
+    timeout_in_minutes: 240
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
+      manual:
+        permit_on_passed: true
+
+    plugins:
+      - elastic/json-watcher#v1.0.0:
+          url: "https://artifacts-staging.elastic.co/elasticsearch/latest/${BRANCH}.json"
+          field: ".version"
+          expected_value: "${NEW_VERSION}"
+          polling_interval: "30"
+      - elastic/json-watcher#v1.0.0:
+          url: "https://storage.googleapis.com/elastic-artifacts-snapshot/elasticsearch/latest/${BRANCH}.json"
+          field: ".version"
+          expected_value: "${NEW_VERSION}-SNAPSHOT"
+          polling_interval: "30"

--- a/.buildkite/pipelines/version-bump-pipeline.yml
+++ b/.buildkite/pipelines/version-bump-pipeline.yml
@@ -35,9 +35,9 @@ steps:
     depends_on: block-get-dra-artifacts
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
-      cpu: 2
-      memory: 4G
-      ephemeralStorage: 10G
+      cpu: 250m
+      memory: 512Mi
+      ephemeralStorage: 1Gi
     command:
       - echo "Starting DRA artifacts retrieval..."
     timeout_in_minutes: 240

--- a/.buildkite/pipelines/version-bump-pipeline.yml
+++ b/.buildkite/pipelines/version-bump-pipeline.yml
@@ -1,11 +1,11 @@
 notify:
   - slack:
       channels:
-        - "#test-channel-for-plugin"
+        - "#es-delivery-alerts"
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
-        - "#test-channel-for-plugin"
+        - "#es-delivery-alerts"
       message: |
         🚦 Pipeline waiting for approval 🚦
         Repo: `${REPO}`

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -417,3 +417,38 @@ spec:
       provider_settings:
         build_pull_requests: true
         trigger_mode: none
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-version-bump
+  description: Buildkite Pipeline for elasticsearch version bump
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-version-bump
+
+spec:
+  type: buildkite-pipeline
+  owner: group:elasticsearch-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Buildkite Pipeline for elasticsearch version bump
+      name: elasticsearch-version-bump
+    spec:
+      pipeline_file: ".buildkite/pipelines/version-bump-pipeline.yml"
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        trigger_mode: none
+      repository: elastic/elasticsearch
+      teams:
+        elasticsearch-team: {}
+        ml-core: {}
+        everyone:
+          access_level: READ_ONLY
+        release-eng:
+          access_level: BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -441,8 +441,6 @@ spec:
     spec:
       pipeline_file: ".buildkite/pipelines/version-bump-pipeline.yml"
       provider_settings:
-        build_branches: false
-        build_pull_requests: false
         trigger_mode: none
       repository: elastic/elasticsearch
       teams:


### PR DESCRIPTION
Hi Team,

This PR is the first phase of the version-bump automation rollout as mentioned in [#mission-control](https://elastic.slack.com/archives/C0JFN9HJL/p1770388488482519). It introduces a generalized Buildkite pipeline for service teams in the DRA process. The baseline pipeline includes a block step that waits for each team to unblock before polling for DRA artifacts using a buildkite plugin [json-watcher-buildkite-plugin](https://github.com/elastic/json-watcher-buildkite-plugin) for the polling.


## Related issue:
- https://elasticco.atlassian.net/browse/ES-14273