### PR TITLE
[CI] Use same test seed for all Buildkite job retries

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -145,19 +145,80 @@ EOF
 EOF
 fi
 
+# =============================================================================
+# PART 1: Test seed retrieval for ANY retry
+# =============================================================================
+# When a job is retried (regardless of SMART_RETRIES setting), retrieve and use
+# the same test seed from the original job to ensure reproducible test failures.
+# =============================================================================
+
+# Initialize variables that may be reused by smart retry logic below
+BUILD_JSON=""
+ORIGIN_JOB_ID=""
+BUILD_SCAN_ID=""
+BUILD_SCAN_URL=""
+TESTS_SEED=""
+
+if [[ "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; then
+  echo "--- Retrieving test seed from original job"
+
+  if BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null); then
+    if ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) && [ "$ORIGIN_JOB_ID" != "null" ] && [ -n "$ORIGIN_JOB_ID" ]; then
+
+      # Retrieve test seed from Buildkite metadata
+      TESTS_SEED=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["tests-seed-" + $job_id]' 2>/dev/null)
+
+      # Retrieve build scan URL and ID for smart retry (reused in Part 2)
+      BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null)
+      BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null)
+
+      if [[ -n "$TESTS_SEED" ]] && [[ "$TESTS_SEED" != "null" ]]; then
+        echo "Using test seed $TESTS_SEED from original job $ORIGIN_JOB_ID"
+        export TESTS_SEED
+      else
+        echo "Warning: Could not find test seed in metadata for original job."
+        echo "Tests will use a new random seed."
+        TESTS_SEED=""
+      fi
+    else
+      echo "Warning: Could not find origin job ID for retry."
+      echo "Tests will use a new random seed."
+    fi
+  else
+    echo "Warning: Failed to fetch build information from Buildkite API"
+    echo "Tests will use a new random seed."
+  fi
+fi
+
+# =============================================================================
+# PART 2: Smart retry test filtering (only when SMART_RETRIES=true)
+# =============================================================================
+# When smart retries are enabled, fetch the list of failed tests from the
+# original job and filter this retry to only run those tests.
+# =============================================================================
 if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; then
   echo "--- Resolving previously failed tests"
   SMART_RETRY_STATUS="disabled"
   SMART_RETRY_DETAILS=""
 
-  if BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null); then
-    if ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) && [ "$ORIGIN_JOB_ID" != "null" ] && [ -n "$ORIGIN_JOB_ID" ]; then
+  # Check if we already have the build info from seed retrieval above
+  if [[ -z "$BUILD_JSON" ]]; then
+    # Fetch build info if not already available (shouldn't happen, but be safe)
+    BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null) || BUILD_JSON=""
+  fi
 
-      # Attempt to retrieve build scan ID directly from metadata
-      BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null)
+  if [[ -n "$BUILD_JSON" ]]; then
+    # Get origin job ID if not already available
+    if [[ -z "$ORIGIN_JOB_ID" ]] || [[ "$ORIGIN_JOB_ID" == "null" ]]; then
+      ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) || ORIGIN_JOB_ID=""
+    fi
 
-      # Retrieve build scan URL for annotation
-      BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null)
+    if [[ -n "$ORIGIN_JOB_ID" ]] && [[ "$ORIGIN_JOB_ID" != "null" ]]; then
+      # Get build scan ID if not already available
+      if [[ -z "$BUILD_SCAN_ID" ]] || [[ "$BUILD_SCAN_ID" == "null" ]]; then
+        BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null) || BUILD_SCAN_ID=""
+        BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null) || BUILD_SCAN_URL=""
+      fi
 
       if [[ -n "$BUILD_SCAN_ID" ]] && [[ "$BUILD_SCAN_ID" != "null" ]]; then
         # Validate BUILD_SCAN_ID format to prevent injection attacks
@@ -171,53 +232,6 @@ if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; 
           DEVELOCITY_BASE_URL="${DEVELOCITY_BASE_URL:-https://gradle-enterprise.elastic.co}"
           DEVELOCITY_FAILED_TEST_API_URL="${DEVELOCITY_BASE_URL}/api/tests/build/${BUILD_SCAN_ID}?testOutcomes=failed"
 
-          # Fetch test seed from build scan custom values
-          # Support both DEVELOCITY_API_KEY and DEVELOCITY_API_ACCESS_KEY
-          API_KEY="${DEVELOCITY_API_KEY:-$DEVELOCITY_API_ACCESS_KEY}"
-
-          if [[ -z "$API_KEY" ]]; then
-            echo "Warning: No Develocity API key available (DEVELOCITY_API_KEY or DEVELOCITY_API_ACCESS_KEY)"
-            echo "Test seed retrieval will be skipped"
-          else
-            DEVELOCITY_BUILD_SCAN_API_URL="${DEVELOCITY_BASE_URL}/api/builds/${BUILD_SCAN_ID}?models=gradle-attributes"
-            TESTS_SEED=""
-
-            echo "Fetching test seed from build scan: $BUILD_SCAN_ID"
-            echo "API URL: $DEVELOCITY_BUILD_SCAN_API_URL"
-
-            if BUILD_SCAN_DATA=$(curl --silent --show-error --compressed --request GET \
-              --url "$DEVELOCITY_BUILD_SCAN_API_URL" \
-              --max-time 30 \
-              --header 'accept: application/json' \
-              --header "authorization: Bearer $API_KEY" \
-              --header 'content-type: application/json' 2>&1); then
-
-              # Check if we got valid JSON
-              if echo "$BUILD_SCAN_DATA" | jq empty 2>/dev/null; then
-                # Extract test seed from gradle attributes
-                TESTS_SEED=$(printf '%s\n' "$BUILD_SCAN_DATA" | jq -r '.models.gradleAttributes.model.values[]? | select(.name == "tests.seed") | .value' 2>/dev/null)
-
-                if [[ -z "$TESTS_SEED" ]] || [[ "$TESTS_SEED" == "null" ]]; then
-                  echo "Could not retrieve test seed from build scan"
-                  echo "Debug: Checking available gradle attributes..."
-                  printf '%s\n' "$BUILD_SCAN_DATA" | jq -r '.models.gradleAttributes.model.values[]? | .name' 2>/dev/null || echo "No gradle attributes found"
-                  TESTS_SEED=""
-                else
-                  echo "Retrieved test seed: $TESTS_SEED"
-                  export TESTS_SEED
-                fi
-              else
-                echo "Error: Invalid JSON response from Develocity API"
-                echo "Response preview: ${BUILD_SCAN_DATA:0:200}"
-                TESTS_SEED=""
-              fi
-            else
-              echo "Error: Failed to fetch build scan data from Develocity API"
-              echo "Curl output: ${BUILD_SCAN_DATA:0:200}"
-              TESTS_SEED=""
-            fi
-          fi
-
           # Add random delay to prevent API rate limiting from parallel retries
           sleep $((RANDOM % 5))
 
@@ -227,7 +241,7 @@ if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; 
             --max-time 30 \
             --header 'accept: application/json' \
             --header "authorization: Bearer $DEVELOCITY_API_ACCESS_KEY" \
-            --header 'content-type: application/json' 2>/dev/null | jq --arg testseed "$TESTS_SEED" '. + {testseed: $testseed}' &> .failed-test-history.json; then
+            --header 'content-type: application/json' 2>/dev/null | jq --arg testseed "${TESTS_SEED:-}" '. + {testseed: $testseed}' &> .failed-test-history.json; then
 
             # Set secure file permissions
             chmod 600 .failed-test-history.json

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -12,11 +12,34 @@ import org.elasticsearch.gradle.OS
 
 import java.lang.management.ManagementFactory
 import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 import static org.elasticsearch.gradle.internal.util.CiUtils.safeName
 
 // Resolving this early to avoid issues with the build scan plugin in combination with the configuration cache usage
 def taskNames = gradle.startParameter.taskNames.join(' ')
+
+/**
+ * Executes a buildkite-agent command with timeout and exit code checking.
+ * Failures are logged as warnings but do not fail the build.
+ */
+def runBuildkiteAgent(List<String> args, String description, Closure stdinWriter = null) {
+  try {
+    def process = new ProcessBuilder(['buildkite-agent'] + args).start()
+    if (stdinWriter != null) {
+      process.withWriter { stdinWriter(it) }
+    }
+    def completed = process.waitFor(30, TimeUnit.SECONDS)
+    if (completed == false) {
+      logger.warn("Timeout ${description}")
+      process.destroyForcibly()
+    } else if (process.exitValue() != 0) {
+      logger.warn("Failed ${description}: exit code ${process.exitValue()}")
+    }
+  } catch (Exception e) {
+    logger.warn("Failed ${description}: ${e.message}")
+  }
+}
 
 develocity {
 
@@ -119,20 +142,10 @@ develocity {
         // where we deal with build metadata within the gradle build.
         def jobId = System.getenv('BUILDKITE_JOB_ID')
         if (jobId) {
-          try {
-            def process = new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
-              .start()
-            def completed = process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
-            if (completed == false) {
-              logger.warn("Timeout storing test seed in Buildkite metadata")
-              process.destroyForcibly()
-            } else if (process.exitValue() != 0) {
-              logger.warn("Failed to store test seed in Buildkite metadata: exit code ${process.exitValue()}")
-            }
-          } catch (Exception e) {
-            // Ignore failures - this is best-effort
-            logger.warn("Failed to store test seed in Buildkite metadata: ${e.message}")
-          }
+          runBuildkiteAgent(
+            ['meta-data', 'set', "tests-seed-${jobId}", testSeed],
+            "storing test seed in Buildkite metadata"
+          )
         }
 
         buildFinished { result ->
@@ -141,32 +154,28 @@ develocity {
             ->
             // Attach build scan link as build metadata
             // See: https://buildkite.com/docs/pipelines/build-meta-data
-            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
-              .start()
-              .waitFor()
+            runBuildkiteAgent(
+              ['meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}"],
+              "storing build scan link in Buildkite metadata"
+            )
 
             // Attach build scan ID as build metadata
-            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-id-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanId}")
-              .start()
-              .waitFor()
+            runBuildkiteAgent(
+              ['meta-data', 'set', "build-scan-id-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanId}"],
+              "storing build scan ID in Buildkite metadata"
+            )
 
             // Add a build annotation
             // See: https://buildkite.com/docs/agent/v3/cli-annotate
             def jobRetryLabel = Integer.parseInt(System.getenv('BUILDKITE_RETRY_COUNT') ?: "0") >
               0 ? " (retry #${System.getenv('BUILDKITE_RETRY_COUNT')})" : ""
             def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}${jobRetryLabel}</span> :gradle: ${result.failures ? 'failed' : 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${taskNames}</code></a></div>"""
-            def process = [
-              'buildkite-agent',
-              'annotate',
-              '--context',
-              result.failures ? 'gradle-build-scans-failed' : 'gradle-build-scans',
-              '--append',
-              '--style',
-              result.failures ? 'error' : 'info'
-            ].execute()
-            process.withWriter { it.write(body) }
             // passing the body in as an argument has issues on Windows, so let's use stdin of the process instead
-            process.waitFor()
+            runBuildkiteAgent(
+              ['annotate', '--context', result.failures ? 'gradle-build-scans-failed' : 'gradle-build-scans', '--append', '--style', result.failures ? 'error' : 'info'],
+              "adding build annotation",
+              { it.write(body) }
+            )
           }
         }
       } else {

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -8,38 +8,18 @@
  */
 
 
+import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 
 import java.lang.management.ManagementFactory
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
+import static org.elasticsearch.gradle.internal.util.CiUtils.runBuildkiteAgent
 import static org.elasticsearch.gradle.internal.util.CiUtils.safeName
 
 // Resolving this early to avoid issues with the build scan plugin in combination with the configuration cache usage
 def taskNames = gradle.startParameter.taskNames.join(' ')
-
-/**
- * Executes a buildkite-agent command with timeout and exit code checking.
- * Failures are logged as warnings but do not fail the build.
- */
-def runBuildkiteAgent(List<String> args, String description, Closure stdinWriter = null) {
-  try {
-    def process = new ProcessBuilder(['buildkite-agent'] + args).start()
-    if (stdinWriter != null) {
-      process.withWriter { stdinWriter(it) }
-    }
-    def completed = process.waitFor(30, TimeUnit.SECONDS)
-    if (completed == false) {
-      logger.warn("Timeout ${description}")
-      process.destroyForcibly()
-    } else if (process.exitValue() != 0) {
-      logger.warn("Failed ${description}: exit code ${process.exitValue()}")
-    }
-  } catch (Exception e) {
-    logger.warn("Failed ${description}: ${e.message}")
-  }
-}
 
 develocity {
 
@@ -142,16 +122,16 @@ develocity {
         // where we deal with build metadata within the gradle build.
         def jobId = System.getenv('BUILDKITE_JOB_ID')
         if (jobId) {
+          // testSeed is a Provider<String>, so we need to call .get() to unwrap the value for the List<String> args
           runBuildkiteAgent(
-            ['meta-data', 'set', "tests-seed-${jobId}", testSeed],
+            ['meta-data', 'set', "tests-seed-${jobId}", testSeed.get()],
             "storing test seed in Buildkite metadata"
           )
         }
 
         buildFinished { result ->
 
-          buildScanPublished { scan
-            ->
+          buildScanPublished { scan ->
             // Attach build scan link as build metadata
             // See: https://buildkite.com/docs/pipelines/build-meta-data
             runBuildkiteAgent(

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -122,8 +122,9 @@ develocity {
         // where we deal with build metadata within the gradle build.
         def jobId = System.getenv('BUILDKITE_JOB_ID')
         if (jobId) {
+          // Explicitly convert to String to avoid Groovy/Java array type mismatch
           runBuildkiteAgent(
-            ['meta-data', 'set', "tests-seed-${jobId}", testSeed],
+            ['meta-data', 'set', "tests-seed-${jobId}".toString(), testSeed.toString()],
             "storing test seed in Buildkite metadata"
           )
         }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -120,9 +120,15 @@ develocity {
         def jobId = System.getenv('BUILDKITE_JOB_ID')
         if (jobId) {
           try {
-            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
+            def process = new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
               .start()
-              .waitFor()
+            def completed = process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+            if (completed == false) {
+              logger.warn("Timeout storing test seed in Buildkite metadata")
+              process.destroyForcibly()
+            } else if (process.exitValue() != 0) {
+              logger.warn("Failed to store test seed in Buildkite metadata: exit code ${process.exitValue()}")
+            }
           } catch (Exception e) {
             // Ignore failures - this is best-effort
             logger.warn("Failed to store test seed in Buildkite metadata: ${e.message}")

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -41,6 +41,22 @@ develocity {
     def gitRevision = buildParams.gitRevision
     def testSeed = buildParams.testSeed
 
+    // Store test seed in Buildkite metadata early (outside build scan hooks)
+    // This ensures retries can retrieve the seed even if the original build failed before publishing a scan
+    if (onCI) {
+      def jobId = System.getenv('BUILDKITE_JOB_ID')
+      if (jobId) {
+        try {
+          new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
+            .start()
+            .waitFor()
+        } catch (Exception e) {
+          // Ignore failures - this is best-effort
+          logger.warn("Failed to store test seed in Buildkite metadata: ${e.message}")
+        }
+      }
+    }
+
     background {
       tag OS.current().name()
       tag Architecture.current().name()

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -122,9 +122,8 @@ develocity {
         // where we deal with build metadata within the gradle build.
         def jobId = System.getenv('BUILDKITE_JOB_ID')
         if (jobId) {
-          // testSeed is a Provider<String>, so we need to call .get() to unwrap the value for the List<String> args
           runBuildkiteAgent(
-            ['meta-data', 'set', "tests-seed-${jobId}", testSeed.get()],
+            ['meta-data', 'set', "tests-seed-${jobId}", testSeed],
             "storing test seed in Buildkite metadata"
           )
         }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -9,9 +9,9 @@
 
 
 import org.elasticsearch.gradle.OS
+
 import java.lang.management.ManagementFactory
 import java.time.LocalDateTime
-import org.elasticsearch.gradle.Architecture
 
 import static org.elasticsearch.gradle.internal.util.CiUtils.safeName
 
@@ -40,22 +40,6 @@ develocity {
     def fips = buildParams.inFipsJvm
     def gitRevision = buildParams.gitRevision
     def testSeed = buildParams.testSeed
-
-    // Store test seed in Buildkite metadata early (outside build scan hooks)
-    // This ensures retries can retrieve the seed even if the original build failed before publishing a scan
-    if (onCI) {
-      def jobId = System.getenv('BUILDKITE_JOB_ID')
-      if (jobId) {
-        try {
-          new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
-            .start()
-            .waitFor()
-        } catch (Exception e) {
-          // Ignore failures - this is best-effort
-          logger.warn("Failed to store test seed in Buildkite metadata: ${e.message}")
-        }
-      }
-    }
 
     background {
       tag OS.current().name()
@@ -130,6 +114,21 @@ develocity {
           link 'Source', "https://github.com/${repository}/tree/${gitRevision.get()}"
         }
 
+        // Store test seed in Buildkite metadata so it can be retrieved by retries or other steps in the pipeline
+        // strictly speaking this is not build scan specific, but it's a convenient place and the one place
+        // where we deal with build metadata within the gradle build.
+        def jobId = System.getenv('BUILDKITE_JOB_ID')
+        if (jobId) {
+          try {
+            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "tests-seed-${jobId}", testSeed)
+              .start()
+              .waitFor()
+          } catch (Exception e) {
+            // Ignore failures - this is best-effort
+            logger.warn("Failed to store test seed in Buildkite metadata: ${e.message}")
+          }
+        }
+
         buildFinished { result ->
 
           buildScanPublished { scan
@@ -147,7 +146,8 @@ develocity {
 
             // Add a build annotation
             // See: https://buildkite.com/docs/agent/v3/cli-annotate
-            def jobRetryLabel = Integer.parseInt(System.getenv('BUILDKITE_RETRY_COUNT')?:"0") > 0 ? " (retry #${System.getenv('BUILDKITE_RETRY_COUNT')})" : ""
+            def jobRetryLabel = Integer.parseInt(System.getenv('BUILDKITE_RETRY_COUNT') ?: "0") >
+              0 ? " (retry #${System.getenv('BUILDKITE_RETRY_COUNT')})" : ""
             def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}${jobRetryLabel}</span> :gradle: ${result.failures ? 'failed' : 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${taskNames}</code></a></div>"""
             def process = [
               'buildkite-agent',


### PR DESCRIPTION
Refactor pre-command hooks to retrieve and reuse the test seed from
the original job for ANY retry, not just when SMART_RETRIES is enabled.
This ensures reproducible test failures across all retry scenarios.

The hooks are now structured in two parts:
- Part 1: Test seed retrieval runs for any retry (BUILDKITE_RETRY_COUNT > 0)
- Part 2: Smart retry test filtering only runs when SMART_RETRIES=true

Seed retrieval fails gracefully: if the Develocity API is unavailable
or the build scan doesn't exist, a warning is logged and tests continue
with a new random seed.