### PR TITLE
Unmute ValueSourceReaderTypeConversionTests#testLoadAll

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -302,9 +302,6 @@ tests:
 - class: org.elasticsearch.compute.operator.topn.TopNOomRaceTests
   method: testRace {repeats = 50}
   issue: https://github.com/elastic/elasticsearch/issues/141773
-- class: org.elasticsearch.compute.lucene.read.ValueSourceReaderTypeConversionTests
-  method: testLoadAll
-  issue: https://github.com/elastic/elasticsearch/issues/141954
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/142032


### PR DESCRIPTION
## Description
- Remove the mute for `ValueSourceReaderTypeConversionTests.testLoadAll` in `muted-tests.yml` since myself, @ncordon, and @mouhc1ne weren't able to repro + Buildkite & history suggest it was transient / a fluke

Closes: #141954