### PR TITLE
Unmute DebMetadataTests#test05CheckLintian

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -407,9 +407,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchContextInvalidationIT
   method: testScrollReturns404WhenNodeLeavesCluster
   issue: https://github.com/elastic/elasticsearch/issues/142810
-- class: org.elasticsearch.packaging.test.DebMetadataTests
-  method: test05CheckLintian
-  issue: https://github.com/elastic/elasticsearch/issues/142819
 - class: org.elasticsearch.xpack.search.AsyncSearchTaskTests
   method: testWithFailure
   issue: https://github.com/elastic/elasticsearch/issues/142821


### PR DESCRIPTION
## Summary
- Unmutes `DebMetadataTests#test05CheckLintian` which was muted in 4f373b1d due to a lintian `codeless-jar` warning on `grpc-context-1.78.0.jar`.
- The root cause was resolved by adding a lintian override in c4f91f19.

Closes #142819

Made with [Cursor](https://cursor.com)