### PR TITLE
IntelliJ Debug config change

### DIFF
--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Elasticsearch" type="Remote">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
-    <option name="SERVER_MODE" value="true" />
+    <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5007" />
-    <option name="AUTO_RESTART" value="true" />
+    <option name="AUTO_RESTART" value="false" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="5007" />
       <option name="LOCAL" value="false" />

--- a/.idea/runConfigurations/Debug_Elasticsearch__node_2_.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch__node_2_.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Elasticsearch (node 2)" type="Remote">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
-    <option name="SERVER_MODE" value="true" />
+    <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5008" />
-    <option name="AUTO_RESTART" value="true" />
+    <option name="AUTO_RESTART" value="false" />
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Debug_Elasticsearch__node_3_.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch__node_3_.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Elasticsearch (node 3)" type="Remote">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
-    <option name="SERVER_MODE" value="true" />
+    <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5009" />
-    <option name="AUTO_RESTART" value="true" />
+    <option name="AUTO_RESTART" value="false" />
     <method v="2" />
   </configuration>
 </component>

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -68,7 +68,7 @@ public interface TestClustersAware extends Task {
         for (ElasticsearchCluster cluster : getClusters()) {
             for (ElasticsearchNode node : cluster.getNodes()) {
                 getLogger().lifecycle("Running elasticsearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
-                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
+                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:" + debugPort);
                 debugPort += 1;
             }
         }


### PR DESCRIPTION
- Allow ES to start in debug mode via the `--debug-jvm` flag without having to run the `Debug Elasticsearch` in debug mode prior to that. The workflow of running ES in debug mode, and _"optionally"_ attaching the debugger, is likely more frequent across teams.
- Right now, ES will fail to start unless the `Debug Elasticsearch` is being debugged and listening, which is not terrible at all! It's just we can skip that altogether. Of course, you now have a short window to debug stuff that happens during the brief start up phase, but that scenario too, I suspect, is a lot less frequent compared to the need to debug things happen during runtime.