### PR TITLE
ES|QL: add known error to generative tests for 'blocks is empty'

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -363,9 +363,6 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
   method: testIndexingStandardSource
   issue: https://github.com/elastic/elasticsearch/issues/143017
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/143023
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -71,6 +71,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "can't find input for", // https://github.com/elastic/elasticsearch/issues/136596
         "out of bounds for length", // https://github.com/elastic/elasticsearch/issues/136851
         "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/138231
+        "blocks is empty", // https://github.com/elastic/elasticsearch/issues/142473
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/129561


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/143023

The error is already allowed in `main` branch, this just backports it to 9.3 and unmutes the tests