### PR TITLE
Revert "Store ignored malformed fields in binary doc values (#142357)"

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -652,7 +652,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                     }
                     return;
                 } else {
@@ -685,7 +685,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 context.addIgnoredField(mappedFieldType.name());
                 if (isSourceSynthetic) {
                     // Save a copy of the field so synthetic source can load it
-                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                 }
                 return;
             } else {
@@ -854,16 +854,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed.value(),
-                indexSettings.getIndexVersionCreated()
-            ) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value()) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(decodeForSyntheticSource(value, scalingFactor));

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -117,8 +117,4 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   task.addAllowedWarningRegex("Use of the \\[max_size\\] rollover condition has been deprecated in favour of the \\[max_primary_shard_size\\] condition and will be removed in a later version")
   task.skipTest("search.vectors/42_knn_search_bbq_flat/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
   task.skipTest("search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
-  task.skipTest(
-    "get/100_synthetic_source/fields with ignore_malformed",
-    "Malformed values are now stored in binary doc values which sort differently than stored fields"
-  )
 })

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -799,8 +799,8 @@ fields with ignore_malformed:
         ip:
           - 10.10.1.1
           - 192.8.1.2
-          - 7 # malformed values come after doc_values and are sorted by encoded byte representation
-          - hot garbage
+          - hot garbage # fields saved by ignore_malformed are sorted after doc values
+          - 7
   - is_false: fields
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -223,8 +223,6 @@ public class IndexVersions {
     public static final IndexVersion ID_FIELD_USE_ES812_POSTINGS_FORMAT = def(9_070_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_94 = def(9_071_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion TIME_SERIES_DOC_VALUES_FORMAT_VERSION_3 = def(9_072_0_00, Version.LUCENE_10_3_2);
-    public static final IndexVersion STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES = def(9_073_0_00, Version.LUCENE_10_3_2);
-
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
+public final class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
 
     private final String name;
     private SortedBinaryDocValues bytesValues;
@@ -42,7 +42,6 @@ public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSynthe
         }
 
         bytesValues = MultiValuedSortedBinaryDocValues.from(leafReader, name, docValues);
-
         return docId -> {
             hasValue = bytesValues.advanceExact(docId);
             return hasValue;
@@ -62,15 +61,8 @@ public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSynthe
 
         for (int i = 0; i < bytesValues.docValueCount(); ++i) {
             BytesRef value = bytesValues.nextValue();
-            writeValue(b, value);
+            b.utf8Value(value.bytes, value.offset, value.length);
         }
-    }
-
-    /**
-     * Write a single value to the builder. Subclasses can override to change the write format.
-     */
-    protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
-        b.utf8Value(value.bytes, value.offset, value.length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -571,7 +571,7 @@ public class BooleanFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (storeMalformedFields) {
                         // Save a copy of the field so synthetic source can load it
-                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                     }
                     return;
                 } else {
@@ -659,16 +659,11 @@ public class BooleanFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed.value(),
-                indexSettings.getIndexVersionCreated()
-            ) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value()) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(value == 1);

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
@@ -11,8 +11,6 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -175,23 +173,11 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
     }
 
     /**
-     * Returns the appropriate malformed values layer for the given index version.
-     * Uses binary doc values for new indices and stored fields for old indices.
-     */
-    public static Layer malformedValuesLayer(String fieldName, IndexVersion indexVersion) {
-        if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new MalformedValuesBinaryDocValuesLayer(fieldName);
-        } else {
-            return new MalformedValuesStoredFieldLayer(fieldName);
-        }
-    }
-
-    /**
-     * Layer that loads malformed values from stored fields for synthetic source.
+     * Layer that loads malformed values stored in a dedicated field with a conventional name.
      * @see IgnoreMalformedStoredValues
      */
-    private static class MalformedValuesStoredFieldLayer extends StoredFieldLayer {
-        MalformedValuesStoredFieldLayer(String fieldName) {
+    public static class MalformedValuesLayer extends StoredFieldLayer {
+        public MalformedValuesLayer(String fieldName) {
             super(IgnoreMalformedStoredValues.name(fieldName));
         }
 
@@ -202,20 +188,6 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
             } else {
                 b.value(value);
             }
-        }
-    }
-
-    /**
-     * Layer that loads malformed values from binary doc values for synthetic source.
-     */
-    private static class MalformedValuesBinaryDocValuesLayer extends BinaryDocValuesSyntheticFieldLoaderLayer {
-        MalformedValuesBinaryDocValuesLayer(String fieldName) {
-            super(IgnoreMalformedStoredValues.name(fieldName));
-        }
-
-        @Override
-        protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
-            XContentDataHelper.decodeAndWrite(b, value);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1164,7 +1164,7 @@ public final class DateFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                     }
                     return;
                 } else {
@@ -1243,12 +1243,7 @@ public final class DateFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (hasDocValues) {
             return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(
-                    fullPath(),
-                    leafName(),
-                    ignoreMalformed,
-                    indexSettings.getIndexVersionCreated()
-                ) {
+                () -> new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed) {
                     @Override
                     protected void writeValue(XContentBuilder b, long value) throws IOException {
                         b.value(fieldType().format(value, fieldType().dateTimeFormatter()));

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -648,7 +648,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         throws IOException {
         super.onMalformedValue(context, malformedDataForSyntheticSource, cause);
         if (malformedDataForSyntheticSource != null) {
-            IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), malformedDataForSyntheticSource);
+            context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), malformedDataForSyntheticSource));
         }
     }
 
@@ -656,12 +656,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (fieldType().hasDocValues()) {
             return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(
-                    fullPath(),
-                    leafName(),
-                    ignoreMalformed(),
-                    indexSettings.getIndexVersionCreated()
-                ) {
+                () -> new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed()) {
                     final GeoPoint point = new GeoPoint();
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -10,17 +10,9 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,72 +22,12 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 
 /**
- * Saves malformed values to stored fields or binary doc values so they can be loaded for synthetic {@code _source}.
+ * Saves malformed values to stored fields so they can be loaded for synthetic
+ * {@code _source}.
  */
 public abstract class IgnoreMalformedStoredValues {
 
     public static final String IGNORE_MALFORMED_FIELD_NAME_SUFFIX = "._ignore_malformed";
-
-    /**
-     * Stores a malformed value in binary doc values (new indices) or in stored fields (old indices) in order to support synthetic source.
-     */
-    public static void storeMalformedValueForSyntheticSource(DocumentParserContext context, String fieldPath, XContentParser parser)
-        throws IOException {
-        IndexVersion indexVersion = context.indexSettings().getIndexVersionCreated();
-        if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            BytesRef encoded = XContentDataHelper.encodeToken(parser);
-            saveToBinaryDocValues(context, fieldPath, encoded);
-        } else {
-            context.doc().add(storedField(fieldPath, parser));
-        }
-    }
-
-    /**
-     * Stores a malformed value in binary doc values (new indices) or in stored fields (old indices) in order to support synthetic source.
-     */
-    public static void storeMalformedValueForSyntheticSource(DocumentParserContext context, String fieldPath, XContentBuilder builder)
-        throws IOException {
-        IndexVersion indexVersion = context.indexSettings().getIndexVersionCreated();
-        if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            BytesRef encoded = encodeBuilderAsJson(builder);
-            saveToBinaryDocValues(context, fieldPath, encoded);
-        } else {
-            context.doc().add(storedField(fieldPath, builder));
-        }
-    }
-
-    /**
-     * Encodes an XContentBuilder's content, normalizing to JSON regardless of the builder's original content type.
-     *
-     * Malformed values are sorted by their encoded {@link BytesRef}. The encoding prefix byte is content-type-specific ('j' for
-     * JSON, 'c' for CBOR, etc.), so without normalization the sort order would depend on which content type the client used when
-     * indexing — an implementation detail that should not affect user-visible {@code _source} output. Normalizing to JSON is cheap in
-     * practice: the extra parse/serialize round-trip only runs when the content type is non-JSON AND the document has a malformed value,
-     * both of which are rare conditions.
-     */
-    private static BytesRef encodeBuilderAsJson(XContentBuilder builder) throws IOException {
-        XContentType originalType = builder.contentType();
-        if (originalType == XContentType.JSON) {
-            return XContentDataHelper.encodeXContentBuilder(builder);
-        }
-        BytesReference rawBytes = BytesReference.bytes(builder);
-        try (XContentParser parser = XContentHelper.createParserNotCompressed(XContentParserConfiguration.EMPTY, rawBytes, originalType)) {
-            XContentBuilder jsonBuilder = JsonXContent.contentBuilder();
-            parser.nextToken();
-            jsonBuilder.copyCurrentStructure(parser);
-            return XContentDataHelper.encodeXContentBuilder(jsonBuilder);
-        }
-    }
-
-    private static void saveToBinaryDocValues(DocumentParserContext context, String fieldPath, BytesRef encoded) {
-        final String fieldName = name(fieldPath);
-        MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fieldName);
-        if (field == null) {
-            field = new MultiValuedBinaryDocValuesField.IntegratedCount(fieldName, true);
-            context.doc().addWithKey(fieldName, field);
-        }
-        field.add(encoded);
-    }
 
     /**
      * Creates a stored field that stores malformed data to be used in synthetic source.
@@ -136,30 +68,10 @@ public abstract class IgnoreMalformedStoredValues {
     }
 
     /**
-     * Build the appropriate {@link IgnoreMalformedStoredValues} for loading malformed values during synthetic source reconstruction.
-     * Uses binary doc values for new indices and stored fields for old indices.
-     */
-    public static IgnoreMalformedStoredValues forSyntheticSource(String fieldName, IndexVersion indexVersion) {
-        if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new DocValues(fieldName);
-        } else {
-            return new Stored(fieldName);
-        }
-    }
-
-    /**
      * A {@link Stream} mapping stored field paths to a place to put them
      * so they can be included in the next document.
      */
     public abstract Stream<Map.Entry<String, SourceLoader.SyntheticFieldLoader.StoredFieldLoader>> storedFieldLoaders();
-
-    /**
-     * Create a doc values loader for loading malformed values from binary doc values.
-     * Returns {@code null} if this implementation does not use doc values or if there are no doc values to load.
-     */
-    public SourceLoader.SyntheticFieldLoader.DocValuesLoader docValuesLoader(LeafReader reader) throws IOException {
-        return null;
-    }
 
     /**
      * How many values has this field loaded for this document?
@@ -230,45 +142,6 @@ public abstract class IgnoreMalformedStoredValues {
         @Override
         public void reset() {
             values = emptyList();
-        }
-    }
-
-    private static class DocValues extends IgnoreMalformedStoredValues {
-
-        private final BinaryDocValuesSyntheticFieldLoaderLayer delegate;
-
-        DocValues(String fieldName) {
-            this.delegate = new BinaryDocValuesSyntheticFieldLoaderLayer(name(fieldName)) {
-                @Override
-                protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
-                    XContentDataHelper.decodeAndWrite(b, value);
-                }
-            };
-        }
-
-        @Override
-        public Stream<Map.Entry<String, SourceLoader.SyntheticFieldLoader.StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.empty();
-        }
-
-        @Override
-        public SourceLoader.SyntheticFieldLoader.DocValuesLoader docValuesLoader(LeafReader reader) throws IOException {
-            return delegate.docValuesLoader(reader, null);
-        }
-
-        @Override
-        public int count() {
-            return (int) delegate.valueCount();
-        }
-
-        @Override
-        public void write(XContentBuilder b) throws IOException {
-            delegate.write(b);
-        }
-
-        @Override
-        public void reset() {
-            // no-op: BinaryDocValuesSyntheticFieldLoaderLayer resets state on advanceToDoc
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -657,7 +657,7 @@ public class IpFieldMapper extends FieldMapper {
                 context.addIgnoredField(fieldType().name());
                 if (storeIgnored) {
                     // Save a copy of the field so synthetic source can load it
-                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                 }
                 return;
             } else {
@@ -753,7 +753,7 @@ public class IpFieldMapper extends FieldMapper {
                 }
 
                 if (ignoreMalformed) {
-                    layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+                    layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
                 }
                 return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
             });

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -128,19 +128,10 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
         }
 
         public static void addToSeparateCountMultiBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef binaryValue) {
-            addToSeparateCountMultiBinaryFieldInDoc(doc, fieldName, binaryValue, false);
-        }
-
-        public static void addToSeparateCountMultiBinaryFieldInDoc(
-            LuceneDocument doc,
-            String fieldName,
-            BytesRef binaryValue,
-            boolean keepDuplicates
-        ) {
             var field = (SeparateCount) doc.getByKey(fieldName);
             var countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
             if (field == null) {
-                field = new SeparateCount(fieldName, keepDuplicates);
+                field = new SeparateCount(fieldName, false);
                 countField = NumericDocValuesField.indexedField(field.countFieldName(), -1); // dummy value
                 doc.addWithKey(field.name(), field);
                 doc.addWithKey(countField.name(), countField);

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -1855,13 +1854,8 @@ public class NumberFieldMapper extends FieldMapper {
 
         abstract void writeValue(XContentBuilder builder, long longValue) throws IOException;
 
-        SourceLoader.SyntheticFieldLoader syntheticFieldLoader(
-            String fieldName,
-            String fieldSimpleName,
-            boolean ignoreMalformed,
-            IndexVersion indexVersion
-        ) {
-            return new SortedNumericDocValuesSyntheticFieldLoader(fieldName, fieldSimpleName, ignoreMalformed, indexVersion) {
+        SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String fieldName, String fieldSimpleName, boolean ignoreMalformed) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(fieldName, fieldSimpleName, ignoreMalformed) {
                 @Override
                 public void writeValue(XContentBuilder b, long value) throws IOException {
                     NumberType.this.writeValue(b, value);
@@ -2377,7 +2371,7 @@ public class NumberFieldMapper extends FieldMapper {
                 context.addIgnoredField(mappedFieldType.name());
                 if (isSyntheticSource) {
                     // Save a copy of the field so synthetic source can load it
-                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                 }
                 return;
             } else {
@@ -2491,11 +2485,11 @@ public class NumberFieldMapper extends FieldMapper {
             var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
             layers.add(new SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer(fullPath(), offsetsFieldName, type::writeValue));
             if (ignoreMalformed.value()) {
-                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return type.syntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value(), indexSettings.getIndexVersionCreated());
+            return type.syntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IPSyntheticSourceNativeArrayIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IPSyntheticSourceNativeArrayIntegrationTests.java
@@ -62,7 +62,7 @@ public class IPSyntheticSourceNativeArrayIntegrationTests extends NativeArrayInt
             new Object[] { "192.168.1.1", "192.168.1.1", "malformed" },
             new Object[] { null, null, null, "malformed" },
             new Object[] { "192.168.1.3", "192.168.1.3", "192.168.1.1", "malformed" } };
-        verifySyntheticArray(arrayValues, mapping, "_id");
+        verifySyntheticArray(arrayValues, mapping, "_id", "field._ignore_malformed");
     }
 
     public void testSynthesizeObjectArray() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
@@ -10,13 +10,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -29,7 +23,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -37,7 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class IgnoreMalformedStoredValuesTests extends ESTestCase {
     public void testIgnoreMalformedBoolean() throws IOException {
         boolean b = randomBoolean();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), b);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), b);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
         assertThat(p.booleanValue(), equalTo(b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -45,7 +38,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedString() throws IOException {
         String s = randomAlphaOfLength(5);
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), s);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), s);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
         assertThat(p.text(), equalTo(s));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -53,7 +46,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedInt() throws IOException {
         int i = randomInt();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), i);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), i);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
         assertThat(p.intValue(), equalTo(i));
@@ -62,7 +55,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedLong() throws IOException {
         long l = randomLong();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), l);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), l);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.LONG));
         assertThat(p.longValue(), equalTo(l));
@@ -71,7 +64,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedFloat() throws IOException {
         float f = randomFloat();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.FLOAT));
         assertThat(p.floatValue(), equalTo(f));
@@ -80,7 +73,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedDouble() throws IOException {
         double d = randomDouble();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), d);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), d);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.DOUBLE));
         assertThat(p.doubleValue(), equalTo(d));
@@ -89,7 +82,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBigInteger() throws IOException {
         BigInteger i = randomBigInteger();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_INTEGER));
         assertThat(p.numberValue(), equalTo(i));
@@ -98,7 +91,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBigDecimal() throws IOException {
         BigDecimal d = new BigDecimal(randomBigInteger(), randomInt());
-        XContentParser p = ignoreMalformedFromStoredField(XContentType.CBOR, d);
+        XContentParser p = ignoreMalformed(XContentType.CBOR, d);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_DECIMAL));
         assertThat(p.numberValue(), equalTo(d));
@@ -107,7 +100,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBytes() throws IOException {
         byte[] b = randomByteArrayOfLength(10);
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_EMBEDDED_OBJECT));
         assertThat(p.binaryValue(), equalTo(b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -115,7 +108,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedObjectBoolean() throws IOException {
         boolean b = randomBoolean();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), Map.of("foo", b));
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), Map.of("foo", b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
         assertThat(p.currentName(), equalTo("foo"));
@@ -129,7 +122,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         int i1 = randomInt();
         int i2 = randomInt();
         int i3 = randomInt();
-        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), List.of(i1, i2, i3));
+        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), List.of(i1, i2, i3));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
@@ -144,186 +137,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
     }
 
-    public void testDocValuesRoundTripString() throws IOException {
-        String s = randomAlphaOfLength(5);
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), s);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
-        assertThat(p.text(), equalTo(s));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripInt() throws IOException {
-        int i = randomInt();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), i);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
-        assertThat(p.intValue(), equalTo(i));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripBoolean() throws IOException {
-        boolean b = randomBoolean();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), b);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
-        assertThat(p.booleanValue(), equalTo(b));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripDouble() throws IOException {
-        double d = randomDouble();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), d);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.DOUBLE));
-        assertThat(p.doubleValue(), equalTo(d));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripLong() throws IOException {
-        long l = randomLong();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), l);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.LONG));
-        assertThat(p.longValue(), equalTo(l));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripFloat() throws IOException {
-        float f = randomFloat();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.FLOAT));
-        assertThat(p.floatValue(), equalTo(f));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripBigInteger() throws IOException {
-        BigInteger i = randomBigInteger();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_INTEGER));
-        assertThat(p.numberValue(), equalTo(i));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripBigDecimal() throws IOException {
-        BigDecimal d = new BigDecimal(randomBigInteger(), randomInt());
-        XContentParser p = ignoreMalformedFromDocValues(XContentType.CBOR, d);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_DECIMAL));
-        assertThat(p.numberValue(), equalTo(d));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripBytes() throws IOException {
-        byte[] b = randomByteArrayOfLength(10);
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_EMBEDDED_OBJECT));
-        assertThat(p.binaryValue(), equalTo(b));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripObject() throws IOException {
-        boolean b = randomBoolean();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), Map.of("foo", b));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-        assertThat(p.currentName(), equalTo("foo"));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
-        assertThat(p.booleanValue(), equalTo(b));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripArray() throws IOException {
-        int i1 = randomInt();
-        int i2 = randomInt();
-        int i3 = randomInt();
-        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), List.of(i1, i2, i3));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
-        assertThat(p.intValue(), equalTo(i1));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
-        assertThat(p.intValue(), equalTo(i2));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
-        assertThat(p.intValue(), equalTo(i3));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_ARRAY));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-    }
-
-    public void testDocValuesRoundTripMultipleValues() throws IOException {
-        String s1 = randomAlphaOfLength(5);
-        String s2 = randomAlphaOfLength(5);
-        String fieldName = "test_field";
-        String dvFieldName = IgnoreMalformedStoredValues.name(fieldName);
-
-        XContentType type = randomFrom(XContentType.values());
-        BytesRef encoded1 = encodeValue(type, s1);
-        BytesRef encoded2 = encodeValue(type, s2);
-
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-                LuceneDocument doc = new LuceneDocument();
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded1, true);
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded2, true);
-                iw.addDocument(doc);
-            }
-
-            try (DirectoryReader reader = DirectoryReader.open(directory)) {
-                LeafReader leafReader = reader.leaves().get(0).reader();
-                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
-                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
-                assertNotNull(loader);
-                assertTrue(loader.advanceToDoc(0));
-                assertThat(values.count(), equalTo(2));
-
-                XContentBuilder b = CborXContent.contentBuilder();
-                b.startObject();
-                b.field(fieldName);
-                b.startArray();
-                values.write(b);
-                b.endArray();
-                b.endObject();
-
-                XContentParser p = CborXContent.cborXContent.createParser(
-                    XContentParserConfiguration.EMPTY,
-                    BytesReference.bytes(b).streamInput()
-                );
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-                assertThat(p.currentName(), equalTo(fieldName));
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
-                String v1 = p.text();
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
-                String v2 = p.text();
-                assertThat(Set.of(v1, v2), equalTo(Set.of(s1, s2)));
-                assertThat(p.nextToken(), equalTo(XContentParser.Token.END_ARRAY));
-            }
-        }
-    }
-
-    public void testDocValuesNoValues() throws IOException {
-        String fieldName = "test_field";
-
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-                iw.addDocument(new LuceneDocument());
-            }
-
-            try (DirectoryReader reader = DirectoryReader.open(directory)) {
-                LeafReader leafReader = reader.leaves().get(0).reader();
-                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
-                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
-                assertNull(loader);
-                assertThat(values.count(), equalTo(0));
-            }
-        }
-    }
-
-    private static XContentParser ignoreMalformedFromStoredField(XContentType type, Object value) throws IOException {
+    private static XContentParser ignoreMalformed(XContentType type, Object value) throws IOException {
         String fieldName = randomAlphaOfLength(10);
         StoredField s = ignoreMalformedStoredField(type, value);
         Object stored = Stream.of(s.numericValue(), s.binaryValue(), s.stringValue()).filter(v -> v != null).findFirst().get();
@@ -341,45 +155,6 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
             assertThat(p.currentName(), equalTo("name"));
             p.nextToken();
             return IgnoreMalformedStoredValues.storedField("foo.name", p);
-        }
-    }
-
-    private XContentParser ignoreMalformedFromDocValues(XContentType type, Object value) throws IOException {
-        String fieldName = randomAlphaOfLength(10);
-        String dvFieldName = IgnoreMalformedStoredValues.name(fieldName);
-        BytesRef encoded = encodeValue(type, value);
-
-        XContentParser result;
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-                LuceneDocument doc = new LuceneDocument();
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded, true);
-                iw.addDocument(doc);
-            }
-
-            try (DirectoryReader reader = DirectoryReader.open(directory)) {
-                LeafReader leafReader = reader.leaves().get(0).reader();
-                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
-                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
-                assertNotNull(loader);
-                assertTrue(loader.advanceToDoc(0));
-                assertThat(values.count(), equalTo(1));
-
-                result = parserFrom(values, fieldName);
-            }
-        }
-        return result;
-    }
-
-    private static BytesRef encodeValue(XContentType type, Object value) throws IOException {
-        XContentBuilder b = XContentBuilder.builder(type.xContent());
-        b.startObject().field("name", value).endObject();
-        try (XContentParser p = type.xContent().createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(b).streamInput())) {
-            assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-            assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-            assertThat(p.currentName(), equalTo("name"));
-            p.nextToken();
-            return XContentDataHelper.encodeToken(p);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1238,33 +1238,6 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }
     }
 
-    /**
-     * Tests that synthetic source with ignore_malformed works correctly using stored fields, which is the storage format used by indices
-     * created before {@link IndexVersions#STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES}.
-     */
-    public void testSyntheticSourceIgnoreMalformedExamplesUsingStoredFields() throws IOException {
-        assumeTrue("type doesn't support ignore_malformed", supportsIgnoreMalformed());
-        syntheticSourceSupport(true);
-
-        IndexVersion oldVersion = IndexVersionUtils.randomPreviousCompatibleVersion(
-            IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES
-        );
-        var settings = Settings.builder().put("index.mapping.source.mode", "synthetic").build();
-        for (ExampleMalformedValue v : exampleMalformedValues()) {
-            CheckedConsumer<XContentBuilder, IOException> mapping = b -> {
-                v.mapping.accept(b);
-                b.field("ignore_malformed", true);
-            };
-            SyntheticSourceExample example = new SyntheticSourceExample(v.value, v.value, mapping);
-            DocumentMapper mapper = createMapperService(oldVersion, settings, () -> true, mapping(b -> {
-                b.startObject("field");
-                example.mapping().accept(b);
-                b.endObject();
-            })).documentMapper();
-            assertThat(syntheticSource(mapper, example::buildInput), equalTo(example.expected()));
-        }
-    }
-
     private void assertSyntheticSource(SyntheticSourceExample example) throws IOException {
         DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
@@ -15,7 +15,6 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -23,19 +22,13 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,8 +81,6 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
             for (int j = 0; j < malformed.length; j++) {
                 malformed[j] = getMalformedValue();
             }
-            // Binary doc values sort malformed values by their encoded BytesRef representation
-            Arrays.sort(malformed, encodedBytesRefComparator());
 
             var expectedDocument = jsonBuilder().startObject();
             var inputDocument = jsonBuilder().startObject();
@@ -453,34 +444,5 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
             logger.info("field name: {}, {}", fieldInfo.name, fieldInfo.attributes());
         }
         return fieldInfos;
-    }
-
-    /**
-     * Returns a comparator that orders objects by their {@link XContentDataHelper} encoded {@code BytesRef} representation.
-     * This matches the sort order used by binary doc values for malformed values.
-     */
-    private static Comparator<Object> encodedBytesRefComparator() {
-        return (a, b) -> {
-            try {
-                return encodeToBytesRef(a).compareTo(encodeToBytesRef(b));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
-    }
-
-    private static BytesRef encodeToBytesRef(Object value) throws IOException {
-        XContentBuilder builder = jsonBuilder().startObject().field("v", value).endObject();
-        try (
-            var parser = JsonXContent.jsonXContent.createParser(
-                XContentParserConfiguration.EMPTY,
-                BytesReference.bytes(builder).streamInput()
-            )
-        ) {
-            parser.nextToken(); // START_OBJECT
-            parser.nextToken(); // FIELD_NAME
-            parser.nextToken(); // value token
-            return XContentDataHelper.encodeToken(parser);
-        }
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -454,8 +454,8 @@ public class HistogramFieldMapperTests extends MapperTestCase {
         {
             expected.startArray("field");
             expected.startObject().field("values", new double[] { 1, 2, 3 }).field("counts", new int[] { 1, 2, 3 }).endObject();
-            expected.value(randomString);
             expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("values", new double[] { 4, 5, 6 }).endObject();
+            expected.value(randomString);
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -182,19 +182,6 @@ tasks.named("yamlRestCompatTestTransform").configure(
     task.skipTest("aggregate-metrics/40_avg_agg/Test avg agg with query", "Default metric cannot be defined, so the query is empty")
     task.skipTest("aggregate-metrics/30_sum_agg/Test sum agg with query", "Default metric cannot be defined, so the query is empty")
     task.skipTest("aggregate-metrics/50_value_count_agg/Test value_count agg with query", "Default metric cannot be defined, so the query is empty")
-    // Malformed values are now stored in binary doc values (sorted) instead of stored fields (insertion order).
-    task.skipTest(
-      "analytics/histogram/histogram with synthetic source and ignore_malformed",
-      "Malformed values are now stored in binary doc values which sort differently than stored fields"
-    )
-    task.skipTest(
-      "analytics/t_digest_fieldtype/histogram with synthetic source and ignore_malformed",
-      "Malformed values are now stored in binary doc values which sort differently than stored fields"
-    )
-    task.skipTest(
-      "aggregate-metrics/100_synthetic_source/aggregate_metric_double with ignore_malformed",
-      "Malformed values are now stored in binary doc values which sort differently than stored fields"
-    )
   }
 )
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/analytics/mapper/TDigestFieldMapperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/analytics/mapper/TDigestFieldMapperTests.java
@@ -414,8 +414,8 @@ public class TDigestFieldMapperTests extends MapperTestCase {
             expected.field("centroids", new double[] { 1, 2, 3 });
             expected.field("counts", new int[] { 1, 2, 3 });
             expected.endObject();
-            expected.value(randomString);
             expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("centroids", new double[] { 4, 5, 6 }).endObject();
+            expected.value(randomString);
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -787,7 +787,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                 }
 
                 if (malformedDataForSyntheticSource != null) {
-                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), malformedDataForSyntheticSource);
+                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), malformedDataForSyntheticSource));
                 }
 
                 context.addIgnoredField(fullPath());
@@ -818,7 +818,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                 leafName(),
                 fullPath(),
                 new AggregateMetricSyntheticFieldLoader(fullPath(), metrics),
-                CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated())
+                new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath())
             )
         );
     }

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
@@ -475,8 +475,8 @@ public class AggregateMetricDoubleFieldMapperTests extends MapperTestCase {
         {
             expected.startArray("field");
             expected.startObject().field("min", 10.0).field("max", 100.0).endObject();
-            expected.value(randomString);
             expected.startObject().field("max", 200).field("min", 20).endObject();
+            expected.value(randomString);
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -753,7 +753,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
+                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
                     }
                     return;
                 } else {
@@ -901,16 +901,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed(),
-                indexSettings.getIndexVersionCreated()
-            ) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed()) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value));

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -34,7 +34,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -446,15 +445,10 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
                 .map(Value::output)
                 .sorted()
                 .toList();
-            // Malformed values are stored as BytesRef with a type-prefix byte and sorted lexicographically.
-            List<Object> malformedOutput = values.stream()
-                .filter(v -> v.malformedOutput != null)
-                .map(Value::malformedOutput)
-                .sorted(Comparator.comparing(Object::toString))
-                .toList();
+            Stream<Object> malformedOutput = values.stream().filter(v -> v.malformedOutput != null).map(Value::malformedOutput);
 
             // Malformed values are always last in the implementation.
-            List<Object> outList = Stream.concat(outputFromDocValues.stream(), malformedOutput.stream()).toList();
+            List<Object> outList = Stream.concat(outputFromDocValues.stream(), malformedOutput).toList();
             Object out = outList.size() == 1 ? outList.get(0) : outList;
 
             return new SyntheticSourceExample(in, out, this::mapping);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -359,4 +359,4 @@ histogram with synthetic source and ignore_malformed:
         id: 2
   - match:
       _source:
-        latency: [{"values": [2.0], "counts": [2]}, "fox", 123, 456, {"values": [1.0], "counts": [1], "hello": "world"}]
+        latency: [{"values": [2.0], "counts": [2]}, {"values": [1.0], "counts": [1], "hello": "world"}, 123, 456, "fox"]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/t_digest_fieldtype.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/t_digest_fieldtype.yml
@@ -245,8 +245,8 @@ histogram with synthetic source and ignore_malformed:
           "centroids": [ 2.0 ],
           "counts": [ 2 ]
         },
-          "fox", 123, 456,
-          { "centroids": [ 1.0 ], "counts": [ 1 ], "hello": "world" } ]
+          { "centroids": [ 1.0 ], "counts": [ 1 ], "hello": "world" },
+          123, 456, "fox" ]
 ---
 TDigest with synthetic source and empty digest:
   - requires:


### PR DESCRIPTION
Broke intake bc of an extra white space: https://buildkite.com/elastic/elasticsearch-intake/builds/35040#019c959d-4611-4614-a578-2bf001a77b8d