### PR TITLE
[9.2] [ES-13980] Adding Rocky 10, Alma Linux 10 and Oraclelinux 10 to our packaging (#142504)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -12,15 +12,18 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
+              - orcalelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404
               - rocky-8
               - rocky-9
+              - rocky-10
               - rhel-8
               - rhel-9
               - almalinux-8
               - almalinux-9
+              - almalinux-10
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -13,15 +13,18 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
+              - orcalelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404
               - rocky-8
               - rocky-9
+              - rocky-10
               - rhel-8
               - rhel-9
               - almalinux-8
               - almalinux-9
+              - almalinux-10
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -14,15 +14,18 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
+              - oraclelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404
               - rocky-8
               - rocky-9
+              - rocky-10
               - rhel-8
               - rhel-9
               - almalinux-8
               - almalinux-9
+              - almalinux-10
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -15,15 +15,18 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
+              - oraclelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404
               - rocky-8
               - rocky-9
+              - rocky-10
               - rhel-8
               - rhel-9
               - almalinux-8
               - almalinux-9
+              - almalinux-10
             PACKAGING_TASK:
               - docker
               - docker-cloud-ess


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [ES-13980] Adding Rocky 10, Alma Linux 10 and Oraclelinux 10 to our packaging (#142504)

[ES-13980]: https://elasticco.atlassian.net/browse/ES-13980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ