### PR TITLE
[9.2] Fixing typo in oracle linux name (#143004)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -12,7 +12,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
-              - orcalelinux-10
+              - oraclelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -13,7 +13,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9
-              - orcalelinux-10
+              - oraclelinux-10
               - sles-15
               - ubuntu-2204
               - ubuntu-2404


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fixing typo in oracle linux name (#143004)