### PR TITLE
Make MappingStatsTests more resilient to changes in zlib implementation

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -355,12 +355,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
     }
 
     private static long mappingSize(Metadata metadata) {
-        return metadata.getProject()
-            .getMappingsByHash()
-            .values()
-            .stream()
-            .mapToLong(v -> v.source().compressed().length)
-            .sum();
+        return metadata.getProject().getMappingsByHash().values().stream().mapToLong(v -> v.source().compressed().length).sum();
     }
 
     private static String scriptAsJSON(String script) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -109,15 +109,14 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         Metadata metadata = Metadata.builder().put(meta, false).put(meta2, false).build();
         assertThat(metadata.getProject().getMappingsByHash(), Matchers.aMapWithSize(1));
         MappingStats mappingStats = MappingStats.of(metadata, () -> {});
-        // RHEL reports slighlty higher mapping size - JVM issue?
-        String mappingStatsString = Strings.toString(mappingStats, true, true).replace("261", "260");
-        assertEquals("""
+        long mappingSize = mappingSize(metadata);
+        assertEquals(Strings.format("""
             {
               "mappings" : {
                 "total_field_count" : 12,
                 "total_deduplicated_field_count" : 6,
-                "total_deduplicated_mapping_size" : "260b",
-                "total_deduplicated_mapping_size_in_bytes" : 260,
+                "total_deduplicated_mapping_size" : "%sb",
+                "total_deduplicated_mapping_size_in_bytes" : %s,
                 "field_types" : [
                   {
                     "name" : "dense_vector",
@@ -219,7 +218,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                   "stored" : 2
                 }
               }
-            }""", mappingStatsString);
+            }""", mappingSize, mappingSize), Strings.toString(mappingStats, true, true));
     }
 
     public void testToXContentWithSomeSharedMappings() {
@@ -243,15 +242,14 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         Metadata metadata = Metadata.builder().put(meta, false).put(meta2, false).put(meta3, false).build();
         assertThat(metadata.getProject().getMappingsByHash(), Matchers.aMapWithSize(2));
         MappingStats mappingStats = MappingStats.of(metadata, () -> {});
-        // RHEL reports slighlty higher mapping size - JVM issue?
-        String mappingStatsString = Strings.toString(mappingStats, true, true).replace("521", "519");
-        assertEquals("""
+        long mappingSize = mappingSize(metadata);
+        assertEquals(Strings.format("""
             {
               "mappings" : {
                 "total_field_count" : 18,
                 "total_deduplicated_field_count" : 12,
-                "total_deduplicated_mapping_size" : "519b",
-                "total_deduplicated_mapping_size_in_bytes" : 519,
+                "total_deduplicated_mapping_size" : "%sb",
+                "total_deduplicated_mapping_size_in_bytes" : %s,
                 "field_types" : [
                   {
                     "name" : "dense_vector",
@@ -353,7 +351,16 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                   "stored" : 3
                 }
               }
-            }""", mappingStatsString);
+            }""", mappingSize, mappingSize), Strings.toString(mappingStats, true, true));
+    }
+
+    private static long mappingSize(Metadata metadata) {
+        return metadata.getProject()
+            .getMappingsByHash()
+            .values()
+            .stream()
+            .mapToLong(v -> v.source().compressed().length)
+            .sum();
     }
 
     private static String scriptAsJSON(String script) {


### PR DESCRIPTION
Rather than checking against a hardcoded value and doing string substitution 
to account for known variants, we explicitly check what the compressed size 
of the stored mappings is and ensure that this is reported correctly.

Closes #143021
Closes #143022