### PR TITLE
[9.3] Guard GpuStatsAction calls by transport version check (#142934)

### DIFF
--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUFeatures.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUFeatures.java
@@ -15,15 +15,15 @@ import java.util.Set;
 public class GPUFeatures implements FeatureSpecification {
 
     public static final NodeFeature VECTORS_INDEXING_USE_GPU = new NodeFeature("vectors.indexing.use_gpu", true);
-    public static final NodeFeature VECTORS_INDEXING_GPU_MONITORING = new NodeFeature("vectors.indexing.gpu_monitoring", true);
+    public static final NodeFeature VECTORS_INDEXING_GPU_MONITORING = new NodeFeature("vectors.indexing.gpu_monitoring");
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of();
+        return Set.of(VECTORS_INDEXING_GPU_MONITORING);
     }
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(VECTORS_INDEXING_USE_GPU, VECTORS_INDEXING_GPU_MONITORING);
+        return Set.of(VECTORS_INDEXING_USE_GPU);
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   javaRestTestImplementation project(path: xpackModule('snapshot-repo-test-kit'))
   javaRestTestImplementation project(path: xpackModule('ent-search'))
   javaRestTestImplementation project(path: xpackModule('inference'))
+  javaRestTestImplementation project(path: xpackModule('gpu'))
   javaRestTestImplementation project(':test:external-modules:test-multi-project')
 }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -100,6 +100,7 @@ import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.core.security.authc.TokenMetadata;
 import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.gpu.GPUPlugin;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.inference.registry.ClearInferenceEndpointCacheAction;
 import org.elasticsearch.xpack.inference.registry.ModelRegistryMetadata;
@@ -175,7 +176,9 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             EsqlCorePlugin.class,
             EsqlPlugin.class,
             // basic multi-project functionality
-            TestOnlyMultiProjectPlugin.class
+            TestOnlyMultiProjectPlugin.class,
+            // GPU plugin needed for node features published by DEFAULT distribution nodes
+            GPUPlugin.class
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Guard GpuStatsAction calls by transport version check (#142934)