### PR TITLE
handle CPS remote project exclusions

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ResolvedIndexExpressions.java
+++ b/server/src/main/java/org/elasticsearch/action/ResolvedIndexExpressions.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ResolvedIndexExpression.LocalExpressions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.regex.Regex;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -109,6 +110,20 @@ public record ResolvedIndexExpressions(List<ResolvedIndexExpression> expressions
                         continue;
                     }
                     localExpressions.removeAll(expressionsToExclude);
+                }
+            }
+        }
+
+        public void excludeRemoteExpressions(String expressionToExclude, String original, Set<String> remoteExpressions) {
+            outer: for (var expression : expressions) {
+                var iter = expression.remoteExpressions().iterator();
+                while (iter.hasNext()) {
+                    if (Regex.simpleMatch(expressionToExclude, iter.next())) {
+                        iter.remove();
+                    } else {
+                        expressions.add(new ResolvedIndexExpression(original, LocalExpressions.NONE, remoteExpressions));
+                        break outer;
+                    }
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 import org.elasticsearch.search.crossproject.CrossProjectIndexExpressionsRewriter;
 import org.elasticsearch.search.crossproject.TargetProjects;
+import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.util.HashSet;
 import java.util.List;
@@ -94,7 +95,7 @@ public class IndexAbstractionResolver {
             if (localIndexExpression == null) {
                 // (there can be an exclusion without any local index expressions)
                 // nothing to resolve locally so skip resolve abstraction call
-                resolvedExpressionsBuilder.addRemoteExpressions(originalIndexExpression, indexRewriteResult.remoteExpressions());
+                handleRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, indexRewriteResult.remoteExpressions());
                 continue;
             }
 
@@ -177,14 +178,14 @@ public class IndexAbstractionResolver {
                     }
                     resolvedExpressionsBuilder.addExpressions(originalIndexExpression, new HashSet<>(), SUCCESS, remoteExpressions);
                 } else {
-                    maybeAddWithRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
+                    handleRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
                 }
             } else {
                 if (minus) {
                     resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
                     // Exclusion from local indices is done by excludeFromLocalExpressions.
                     // No need to add itself unless it has remote expressions.
-                    maybeAddWithRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
+                    handleRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
                 } else {
                     resolvedExpressionsBuilder.addExpressions(originalIndexExpression, resolvedIndices, SUCCESS, remoteExpressions);
                 }
@@ -194,7 +195,7 @@ public class IndexAbstractionResolver {
             resolveSelectorsAndCollect(indexAbstraction, selectorString, indicesOptions, resolvedIndices, projectMetadata);
             if (minus) {
                 resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
-                maybeAddWithRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
+                handleRemoteExpressions(resolvedExpressionsBuilder, originalIndexExpression, remoteExpressions);
             } else {
                 final boolean authorized = isAuthorized.test(indexAbstraction, selector);
                 if (authorized) {
@@ -231,13 +232,30 @@ public class IndexAbstractionResolver {
         }
     }
 
-    private static void maybeAddWithRemoteExpressions(
+    private static void handleRemoteExpressions(
         ResolvedIndexExpressions.Builder resolvedExpressionsBuilder,
         String originalIndexExpression,
         Set<String> remoteExpressions
     ) {
         if (false == remoteExpressions.isEmpty()) {
-            resolvedExpressionsBuilder.addRemoteExpressions(originalIndexExpression, remoteExpressions);
+            if (originalIndexExpression.charAt(0) == '-') {
+                resolvedExpressionsBuilder.excludeRemoteExpressions(
+                    originalIndexExpression.substring(1),
+                    originalIndexExpression,
+                    remoteExpressions
+                );
+            } else {
+                var split = RemoteClusterAware.splitIndexName(originalIndexExpression);
+                if (split[1].charAt(0) == '-') {
+                    resolvedExpressionsBuilder.excludeRemoteExpressions(
+                        split[0] + ":" + split[1].substring(1),
+                        originalIndexExpression,
+                        remoteExpressions
+                    );
+                } else {
+                    resolvedExpressionsBuilder.addRemoteExpressions(originalIndexExpression, remoteExpressions);
+                }
+            }
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -3476,7 +3476,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         when(crossProjectModeDecider.resolvesCrossProject(any(IndicesRequest.Replaceable.class))).thenReturn(true);
 
         final var excludedProject = randomFrom("P1", "P2", "P3");
-        final var excludedIndex = randomFrom("*", "foo*", "foo");
+        final var excludedIndex = randomFrom("foo*", "foo");
         final String excludeExpression = randomBoolean()
             ? "-" + excludedProject + ":" + excludedIndex
             : excludedProject + ":-" + excludedIndex;
@@ -3513,7 +3513,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         when(crossProjectModeDecider.resolvesCrossProject(any(IndicesRequest.Replaceable.class))).thenReturn(true);
 
         final var excludedProject = "P*";
-        final var excludedIndex = randomFrom("*", "foo*", "foo");
+        final var excludedIndex = randomFrom("foo*", "foo");
         final String excludeExpression = randomBoolean()
             ? "-" + excludedProject + ":" + excludedIndex
             : excludedProject + ":-" + excludedIndex;


### PR DESCRIPTION
The issue with remote project exclusion seems to be that the origin project delegates all handling of remote exclusion expressions to the remote, but certain expressions need to be handled locally.

In particular, an expression such as `*:logs,-linked:logs` always fails, because the origin project expects successful resolution for `linked:logs` even though it's excluded.

Furthermore, there are a few edge cases (e.g. `*:shared-index-1,*:-*`) that result in pointless queries such as `linked_project:shared-index-1,-linked_project:*` being sent to linked projects, which throws an exception [here](https://github.com/elastic/elasticsearch/blob/f4d969db0e84278e147825ba8ea8dfe45b3a6430/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java#L219-L223)

As a first draft at resolving this, I've added `excludeRemoteExpression`, which removes any matching remote expressions from the previously expanded local expressions, such that when `CrossProjectIndexResolutionValidator` validates `*:logs,-linked:logs`, it no longer expects a remote result for `linked:logs`