### PR TITLE
[8.19] Fix ClassCastException when merging TopHits with mixed sort field types (#141919)

### DIFF
--- a/docs/changelog/141919.yaml
+++ b/docs/changelog/141919.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 141714
+pr: 141919
+summary: Fix `ClassCastException` when merging `TopHits` with mixed sort field types
+type: bug

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -174,6 +174,16 @@ public class DockerTests extends PackagingTestCase {
     }
 
     /**
+     * Checks that dotted env vars are respected
+     */
+    public void test013DottedEnvVarsPersist() throws Exception {
+        runContainer(distribution(), builder().volume(tempDir, "/usr/share/elasticsearch/config").envVar("discovery.seed_hosts", "host1"));
+        waitForElasticsearch(installation);
+        Result result = sh.run("env | grep discovery");
+        assertThat(result.stdout(), containsString("discovery.seed_hosts=host1"));
+    }
+
+    /**
      * Checks that no plugins are initially active.
      */
     public void test020PluginsListWithNoPlugins() {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -177,8 +177,34 @@ public class DockerTests extends PackagingTestCase {
      * Checks that dotted env vars are respected
      */
     public void test013DottedEnvVarsPersist() throws Exception {
-        runContainer(distribution(), builder().volume(tempDir, "/usr/share/elasticsearch/config").envVar("discovery.seed_hosts", "host1"));
-        waitForElasticsearch(installation);
+        // Populate tempDir with config from the running container so the bind-mounted config has
+        // required files (e.g. log4j2.properties). Otherwise ServerCli fails with "Missing logging config file".
+        copyFromContainer(installation.config("elasticsearch.yml"), tempDir.resolve("elasticsearch.yml"));
+        copyFromContainer(installation.config("elasticsearch.keystore"), tempDir.resolve("elasticsearch.keystore"));
+        copyFromContainer(installation.config("log4j2.properties"), tempDir.resolve("log4j2.properties"));
+        copyFromContainer(installation.config("jvm.options"), tempDir.resolve("jvm.options"));
+        final Path autoConfigurationDir = findInContainer(installation.config, "d", "\"certs\"");
+        if (autoConfigurationDir != null) {
+            final String autoConfigurationDirName = autoConfigurationDir.getFileName().toString();
+            copyFromContainer(autoConfigurationDir, tempDir.resolve(autoConfigurationDirName));
+            Files.setPosixFilePermissions(tempDir.resolve(autoConfigurationDirName), p750);
+        }
+
+        Files.setPosixFilePermissions(tempDir, fromString("rwxrwxrwx"));
+        Files.setPosixFilePermissions(tempDir.resolve("elasticsearch.yml"), p644);
+        Files.setPosixFilePermissions(tempDir.resolve("elasticsearch.keystore"), p644);
+        Files.setPosixFilePermissions(tempDir.resolve("log4j2.properties"), p644);
+        Files.setPosixFilePermissions(tempDir.resolve("jvm.options"), p644);
+
+        ServerUtils.removeSettingFromExistingConfiguration(tempDir, "cluster.initial_master_nodes");
+        runContainer(
+            distribution(),
+            builder().volume(tempDir, "/usr/share/elasticsearch/config")
+                .envVar("ELASTIC_PASSWORD", PASSWORD)
+                .envVar("discovery.seed_hosts", "host1")
+                .envVar("discovery.type", "single-node")
+        );
+        waitForElasticsearch(installation, "elastic", PASSWORD);
         Result result = sh.run("env | grep discovery");
         assertThat(result.stdout(), containsString("discovery.seed_hosts=host1"));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -2259,17 +2259,20 @@ public class FieldSortIT extends ESIntegTestCase {
 
     public void testSortMixedFieldTypes() throws IOException {
         assertAcked(
-            prepareCreate("index_long").setMapping("foo", "type=long"),
+            prepareCreate("index_long").setMapping("foo", "type=long").setSettings(Settings.builder().put("number_of_shards", 2)),
             prepareCreate("index_integer").setMapping("foo", "type=integer"),
             prepareCreate("index_double").setMapping("foo", "type=double"),
-            prepareCreate("index_keyword").setMapping("foo", "type=keyword")
+            prepareCreate("index_keyword").setMapping("foo", "type=keyword").setSettings(Settings.builder().put("number_of_shards", 2))
         );
 
         prepareIndex("index_long").setId("1").setSource("foo", "123").get();
+        prepareIndex("index_long").setId("2").setSource("foo", "124").get();
         prepareIndex("index_integer").setId("1").setSource("foo", "123").get();
         prepareIndex("index_double").setId("1").setSource("foo", "123").get();
         prepareIndex("index_keyword").setId("1").setSource("foo", "123").get();
+        prepareIndex("index_keyword").setId("2").setSource("foo", "124").get();
         refresh();
+        ensureGreen("index_long", "index_keyword");
 
         // for debugging, we try to see where the documents are located
         try (RestClient restClient = createRestClient()) {
@@ -2285,15 +2288,11 @@ public class FieldSortIT extends ESIntegTestCase {
             assertNoFailures(prepareSearch("index_long", "index_integer").addSort(new FieldSortBuilder("foo")).setSize(10));
         }
 
-        String errMsg = "Can't sort on field [foo]; the field has incompatible sort types";
-
-        { // mixing long and double types is not allowed
-            SearchPhaseExecutionException exc = expectThrows(
-                SearchPhaseExecutionException.class,
-                prepareSearch("index_long", "index_double").addSort(new FieldSortBuilder("foo")).setSize(10)
-            );
-            assertThat(exc.getCause().toString(), containsString(errMsg));
+        { // mixing long and double types is ok, as we convert to double sort
+            assertNoFailures(prepareSearch("index_long", "index_double").addSort(new FieldSortBuilder("foo")).setSize(10));
         }
+
+        String errMsg = "Can't sort on field [foo]; the field has incompatible sort types";
 
         { // mixing long and keyword types is not allowed
             SearchPhaseExecutionException exc = expectThrows(

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -66,6 +66,21 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
         this.rawSortValues = rawSortValues;
     }
 
+    /**
+     * Build sort values from pre-formatted and raw arrays. Use this when the formatted values
+     * were produced with the correct per-field format (e.g. from a shard hit) and must not be
+     * re-formatted with a single format like RAW, which would fail for non-UTF-8 BytesRefs
+     * (e.g. version field).
+     */
+    public static SearchSortValues fromFormattedAndRaw(Object[] formattedSortValues, Object[] rawSortValues) {
+        Objects.requireNonNull(formattedSortValues);
+        Objects.requireNonNull(rawSortValues);
+        if (formattedSortValues.length != rawSortValues.length) {
+            throw new IllegalArgumentException("formattedSortValues and rawSortValues must have the same length");
+        }
+        return new SearchSortValues(formattedSortValues, rawSortValues);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(Lucene::writeSortValue, this.formattedSortValues);

--- a/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
@@ -179,7 +179,11 @@ public final class SortFieldValidation {
             // Rewrite the sort field to DOUBLE
             SortField originalField = newSortFields[fieldIdx];
             SortField doubleField = new SortField(originalField.getField(), SortField.Type.DOUBLE, originalField.getReverse());
-            doubleField.setMissingValue(originalField.getMissingValue());
+            Object missingValue = originalField.getMissingValue();
+            if (missingValue != null && missingValue instanceof Number num) {
+                missingValue = num.doubleValue();
+            }
+            doubleField.setMissingValue(missingValue);
             newSortFields[fieldIdx] = doubleField;
 
             // Convert all sort values to Double


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix ClassCastException when merging TopHits with mixed sort field types (#141919)