### PR TITLE
[9.3] Fix NPE when querying pattern_text field

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldType.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldType.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
@@ -119,6 +120,9 @@ public class PatternTextFieldType extends TextFamilyFieldType {
 
     @Override
     public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+        if (disableTemplating) {
+            return storedFieldValueFetcher();
+        }
         return new ValueFetcher() {
             BinaryDocValues docValues;
 
@@ -133,7 +137,7 @@ public class PatternTextFieldType extends TextFamilyFieldType {
 
             @Override
             public List<Object> fetchValues(Source source, int doc, List<Object> ignoredValues) throws IOException {
-                if (false == docValues.advanceExact(doc)) {
+                if (docValues == null || false == docValues.advanceExact(doc)) {
                     return List.of();
                 }
                 return List.of(docValues.binaryValue().utf8ToString());
@@ -141,7 +145,39 @@ public class PatternTextFieldType extends TextFamilyFieldType {
 
             @Override
             public StoredFieldsSpec storedFieldsSpec() {
-                // PatternedTextCompositeValues may require a stored field, but it handles loading this field internally.
+                // PatternTextCompositeValues may require a stored field, but it handles loading this field internally.
+                return StoredFieldsSpec.NO_REQUIREMENTS;
+            }
+        };
+    }
+
+    private ValueFetcher storedFieldValueFetcher() {
+        var loader = StoredFieldLoader.create(false, Set.of(storedNamed()));
+        return new ValueFetcher() {
+            LeafStoredFieldLoader leafLoader;
+
+            @Override
+            public void setNextReader(LeafReaderContext context) {
+                try {
+                    this.leafLoader = loader.getLoader(context, null);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+
+            @Override
+            public List<Object> fetchValues(Source source, int doc, List<Object> ignoredValues) throws IOException {
+                leafLoader.advanceTo(doc);
+                var storedFields = leafLoader.storedFields();
+                var values = storedFields.get(storedNamed());
+                if (values == null || values.isEmpty()) {
+                    return List.of();
+                }
+                return List.of(((BytesRef) values.getFirst()).utf8ToString());
+            }
+
+            @Override
+            public StoredFieldsSpec storedFieldsSpec() {
                 return StoredFieldsSpec.NO_REQUIREMENTS;
             }
         };
@@ -174,7 +210,11 @@ public class PatternTextFieldType extends TextFamilyFieldType {
             return docId -> {
                 leafLoader.advanceTo(docId);
                 var storedFields = leafLoader.storedFields();
-                return storedFields.get(name);
+                var values = storedFields.get(name);
+                if (values == null || values.isEmpty()) {
+                    return List.of();
+                }
+                return List.of(((BytesRef) values.getFirst()).utf8ToString());
             };
         };
     }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextIndexFieldData.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextIndexFieldData.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.logsdb.patterntext;
 
-import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BytesRef;
@@ -16,6 +16,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.KeywordDocValuesField;
@@ -28,6 +29,7 @@ import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Set;
 
 public class PatternTextIndexFieldData implements IndexFieldData<LeafFieldData> {
 
@@ -71,8 +73,12 @@ public class PatternTextIndexFieldData implements IndexFieldData<LeafFieldData> 
 
     @Override
     public LeafFieldData loadDirect(LeafReaderContext context) throws IOException {
-        LeafReader leafReader = context.reader();
-        var values = PatternTextCompositeValues.from(leafReader, fieldType);
+        final BinaryDocValues values;
+        if (fieldType.disableTemplating()) {
+            values = loadStoredFieldDocValues(context);
+        } else {
+            values = PatternTextCompositeValues.from(context.reader(), fieldType);
+        }
         return new LeafFieldData() {
 
             final ToScriptFieldFactory<SortedBinaryDocValues> factory = KeywordDocValuesField::new;
@@ -87,7 +93,7 @@ public class PatternTextIndexFieldData implements IndexFieldData<LeafFieldData> 
                 return new SortedBinaryDocValues() {
                     @Override
                     public boolean advanceExact(int doc) throws IOException {
-                        return values.advanceExact(doc);
+                        return values != null && values.advanceExact(doc);
                     }
 
                     @Override
@@ -105,6 +111,52 @@ public class PatternTextIndexFieldData implements IndexFieldData<LeafFieldData> 
             @Override
             public long ramBytesUsed() {
                 return 1L;
+            }
+        };
+    }
+
+    private BinaryDocValues loadStoredFieldDocValues(LeafReaderContext context) throws IOException {
+        var loader = StoredFieldLoader.create(false, Set.of(fieldType.storedNamed()));
+        var leafLoader = loader.getLoader(context, null);
+        return new BinaryDocValues() {
+            BytesRef currentValue;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                leafLoader.advanceTo(target);
+                var storedFields = leafLoader.storedFields();
+                var fieldValues = storedFields.get(fieldType.storedNamed());
+                if (fieldValues != null && fieldValues.isEmpty() == false) {
+                    currentValue = (BytesRef) fieldValues.getFirst();
+                    return true;
+                }
+                currentValue = null;
+                return false;
+            }
+
+            @Override
+            public BytesRef binaryValue() {
+                return currentValue;
+            }
+
+            @Override
+            public int docID() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int nextDoc() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int advance(int target) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long cost() {
+                return 0;
             }
         };
     }

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperTests.java
@@ -11,8 +11,13 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.queries.intervals.IntervalQuery;
+import org.apache.lucene.queries.intervals.IntervalsSource;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
@@ -21,6 +26,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -464,6 +470,226 @@ public class PatternTextFieldMapperTests extends MapperTestCase {
     @Override
     public void testSyntheticSourceKeepArrays() {
         // This mapper does not allow arrays
+    }
+
+    public void testIntervalsQueryWithDisabledTemplating() throws IOException {
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "pattern_text").field("disable_templating", true))
+        );
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            LuceneDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", "the quick brown fox 1"))).rootDoc();
+            iw.addDocument(doc);
+            iw.close();
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(reader));
+                PatternTextFieldType ft = (PatternTextFieldType) mapperService.fieldType("field");
+                IntervalsSource intervalsSource = ft.termIntervals(new BytesRef("brown"), context);
+                Query query = new IntervalQuery("field", intervalsSource);
+                TopDocs docs = context.searcher().search(query, 1);
+                assertThat(docs.totalHits.value(), equalTo(1L));
+                assertThat(docs.totalHits.relation(), equalTo(TotalHits.Relation.EQUAL_TO));
+            }
+        }
+    }
+
+    public void testValueFetcherWithMissingFieldSegment() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "pattern_text")));
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> {})).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                SearchExecutionContext ctx = createSearchExecutionContext(mapperService, newSearcher(reader));
+                ValueFetcher fetcher = ft.valueFetcher(ctx, null);
+
+                fetcher.setNextReader(reader.leaves().get(0));
+                List<Object> values = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(1, values.size());
+                assertEquals("abc 123", values.get(0));
+
+                fetcher.setNextReader(reader.leaves().get(1));
+                List<Object> emptyValues = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(0, emptyValues.size());
+            }
+        }
+    }
+
+    public void testFieldDataWithMissingFieldSegment() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "pattern_text")));
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> {})).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                var fieldDataContext = new FieldDataContext("", null, () -> null, Set::of, MappedFieldType.FielddataOperation.SCRIPT);
+                var fieldData = ft.fielddataBuilder(fieldDataContext)
+                    .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
+
+                var leafData0 = fieldData.load(reader.leaves().get(0));
+                var bytesValues0 = leafData0.getBytesValues();
+                assertTrue(bytesValues0.advanceExact(0));
+                assertEquals("abc 123", bytesValues0.nextValue().utf8ToString());
+
+                var leafData1 = fieldData.load(reader.leaves().get(1));
+                var bytesValues1 = leafData1.getBytesValues();
+                assertFalse(bytesValues1.advanceExact(0));
+            }
+        }
+    }
+
+    public void testValueFetcherWithDisabledTemplating() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder().put("index.mapping.pattern_text.disable_templating", true).build(),
+            fieldMapping(b -> b.field("type", "pattern_text"))
+        );
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> b.field("field", "foo 12"))).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                SearchExecutionContext ctx = createSearchExecutionContext(mapperService, newSearcher(reader));
+                ValueFetcher fetcher = ft.valueFetcher(ctx, null);
+
+                fetcher.setNextReader(reader.leaves().get(0));
+                List<Object> values0 = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(1, values0.size());
+                assertEquals("abc 123", values0.get(0));
+
+                fetcher.setNextReader(reader.leaves().get(1));
+                List<Object> values1 = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(1, values1.size());
+                assertEquals("foo 12", values1.get(0));
+            }
+        }
+    }
+
+    public void testValueFetcherWithDisabledTemplatingAndMissingFieldSegment() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder().put("index.mapping.pattern_text.disable_templating", true).build(),
+            fieldMapping(b -> b.field("type", "pattern_text"))
+        );
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> {})).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                SearchExecutionContext ctx = createSearchExecutionContext(mapperService, newSearcher(reader));
+                ValueFetcher fetcher = ft.valueFetcher(ctx, null);
+
+                fetcher.setNextReader(reader.leaves().get(0));
+                List<Object> values = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(1, values.size());
+                assertEquals("abc 123", values.get(0));
+
+                fetcher.setNextReader(reader.leaves().get(1));
+                List<Object> emptyValues = fetcher.fetchValues(null, 0, new ArrayList<>());
+                assertEquals(0, emptyValues.size());
+            }
+        }
+    }
+
+    public void testFieldDataWithDisabledTemplating() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder().put("index.mapping.pattern_text.disable_templating", true).build(),
+            fieldMapping(b -> b.field("type", "pattern_text"))
+        );
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> {})).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                var fieldDataContext = new FieldDataContext("", null, () -> null, Set::of, MappedFieldType.FielddataOperation.SCRIPT);
+                var fieldData = ft.fielddataBuilder(fieldDataContext)
+                    .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
+
+                var leafData0 = fieldData.load(reader.leaves().get(0));
+                var bytesValues0 = leafData0.getBytesValues();
+                assertTrue(bytesValues0.advanceExact(0));
+                assertEquals("abc 123", bytesValues0.nextValue().utf8ToString());
+
+                var leafData1 = fieldData.load(reader.leaves().get(1));
+                var bytesValues1 = leafData1.getBytesValues();
+                assertFalse(bytesValues1.advanceExact(0));
+            }
+        }
+    }
+
+    public void testFieldDataWithDisabledTemplatingAllDocsHaveField() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder().put("index.mapping.pattern_text.disable_templating", true).build(),
+            fieldMapping(b -> b.field("type", "pattern_text"))
+        );
+        MappedFieldType ft = mapperService.fieldType("field");
+
+        try (Directory dir = newDirectory()) {
+            indexDocPerSegment(
+                dir,
+                mapperService.documentMapper().parse(source(b -> b.field("field", "abc 123"))).rootDoc(),
+                mapperService.documentMapper().parse(source(b -> b.field("field", "foo 12"))).rootDoc()
+            );
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(2, reader.leaves().size());
+
+                var fieldDataContext = new FieldDataContext("", null, () -> null, Set::of, MappedFieldType.FielddataOperation.SCRIPT);
+                var fieldData = ft.fielddataBuilder(fieldDataContext)
+                    .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
+
+                var leafData0 = fieldData.load(reader.leaves().get(0));
+                var bytesValues0 = leafData0.getBytesValues();
+                assertTrue(bytesValues0.advanceExact(0));
+                assertEquals("abc 123", bytesValues0.nextValue().utf8ToString());
+
+                var leafData1 = fieldData.load(reader.leaves().get(1));
+                var bytesValues1 = leafData1.getBytesValues();
+                assertTrue(bytesValues1.advanceExact(0));
+                assertEquals("foo 12", bytesValues1.nextValue().utf8ToString());
+            }
+        }
+    }
+
+    /**
+     * Writes each document into its own segment with no merging, guaranteeing one leaf per doc.
+     */
+    private static void indexDocPerSegment(Directory dir, LuceneDocument... docs) throws IOException {
+        IndexWriterConfig iwc = new IndexWriterConfig();
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        try (IndexWriter iw = new IndexWriter(dir, iwc)) {
+            for (LuceneDocument doc : docs) {
+                iw.addDocument(doc);
+                iw.commit();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Targeted backport of #142767 to 9.3. Fixes three bugs:

1. Empty segment NPE when PatternTextCompositeValues.from() returns null in valueFetcher and PatternTextIndexFieldData.
2. Disabled templating NPE where valueFetcher and PatternTextIndexFieldData called CompositeValues.from() which always returns null without template_id values.
3. BytesRef hex output in getValueFetcherProvider where SourceIntervalsSource received raw BytesRef instead of String, causing intervals queries to never match.

#142767 was built on top of the changes from #140191, #140939, and #142051. Since these were not backported, a single backport of #142767 onto 9.3 would be difficult. For this reason, I chose to make the same bug fixes from #142767 directly on 9.3 (without the other refactors).