### PR TITLE
ESQL: Add distribution strategy for external sources

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+
+import java.util.List;
+
+/**
+ * Adaptive distribution strategy for external sources.
+ * <p>
+ * Distributes when the plan contains aggregations and there are multiple splits,
+ * or when the split count exceeds the number of eligible nodes.
+ * Stays on the coordinator for single splits or LIMIT-only plans.
+ */
+public final class AdaptiveStrategy implements ExternalDistributionStrategy {
+
+    private final NodeEligibilityStrategy eligibility;
+
+    public AdaptiveStrategy(NodeEligibilityStrategy eligibility) {
+        if (eligibility == null) {
+            throw new IllegalArgumentException("eligibility must not be null");
+        }
+        this.eligibility = eligibility;
+    }
+
+    public AdaptiveStrategy() {
+        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+    }
+
+    @Override
+    public ExternalDistributionPlan planDistribution(ExternalDistributionContext context) {
+        List<ExternalSplit> splits = context.splits();
+        if (splits.size() <= 1) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        PhysicalPlan plan = context.plan();
+
+        if (isLimitOnly(plan)) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        List<DiscoveryNode> nodes = eligibility.eligibleNodes(context.availableNodes());
+        if (nodes.isEmpty()) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        boolean hasAggregation = plan.anyMatch(n -> n instanceof AggregateExec);
+        boolean manySplits = splits.size() > nodes.size();
+
+        if (hasAggregation || manySplits) {
+            return RoundRobinStrategy.assignRoundRobin(splits, nodes);
+        }
+
+        return ExternalDistributionPlan.LOCAL;
+    }
+
+    private static boolean isLimitOnly(PhysicalPlan plan) {
+        boolean hasLimit = plan.anyMatch(n -> n instanceof LimitExec);
+        boolean hasAgg = plan.anyMatch(n -> n instanceof AggregateExec);
+        boolean hasTopN = plan.anyMatch(n -> n instanceof TopNExec);
+        return hasLimit && hasAgg == false && hasTopN == false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+/**
+ * Always executes external sources on the coordinator — no distribution.
+ */
+public final class CoordinatorOnlyStrategy implements ExternalDistributionStrategy {
+
+    public static final CoordinatorOnlyStrategy INSTANCE = new CoordinatorOnlyStrategy();
+
+    private CoordinatorOnlyStrategy() {}
+
+    @Override
+    public ExternalDistributionPlan planDistribution(ExternalDistributionContext context) {
+        return ExternalDistributionPlan.LOCAL;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.List;
+
+/**
+ * Context provided to an {@link ExternalDistributionStrategy} so it can decide
+ * how (or whether) to distribute external-source splits across data nodes.
+ */
+public record ExternalDistributionContext(
+    PhysicalPlan plan,
+    List<ExternalSplit> splits,
+    DiscoveryNodes availableNodes,
+    QueryPragmas pragmas
+) {
+    public ExternalDistributionContext {
+        if (plan == null) {
+            throw new IllegalArgumentException("plan must not be null");
+        }
+        if (splits == null) {
+            throw new IllegalArgumentException("splits must not be null");
+        }
+        if (availableNodes == null) {
+            throw new IllegalArgumentException("availableNodes must not be null");
+        }
+        if (pragmas == null) {
+            throw new IllegalArgumentException("pragmas must not be null");
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionPlan.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The result of an {@link ExternalDistributionStrategy} decision: whether to distribute
+ * and, if so, which splits go to which node.
+ *
+ * @param nodeAssignments mapping from node id to the splits assigned to that node; empty when not distributed
+ * @param distributed     true when the query should be fanned out to data nodes
+ */
+public record ExternalDistributionPlan(Map<String, List<ExternalSplit>> nodeAssignments, boolean distributed) {
+
+    public static final ExternalDistributionPlan LOCAL = new ExternalDistributionPlan(Map.of(), false);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+/**
+ * Decides whether an external source query should be distributed across data nodes
+ * or executed locally on the coordinator.
+ */
+public interface ExternalDistributionStrategy {
+
+    ExternalDistributionPlan planDistribution(ExternalDistributionContext context);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Determines which nodes are eligible to execute external-source splits.
+ */
+public interface NodeEligibilityStrategy {
+
+    List<DiscoveryNode> eligibleNodes(DiscoveryNodes allNodes);
+
+    NodeEligibilityStrategy ALL_NODES = allNodes -> {
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        for (DiscoveryNode node : allNodes) {
+            nodes.add(node);
+        }
+        return nodes;
+    };
+
+    NodeEligibilityStrategy DATA_NODES_ONLY = allNodes -> {
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        for (DiscoveryNode node : allNodes) {
+            if (node.canContainData()) {
+                nodes.add(node);
+            }
+        }
+        return nodes;
+    };
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -102,6 +102,12 @@ public final class QueryPragmas implements Writeable {
      */
     public static final Setting<Integer> MAX_KEYWORD_SORT_FIELDS = Setting.intSetting("max_keyword_sort_fields", -1, -1);
 
+    /**
+     * Controls how external source queries are distributed across nodes.
+     * Valid values: "adaptive" (default), "coordinator_only", "round_robin".
+     */
+    public static final Setting<String> EXTERNAL_DISTRIBUTION = Setting.simpleString("external_distribution", "adaptive");
+
     public static final Setting<Boolean> FORK_IMPLICIT_LIMIT = Setting.boolSetting("fork_implicit_limit", true);
 
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
@@ -234,6 +240,10 @@ public final class QueryPragmas implements Writeable {
 
     public int maxKeywordSortFields() {
         return MAX_KEYWORD_SORT_FIELDS.get(settings);
+    }
+
+    public String externalDistribution() {
+        return EXTERNAL_DISTRIBUTION.get(settings);
     }
 
     public int partialAggregationEmitKeysThreshold(int defaultThreshold) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Distributes external splits evenly across eligible data nodes in round-robin order.
+ * Falls back to coordinator-only when there are no splits or no eligible nodes.
+ */
+public final class RoundRobinStrategy implements ExternalDistributionStrategy {
+
+    private final NodeEligibilityStrategy eligibility;
+
+    public RoundRobinStrategy(NodeEligibilityStrategy eligibility) {
+        if (eligibility == null) {
+            throw new IllegalArgumentException("eligibility must not be null");
+        }
+        this.eligibility = eligibility;
+    }
+
+    public RoundRobinStrategy() {
+        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+    }
+
+    @Override
+    public ExternalDistributionPlan planDistribution(ExternalDistributionContext context) {
+        List<ExternalSplit> splits = context.splits();
+        if (splits.isEmpty()) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        List<DiscoveryNode> nodes = eligibility.eligibleNodes(context.availableNodes());
+        if (nodes.isEmpty()) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        return assignRoundRobin(splits, nodes);
+    }
+
+    static ExternalDistributionPlan assignRoundRobin(List<ExternalSplit> splits, List<DiscoveryNode> nodes) {
+        Map<String, List<ExternalSplit>> assignments = new LinkedHashMap<>();
+        for (DiscoveryNode node : nodes) {
+            assignments.put(node.getId(), new ArrayList<>());
+        }
+        for (int i = 0; i < splits.size(); i++) {
+            String nodeId = nodes.get(i % nodes.size()).getId();
+            assignments.get(nodeId).add(splits.get(i));
+        }
+        return new ExternalDistributionPlan(assignments, true);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategyTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+
+public class AdaptiveStrategyTests extends ESTestCase {
+
+    private final AdaptiveStrategy strategy = new AdaptiveStrategy();
+
+    public void testSingleSplitReturnsCoordinator() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createExternalSourceExec(),
+            createSplits(1),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testEmptySplitsReturnsCoordinator() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createExternalSourceExec(),
+            List.of(),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testAggregationWithMultipleSplitsDistributes() {
+        PhysicalPlan source = createExternalSourceExec();
+        PhysicalPlan planWithAgg = new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.SINGLE, List.of(), null);
+
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            planWithAgg,
+            createSplits(4),
+            createNodes(2),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(2, plan.nodeAssignments().size());
+    }
+
+    public void testLimitOnlyReturnsCoordinator() {
+        PhysicalPlan source = createExternalSourceExec();
+        Literal limitExpr = new Literal(Source.EMPTY, 10, DataType.INTEGER);
+        PhysicalPlan planWithLimit = new LimitExec(Source.EMPTY, source, limitExpr, null);
+
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            planWithLimit,
+            createSplits(5),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testManySplitsNoAggregationDistributes() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createExternalSourceExec(),
+            createSplits(10),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(3, plan.nodeAssignments().size());
+    }
+
+    public void testFewSplitsNoAggregationStaysLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createExternalSourceExec(),
+            createSplits(2),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testNoEligibleNodesReturnsLocal() {
+        PhysicalPlan source = createExternalSourceExec();
+        PhysicalPlan planWithAgg = new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.SINGLE, List.of(), null);
+
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            planWithAgg,
+            createSplits(5),
+            DiscoveryNodes.builder().build(),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testDistributionIsEvenRoundRobin() {
+        PhysicalPlan source = createExternalSourceExec();
+        PhysicalPlan planWithAgg = new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.SINGLE, List.of(), null);
+
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            planWithAgg,
+            createSplits(6),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            assertEquals(2, assigned.size());
+        }
+    }
+
+    private static ExternalSourceExec createExternalSourceExec() {
+        return new ExternalSourceExec(Source.EMPTY, "s3://bucket/data/*.parquet", "parquet", List.of(), Map.of(), Map.of(), null);
+    }
+
+    private static List<ExternalSplit> createSplits(int count) {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+            );
+        }
+        return splits;
+    }
+
+    private static DiscoveryNodes createNodes(int count) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < count; i++) {
+            builder.add(DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build());
+        }
+        return builder.build();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategyTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+
+public class CoordinatorOnlyStrategyTests extends ESTestCase {
+
+    public void testAlwaysReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createPlan(),
+            createSplits(5),
+            createNodes(3),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = CoordinatorOnlyStrategy.INSTANCE.planDistribution(context);
+
+        assertFalse(plan.distributed());
+        assertTrue(plan.nodeAssignments().isEmpty());
+    }
+
+    public void testEmptySplitsReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), List.of(), createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = CoordinatorOnlyStrategy.INSTANCE.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    private static PhysicalPlan createPlan() {
+        ExternalSourceExec source = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/*.parquet",
+            "parquet",
+            List.of(),
+            Map.of(),
+            Map.of(),
+            null
+        );
+        return new LimitExec(Source.EMPTY, source, new Literal(Source.EMPTY, 10, DataType.INTEGER), null);
+    }
+
+    private static List<ExternalSplit> createSplits(int count) {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+            );
+        }
+        return splits;
+    }
+
+    private static DiscoveryNodes createNodes(int count) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < count; i++) {
+            builder.add(DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build());
+        }
+        return builder.build();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.session.Versioned;
+
+import java.util.List;
+import java.util.Map;
+
+public class ExternalDistributionTests extends ESTestCase {
+
+    private static final Source SRC = Source.EMPTY;
+
+    // --- Mapper tests ---
+
+    public void testMapperCreatesSingleAggForExternalSource() {
+        ExternalRelation external = createExternalRelation();
+        List<Expression> groupings = List.of();
+        List<? extends NamedExpression> aggregates = List.of();
+        Aggregate aggregate = new Aggregate(SRC, external, groupings, aggregates);
+
+        Mapper mapper = new Mapper();
+        PhysicalPlan physicalPlan = mapper.map(new Versioned<>(aggregate, TransportVersion.current()));
+
+        assertTrue("Expected AggregateExec at top, got: " + physicalPlan.getClass().getSimpleName(), physicalPlan instanceof AggregateExec);
+        AggregateExec aggExec = (AggregateExec) physicalPlan;
+        assertEquals(AggregatorMode.SINGLE, aggExec.getMode());
+        assertTrue(
+            "Expected ExternalSourceExec child, got: " + aggExec.child().getClass().getSimpleName(),
+            aggExec.child() instanceof ExternalSourceExec
+        );
+    }
+
+    public void testMapperDoesNotInsertExchangeForLimitAboveExternalSource() {
+        ExternalRelation external = createExternalRelation();
+        Limit limit = new Limit(SRC, new Literal(SRC, 10, DataType.INTEGER), external);
+
+        Mapper mapper = new Mapper();
+        PhysicalPlan physicalPlan = mapper.map(new Versioned<>(limit, TransportVersion.current()));
+
+        assertTrue("Expected LimitExec at top, got: " + physicalPlan.getClass().getSimpleName(), physicalPlan instanceof LimitExec);
+        LimitExec limitExec = (LimitExec) physicalPlan;
+        assertTrue(
+            "Expected ExternalSourceExec child (no exchange), got: " + limitExec.child().getClass().getSimpleName(),
+            limitExec.child() instanceof ExternalSourceExec
+        );
+    }
+
+    // --- Context validation tests ---
+
+    public void testContextRejectsNullSplits() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new ExternalDistributionContext(createExternalSourceExec(), null, null, QueryPragmas.EMPTY)
+        );
+    }
+
+    public void testContextRejectsNullPlan() {
+        expectThrows(IllegalArgumentException.class, () -> new ExternalDistributionContext(null, List.of(), null, QueryPragmas.EMPTY));
+    }
+
+    // --- Strategy resolution tests ---
+
+    public void testResolveStrategyAdaptiveDefault() {
+        ExternalDistributionStrategy strategy = ComputeService.resolveExternalDistributionStrategy(QueryPragmas.EMPTY);
+        assertTrue(strategy instanceof AdaptiveStrategy);
+    }
+
+    public void testResolveStrategyCoordinatorOnly() {
+        Settings settings = Settings.builder().put("external_distribution", "coordinator_only").build();
+        QueryPragmas pragmas = new QueryPragmas(settings);
+        ExternalDistributionStrategy strategy = ComputeService.resolveExternalDistributionStrategy(pragmas);
+        assertTrue(strategy instanceof CoordinatorOnlyStrategy);
+    }
+
+    public void testResolveStrategyRoundRobin() {
+        Settings settings = Settings.builder().put("external_distribution", "round_robin").build();
+        QueryPragmas pragmas = new QueryPragmas(settings);
+        ExternalDistributionStrategy strategy = ComputeService.resolveExternalDistributionStrategy(pragmas);
+        assertTrue(strategy instanceof RoundRobinStrategy);
+    }
+
+    // --- Exchange collapsing tests (safety net for PR5) ---
+
+    public void testCollapseExternalSourceExchangeRemovesExchange() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        ExchangeExec exchange = new ExchangeExec(SRC, externalSource);
+        LimitExec limit = new LimitExec(SRC, exchange, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        PhysicalPlan collapsed = ComputeService.collapseExternalSourceExchanges(limit);
+
+        assertTrue("Expected LimitExec at top", collapsed instanceof LimitExec);
+        LimitExec collapsedLimit = (LimitExec) collapsed;
+        assertTrue(
+            "Expected ExternalSourceExec directly under LimitExec, got: " + collapsedLimit.child().getClass().getSimpleName(),
+            collapsedLimit.child() instanceof ExternalSourceExec
+        );
+    }
+
+    public void testCollapseExternalSourceExchangePreservesNonExternalExchanges() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        AggregateExec agg = new AggregateExec(SRC, externalSource, List.of(), List.of(), AggregatorMode.INITIAL, List.of(), null);
+        ExchangeExec exchange = new ExchangeExec(SRC, agg);
+
+        PhysicalPlan collapsed = ComputeService.collapseExternalSourceExchanges(exchange);
+
+        assertTrue("Exchange wrapping non-ExternalSourceExec should be preserved", collapsed instanceof ExchangeExec);
+    }
+
+    public void testCollapseDoesNothingWhenNoExchanges() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        LimitExec limit = new LimitExec(SRC, externalSource, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        PhysicalPlan collapsed = ComputeService.collapseExternalSourceExchanges(limit);
+
+        assertTrue(collapsed instanceof LimitExec);
+        LimitExec collapsedLimit = (LimitExec) collapsed;
+        assertTrue(collapsedLimit.child() instanceof ExternalSourceExec);
+    }
+
+    public void testCollapseWithSplitsOnExternalSource() {
+        List<ExternalSplit> splits = List.of(
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file1.parquet"), 0, 1024, ".parquet", Map.of(), Map.of()),
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file2.parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+        );
+        ExternalSourceExec externalSource = createExternalSourceExec().withSplits(splits);
+        ExchangeExec exchange = new ExchangeExec(SRC, externalSource);
+        LimitExec limit = new LimitExec(SRC, exchange, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        PhysicalPlan collapsed = ComputeService.collapseExternalSourceExchanges(limit);
+
+        assertTrue(collapsed instanceof LimitExec);
+        LimitExec collapsedLimit = (LimitExec) collapsed;
+        assertTrue(collapsedLimit.child() instanceof ExternalSourceExec);
+        ExternalSourceExec collapsedSource = (ExternalSourceExec) collapsedLimit.child();
+        assertEquals(2, collapsedSource.splits().size());
+    }
+
+    // --- Helpers ---
+
+    private static ExternalRelation createExternalRelation() {
+        List<Attribute> output = List.of(
+            new FieldAttribute(SRC, "name", new EsField("name", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+        );
+        SimpleSourceMetadata metadata = new SimpleSourceMetadata(output, "parquet", "s3://bucket/data/*.parquet");
+        return new ExternalRelation(SRC, "s3://bucket/data/*.parquet", metadata, output, null);
+    }
+
+    private static ExternalSourceExec createExternalSourceExec() {
+        return new ExternalSourceExec(
+            SRC,
+            "s3://bucket/data/*.parquet",
+            "parquet",
+            List.of(
+                new FieldAttribute(SRC, "name", new EsField("name", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+            ),
+            Map.of(),
+            Map.of(),
+            null
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategyTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.MASTER_ROLE;
+
+public class NodeEligibilityStrategyTests extends ESTestCase {
+
+    public void testAllNodesReturnsEveryNode() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("master-1").roles(Set.of(MASTER_ROLE)).build())
+            .build();
+
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.ALL_NODES.eligibleNodes(nodes);
+
+        assertEquals(2, eligible.size());
+    }
+
+    public void testDataNodesOnlyExcludesMasterOnly() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("master-1").roles(Set.of(MASTER_ROLE)).build())
+            .build();
+
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes);
+
+        assertEquals(1, eligible.size());
+        assertEquals("data-1", eligible.get(0).getId());
+    }
+
+    public void testDataNodesOnlyIncludesMultiRoleNode() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("multi-1").roles(Set.of(DATA_HOT_NODE_ROLE, MASTER_ROLE)).build())
+            .build();
+
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes);
+
+        assertEquals(1, eligible.size());
+    }
+
+    public void testEmptyNodesReturnsEmpty() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().build();
+
+        assertTrue(NodeEligibilityStrategy.ALL_NODES.eligibleNodes(nodes).isEmpty());
+        assertTrue(NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes).isEmpty());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategyTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+
+public class RoundRobinStrategyTests extends ESTestCase {
+
+    private final RoundRobinStrategy strategy = new RoundRobinStrategy();
+
+    public void testEvenDistribution() {
+        List<ExternalSplit> splits = createSplits(6);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(3, plan.nodeAssignments().size());
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            assertEquals(2, assigned.size());
+        }
+    }
+
+    public void testUnevenDistribution() {
+        List<ExternalSplit> splits = createSplits(5);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(3, plan.nodeAssignments().size());
+        int total = 0;
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            total += assigned.size();
+        }
+        assertEquals(5, total);
+    }
+
+    public void testWrapsAround() {
+        List<ExternalSplit> splits = createSplits(7);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(2), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(2, plan.nodeAssignments().size());
+        List<List<ExternalSplit>> values = List.copyOf(plan.nodeAssignments().values());
+        assertEquals(4, values.get(0).size());
+        assertEquals(3, values.get(1).size());
+    }
+
+    public void testSingleNodeGetsAllSplits() {
+        List<ExternalSplit> splits = createSplits(5);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(1), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(1, plan.nodeAssignments().size());
+        assertEquals(5, plan.nodeAssignments().values().iterator().next().size());
+    }
+
+    public void testEmptySplitsReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), List.of(), createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testNoEligibleNodesReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createPlan(),
+            createSplits(3),
+            DiscoveryNodes.builder().build(),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    private static PhysicalPlan createPlan() {
+        ExternalSourceExec source = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/*.parquet",
+            "parquet",
+            List.of(),
+            Map.of(),
+            Map.of(),
+            null
+        );
+        return new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.SINGLE, List.of(), null);
+    }
+
+    private static List<ExternalSplit> createSplits(int count) {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+            );
+        }
+        return splits;
+    }
+
+    private static DiscoveryNodes createNodes(int count) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < count; i++) {
+            builder.add(DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build());
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Add a pluggable distribution strategy for external source queries,
enabling future distributed execution across data nodes.

- ExternalDistributionStrategy, ExternalDistributionContext,
  ExternalDistributionPlan, NodeEligibilityStrategy: core interfaces
  for deciding how external source splits should be distributed
- CoordinatorOnlyStrategy, RoundRobinStrategy, AdaptiveStrategy:
  concrete implementations with shared round-robin assignment logic
- Mapper: insert ExchangeExec above ExternalSourceExec when pipeline
  breakers are present, mirroring FragmentExec handling
- ComputeService: resolve strategy from `external_distribution` pragma,
  apply strategy; always collapse exchanges to coordinator-only until
  data node dispatch is implemented (PR5)
- QueryPragmas: add `external_distribution` setting (adaptive/coordinator_only/round_robin)

Relates #142996

Developed using AI-assisted tooling