### PR TITLE
Remove s3 copy time metric

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -261,12 +261,6 @@ class S3BlobStore implements BlobStore {
                     .httpRequestTimeInMillisHistogram()
                     .record(TimeUnit.NANOSECONDS.toMillis(totalTimeNanoseconds), attributes);
             }
-
-            if (operation == Operation.COPY_OBJECT || operation == Operation.COPY_MULTIPART_OBJECT) {
-                s3RepositoriesMetrics.common()
-                    .copyRequestTimeInSecondsHistogram()
-                    .record(TimeUnit.NANOSECONDS.toSeconds(totalTimeNanoseconds), attributes);
-            }
         }
 
         @Override

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -443,9 +443,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/143023
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.S3RepositoryAnalysisRestIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/143091
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesMetrics.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesMetrics.java
@@ -11,7 +11,6 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.blobstore.OperationPurpose;
-import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -34,8 +33,7 @@ public record RepositoriesMetrics(
     LongHistogram httpRequestTimeInMillisHistogram,
     LongCounter inputStreamRetryStartedCounter,
     LongCounter inputStreamRetryCompletedCounter,
-    LongHistogram inputStreamRetryHistogram,
-    DoubleHistogram copyRequestTimeInSecondsHistogram
+    LongHistogram inputStreamRetryHistogram
 ) {
 
     public static final RepositoriesMetrics NOOP = new RepositoriesMetrics(MeterRegistry.NOOP);
@@ -118,12 +116,6 @@ public record RepositoriesMetrics(
      * Exposed via {@link #httpRequestTimeInMillisHistogram()}
      */
     public static final String HTTP_REQUEST_TIME_IN_MILLIS_HISTOGRAM = "es.repositories.requests.http_request_time.histogram";
-    /**
-     * Duration of copy operation;
-     *
-     * Exposed via {@link #copyRequestTimeInSecondsHistogram()}
-     */
-    public static final String COPY_REQUEST_TIME_IN_SECONDS_HISTOGRAM = "es.repositories.requests.copy_request_time.histogram";
 
     public RepositoriesMetrics(MeterRegistry meterRegistry) {
         this(
@@ -151,8 +143,7 @@ public record RepositoriesMetrics(
                 METRIC_INPUT_STREAM_RETRY_ATTEMPTS_HISTOGRAM,
                 "retrying input stream retry attempts histogram",
                 "unit"
-            ),
-            meterRegistry.registerDoubleHistogram(COPY_REQUEST_TIME_IN_SECONDS_HISTOGRAM, "Duration for copy requests", "s")
+            )
         );
     }
 


### PR DESCRIPTION
The test was failing due to not registering the recently added s3 copy time metric to skip validation for repo attributes, but I realized we don't actually need it, we can just use the http request time metric and filter by operation and purpose

Closes #143091
Closes #143100
Closes #143099