### PR TITLE
Fix off-by-one error in HyperLogLogPlusPlus LinearCounting

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -350,9 +350,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.FieldExtractorIT
   method: testTsIndexConflictingTypes {NONE}
   issue: https://github.com/elastic/elasticsearch/issues/142477
-- class: org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests
-  method: testOrderByCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/142484
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:match-function.TestMatchWithReplace}
   issue: https://github.com/elastic/elasticsearch/issues/142501

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -490,7 +490,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
 
         long maxOrd() {
-            return cells.size() - 1;
+            return cells.size();
         }
 
         @Override


### PR DESCRIPTION
LinearCounting.maxOrd() was returning an inclusive upper bound, rather 
than an exclusive.  This could cause CardinalityAggregator to mistakenly 
create an empty bucket instead of correctly reporting the cardinality if the 
number of buckets happened to coincide exactly with an oversized bucket 
allocation.

Fixes #142484