### PR TITLE
Store ignored malformed fields in binary doc values (#142357)

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -652,7 +652,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                     }
                     return;
                 } else {
@@ -685,7 +685,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 context.addIgnoredField(mappedFieldType.name());
                 if (isSourceSynthetic) {
                     // Save a copy of the field so synthetic source can load it
-                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                 }
                 return;
             } else {
@@ -854,11 +854,16 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value()) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(
+                fullPath(),
+                leafName(),
+                ignoreMalformed.value(),
+                indexSettings.getIndexVersionCreated()
+            ) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(decodeForSyntheticSource(value, scalingFactor));

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -117,4 +117,8 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   task.addAllowedWarningRegex("Use of the \\[max_size\\] rollover condition has been deprecated in favour of the \\[max_primary_shard_size\\] condition and will be removed in a later version")
   task.skipTest("search.vectors/42_knn_search_bbq_flat/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
   task.skipTest("search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section", "scores have changed slightly with native implementations")
+  task.skipTest(
+    "get/100_synthetic_source/fields with ignore_malformed",
+    "Malformed values are now stored in binary doc values which sort differently than stored fields"
+  )
 })

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -799,8 +799,8 @@ fields with ignore_malformed:
         ip:
           - 10.10.1.1
           - 192.8.1.2
-          - hot garbage # fields saved by ignore_malformed are sorted after doc values
-          - 7
+          - 7 # malformed values come after doc_values and are sorted by encoded byte representation
+          - hot garbage
   - is_false: fields
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -223,6 +223,8 @@ public class IndexVersions {
     public static final IndexVersion ID_FIELD_USE_ES812_POSTINGS_FORMAT = def(9_070_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_94 = def(9_071_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion TIME_SERIES_DOC_VALUES_FORMAT_VERSION_3 = def(9_072_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES = def(9_073_0_00, Version.LUCENE_10_3_2);
+
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -225,7 +225,6 @@ public class IndexVersions {
     public static final IndexVersion TIME_SERIES_DOC_VALUES_FORMAT_VERSION_3 = def(9_072_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES = def(9_073_0_00, Version.LUCENE_10_3_2);
 
-
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public final class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
+public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
 
     private final String name;
     private SortedBinaryDocValues bytesValues;
@@ -42,6 +42,7 @@ public final class BinaryDocValuesSyntheticFieldLoaderLayer implements Composite
         }
 
         bytesValues = MultiValuedSortedBinaryDocValues.from(leafReader, name, docValues);
+
         return docId -> {
             hasValue = bytesValues.advanceExact(docId);
             return hasValue;
@@ -61,8 +62,15 @@ public final class BinaryDocValuesSyntheticFieldLoaderLayer implements Composite
 
         for (int i = 0; i < bytesValues.docValueCount(); ++i) {
             BytesRef value = bytesValues.nextValue();
-            b.utf8Value(value.bytes, value.offset, value.length);
+            writeValue(b, value);
         }
+    }
+
+    /**
+     * Write a single value to the builder. Subclasses can override to change the write format.
+     */
+    protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
+        b.utf8Value(value.bytes, value.offset, value.length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -571,7 +571,7 @@ public class BooleanFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (storeMalformedFields) {
                         // Save a copy of the field so synthetic source can load it
-                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                     }
                     return;
                 } else {
@@ -659,11 +659,16 @@ public class BooleanFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed.value()) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(
+                fullPath(),
+                leafName(),
+                ignoreMalformed.value(),
+                indexSettings.getIndexVersionCreated()
+            ) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(value == 1);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1164,7 +1164,7 @@ public final class DateFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                     }
                     return;
                 } else {
@@ -1243,7 +1243,12 @@ public final class DateFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (hasDocValues) {
             return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed) {
+                () -> new SortedNumericDocValuesSyntheticFieldLoader(
+                    fullPath(),
+                    leafName(),
+                    ignoreMalformed,
+                    indexSettings.getIndexVersionCreated()
+                ) {
                     @Override
                     protected void writeValue(XContentBuilder b, long value) throws IOException {
                         b.value(fieldType().format(value, fieldType().dateTimeFormatter()));

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -648,7 +648,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         throws IOException {
         super.onMalformedValue(context, malformedDataForSyntheticSource, cause);
         if (malformedDataForSyntheticSource != null) {
-            context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), malformedDataForSyntheticSource));
+            IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), malformedDataForSyntheticSource);
         }
     }
 
@@ -656,7 +656,12 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (fieldType().hasDocValues()) {
             return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed()) {
+                () -> new SortedNumericDocValuesSyntheticFieldLoader(
+                    fullPath(),
+                    leafName(),
+                    ignoreMalformed(),
+                    indexSettings.getIndexVersionCreated()
+                ) {
                     final GeoPoint point = new GeoPoint();
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -657,7 +657,7 @@ public class IpFieldMapper extends FieldMapper {
                 context.addIgnoredField(fieldType().name());
                 if (storeIgnored) {
                     // Save a copy of the field so synthetic source can load it
-                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                 }
                 return;
             } else {
@@ -753,7 +753,7 @@ public class IpFieldMapper extends FieldMapper {
                 }
 
                 if (ignoreMalformed) {
-                    layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
+                    layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
                 }
                 return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
             });

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -128,10 +128,19 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
         }
 
         public static void addToSeparateCountMultiBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef binaryValue) {
+            addToSeparateCountMultiBinaryFieldInDoc(doc, fieldName, binaryValue, false);
+        }
+
+        public static void addToSeparateCountMultiBinaryFieldInDoc(
+            LuceneDocument doc,
+            String fieldName,
+            BytesRef binaryValue,
+            boolean keepDuplicates
+        ) {
             var field = (SeparateCount) doc.getByKey(fieldName);
             var countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
             if (field == null) {
-                field = new SeparateCount(fieldName, false);
+                field = new SeparateCount(fieldName, keepDuplicates);
                 countField = NumericDocValuesField.indexedField(field.countFieldName(), -1); // dummy value
                 doc.addWithKey(field.name(), field);
                 doc.addWithKey(countField.name(), countField);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -34,17 +35,34 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
     private Values values = NO_VALUES;
 
     /**
-     * Build a loader from doc values and, optionally, a stored field.
+     * Build a loader from doc values and, optionally, a stored field for malformed values.
      * @param name the name of the field to load from doc values
      * @param simpleName the name to give the field in the rendered {@code _source}
      * @param loadIgnoreMalformedValues should we load values skipped by {@code ignore_malformed}
      */
     protected SortedNumericDocValuesSyntheticFieldLoader(String name, String simpleName, boolean loadIgnoreMalformedValues) {
+        this(name, simpleName, loadIgnoreMalformedValues ? IgnoreMalformedStoredValues.stored(name) : IgnoreMalformedStoredValues.empty());
+    }
+
+    protected SortedNumericDocValuesSyntheticFieldLoader(
+        String name,
+        String simpleName,
+        boolean loadIgnoreMalformedValues,
+        IndexVersion indexVersion
+    ) {
+        this(
+            name,
+            simpleName,
+            loadIgnoreMalformedValues
+                ? IgnoreMalformedStoredValues.forSyntheticSource(name, indexVersion)
+                : IgnoreMalformedStoredValues.empty()
+        );
+    }
+
+    private SortedNumericDocValuesSyntheticFieldLoader(String name, String simpleName, IgnoreMalformedStoredValues ignoreMalformedValues) {
         this.name = name;
         this.simpleName = simpleName;
-        this.ignoreMalformedValues = loadIgnoreMalformedValues
-            ? IgnoreMalformedStoredValues.stored(name)
-            : IgnoreMalformedStoredValues.empty();
+        this.ignoreMalformedValues = ignoreMalformedValues;
     }
 
     protected abstract void writeValue(XContentBuilder b, long value) throws IOException;
@@ -56,6 +74,19 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
 
     @Override
     public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
+        DocValuesLoader fieldLoader = fieldDocValuesLoader(reader, docIdsInLeaf);
+        DocValuesLoader malformedLoader = ignoreMalformedValues.docValuesLoader(reader);
+
+        if (fieldLoader != null && malformedLoader != null) {
+            return docId -> fieldLoader.advanceToDoc(docId) | malformedLoader.advanceToDoc(docId);
+        } else if (malformedLoader != null) {
+            return malformedLoader;
+        } else {
+            return fieldLoader;
+        }
+    }
+
+    private DocValuesLoader fieldDocValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
         SortedNumericDocValues dv = docValuesOrNull(reader, name);
         if (dv == null) {
             values = NO_VALUES;

--- a/server/src/test/java/org/elasticsearch/index/mapper/IPSyntheticSourceNativeArrayIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IPSyntheticSourceNativeArrayIntegrationTests.java
@@ -62,7 +62,7 @@ public class IPSyntheticSourceNativeArrayIntegrationTests extends NativeArrayInt
             new Object[] { "192.168.1.1", "192.168.1.1", "malformed" },
             new Object[] { null, null, null, "malformed" },
             new Object[] { "192.168.1.3", "192.168.1.3", "192.168.1.1", "malformed" } };
-        verifySyntheticArray(arrayValues, mapping, "_id", "field._ignore_malformed");
+        verifySyntheticArray(arrayValues, mapping, "_id");
     }
 
     public void testSynthesizeObjectArray() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
@@ -10,7 +10,13 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -23,6 +29,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -30,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class IgnoreMalformedStoredValuesTests extends ESTestCase {
     public void testIgnoreMalformedBoolean() throws IOException {
         boolean b = randomBoolean();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), b);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), b);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
         assertThat(p.booleanValue(), equalTo(b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -38,7 +45,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedString() throws IOException {
         String s = randomAlphaOfLength(5);
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), s);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), s);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
         assertThat(p.text(), equalTo(s));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -46,7 +53,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedInt() throws IOException {
         int i = randomInt();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), i);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), i);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
         assertThat(p.intValue(), equalTo(i));
@@ -55,7 +62,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedLong() throws IOException {
         long l = randomLong();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), l);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), l);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.LONG));
         assertThat(p.longValue(), equalTo(l));
@@ -64,7 +71,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedFloat() throws IOException {
         float f = randomFloat();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.FLOAT));
         assertThat(p.floatValue(), equalTo(f));
@@ -73,7 +80,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedDouble() throws IOException {
         double d = randomDouble();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), d);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), d);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.DOUBLE));
         assertThat(p.doubleValue(), equalTo(d));
@@ -82,7 +89,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBigInteger() throws IOException {
         BigInteger i = randomBigInteger();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_INTEGER));
         assertThat(p.numberValue(), equalTo(i));
@@ -91,7 +98,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBigDecimal() throws IOException {
         BigDecimal d = new BigDecimal(randomBigInteger(), randomInt());
-        XContentParser p = ignoreMalformed(XContentType.CBOR, d);
+        XContentParser p = ignoreMalformedFromStoredField(XContentType.CBOR, d);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_DECIMAL));
         assertThat(p.numberValue(), equalTo(d));
@@ -100,7 +107,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedBytes() throws IOException {
         byte[] b = randomByteArrayOfLength(10);
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_EMBEDDED_OBJECT));
         assertThat(p.binaryValue(), equalTo(b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
@@ -108,7 +115,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
 
     public void testIgnoreMalformedObjectBoolean() throws IOException {
         boolean b = randomBoolean();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), Map.of("foo", b));
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), Map.of("foo", b));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
         assertThat(p.currentName(), equalTo("foo"));
@@ -122,7 +129,7 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         int i1 = randomInt();
         int i2 = randomInt();
         int i3 = randomInt();
-        XContentParser p = ignoreMalformed(randomFrom(XContentType.values()), List.of(i1, i2, i3));
+        XContentParser p = ignoreMalformedFromStoredField(randomFrom(XContentType.values()), List.of(i1, i2, i3));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
         assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
         assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
@@ -137,7 +144,186 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
     }
 
-    private static XContentParser ignoreMalformed(XContentType type, Object value) throws IOException {
+    public void testDocValuesRoundTripString() throws IOException {
+        String s = randomAlphaOfLength(5);
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), s);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
+        assertThat(p.text(), equalTo(s));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripInt() throws IOException {
+        int i = randomInt();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), i);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
+        assertThat(p.intValue(), equalTo(i));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripBoolean() throws IOException {
+        boolean b = randomBoolean();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), b);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
+        assertThat(p.booleanValue(), equalTo(b));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripDouble() throws IOException {
+        double d = randomDouble();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), d);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.DOUBLE));
+        assertThat(p.doubleValue(), equalTo(d));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripLong() throws IOException {
+        long l = randomLong();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), l);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.LONG));
+        assertThat(p.longValue(), equalTo(l));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripFloat() throws IOException {
+        float f = randomFloat();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), f);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.FLOAT));
+        assertThat(p.floatValue(), equalTo(f));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripBigInteger() throws IOException {
+        BigInteger i = randomBigInteger();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), i);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_INTEGER));
+        assertThat(p.numberValue(), equalTo(i));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripBigDecimal() throws IOException {
+        BigDecimal d = new BigDecimal(randomBigInteger(), randomInt());
+        XContentParser p = ignoreMalformedFromDocValues(XContentType.CBOR, d);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.BIG_DECIMAL));
+        assertThat(p.numberValue(), equalTo(d));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripBytes() throws IOException {
+        byte[] b = randomByteArrayOfLength(10);
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.SMILE, XContentType.CBOR), b);
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_EMBEDDED_OBJECT));
+        assertThat(p.binaryValue(), equalTo(b));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripObject() throws IOException {
+        boolean b = randomBoolean();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), Map.of("foo", b));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+        assertThat(p.currentName(), equalTo("foo"));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_BOOLEAN));
+        assertThat(p.booleanValue(), equalTo(b));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripArray() throws IOException {
+        int i1 = randomInt();
+        int i2 = randomInt();
+        int i3 = randomInt();
+        XContentParser p = ignoreMalformedFromDocValues(randomFrom(XContentType.values()), List.of(i1, i2, i3));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
+        assertThat(p.intValue(), equalTo(i1));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
+        assertThat(p.intValue(), equalTo(i2));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+        assertThat(p.numberType(), equalTo(XContentParser.NumberType.INT));
+        assertThat(p.intValue(), equalTo(i3));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_ARRAY));
+        assertThat(p.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+    }
+
+    public void testDocValuesRoundTripMultipleValues() throws IOException {
+        String s1 = randomAlphaOfLength(5);
+        String s2 = randomAlphaOfLength(5);
+        String fieldName = "test_field";
+        String dvFieldName = IgnoreMalformedStoredValues.name(fieldName);
+
+        XContentType type = randomFrom(XContentType.values());
+        BytesRef encoded1 = encodeValue(type, s1);
+        BytesRef encoded2 = encodeValue(type, s2);
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded1, true);
+                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded2, true);
+                iw.addDocument(doc);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
+                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
+                assertNotNull(loader);
+                assertTrue(loader.advanceToDoc(0));
+                assertThat(values.count(), equalTo(2));
+
+                XContentBuilder b = CborXContent.contentBuilder();
+                b.startObject();
+                b.field(fieldName);
+                b.startArray();
+                values.write(b);
+                b.endArray();
+                b.endObject();
+
+                XContentParser p = CborXContent.cborXContent.createParser(
+                    XContentParserConfiguration.EMPTY,
+                    BytesReference.bytes(b).streamInput()
+                );
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+                assertThat(p.currentName(), equalTo(fieldName));
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.START_ARRAY));
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
+                String v1 = p.text();
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
+                String v2 = p.text();
+                assertThat(Set.of(v1, v2), equalTo(Set.of(s1, s2)));
+                assertThat(p.nextToken(), equalTo(XContentParser.Token.END_ARRAY));
+            }
+        }
+    }
+
+    public void testDocValuesNoValues() throws IOException {
+        String fieldName = "test_field";
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                iw.addDocument(new LuceneDocument());
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
+                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
+                assertNull(loader);
+                assertThat(values.count(), equalTo(0));
+            }
+        }
+    }
+
+    private static XContentParser ignoreMalformedFromStoredField(XContentType type, Object value) throws IOException {
         String fieldName = randomAlphaOfLength(10);
         StoredField s = ignoreMalformedStoredField(type, value);
         Object stored = Stream.of(s.numericValue(), s.binaryValue(), s.stringValue()).filter(v -> v != null).findFirst().get();
@@ -155,6 +341,45 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
             assertThat(p.currentName(), equalTo("name"));
             p.nextToken();
             return IgnoreMalformedStoredValues.storedField("foo.name", p);
+        }
+    }
+
+    private XContentParser ignoreMalformedFromDocValues(XContentType type, Object value) throws IOException {
+        String fieldName = randomAlphaOfLength(10);
+        String dvFieldName = IgnoreMalformedStoredValues.name(fieldName);
+        BytesRef encoded = encodeValue(type, value);
+
+        XContentParser result;
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded, true);
+                iw.addDocument(doc);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                IgnoreMalformedStoredValues values = IgnoreMalformedStoredValues.forSyntheticSource(fieldName, IndexVersion.current());
+                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = values.docValuesLoader(leafReader);
+                assertNotNull(loader);
+                assertTrue(loader.advanceToDoc(0));
+                assertThat(values.count(), equalTo(1));
+
+                result = parserFrom(values, fieldName);
+            }
+        }
+        return result;
+    }
+
+    private static BytesRef encodeValue(XContentType type, Object value) throws IOException {
+        XContentBuilder b = XContentBuilder.builder(type.xContent());
+        b.startObject().field("name", value).endObject();
+        try (XContentParser p = type.xContent().createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(b).streamInput())) {
+            assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+            assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+            assertThat(p.currentName(), equalTo("name"));
+            p.nextToken();
+            return XContentDataHelper.encodeToken(p);
         }
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.HistogramValue;
@@ -87,9 +88,11 @@ public class HistogramFieldMapper extends FieldMapper {
          * Only the metric type histogram is supported.
          */
         private final Parameter<TimeSeriesParams.MetricType> metric;
+        private final IndexVersion indexCreatedVersion;
 
-        public Builder(String name, boolean ignoreMalformedByDefault, boolean coerceByDefault) {
+        public Builder(String name, boolean ignoreMalformedByDefault, boolean coerceByDefault, IndexVersion indexCreatedVersion) {
             super(name);
+            this.indexCreatedVersion = indexCreatedVersion;
             this.ignoreMalformed = Parameter.explicitBoolParam(
                 "ignore_malformed",
                 true,
@@ -127,7 +130,12 @@ public class HistogramFieldMapper extends FieldMapper {
     }
 
     public static final TypeParser PARSER = new TypeParser(
-        (n, c) -> new Builder(n, IGNORE_MALFORMED_SETTING.get(c.getSettings()), COERCE_SETTING.get(c.getSettings())),
+        (n, c) -> new Builder(
+            n,
+            IGNORE_MALFORMED_SETTING.get(c.getSettings()),
+            COERCE_SETTING.get(c.getSettings()),
+            c.getIndexSettings().getIndexVersionCreated()
+        ),
         notInMultiFields(CONTENT_TYPE)
     );
 
@@ -137,11 +145,13 @@ public class HistogramFieldMapper extends FieldMapper {
     private final Explicit<Boolean> coerce;
     private final boolean coerceByDefault;
     private final TimeSeriesParams.MetricType metricType;
+    private final IndexVersion indexCreatedVersion;
 
     public HistogramFieldMapper(String simpleName, MappedFieldType mappedFieldType, BuilderParams builderParams, Builder builder) {
         super(simpleName, mappedFieldType, builderParams);
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.ignoreMalformedByDefault = builder.ignoreMalformed.getDefaultValue().value();
+        this.indexCreatedVersion = builder.indexCreatedVersion;
         this.coerce = builder.coerce.getValue();
         this.coerceByDefault = builder.coerce.getDefaultValue().value();
         this.metricType = builder.metric.get();
@@ -163,7 +173,7 @@ public class HistogramFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(leafName(), ignoreMalformedByDefault, coerceByDefault).metric(metricType).init(this);
+        return new Builder(leafName(), ignoreMalformedByDefault, coerceByDefault, indexCreatedVersion).metric(metricType).init(this);
     }
 
     @Override
@@ -401,7 +411,7 @@ public class HistogramFieldMapper extends FieldMapper {
             }
 
             if (malformedDataForSyntheticSource != null) {
-                context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), malformedDataForSyntheticSource));
+                IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), malformedDataForSyntheticSource);
             }
 
             context.addIgnoredField(fieldType().name());
@@ -479,7 +489,7 @@ public class HistogramFieldMapper extends FieldMapper {
                 leafName(),
                 fullPath(),
                 new HistogramSyntheticFieldLoader(),
-                new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath())
+                CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexCreatedVersion)
             )
         );
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -454,8 +454,8 @@ public class HistogramFieldMapperTests extends MapperTestCase {
         {
             expected.startArray("field");
             expected.startObject().field("values", new double[] { 1, 2, 3 }).field("counts", new int[] { 1, 2, 3 }).endObject();
-            expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("values", new double[] { 4, 5, 6 }).endObject();
             expected.value(randomString);
+            expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("values", new double[] { 4, 5, 6 }).endObject();
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -182,6 +182,19 @@ tasks.named("yamlRestCompatTestTransform").configure(
     task.skipTest("aggregate-metrics/40_avg_agg/Test avg agg with query", "Default metric cannot be defined, so the query is empty")
     task.skipTest("aggregate-metrics/30_sum_agg/Test sum agg with query", "Default metric cannot be defined, so the query is empty")
     task.skipTest("aggregate-metrics/50_value_count_agg/Test value_count agg with query", "Default metric cannot be defined, so the query is empty")
+    // Malformed values are now stored in binary doc values (sorted) instead of stored fields (insertion order).
+    task.skipTest(
+      "analytics/histogram/histogram with synthetic source and ignore_malformed",
+      "Malformed values are now stored in binary doc values which sort differently than stored fields"
+    )
+    task.skipTest(
+      "analytics/t_digest_fieldtype/histogram with synthetic source and ignore_malformed",
+      "Malformed values are now stored in binary doc values which sort differently than stored fields"
+    )
+    task.skipTest(
+      "aggregate-metrics/100_synthetic_source/aggregate_metric_double with ignore_malformed",
+      "Malformed values are now stored in binary doc values which sort differently than stored fields"
+    )
   }
 )
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/analytics/mapper/TDigestFieldMapperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/analytics/mapper/TDigestFieldMapperTests.java
@@ -414,8 +414,8 @@ public class TDigestFieldMapperTests extends MapperTestCase {
             expected.field("centroids", new double[] { 1, 2, 3 });
             expected.field("counts", new int[] { 1, 2, 3 });
             expected.endObject();
-            expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("centroids", new double[] { 4, 5, 6 }).endObject();
             expected.value(randomString);
+            expected.startObject().field("counts", new int[] { 4, 5, 6 }).field("centroids", new double[] { 4, 5, 6 }).endObject();
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -787,7 +787,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                 }
 
                 if (malformedDataForSyntheticSource != null) {
-                    context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), malformedDataForSyntheticSource));
+                    IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), malformedDataForSyntheticSource);
                 }
 
                 context.addIgnoredField(fullPath());
@@ -818,7 +818,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                 leafName(),
                 fullPath(),
                 new AggregateMetricSyntheticFieldLoader(fullPath(), metrics),
-                new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath())
+                CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated())
             )
         );
     }

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
@@ -475,8 +475,8 @@ public class AggregateMetricDoubleFieldMapperTests extends MapperTestCase {
         {
             expected.startArray("field");
             expected.startObject().field("min", 10.0).field("max", 100.0).endObject();
-            expected.startObject().field("max", 200).field("min", 20).endObject();
             expected.value(randomString);
+            expected.startObject().field("max", 200).field("min", 20).endObject();
             expected.endArray();
         }
         expected.endObject();

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -753,7 +753,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                     context.addIgnoredField(mappedFieldType.name());
                     if (isSourceSynthetic) {
                         // Save a copy of the field so synthetic source can load it
-                        context.doc().add(IgnoreMalformedStoredValues.storedField(fullPath(), context.parser()));
+                        IgnoreMalformedStoredValues.storeMalformedValueForSyntheticSource(context, fullPath(), context.parser());
                     }
                     return;
                 } else {
@@ -901,11 +901,16 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 )
             );
             if (ignoreMalformed.value()) {
-                layers.add(new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath()));
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), ignoreMalformed()) {
+            return new SortedNumericDocValuesSyntheticFieldLoader(
+                fullPath(),
+                leafName(),
+                ignoreMalformed(),
+                indexSettings.getIndexVersionCreated()
+            ) {
                 @Override
                 protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value));

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -445,10 +446,15 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
                 .map(Value::output)
                 .sorted()
                 .toList();
-            Stream<Object> malformedOutput = values.stream().filter(v -> v.malformedOutput != null).map(Value::malformedOutput);
+            // Malformed values are stored as BytesRef with a type-prefix byte and sorted lexicographically.
+            List<Object> malformedOutput = values.stream()
+                .filter(v -> v.malformedOutput != null)
+                .map(Value::malformedOutput)
+                .sorted(Comparator.comparing(Object::toString))
+                .toList();
 
             // Malformed values are always last in the implementation.
-            List<Object> outList = Stream.concat(outputFromDocValues.stream(), malformedOutput).toList();
+            List<Object> outList = Stream.concat(outputFromDocValues.stream(), malformedOutput.stream()).toList();
             Object out = outList.size() == 1 ? outList.get(0) : outList;
 
             return new SyntheticSourceExample(in, out, this::mapping);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -359,4 +359,4 @@ histogram with synthetic source and ignore_malformed:
         id: 2
   - match:
       _source:
-        latency: [{"values": [2.0], "counts": [2]}, {"values": [1.0], "counts": [1], "hello": "world"}, 123, 456, "fox"]
+        latency: [{"values": [2.0], "counts": [2]}, "fox", 123, 456, {"values": [1.0], "counts": [1], "hello": "world"}]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/t_digest_fieldtype.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/t_digest_fieldtype.yml
@@ -245,8 +245,8 @@ histogram with synthetic source and ignore_malformed:
           "centroids": [ 2.0 ],
           "counts": [ 2 ]
         },
-          { "centroids": [ 1.0 ], "counts": [ 1 ], "hello": "world" },
-          123, 456, "fox" ]
+          "fox", 123, 456,
+          { "centroids": [ 1.0 ], "counts": [ 1 ], "hello": "world" } ]
 ---
 TDigest with synthetic source and empty digest:
   - requires:


### PR DESCRIPTION
This reverts commit 26ca5c3ab628ef97783e183ea9309f0e1a025753.

I broke [intake](https://buildkite.com/elastic/elasticsearch-intake/builds/35040) earlier due to an extra white line that I overlooked when resolving a conflict. 