### PR TITLE
[9.3] [CI] Update future release endpoint (#141991)

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -16,7 +16,7 @@ echo "Selecting the most recent build from branch [$BUILDKITE_BRANCH]."
 # Select the most recent build from the current branch.
 # We collect snapshots, order by date, then collect BCs, order by date, and concat them; then we select the last.
 # So if we have one (or more) BC, we will always prefer to use that. Otherwise we will use the latest snapshot.
-MANIFEST_URL="$(curl -s https://artifacts.elastic.co/releases/TfEVhiaBGqR64ie0g0r0uUwNAbEQMu1Z/future-releases/stack.json |
+MANIFEST_URL="$(curl -s https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json |
 jq ".releases[] |
 select(.branch == \"$BUILDKITE_BRANCH\") |
 select(.active_release == true) |


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Update future release endpoint (#141991)](https://github.com/elastic/elasticsearch/pull/141991)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)