### PR TITLE
Give system role permission to invoke shard refresh

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.readonly.TransportAddIndexBlockAction;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
 import org.elasticsearch.action.search.TransportSearchShardsAction;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
@@ -38,7 +37,6 @@ public final class SystemPrivilege extends Privilege {
         "indices:admin/template/put", // needed for the TemplateUpgradeService
         "indices:admin/template/delete", // needed for the TemplateUpgradeService
         "indices:admin/seq_no/global_checkpoint_sync*", // needed for global checkpoint syncs
-        RefreshAction.NAME + "*", // needed for reshard to invoke refresh
         "indices:admin/reshard/split*", // needed for reshard operations
         RetentionLeaseSyncAction.ACTION_NAME + "*", // needed for retention lease syncs
         RetentionLeaseBackgroundSyncAction.ACTION_NAME + "*", // needed for background retention lease syncs
@@ -49,7 +47,7 @@ public final class SystemPrivilege extends Privilege {
         CompletionPersistentTaskAction.INSTANCE.name(), // needed for ShardFollowTaskCleaner
         "indices:data/write/*", // needed for SystemIndexMigrator
         "indices:data/read/*", // needed for SystemIndexMigrator
-        "indices:admin/refresh", // needed for SystemIndexMigrator
+        "indices:admin/refresh*", // needed for SystemIndexMigrator and resharding
         "indices:admin/aliases", // needed for SystemIndexMigrator
         TransportCreateIndexAction.TYPE.name() + "*", // needed for SystemIndexMigrator
         TransportAddIndexBlockAction.TYPE.name() + "*", // needed for SystemIndexMigrator

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.readonly.TransportAddIndexBlockAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
 import org.elasticsearch.action.search.TransportSearchShardsAction;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
@@ -37,6 +38,7 @@ public final class SystemPrivilege extends Privilege {
         "indices:admin/template/put", // needed for the TemplateUpgradeService
         "indices:admin/template/delete", // needed for the TemplateUpgradeService
         "indices:admin/seq_no/global_checkpoint_sync*", // needed for global checkpoint syncs
+        RefreshAction.NAME + "*", // needed for reshard to invoke refresh
         "indices:admin/reshard/split*", // needed for reshard operations
         RetentionLeaseSyncAction.ACTION_NAME + "*", // needed for retention lease syncs
         RetentionLeaseBackgroundSyncAction.ACTION_NAME + "*", // needed for background retention lease syncs


### PR DESCRIPTION
This is needed for resharding because resharding invokes refresh after deleting unowned objects from split shards and flushing the delete to the object store. It invokes refresh in order to confirm that the delete is visible at search nodes before removing the search filters that hide unowned objects while resharding is in progress.