### PR TITLE
ESQL: Fix incorrect error message for double division overflow

### DIFF
--- a/docs/changelog/138798.yaml
+++ b/docs/changelog/138798.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 138798
+summary: Fix incorrect error message for double division overflow in ESQL
+type: bug

--- a/docs/changelog/138798.yaml
+++ b/docs/changelog/138798.yaml
@@ -1,5 +1,0 @@
-area: ES|QL
-issues: []
-pr: 138798
-summary: Fix incorrect error message for double division overflow in ESQL
-type: bug

--- a/docs/changelog/143139.yaml
+++ b/docs/changelog/143139.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 138798
+summary: Fix incorrect error message for double division overflow in ESQL
+type: bug

--- a/docs/changelog/143139.yaml
+++ b/docs/changelog/143139.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
-pr: 138798
+pr: 143139
 summary: Fix incorrect error message for double division overflow in ESQL
 type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -1871,3 +1871,15 @@ emp_no:integer | salary:integer | salary_change:double | cs1:integer
 10003          | 61805          | [12.82, 14.68]       | 61805
 // end::copy_sign-result[]
 ;
+
+# division overflow positive
+ROW x = 1e308 / 0.1
+----
+null
+;
+
+# division overflow negative
+ROW x = -1e308 / 0.1
+----
+null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -1873,22 +1873,24 @@ emp_no:integer | salary:integer | salary_change:double | cs1:integer
 ;
 
 divDoubleOverflowPositive
+required_capability: fn_div_overflow
 
 row x = 1e308 / 0.1 | keep x;
 
 warning:Line 1:13: evaluation of [1e308 / 0.1] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:13: java.lang.ArithmeticException: double overflow
+warning:Line 1:13: java.lang.ArithmeticException: not a finite double number: Infinity
 
 x:double
 null
 ;
 
 divDoubleOverflowNegative
+required_capability: fn_div_overflow
 
 row x = -1e308 / 0.1 | keep x;
 
 warning:Line 1:14: evaluation of [-1e308 / 0.1] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:14: java.lang.ArithmeticException: double overflow
+warning:Line 1:14: java.lang.ArithmeticException: not a finite double number: -Infinity
 
 x:double
 null

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -1872,14 +1872,24 @@ emp_no:integer | salary:integer | salary_change:double | cs1:integer
 // end::copy_sign-result[]
 ;
 
-# division overflow positive
-ROW x = 1e308 / 0.1
-----
+divDoubleOverflowPositive
+
+row x = 1e308 / 0.1 | keep x;
+
+warning:Line 1:13: evaluation of [1e308 / 0.1] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.ArithmeticException: double overflow
+
+x:double
 null
 ;
 
-# division overflow negative
-ROW x = -1e308 / 0.1
-----
+divDoubleOverflowNegative
+
+row x = -1e308 / 0.1 | keep x;
+
+warning:Line 1:14: evaluation of [-1e308 / 0.1] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:14: java.lang.ArithmeticException: double overflow
+
+x:double
 null
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -232,6 +232,11 @@ public class EsqlCapabilities {
         FN_HYPOT,
 
         /**
+         * Handle double division overflow by returning null and emitting warning.
+         */
+        FN_DIV_OVERFLOW,
+
+        /**
          * Support for {@code MV_APPEND} function. #107001
          */
         FN_MV_APPEND,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -123,10 +123,20 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
 
     @Evaluator(extraName = "Doubles", warnExceptions = { ArithmeticException.class })
     static double processDoubles(double lhs, double rhs) {
-        double value = lhs / rhs;
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
+        if (rhs == 0d) {
             throw new ArithmeticException("/ by zero");
         }
+
+        double value = lhs / rhs;
+
+        if (Double.isInfinite(value)) {
+            throw new ArithmeticException("double overflow");
+        }
+
+        if (Double.isNaN(value)) {
+            throw new ArithmeticException("invalid floating point operation");
+        }
+
         return value;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -129,6 +129,7 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
 
         double value = lhs / rhs;
 
+<<<<<<< Updated upstream
         if (Double.isInfinite(value)) {
             throw new ArithmeticException("double overflow");
         }
@@ -137,6 +138,12 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
             throw new ArithmeticException("invalid floating point operation");
         }
 
+=======
+        if (Double.isFinite(value) == false) {
+            throw new ArithmeticException("double overflow");
+        }
+
+>>>>>>> Stashed changes
         return value;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -129,21 +129,10 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
 
         double value = lhs / rhs;
 
-<<<<<<< Updated upstream
-        if (Double.isInfinite(value)) {
-            throw new ArithmeticException("double overflow");
-        }
-
-        if (Double.isNaN(value)) {
-            throw new ArithmeticException("invalid floating point operation");
-        }
-
-=======
         if (Double.isFinite(value) == false) {
             throw new ArithmeticException("double overflow");
         }
 
->>>>>>> Stashed changes
         return value;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -127,12 +127,6 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
             throw new ArithmeticException("/ by zero");
         }
 
-        double value = lhs / rhs;
-
-        if (Double.isFinite(value) == false) {
-            throw new ArithmeticException("double overflow");
-        }
-
-        return value;
+        return NumericUtils.asFiniteNumber(lhs / rhs);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -223,7 +223,7 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                     DataType.DOUBLE,
                     equalTo(null)
                 ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                .withWarning("Line 1:1: java.lang.ArithmeticException: double overflow")
+                .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: Infinity")
             )
         );
 
@@ -239,7 +239,7 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                     DataType.DOUBLE,
                     equalTo(null)
                 ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                .withWarning("Line 1:1: java.lang.ArithmeticException: double overflow")
+                .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: -Infinity")
             )
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -223,7 +223,7 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                     DataType.DOUBLE,
                     equalTo(null)
                 ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: Infinity")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: Infinity")
             )
         );
 
@@ -239,7 +239,7 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                     DataType.DOUBLE,
                     equalTo(null)
                 ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: -Infinity")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: not a finite double number: -Infinity")
             )
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -239,4 +239,20 @@ public class DivTests extends AbstractScalarFunctionTestCase {
         }
         return result;
     }
+
+    public void testDoubleOverflowPositive() {
+        ArithmeticException e = expectThrows(
+            ArithmeticException.class,
+            () -> Div.processDoubles(1e308, 0.1)
+        );
+        assertEquals("double overflow", e.getMessage());
+    }
+
+    public void testDoubleOverflowNegative() {
+        ArithmeticException e = expectThrows(
+            ArithmeticException.class,
+            () -> Div.processDoubles(-1e308, 0.1)
+        );
+        assertEquals("double overflow", e.getMessage());
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DivTests.java
@@ -211,6 +211,38 @@ public class DivTests extends AbstractScalarFunctionTestCase {
                 .withWarning("Line 1:1: java.lang.ArithmeticException: / by zero");
         }));
 
+        suppliers.add(
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(1e308, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(0.1, DataType.DOUBLE, "rhs")
+                    ),
+                    "DivDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                .withWarning("Line 1:1: java.lang.ArithmeticException: double overflow")
+            )
+        );
+
+        suppliers.add(
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(-1e308, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(0.1, DataType.DOUBLE, "rhs")
+                    ),
+                    "DivDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                .withWarning("Line 1:1: java.lang.ArithmeticException: double overflow")
+            )
+        );
+
         suppliers = errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers), DivTests::divErrorMessageString);
 
         // Cannot use parameterSuppliersFromTypedDataWithDefaultChecks as error messages are non-trivial
@@ -238,21 +270,5 @@ public class DivTests extends AbstractScalarFunctionTestCase {
             result.add(left.get(i) / right.get(i));
         }
         return result;
-    }
-
-    public void testDoubleOverflowPositive() {
-        ArithmeticException e = expectThrows(
-            ArithmeticException.class,
-            () -> Div.processDoubles(1e308, 0.1)
-        );
-        assertEquals("double overflow", e.getMessage());
-    }
-
-    public void testDoubleOverflowNegative() {
-        ArithmeticException e = expectThrows(
-            ArithmeticException.class,
-            () -> Div.processDoubles(-1e308, 0.1)
-        );
-        assertEquals("double overflow", e.getMessage());
     }
 }


### PR DESCRIPTION
## ESQL: Fix incorrect error message for double division overflow

### Problem

When dividing large double values, overflow can occur and produce `Infinity`. For example:

ROW x = 1e308 / 0.1

This correctly returns `null`, but the warning message currently reports:

java.lang.ArithmeticException: / by zero

This is misleading because the denominator is not zero. The actual issue is floating-point overflow (the result exceeds Double.MAX_VALUE).

### Root Cause

In Div.processDoubles, both NaN and Infinity results were treated as divide-by-zero and mapped to the same error message ("/ by zero"). This incorrectly classifies overflow scenarios.

### Changes

- Explicitly check rhs == 0d to detect true divide-by-zero
- Detect overflow using Double.isInfinite
- Detect invalid floating-point results using Double.isNaN
- Emit accurate error messages:
  - / by zero
  - double overflow
  - invalid floating point operation

### Impact

- Null-on-error semantics remain unchanged
- Integer division behavior is unaffected
- Only error classification is corrected

This improves accuracy and clarity of error reporting without changing query results.