### PR TITLE
[ES|QL] Support integer type in the second parameter of FIRST/LAST aggs.

### DIFF
--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -1023,7 +1023,7 @@ tasks.named('stringTemplates').configure {
   }
 
   generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-ValueByTimestampAggregator.java.st")
-  generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st", true, false, "All")
+  generateTimestampAggregatorClasses("src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st", true, true, "All")
 
   File rateAggregatorInputFile = file("src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st")
   template {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,41 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "BYTES_REF_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "BYTES_REF_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllFirstBytesRefByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_first_bytesref_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntBytesRefState initSingle(DriverContext driverContext) {
+        return new AllIntBytesRefState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
     private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBytesRefState current,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
+        int timestamp,
+        BytesRefBlock values,
         int position
     ) {
-    $endif$
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +73,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
             BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
                 a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
                     BytesRef bytesScratch = new BytesRef();
                     values.getBytesRef(offset + i, bytesScratch);
                     a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +93,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.min(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntBytesRefState current, @Position int position, BytesRefBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBytesRefState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        BytesRefBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +137,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +146,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntBytesRefState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +154,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +164,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        BytesRefBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +197,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<BytesRefArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +212,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +225,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +249,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, BytesRefBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp < timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,7 +273,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
                 BytesRefArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
@@ -341,33 +292,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +310,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +318,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +344,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +353,17 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
                         case 1 -> {
                             BytesRef bytesScratch = new BytesRef();
                             values.get(group).get(0, bytesScratch);
                             valuesBuilder.appendBytesRef(bytesScratch);
                         }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
                                 BytesRef bytesScratch = new BytesRef();
                                 values.get(group).get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,41 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllFirstDoubleByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_first_double_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntDoubleState initSingle(DriverContext driverContext) {
+        return new AllIntDoubleState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
     private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntDoubleState current,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
+        int timestamp,
+        DoubleBlock values,
         int position
     ) {
-    $endif$
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +73,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            DoubleArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newDoubleArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getDouble(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +91,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.min(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntDoubleState current, @Position int position, DoubleBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntDoubleState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        DoubleBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +135,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +144,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntDoubleState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +152,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, DoubleBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +162,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        DoubleBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +195,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<DoubleArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +210,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +223,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +247,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, DoubleBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp < timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +271,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                DoubleArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newDoubleArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getDouble(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +289,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +307,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +315,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +341,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +350,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendDouble(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "FLOAT_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "FLOAT_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllFirstFloatByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_first_float_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntFloatState initSingle(DriverContext driverContext) {
+        return new AllIntFloatState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntFloatState current, boolean timestampPresent, int timestamp, FloatBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            FloatArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newFloatArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getFloat(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.min(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntFloatState current, @Position int position, FloatBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntFloatState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        FloatBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntFloatState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, FloatBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        FloatBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<FloatArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, FloatBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp < timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                FloatArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newFloatArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getFloat(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendFloat(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "INT_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "INT_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllFirstIntByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_first_int_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntIntState initSingle(DriverContext driverContext) {
+        return new AllIntIntState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntIntState current, boolean timestampPresent, int timestamp, IntBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            IntArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newIntArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getInt(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.min(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntIntState current, @Position int position, IntBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntIntState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        IntBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntIntState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, IntBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        IntBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<IntArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, IntBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp < timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                IntArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newIntArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getInt(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendInt(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "LONG_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "LONG_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllFirstLongByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_first_long_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntLongState initSingle(DriverContext driverContext) {
+        return new AllIntLongState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntLongState current, boolean timestampPresent, int timestamp, LongBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            LongArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newLongArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getLong(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.min(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntLongState current, @Position int position, LongBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntLongState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        LongBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntLongState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, LongBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        LongBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<LongArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, LongBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp < timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                LongArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newLongArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getLong(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendLong(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregator.java
@@ -13,19 +13,16 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +30,41 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "BOOLEAN_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "BOOLEAN_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastBooleanByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_boolean_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntBooleanState initSingle(DriverContext driverContext) {
+        return new AllIntBooleanState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
     private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBooleanState current,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
+        int timestamp,
+        BooleanBlock values,
         int position
     ) {
-    $endif$
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +72,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
             ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
                 a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, (byte) (values.getBoolean(offset + i) ? 1 : 0));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +90,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntBooleanState current, @Position int position, BooleanBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBooleanState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        BooleanBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +134,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +143,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntBooleanState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +151,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, BooleanBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +161,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        BooleanBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +194,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<ByteArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +209,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +222,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +246,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, BooleanBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,43 +270,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                ByteArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
                         groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
+                            groupValues.set(i, (byte) (valuesBlock.getBoolean(i + offset) ? 1 : 0));
                         }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
                     }
                     success = true;
                     Releasables.close(values.get(group));
@@ -367,7 +288,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +306,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +314,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +340,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newBooleanBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +349,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendBoolean(values.get(group).get(0) == 1);
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendBoolean(values.get(group).get(i) == 1);
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,41 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "BYTES_REF_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "BYTES_REF_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastBytesRefByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_bytesref_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntBytesRefState initSingle(DriverContext driverContext) {
+        return new AllIntBytesRefState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
     private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBytesRefState current,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
+        int timestamp,
+        BytesRefBlock values,
         int position
     ) {
-    $endif$
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +73,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
             BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
                 a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
                     BytesRef bytesScratch = new BytesRef();
                     values.getBytesRef(offset + i, bytesScratch);
                     a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +93,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntBytesRefState current, @Position int position, BytesRefBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntBytesRefState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        BytesRefBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +137,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +146,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntBytesRefState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +154,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +164,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        BytesRefBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +197,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<BytesRefArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +212,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +225,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +249,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, BytesRefBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,7 +273,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
                 BytesRefArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
@@ -341,33 +292,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +310,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +318,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +344,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +353,17 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
                         case 1 -> {
                             BytesRef bytesScratch = new BytesRef();
                             values.get(group).get(0, bytesScratch);
                             valuesBuilder.appendBytesRef(bytesScratch);
                         }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
                                 BytesRef bytesScratch = new BytesRef();
                                 values.get(group).get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,41 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastDoubleByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_double_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntDoubleState initSingle(DriverContext driverContext) {
+        return new AllIntDoubleState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
     private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntDoubleState current,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
+        int timestamp,
+        DoubleBlock values,
         int position
     ) {
-    $endif$
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +73,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            DoubleArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newDoubleArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getDouble(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +91,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntDoubleState current, @Position int position, DoubleBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntDoubleState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        DoubleBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +135,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +144,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntDoubleState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +152,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, DoubleBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +162,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        DoubleBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +195,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<DoubleArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +210,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +223,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +247,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, DoubleBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +271,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                DoubleArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newDoubleArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getDouble(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +289,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +307,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +315,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +341,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +350,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendDouble(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "FLOAT_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "FLOAT_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastFloatByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_float_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntFloatState initSingle(DriverContext driverContext) {
+        return new AllIntFloatState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntFloatState current, boolean timestampPresent, int timestamp, FloatBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            FloatArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newFloatArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getFloat(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntFloatState current, @Position int position, FloatBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntFloatState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        FloatBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntFloatState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, FloatBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        FloatBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<FloatArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, FloatBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                FloatArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newFloatArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getFloat(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendFloat(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "INT_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "INT_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastIntByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_int_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntIntState initSingle(DriverContext driverContext) {
+        return new AllIntIntState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntIntState current, boolean timestampPresent, int timestamp, IntBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            IntArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newIntArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getInt(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntIntState current, @Position int position, IntBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntIntState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        IntBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntIntState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, IntBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        IntBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<IntArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, IntBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                IntArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newIntArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getInt(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendInt(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregator.java
@@ -13,19 +13,17 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
-import org.elasticsearch.common.util.$v1_Type$Array;
-$endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.$v1_Type$Block;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.$v2_Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
@@ -33,53 +31,35 @@ import java.util.BitSet;
 // end generated imports
 
 /**
- * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
+ * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
  * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
  */
 @Aggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN"),
         @IntermediateState(name = "timestampPresent", type = "BOOLEAN"),
-        @IntermediateState(name = "timestamp", type = "$v2_TYPE$"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamp", type = "INT"),
+        @IntermediateState(name = "values", type = "LONG_BLOCK") }
 )
 @GroupingAggregator(
     {
         @IntermediateState(name = "observed", type = "BOOLEAN_BLOCK"),
         @IntermediateState(name = "timestampsPresent", type = "BOOLEAN_BLOCK"),
-        @IntermediateState(name = "timestamps", type = "$v2_TYPE$_BLOCK"),
-        @IntermediateState(name = "values", type = "$v1_TYPE$_BLOCK") }
+        @IntermediateState(name = "timestamps", type = "INT_BLOCK"),
+        @IntermediateState(name = "values", type = "LONG_BLOCK") }
 )
-public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
+public class AllLastLongByIntAggregator {
     public static String describe() {
-        $if(v1_BytesRef)$
-        return "all_$occurrence$_bytesref_by_$v2_type$";
-        $else$
-        return "all_$occurrence$_$v1_type$_by_$v2_type$";
-        $endif$
+        return "all_last_long_by_int";
     }
 
-    public static $Prefix$$v2_Type$$v1_Type$State initSingle(DriverContext driverContext) {
-        return new $Prefix$$v2_Type$$v1_Type$State(driverContext.bigArrays());
+    public static AllIntLongState initSingle(DriverContext driverContext) {
+        return new AllIntLongState(driverContext.bigArrays());
     }
 
-    $if(v1_long || v1_int || (v1_float && v2_int))$
-    private static void overrideState($Prefix$$v2_Type$$v1_Type$State current, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block values, int position) {
-    $else$
-    private static void overrideState(
-        $Prefix$$v2_Type$$v1_Type$State current,
-        boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values,
-        int position
-    ) {
-    $endif$
+    private static void overrideState(AllIntLongState current, boolean timestampPresent, int timestamp, LongBlock values, int position) {
         current.observed(true);
-        $if(v2_long)$
-        current.v1(timestampPresent ? timestamp : -1L);
-        $else$
         current.v1(timestampPresent ? timestamp : -1);
-        $endif$
         current.v1Seen(timestampPresent);
         if (values.isNull(position)) {
             Releasables.close(current.v2());
@@ -87,32 +67,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         } else {
             int count = values.getValueCount(position);
             int offset = values.getFirstValueIndex(position);
-            $if(v1_BytesRef)$
-            BytesRefArray a = null;
-            $elseif(v1_boolean)$
-            ByteArray a = null;
-            $else$
-            $v1_Type$Array a = null;
-            $endif$
+            LongArray a = null;
             boolean success = false;
             try {
-                $if(v1_BytesRef)$
-                a = new BytesRefArray(0, current.bigArrays());
-                $elseif(v1_boolean)$
-                a = current.bigArrays().newByteArray(count);
-                $else$
-                a = current.bigArrays().new$v1_Type$Array(count);
-                $endif$
+                a = current.bigArrays().newLongArray(count);
                 for (int i = 0; i < count; ++i) {
-                    $if(v1_BytesRef)$
-                    BytesRef bytesScratch = new BytesRef();
-                    values.getBytesRef(offset + i, bytesScratch);
-                    a.append(bytesScratch);
-                    $elseif(v1_boolean)$
-                    a.set(i, (byte) (values.get$v1_Type$(offset + i) ? 1 : 0));
-                    $else$
-                    a.set(i, values.get$v1_Type$(offset + i));
-                    $endif$
+                    a.set(i, values.getLong(offset + i));
                 }
                 success = true;
                 Releasables.close(current.v2());
@@ -125,42 +85,38 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    private static $v2_type$ dominantTimestampAtPosition(int position, $v2_Type$Block timestamps) {
+    private static int dominantTimestampAtPosition(int position, IntBlock timestamps) {
         assert timestamps.isNull(position) == false : "The timestamp is null at this position";
         int lo = timestamps.getFirstValueIndex(position);
         int hi = lo + timestamps.getValueCount(position);
-        $v2_type$ result = timestamps.get$v2_Type$(lo++);
+        int result = timestamps.getInt(lo++);
 
         for (int i = lo; i < hi; i++) {
-            $if(First)$
-            result = Math.min(result, timestamps.get$v2_Type$(i));
-            $else$
-            result = Math.max(result, timestamps.get$v2_Type$(i));
-            $endif$
+            result = Math.max(result, timestamps.getInt(i));
         }
 
         return result;
     }
 
-    public static void combine($Prefix$$v2_Type$$v1_Type$State current, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $v2_type$ timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
+    public static void combine(AllIntLongState current, @Position int position, LongBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? -1 : dominantTimestampAtPosition(position, timestamps);
         boolean timestampPresent = timestamps.isNull(position) == false;
 
         if (current.observed() == false) {
             // We never saw a timestamp before, regardless of nullability.
             overrideState(current, timestampPresent, timestamp, values, position);
-        } else if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+        } else if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
             // The incoming timestamp wins against the current one because the latter was either null or older/newer.
             overrideState(current, true, timestamp, values, position);
         }
     }
 
     public static void combineIntermediate(
-        $Prefix$$v2_Type$$v1_Type$State current,
+        AllIntLongState current,
         boolean observed,
         boolean timestampPresent,
-        $v2_type$ timestamp,
-        $v1_Type$Block values
+        int timestamp,
+        LongBlock values
     ) {
         if (observed == false) {
             // The incoming state hasn't observed anything. No work is needed.
@@ -173,7 +129,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {
@@ -182,7 +138,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
     }
 
-    public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
+    public static Block evaluateFinal(AllIntLongState current, DriverContext ctx) {
         return current.intermediateValuesBlockBuilder(ctx);
     }
 
@@ -190,12 +146,8 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return new GroupingState(driverContext.bigArrays());
     }
 
-    public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
-        $if(v2_long)$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0L : dominantTimestampAtPosition(position, timestamps);
-        $else$
-        $v2_type$ timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
-        $endif$
+    public static void combine(GroupingState current, int group, @Position int position, LongBlock values, IntBlock timestamps) {
+        int timestamp = timestamps.isNull(position) ? 0 : dominantTimestampAtPosition(position, timestamps);
         current.collectValue(group, timestamps.isNull(position) == false, timestamp, position, values);
     }
 
@@ -204,15 +156,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         int group,
         BooleanBlock observed,
         BooleanBlock timestampPresent,
-        $v2_Type$Block timestamps,
-        $v1_Type$Block values,
+        IntBlock timestamps,
+        LongBlock values,
         int otherPosition
     ) {
         if (group < observed.getPositionCount() && observed.getBoolean(observed.getFirstValueIndex(otherPosition)) == false) {
             // The incoming state hasn't observed anything for this particular group. No work is needed.
             return;
         }
-        $v2_type$ timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.get$v2_Type$(timestamps.getFirstValueIndex(otherPosition));
+        int timestamp = timestamps.isNull(otherPosition) ? -1 : timestamps.getInt(timestamps.getFirstValueIndex(otherPosition));
         boolean hasTimestamp = timestampPresent.getBoolean(timestampPresent.getFirstValueIndex(otherPosition));
         current.collectValue(group, hasTimestamp, timestamp, otherPosition, values);
     }
@@ -237,12 +189,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         /**
          * The group-indexed timestamps
          */
-        private $v2_Type$Array timestamps;
+        private IntArray timestamps;
 
         /**
          * The group-indexed values
          */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<LongArray> values;
 
         private int maxGroupId = -1;
 
@@ -252,7 +204,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             boolean success = false;
             ByteArray observed = null;
             ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
+            IntArray timestamps = null;
             try {
                 // Initialize observed
                 observed = bigArrays.newByteArray(1, false);
@@ -265,20 +217,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 this.hasTimestamp = hasTimestamp;
 
                 // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
+                timestamps = bigArrays.newIntArray(1, false);
                 timestamps.set(0, -1);
-                $endif$
                 this.timestamps = timestamps;
 
                 // Initialize values
-                $if(v1_BytesRef)$
                 this.values = bigArrays.newObjectArray(1);
-                $else$
-                this.values = bigArrays.newObjectArray(1);
-                $endif$
                 this.values.set(0, null);
 
                 // Enable group id tracking because we use has hasValue in the
@@ -297,12 +241,12 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             }
         }
 
-        void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
+        void collectValue(int group, boolean timestampPresent, int timestamp, int position, LongBlock valuesBlock) {
             boolean updated = false;
             if (withinBounds(group)) {
                 if (hasValue(group) == false
                     || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
+                    || (timestampPresent && timestamp > timestamps.get(group))) {
                     // We never saw this group before, even if it's within bounds.
                     // Or, the incoming non-null timestamp wins against the null one in the state.
                     // Or, we found a better timestamp for this group.
@@ -321,16 +265,14 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
                 timestamps.set(group, timestamp);
                 boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
+                LongArray groupValues = null;
                 try {
                     if (valuesBlock.isNull(position) == false) {
                         int count = valuesBlock.getValueCount(position);
                         int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
+                        groupValues = bigArrays.newLongArray(count);
                         for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
+                            groupValues.set(i, valuesBlock.getLong(i + offset));
                         }
                     }
                     success = true;
@@ -341,33 +283,6 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         Releasables.close(groupValues);
                     }
                 }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
             }
             maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
@@ -386,7 +301,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             try (
                 var observedBlockBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
                 var hasTimestampBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount());
-                var timestampsBuilder = driverContext.blockFactory().new$v2_Type$BlockBuilder(selected.getPositionCount())
+                var timestampsBuilder = driverContext.blockFactory().newIntBlockBuilder(selected.getPositionCount())
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
@@ -394,7 +309,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                         // We must have seen this group before and saved its state
                         observedBlockBuilder.appendBoolean(observed.get(group) == 1);
                         hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        timestampsBuilder.appendInt(timestamps.get(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -420,7 +335,7 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         }
 
         private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
-            try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
+            try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
                     int count = 0;
@@ -429,33 +344,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                     }
                     switch (count) {
                         case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
+                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
                         default -> {
                             valuesBuilder.beginPositionEntry();
                             for (int i = 0; i < count; ++i) {
-                                $if(v1_BytesRef)$
-                                BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
-                                valuesBuilder.appendBytesRef(bytesScratch);
-                                $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
-                                $endif$
+                                valuesBuilder.appendLong(values.get(group).get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunction.java
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstBooleanByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstBooleanByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BOOLEAN)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntBooleanState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstBooleanByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntBooleanState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstBooleanByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstBooleanByIntAggregatorFunction(driverContext, channels, AllFirstBooleanByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(BooleanBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstBooleanByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(BooleanBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstBooleanByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllFirstBooleanByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstBooleanByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstBooleanByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstBooleanByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstBooleanByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstBooleanByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstBooleanByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstBooleanByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstBooleanByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstBooleanByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllFirstBooleanByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstBooleanByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunction.java
@@ -1,0 +1,242 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstBooleanByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstBooleanByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BOOLEAN)  );
+
+  private final AllFirstBooleanByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstBooleanByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstBooleanByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstBooleanByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstBooleanByIntGroupingAggregatorFunction(channels, AllFirstBooleanByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstBooleanByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunction.java
@@ -1,0 +1,142 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstBytesRefByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntBytesRefState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstBytesRefByIntAggregatorFunction(DriverContext driverContext,
+      List<Integer> channels, AllIntBytesRefState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstBytesRefByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstBytesRefByIntAggregatorFunction(driverContext, channels, AllFirstBytesRefByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(BytesRefBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstBytesRefByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock valuesBlock, IntBlock timestampsBlock,
+      BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstBytesRefByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    BytesRef valuesScratch = new BytesRef();
+    AllFirstBytesRefByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstBytesRefByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstBytesRefByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstBytesRefByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstBytesRefByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstBytesRefByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstBytesRefByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstBytesRefByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstBytesRefByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllFirstBytesRefByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstBytesRefByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunction.java
@@ -1,0 +1,247 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstBytesRefByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BYTES_REF)  );
+
+  private final AllFirstBytesRefByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstBytesRefByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstBytesRefByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstBytesRefByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstBytesRefByIntGroupingAggregatorFunction(channels, AllFirstBytesRefByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstBytesRefByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstDoubleByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstDoubleByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntDoubleState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstDoubleByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntDoubleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstDoubleByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstDoubleByIntAggregatorFunction(driverContext, channels, AllFirstDoubleByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(DoubleBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstDoubleByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(DoubleBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstDoubleByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllFirstDoubleByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstDoubleByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstDoubleByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstDoubleByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstDoubleByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstDoubleByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstDoubleByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstDoubleByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstDoubleByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstDoubleByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllFirstDoubleByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstDoubleByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstDoubleByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstDoubleByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final AllFirstDoubleByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstDoubleByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstDoubleByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstDoubleByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstDoubleByIntGroupingAggregatorFunction(channels, AllFirstDoubleByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstDoubleByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstFloatByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstFloatByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.FLOAT)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntFloatState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstFloatByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntFloatState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstFloatByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstFloatByIntAggregatorFunction(driverContext, channels, AllFirstFloatByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(FloatBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstFloatByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(FloatBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstFloatByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllFirstFloatByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstFloatByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstFloatByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstFloatByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstFloatByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstFloatByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstFloatByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstFloatByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstFloatByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstFloatByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllFirstFloatByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstFloatByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstFloatByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstFloatByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.FLOAT)  );
+
+  private final AllFirstFloatByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstFloatByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstFloatByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstFloatByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstFloatByIntGroupingAggregatorFunction(channels, AllFirstFloatByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstFloatByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunction.java
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstIntByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstIntByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.INT)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntIntState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstIntByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntIntState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstIntByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstIntByIntAggregatorFunction(driverContext, channels, AllFirstIntByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(IntBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstIntByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(IntBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstIntByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllFirstIntByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstIntByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstIntByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstIntByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstIntByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstIntByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstIntByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstIntByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstIntByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstIntByIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstIntByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstIntByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunction.java
@@ -1,0 +1,242 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstIntByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstIntByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.INT)  );
+
+  private final AllFirstIntByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstIntByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstIntByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstIntByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstIntByIntGroupingAggregatorFunction(channels, AllFirstIntByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstIntByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllFirstLongByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllFirstLongByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntLongState state;
+
+  private final List<Integer> channels;
+
+  public AllFirstLongByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntLongState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllFirstLongByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllFirstLongByIntAggregatorFunction(driverContext, channels, AllFirstLongByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(LongBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllFirstLongByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(LongBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllFirstLongByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllFirstLongByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllFirstLongByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllFirstLongByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllFirstLongByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllFirstLongByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllFirstLongByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllFirstLongByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllFirstLongByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstLongByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllFirstLongByIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllFirstLongByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllFirstLongByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllFirstLongByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllFirstLongByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final AllFirstLongByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllFirstLongByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllFirstLongByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllFirstLongByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllFirstLongByIntGroupingAggregatorFunction(channels, AllFirstLongByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllFirstLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllFirstLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllFirstLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllFirstLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllFirstLongByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunction.java
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastBooleanByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastBooleanByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BOOLEAN)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntBooleanState state;
+
+  private final List<Integer> channels;
+
+  public AllLastBooleanByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntBooleanState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastBooleanByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastBooleanByIntAggregatorFunction(driverContext, channels, AllLastBooleanByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(BooleanBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastBooleanByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(BooleanBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastBooleanByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllLastBooleanByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastBooleanByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastBooleanByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastBooleanByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastBooleanByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastBooleanByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastBooleanByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastBooleanByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastBooleanByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastBooleanByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllLastBooleanByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastBooleanByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunction.java
@@ -1,0 +1,242 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastBooleanByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastBooleanByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BOOLEAN)  );
+
+  private final AllLastBooleanByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastBooleanByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastBooleanByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastBooleanByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastBooleanByIntGroupingAggregatorFunction(channels, AllLastBooleanByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BooleanBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastBooleanByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BooleanBlock values = (BooleanBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastBooleanByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BooleanBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastBooleanByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunction.java
@@ -1,0 +1,142 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastBytesRefByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BYTES_REF)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntBytesRefState state;
+
+  private final List<Integer> channels;
+
+  public AllLastBytesRefByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntBytesRefState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastBytesRefByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastBytesRefByIntAggregatorFunction(driverContext, channels, AllLastBytesRefByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(BytesRefBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastBytesRefByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock valuesBlock, IntBlock timestampsBlock,
+      BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastBytesRefByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    BytesRef valuesScratch = new BytesRef();
+    AllLastBytesRefByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastBytesRefByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastBytesRefByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastBytesRefByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastBytesRefByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastBytesRefByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastBytesRefByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastBytesRefByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastBytesRefByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllLastBytesRefByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastBytesRefByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunction.java
@@ -1,0 +1,247 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastBytesRefByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastBytesRefByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.BYTES_REF)  );
+
+  private final AllLastBytesRefByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastBytesRefByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastBytesRefByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastBytesRefByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastBytesRefByIntGroupingAggregatorFunction(channels, AllLastBytesRefByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    BytesRefBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastBytesRefByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    BytesRefBlock values = (BytesRefBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    BytesRef valuesScratch = new BytesRef();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastBytesRefByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, BytesRefBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastBytesRefByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastDoubleByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastDoubleByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntDoubleState state;
+
+  private final List<Integer> channels;
+
+  public AllLastDoubleByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntDoubleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastDoubleByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastDoubleByIntAggregatorFunction(driverContext, channels, AllLastDoubleByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(DoubleBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastDoubleByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(DoubleBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastDoubleByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllLastDoubleByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastDoubleByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastDoubleByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastDoubleByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastDoubleByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastDoubleByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastDoubleByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastDoubleByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastDoubleByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastDoubleByIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext, List<Integer> channels) {
+    return AllLastDoubleByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastDoubleByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastDoubleByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastDoubleByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final AllLastDoubleByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastDoubleByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastDoubleByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastDoubleByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastDoubleByIntGroupingAggregatorFunction(channels, AllLastDoubleByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastDoubleByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastDoubleByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, DoubleBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastDoubleByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastFloatByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastFloatByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.FLOAT)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntFloatState state;
+
+  private final List<Integer> channels;
+
+  public AllLastFloatByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntFloatState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastFloatByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastFloatByIntAggregatorFunction(driverContext, channels, AllLastFloatByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(FloatBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastFloatByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(FloatBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastFloatByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllLastFloatByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastFloatByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastFloatByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastFloatByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastFloatByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastFloatByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastFloatByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastFloatByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastFloatByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastFloatByIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastFloatByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastFloatByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastFloatByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastFloatByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.FLOAT)  );
+
+  private final AllLastFloatByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastFloatByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastFloatByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastFloatByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastFloatByIntGroupingAggregatorFunction(channels, AllLastFloatByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastFloatByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    FloatBlock values = (FloatBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastFloatByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, FloatBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastFloatByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunction.java
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastIntByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastIntByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.INT)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntIntState state;
+
+  private final List<Integer> channels;
+
+  public AllLastIntByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntIntState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastIntByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastIntByIntAggregatorFunction(driverContext, channels, AllLastIntByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(IntBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastIntByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(IntBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastIntByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllLastIntByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastIntByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastIntByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastIntByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastIntByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastIntByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastIntByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastIntByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastIntByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastIntByIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastIntByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastIntByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunction.java
@@ -1,0 +1,242 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastIntByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastIntByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.INT)  );
+
+  private final AllLastIntByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastIntByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastIntByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastIntByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastIntByIntGroupingAggregatorFunction(channels, AllLastIntByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastIntByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    IntBlock values = (IntBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastIntByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, IntBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastIntByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunction.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link AllLastLongByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class AllLastLongByIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamp", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final DriverContext driverContext;
+
+  private final AllIntLongState state;
+
+  private final List<Integer> channels;
+
+  public AllLastLongByIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      AllIntLongState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static AllLastLongByIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new AllLastLongByIntAggregatorFunction(driverContext, channels, AllLastLongByIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    addRawBlock(valuesBlock, timestampsBlock);
+  }
+
+  private void addRawBlock(LongBlock valuesBlock, IntBlock timestampsBlock) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      AllLastLongByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  private void addRawBlock(LongBlock valuesBlock, IntBlock timestampsBlock, BooleanVector mask) {
+    for (int p = 0; p < valuesBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      AllLastLongByIntAggregator.combine(state, p, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    assert observed.getPositionCount() == 1;
+    Block timestampPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampPresent = (BooleanBlock) timestampPresentUncast;
+    assert timestampPresent.getPositionCount() == 1;
+    Block timestampUncast = page.getBlock(channels.get(2));
+    IntBlock timestamp = (IntBlock) timestampUncast;
+    assert timestamp.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    AllLastLongByIntAggregator.combineIntermediate(state, observed.getBoolean(0), timestampPresent.getBoolean(0), timestamp.getInt(0), values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = AllLastLongByIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link AllLastLongByIntAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class AllLastLongByIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public AllLastLongByIntAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return AllLastLongByIntAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return AllLastLongByIntGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public AllLastLongByIntAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastLongByIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public AllLastLongByIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return AllLastLongByIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return AllLastLongByIntAggregator.describe();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunction.java
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link AllLastLongByIntAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class AllLastLongByIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("observed", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestampsPresent", ElementType.BOOLEAN),
+      new IntermediateStateDesc("timestamps", ElementType.INT),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final AllLastLongByIntAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public AllLastLongByIntGroupingAggregatorFunction(List<Integer> channels,
+      AllLastLongByIntAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static AllLastLongByIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new AllLastLongByIntGroupingAggregatorFunction(channels, AllLastLongByIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    IntBlock timestampsBlock = page.getBlock(channels.get(1));
+    maybeEnableGroupIdTracking(seenGroupIds, valuesBlock, timestampsBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesBlock, timestampsBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        AllLastLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        AllLastLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      AllLastLongByIntAggregator.combine(state, groupId, valuesPosition, valuesBlock, timestampsBlock);
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block observedUncast = page.getBlock(channels.get(0));
+    BooleanBlock observed = (BooleanBlock) observedUncast;
+    Block timestampsPresentUncast = page.getBlock(channels.get(1));
+    BooleanBlock timestampsPresent = (BooleanBlock) timestampsPresentUncast;
+    Block timestampsUncast = page.getBlock(channels.get(2));
+    IntBlock timestamps = (IntBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(3));
+    LongBlock values = (LongBlock) valuesUncast;
+    assert observed.getPositionCount() == timestampsPresent.getPositionCount() && observed.getPositionCount() == timestamps.getPositionCount() && observed.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      AllLastLongByIntAggregator.combineIntermediate(state, groupId, observed, timestampsPresent, timestamps, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, LongBlock valuesBlock,
+      IntBlock timestampsBlock) {
+    if (valuesBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+    if (timestampsBlock.mayHaveNulls()) {
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    blocks[offset] = AllLastLongByIntAggregator.evaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstBooleanByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.BOOLEAN, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomBoolean(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllFirstBooleanByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,12 +43,12 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_first_boolean_by_int";
     }
 
     @Override
     public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstBooleanByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.BOOLEAN, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomBoolean(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstBooleanByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_boolean_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstBytesRefByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.BYTES_REF, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllFirstBytesRefByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,12 +43,12 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_first_bytesref_by_int";
     }
 
     @Override
     public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,16 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstBytesRefByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.BYTES_REF, ElementType.INT),
+            IntStream.range(0, size)
+                .mapToObj(l -> List.of(randomLongBetween(0, 4), randomAlphanumericOfLength(randomInt(20)), randomInt()))
+                .toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +39,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstBytesRefByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_bytesref_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstDoubleByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.DOUBLE, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomDouble(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllFirstDoubleByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,12 +43,12 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_first_double_by_int";
     }
 
     @Override
     public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstDoubleByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.DOUBLE, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomDouble(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstDoubleByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_double_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstFloatByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.FLOAT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomFloat(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllFirstFloatByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,12 +43,12 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_first_float_by_int";
     }
 
     @Override
     public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstFloatByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.FLOAT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomFloat(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstFloatByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_float_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstIntByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.INT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomInt(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllFirstIntByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,12 +43,12 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_first_int_by_int";
     }
 
     @Override
     public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstIntByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.INT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomInt(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstIntByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_int_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregatorFunctionTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.GroundTruthFirstLastAggregator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.operator.blocksource.LongIntBlockSourceOperator;
+import org.elasticsearch.core.Tuple;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class AllFirstLongByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
+    @Override
+    protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
+        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
+            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
+        );
+
+        return new LongIntBlockSourceOperator(
+            blockFactory,
+            IntStream.range(0, size).mapToObj(l -> Tuple.tuple(randomBoolean() ? null : randomLong(), randomInt()))
+        );
+    }
+
+    @Override
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstLongByIntAggregatorFunctionSupplier();
+    }
+
+    @Override
+    protected int inputCount() {
+        return 2;
+    }
+
+    @Override
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_long_by_int";
+    }
+
+    @Override
+    public void assertSimpleOutput(List<Page> input, Block result) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input);
+        work.check(BlockUtils.toJavaObject(result, 0));
+    }
+
+    /**
+     * Reproduces a scenario where null timestamps incorrectly win over valid timestamps when combineIntermediate is called. We don't need
+     * multivalues anywhere to reproduce the bug.
+     *
+     * See https://github.com/elastic/elasticsearch-serverless/issues/5348
+     */
+    public void testNullTimestampDoesNotWinOverValidTimestamp() {
+        DriverContext driverContext = driverContext();
+        BlockFactory blockFactory = driverContext.blockFactory();
+
+        Page page1 = new Page(
+            // value
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(2).build(),
+            // valid and earliest timestamp
+            blockFactory.newIntBlockBuilder(1).beginPositionEntry().appendInt(1).build()
+        );
+
+        Page page2 = new Page(
+            // value
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(3).build(),
+            // null timestamp
+            blockFactory.newIntBlockBuilder(1).appendNull().build()
+        );
+
+        // Run each page through separate aggregators
+        List<Page> intermediatePages1 = new TestDriverRunner().builder(driverContext)
+            .input(page1)
+            .run(simpleWithMode(AggregatorMode.INITIAL));
+        List<Page> intermediatePages2 = new TestDriverRunner().builder(driverContext)
+            .input(page2)
+            .run(simpleWithMode(AggregatorMode.INITIAL));
+
+        Iterator<Page> finalInput = Iterators.concat(intermediatePages1.iterator(), intermediatePages2.iterator());
+
+        // Combine intermediate results (this calls combineIntermediate to expose the bug)
+        List<Page> results = new TestDriverRunner().builder(driverContext).input(finalInput).run(simpleWithMode(AggregatorMode.FINAL));
+
+        assertThat(results, hasSize(1));
+        Block result = results.get(0).getBlock(0);
+        assertThat(BlockUtils.toJavaObject(result, 0), equalTo(2L));
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllFirstLongByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.LONG, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomLong(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllFirstLongByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
-        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+    protected String expectedDescriptionOfAggregator() {
+        return "all_first_long_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
+        GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastBooleanByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.BOOLEAN, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomBoolean(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastBooleanByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +43,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_boolean_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastBooleanByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.BOOLEAN, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomBoolean(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastBooleanByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_boolean_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastBytesRefByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.BYTES_REF, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastBytesRefByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +43,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_bytesref_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,16 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastBytesRefByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.BYTES_REF, ElementType.INT),
+            IntStream.range(0, size)
+                .mapToObj(l -> List.of(randomLongBetween(0, 4), randomAlphanumericOfLength(randomInt(20)), randomInt()))
+                .toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +39,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastBytesRefByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_bytesref_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastDoubleByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.DOUBLE, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomDouble(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastDoubleByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +43,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_double_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastDoubleByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.DOUBLE, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomDouble(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastDoubleByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_double_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastFloatByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.FLOAT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomFloat(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastFloatByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +43,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_float_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastFloatByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.FLOAT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomFloat(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastFloatByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_float_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregatorFunctionTests.java
@@ -21,22 +21,19 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastIntByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.INT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomInt(), randomInt())).toList()
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastIntByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +43,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_int_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastIntByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.INT, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomInt(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastIntByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_int_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregatorFunctionTests.java
@@ -11,32 +11,28 @@ import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.Gro
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
-import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
-import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
+import org.elasticsearch.compute.test.operator.blocksource.LongIntBlockSourceOperator;
+import org.elasticsearch.core.Tuple;
 
 import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastLongByIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
-        return new ListRowsBlockSourceOperator(
+        return new LongIntBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            IntStream.range(0, size).mapToObj(l -> Tuple.tuple(randomBoolean() ? null : randomLong(), randomInt()))
         );
     }
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
+        return new AllLastLongByIntAggregatorFunctionSupplier();
     }
 
     @Override
@@ -46,7 +42,7 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
 
     @Override
     protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+        return "all_last_long_by_int";
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunctionTests.java
@@ -21,22 +21,14 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.processPages;
 
-public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
+public class AllLastLongByIntGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen tsgen = randomFrom(
-            FirstLongByTimestampGroupingAggregatorFunctionTests.TimestampGen.values()
-        );
         return new ListRowsBlockSourceOperator(
             blockFactory,
-            List.of(ElementType.BYTES_REF, ElementType.LONG),
-            IntStream.range(0, size).mapToObj(l -> List.of(randomAlphanumericOfLength(randomInt(20)), tsgen.gen())).toList()
+            List.of(ElementType.LONG, ElementType.LONG, ElementType.INT),
+            IntStream.range(0, size).mapToObj(l -> List.of(randomLongBetween(0, 4), randomLong(), randomInt())).toList()
         );
-    }
-
-    @Override
-    protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new AllLastBytesRefByLongAggregatorFunctionSupplier();
     }
 
     @Override
@@ -45,14 +37,19 @@ public class AllLastBytesRefByLongAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected String expectedDescriptionOfAggregator() {
-        return "all_last_bytesref_by_long";
+    protected AggregatorFunctionSupplier aggregatorFunction() {
+        return new AllLastLongByIntAggregatorFunctionSupplier();
     }
 
     @Override
-    public void assertSimpleOutput(List<Page> input, Block result) {
+    protected String expectedDescriptionOfAggregator() {
+        return "all_last_long_by_int";
+    }
+
+    @Override
+    protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
-        processPages(work, input);
-        work.check(BlockUtils.toJavaObject(result, 0));
+        processPages(work, input, group);
+        work.check(BlockUtils.toJavaObject(result, position));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FirstLastAggregatorTestingUtils.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FirstLastAggregatorTestingUtils.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.test.BlockTestUtils;
 import org.elasticsearch.core.Tuple;
@@ -31,7 +30,7 @@ public class FirstLastAggregatorTestingUtils {
         for (Page page : input) {
             matchingGroups(page, group).forEach(p -> {
                 Block values = page.getBlock(1);
-                LongBlock timestamps = page.getBlock(2);
+                Block timestamps = page.getBlock(2);
                 Tuple<List<Long>, List<Object>> pair = unpack(timestamps, values, p);
                 work.add(pair.v1(), pair.v2());
             });
@@ -44,7 +43,7 @@ public class FirstLastAggregatorTestingUtils {
     public static void processPages(GroundTruthFirstLastAggregator work, List<Page> input) {
         for (Page page : input) {
             Block values = page.getBlock(0);
-            LongBlock timestamps = page.getBlock(1);
+            Block timestamps = page.getBlock(1);
 
             for (int p = 0; p < page.getPositionCount(); ++p) {
                 Tuple<List<Long>, List<Object>> pair = unpack(timestamps, values, p);
@@ -57,9 +56,12 @@ public class FirstLastAggregatorTestingUtils {
      * Unpacks values of the passed two blocks, at the given position, into two lists. If there are no values for a particular block
      * at that position, the corresponding list is empty.
      */
-    private static Tuple<List<Long>, List<Object>> unpack(LongBlock timestamps, Block values, int p) {
+    private static Tuple<List<Long>, List<Object>> unpack(Block timestamps, Block values, int p) {
         // extract all timestamps at this position into a list
-        List<Long> timestampsAtPosition = BlockTestUtils.valuesAtPosition(timestamps, p, true);
+        List<Long> timestampsAtPosition = BlockTestUtils.valuesAtPosition(timestamps, p, true)
+            .stream()
+            .map(v -> ((Number) v).longValue())
+            .toList();
 
         // extract all values at this position into a list
         List<Object> valuesAtPosition = BlockTestUtils.valuesAtPosition(values, p, true);


### PR DESCRIPTION
- Change the agg template to allow aggregating on the passed `v2_type` instead of always aggregating on longs.
- Trigger the generation of the integer aggregators from `build.gradle`
- Add agg functions unit tests (grouped and ungrouped) for all types on ints
