### PR TITLE
[8.19] [Transform] Skip checkpoint query filter when runtime_mappings are present (#142452)

### DIFF
--- a/docs/changelog/142452.yaml
+++ b/docs/changelog/142452.yaml
@@ -1,0 +1,5 @@
+area: Transform
+issues: []
+pr: 142452
+summary: Skip checkpoint query filter when `runtime_mappings` are present
+type: enhancement

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
@@ -136,6 +136,12 @@ class DefaultCheckpointProvider implements CheckpointProvider {
 
             final var threadContext = client.threadPool().getThreadContext();
 
+            // Only use the query for shard filtering when there are no runtime mappings,
+            // because SearchShardsRequest does not support runtime_mappings and the query may reference runtime fields
+            final QueryBuilder queryForShardFiltering = transformConfig.getSource().getRuntimeMappings().isEmpty()
+                ? transformConfig.getSource().getQueryConfig().getQuery()
+                : null;
+
             if (resolvedIndexes.getLocalIndices().isEmpty() == false) {
                 getCheckpointsFromOneCluster(
                     threadContext,
@@ -143,7 +149,7 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                     timeout,
                     transformConfig.getHeaders(),
                     resolvedIndexes.getLocalIndices().toArray(new String[0]),
-                    transformConfig.getSource().getQueryConfig().getQuery(),
+                    queryForShardFiltering,
                     RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY,
                     groupedListener
                 );
@@ -163,7 +169,7 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                     timeout,
                     transformConfig.getHeaders(),
                     remoteIndex.getValue().toArray(new String[0]),
-                    transformConfig.getSource().getQueryConfig().getQuery(),
+                    queryForShardFiltering,
                     cluster,
                     groupedListener
                 );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction;
+import org.elasticsearch.xpack.core.transform.transforms.QueryConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -42,6 +43,7 @@ import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor.AuditExpectation;
 import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
 import java.time.Clock;
@@ -460,6 +462,111 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         assertThat(
             checkpointHolder.get().getIndicesCheckpoints().keySet(),
             containsInAnyOrder("remote-1:index-1", "remote-2:index-1", "remote-3:index-1")
+        );
+    }
+
+    public void testGetIndexCheckpointsQueryOmittedWhenRuntimeMappingsPresent() throws InterruptedException {
+        // Arrange: create a config with runtime_mappings and a query filter
+        String transformId = getTestName();
+        SourceConfig sourceWithRuntimeMappings = new SourceConfig(
+            new String[] { "source_index" },
+            QueryConfig.matchAll(),
+            Map.of("total_price_with_tax", Map.of("type", "double", "script", Map.of("source", "emit(1.0)"))),
+            null
+        );
+        TransformConfig transformConfig = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId)).setSource(
+            sourceWithRuntimeMappings
+        ).build();
+
+        GetCheckpointAction.Response checkpointResponse = new GetCheckpointAction.Response(
+            Map.of("source_index", new long[] { 1L, 2L, 3L })
+        );
+        ArgumentCaptor<GetCheckpointAction.Request> requestCaptor = ArgumentCaptor.forClass(GetCheckpointAction.Request.class);
+        doAnswer(withResponse(checkpointResponse)).when(client).execute(eq(GetCheckpointAction.INSTANCE), requestCaptor.capture(), any());
+
+        RemoteClusterResolver remoteClusterResolver = mock(RemoteClusterResolver.class);
+        when(remoteClusterResolver.resolve(any(String[].class))).thenReturn(
+            new RemoteClusterResolver.ResolvedIndices(Map.of(), List.of("source_index"))
+        );
+
+        DefaultCheckpointProvider provider = new DefaultCheckpointProvider(
+            clock,
+            parentTaskClient,
+            remoteClusterResolver,
+            transformConfigManager,
+            transformAuditor,
+            transformConfig
+        );
+
+        // Act: trigger checkpoint creation which calls getIndexCheckpoints
+        SetOnce<TransformCheckpoint> checkpointHolder = new SetOnce<>();
+        SetOnce<Exception> exceptionHolder = new SetOnce<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        provider.createNextCheckpoint(
+            null,
+            new LatchedActionListener<>(ActionListener.wrap(checkpointHolder::set, exceptionHolder::set), latch)
+        );
+        assertThat(latch.await(100, TimeUnit.MILLISECONDS), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+
+        // Assert: the query should be null because runtime_mappings are present
+        GetCheckpointAction.Request capturedRequest = requestCaptor.getValue();
+        assertNull(
+            "GetCheckpointAction.Request query should be null when runtime_mappings are present, "
+                + "because SearchShardsRequest does not support runtime_mappings",
+            capturedRequest.getQuery()
+        );
+    }
+
+    public void testGetIndexCheckpointsQuerySetWhenNoRuntimeMappings() throws InterruptedException {
+        // Arrange: create a config WITHOUT runtime_mappings but with a query filter
+        String transformId = getTestName();
+        SourceConfig sourceWithoutRuntimeMappings = new SourceConfig(
+            new String[] { "source_index" },
+            QueryConfig.matchAll(),
+            Collections.emptyMap(),
+            null
+        );
+        TransformConfig transformConfig = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId)).setSource(
+            sourceWithoutRuntimeMappings
+        ).build();
+
+        GetCheckpointAction.Response checkpointResponse = new GetCheckpointAction.Response(
+            Map.of("source_index", new long[] { 1L, 2L, 3L })
+        );
+        ArgumentCaptor<GetCheckpointAction.Request> requestCaptor = ArgumentCaptor.forClass(GetCheckpointAction.Request.class);
+        doAnswer(withResponse(checkpointResponse)).when(client).execute(eq(GetCheckpointAction.INSTANCE), requestCaptor.capture(), any());
+
+        RemoteClusterResolver remoteClusterResolver = mock(RemoteClusterResolver.class);
+        when(remoteClusterResolver.resolve(any(String[].class))).thenReturn(
+            new RemoteClusterResolver.ResolvedIndices(Map.of(), List.of("source_index"))
+        );
+
+        DefaultCheckpointProvider provider = new DefaultCheckpointProvider(
+            clock,
+            parentTaskClient,
+            remoteClusterResolver,
+            transformConfigManager,
+            transformAuditor,
+            transformConfig
+        );
+
+        // Act: trigger checkpoint creation which calls getIndexCheckpoints
+        SetOnce<TransformCheckpoint> checkpointHolder = new SetOnce<>();
+        SetOnce<Exception> exceptionHolder = new SetOnce<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        provider.createNextCheckpoint(
+            null,
+            new LatchedActionListener<>(ActionListener.wrap(checkpointHolder::set, exceptionHolder::set), latch)
+        );
+        assertThat(latch.await(100, TimeUnit.MILLISECONDS), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+
+        // Assert: the query should be set when no runtime_mappings are present (for shard-skipping optimization)
+        GetCheckpointAction.Request capturedRequest = requestCaptor.getValue();
+        assertNotNull(
+            "GetCheckpointAction.Request query should be set when no runtime_mappings are present for shard-skipping optimization",
+            capturedRequest.getQuery()
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -471,8 +471,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         SourceConfig sourceWithRuntimeMappings = new SourceConfig(
             new String[] { "source_index" },
             QueryConfig.matchAll(),
-            Map.of("total_price_with_tax", Map.of("type", "double", "script", Map.of("source", "emit(1.0)"))),
-            null
+            Map.of("total_price_with_tax", Map.of("type", "double", "script", Map.of("source", "emit(1.0)")))
         );
         TransformConfig transformConfig = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId)).setSource(
             sourceWithRuntimeMappings
@@ -524,8 +523,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         SourceConfig sourceWithoutRuntimeMappings = new SourceConfig(
             new String[] { "source_index" },
             QueryConfig.matchAll(),
-            Collections.emptyMap(),
-            null
+            Collections.emptyMap()
         );
         TransformConfig transformConfig = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId)).setSource(
             sourceWithoutRuntimeMappings


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Transform] Skip checkpoint query filter when runtime_mappings are present (#142452)