### PR TITLE
[9.3] Fix ClassCastException when merging TopHits with mixed sort field types (#141919)

### DIFF
--- a/docs/changelog/141919.yaml
+++ b/docs/changelog/141919.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 141714
+pr: 141919
+summary: Fix `ClassCastException` when merging `TopHits` with mixed sort field types
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -2162,17 +2162,20 @@ public class FieldSortIT extends ESIntegTestCase {
 
     public void testSortMixedFieldTypes() throws IOException {
         assertAcked(
-            prepareCreate("index_long").setMapping("foo", "type=long"),
+            prepareCreate("index_long").setMapping("foo", "type=long").setSettings(Settings.builder().put("number_of_shards", 2)),
             prepareCreate("index_integer").setMapping("foo", "type=integer"),
             prepareCreate("index_double").setMapping("foo", "type=double"),
-            prepareCreate("index_keyword").setMapping("foo", "type=keyword")
+            prepareCreate("index_keyword").setMapping("foo", "type=keyword").setSettings(Settings.builder().put("number_of_shards", 2))
         );
 
         prepareIndex("index_long").setId("1").setSource("foo", "123").get();
+        prepareIndex("index_long").setId("2").setSource("foo", "124").get();
         prepareIndex("index_integer").setId("1").setSource("foo", "123").get();
         prepareIndex("index_double").setId("1").setSource("foo", "123").get();
         prepareIndex("index_keyword").setId("1").setSource("foo", "123").get();
+        prepareIndex("index_keyword").setId("2").setSource("foo", "124").get();
         refresh();
+        ensureGreen("index_long", "index_keyword");
 
         // for debugging, we try to see where the documents are located
         try (RestClient restClient = createRestClient()) {
@@ -2188,15 +2191,11 @@ public class FieldSortIT extends ESIntegTestCase {
             assertNoFailures(prepareSearch("index_long", "index_integer").addSort(new FieldSortBuilder("foo")).setSize(10));
         }
 
-        String errMsg = "Can't sort on field [foo]; the field has incompatible sort types";
-
-        { // mixing long and double types is not allowed
-            SearchPhaseExecutionException exc = expectThrows(
-                SearchPhaseExecutionException.class,
-                prepareSearch("index_long", "index_double").addSort(new FieldSortBuilder("foo")).setSize(10)
-            );
-            assertThat(exc.getCause().toString(), containsString(errMsg));
+        { // mixing long and double types is ok, as we convert to double sort
+            assertNoFailures(prepareSearch("index_long", "index_double").addSort(new FieldSortBuilder("foo")).setSize(10));
         }
+
+        String errMsg = "Can't sort on field [foo]; the field has incompatible sort types";
 
         { // mixing long and keyword types is not allowed
             SearchPhaseExecutionException exc = expectThrows(

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -64,6 +64,21 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
         this.rawSortValues = rawSortValues;
     }
 
+    /**
+     * Build sort values from pre-formatted and raw arrays. Use this when the formatted values
+     * were produced with the correct per-field format (e.g. from a shard hit) and must not be
+     * re-formatted with a single format like RAW, which would fail for non-UTF-8 BytesRefs
+     * (e.g. version field).
+     */
+    public static SearchSortValues fromFormattedAndRaw(Object[] formattedSortValues, Object[] rawSortValues) {
+        Objects.requireNonNull(formattedSortValues);
+        Objects.requireNonNull(rawSortValues);
+        if (formattedSortValues.length != rawSortValues.length) {
+            throw new IllegalArgumentException("formattedSortValues and rawSortValues must have the same length");
+        }
+        return new SearchSortValues(formattedSortValues, rawSortValues);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(Lucene::writeSortValue, this.formattedSortValues);


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix ClassCastException when merging TopHits with mixed sort field types (#141919)