### PR TITLE
Add reindex relocation node picker to enrich

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -102,7 +102,6 @@ public class Reindexer {
     private final ReindexSslConfig reindexSslConfig;
     private final ReindexMetrics reindexMetrics;
     private final TransportService transportService;
-    @Nullable // might be null for modules which use reindex but don't currently have relocations, as of writing: enrich module
     private final ReindexRelocationNodePicker relocationNodePicker;
 
     Reindexer(
@@ -114,7 +113,7 @@ public class Reindexer {
         ReindexSslConfig reindexSslConfig,
         @Nullable ReindexMetrics reindexMetrics,
         TransportService transportService,
-        @Nullable ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker
     ) {
         this.clusterService = clusterService;
         this.projectResolver = projectResolver;
@@ -124,7 +123,7 @@ public class Reindexer {
         this.reindexSslConfig = reindexSslConfig;
         this.reindexMetrics = reindexMetrics;
         this.transportService = Objects.requireNonNull(transportService);
-        this.relocationNodePicker = relocationNodePicker;
+        this.relocationNodePicker = Objects.requireNonNull(relocationNodePicker);
     }
 
     public void initTask(BulkByScrollTask task, ReindexRequest request, ActionListener<Void> listener) {
@@ -296,7 +295,7 @@ public class Reindexer {
     private void initTaskForRelocationIfEnabled(final BulkByScrollTask task) {
         // todo: move initialization to BulkByPaginatedSearchParallelizationHelper rather than having it in Reindexer, makes it generic
         // for update-by-query and delete-by-query
-        if (ReindexPlugin.REINDEX_RESILIENCE_ENABLED == false || relocationNodePicker == null) {
+        if (ReindexPlugin.REINDEX_RESILIENCE_ENABLED == false) {
             return;
         }
         final boolean nonSlicedThereforeSetupRelocation = task.isWorker() && task.getParentTaskId().isSet() == false;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -61,7 +61,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         TransportService transportService,
         ReindexSslConfig sslConfig,
         @Nullable ReindexMetrics reindexMetrics,
-        @Nullable ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker
     ) {
         this(
             ReindexAction.NAME,
@@ -95,7 +95,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         TransportService transportService,
         ReindexSslConfig sslConfig,
         @Nullable ReindexMetrics reindexMetrics,
-        @Nullable ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker
     ) {
         super(name, transportService, actionFilters, ReindexRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.reindex.ReindexSslConfig;
 import org.elasticsearch.reindex.TransportReindexAction;
 import org.elasticsearch.script.ScriptService;
@@ -66,11 +67,8 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
             transportService,
             new ReindexSslConfig(settings, environment, watcherService),
             null,
-            // no relocation support as of now. to do so, create a ReindexRelocationNodePicker instance here, similar to Reindex plugin.
-            // same idea as SSL config above, you can't inject into constructor because (my understanding) classloader isolation between the
-            // enrich plugin and reindex module means Guice bindings registered by ReindexPlugin won't match the Class identity seen here.
-            // also, if you add relocation support here, remove `@Nullable` annotations from reindex on ReindexRelocationNodePicker.
-            null
+            // can't be injected due to different classloaders between enrich and reindex (enrich doesn't extend reindex).
+            ReindexPlugin.getReindexRelocationNodePicker(environment)
         );
         this.bulkClient = new OriginSettingClient(client, ENRICH_ORIGIN);
     }


### PR DESCRIPTION
- As discussed in previous PR, pass down ReindexRelocationNodePicker from enrich into Reindexer
- means we don't need the Nullable stuff and no trip-wire if enrich some day in the future wants to have relocations but it's not passed down

Closes https://github.com/elastic/elasticsearch-team/issues/2292