### PR TITLE
[9.3] [ML] Fix Duplicate ML Model Allocations on Same Node (#142872)

### DIFF
--- a/docs/changelog/142872.yaml
+++ b/docs/changelog/142872.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 142872
+summary: Fix Duplicate ML Model Allocations on Same Node
+type: bug


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [ML] Fix Duplicate ML Model Allocations on Same Node (#142872)