### PR TITLE
[8.19] [CI] Use same test seed for all Buildkite job retries (#143090)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -145,19 +145,80 @@ EOF
 EOF
 fi
 
+# =============================================================================
+# PART 1: Test seed retrieval for ANY retry
+# =============================================================================
+# When a job is retried (regardless of SMART_RETRIES setting), retrieve and use
+# the same test seed from the original job to ensure reproducible test failures.
+# =============================================================================
+
+# Initialize variables that may be reused by smart retry logic below
+BUILD_JSON=""
+ORIGIN_JOB_ID=""
+BUILD_SCAN_ID=""
+BUILD_SCAN_URL=""
+TESTS_SEED=""
+
+if [[ "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; then
+  echo "--- Retrieving test seed from original job"
+
+  if BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null); then
+    if ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) && [ "$ORIGIN_JOB_ID" != "null" ] && [ -n "$ORIGIN_JOB_ID" ]; then
+
+      # Retrieve test seed from Buildkite metadata
+      TESTS_SEED=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["tests-seed-" + $job_id]' 2>/dev/null)
+
+      # Retrieve build scan URL and ID for smart retry (reused in Part 2)
+      BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null)
+      BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null)
+
+      if [[ -n "$TESTS_SEED" ]] && [[ "$TESTS_SEED" != "null" ]]; then
+        echo "Using test seed $TESTS_SEED from original job $ORIGIN_JOB_ID"
+        export TESTS_SEED
+      else
+        echo "Warning: Could not find test seed in metadata for original job."
+        echo "Tests will use a new random seed."
+        TESTS_SEED=""
+      fi
+    else
+      echo "Warning: Could not find origin job ID for retry."
+      echo "Tests will use a new random seed."
+    fi
+  else
+    echo "Warning: Failed to fetch build information from Buildkite API"
+    echo "Tests will use a new random seed."
+  fi
+fi
+
+# =============================================================================
+# PART 2: Smart retry test filtering (only when SMART_RETRIES=true)
+# =============================================================================
+# When smart retries are enabled, fetch the list of failed tests from the
+# original job and filter this retry to only run those tests.
+# =============================================================================
 if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; then
   echo "--- Resolving previously failed tests"
   SMART_RETRY_STATUS="disabled"
   SMART_RETRY_DETAILS=""
 
-  if BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null); then
-    if ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) && [ "$ORIGIN_JOB_ID" != "null" ] && [ -n "$ORIGIN_JOB_ID" ]; then
-      
-      # Attempt to retrieve build scan ID directly from metadata
-      BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null)
+  # Check if we already have the build info from seed retrieval above
+  if [[ -z "$BUILD_JSON" ]]; then
+    # Fetch build info if not already available (shouldn't happen, but be safe)
+    BUILD_JSON=$(curl --max-time 30 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" 2>/dev/null) || BUILD_JSON=""
+  fi
 
-      # Retrieve build scan URL for annotation
-      BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null)
+  if [[ -n "$BUILD_JSON" ]]; then
+    # Get origin job ID if not already available
+    if [[ -z "$ORIGIN_JOB_ID" ]] || [[ "$ORIGIN_JOB_ID" == "null" ]]; then
+      ORIGIN_JOB_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg jobId "$BUILDKITE_JOB_ID" ' .jobs[] | select(.id == $jobId) | .retry_source.job_id' 2>/dev/null) || ORIGIN_JOB_ID=""
+    fi
+
+    if [[ -n "$ORIGIN_JOB_ID" ]] && [[ "$ORIGIN_JOB_ID" != "null" ]]; then
+      # Get build scan ID if not already available
+      if [[ -z "$BUILD_SCAN_ID" ]] || [[ "$BUILD_SCAN_ID" == "null" ]]; then
+        BUILD_SCAN_ID=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-id-" + $job_id]' 2>/dev/null) || BUILD_SCAN_ID=""
+        BUILD_SCAN_URL=$(printf '%s\n' "$BUILD_JSON" | jq -r --arg job_id "$ORIGIN_JOB_ID" '.meta_data["build-scan-" + $job_id]' 2>/dev/null) || BUILD_SCAN_URL=""
+      fi
 
       if [[ -n "$BUILD_SCAN_ID" ]] && [[ "$BUILD_SCAN_ID" != "null" ]]; then
         # Validate BUILD_SCAN_ID format to prevent injection attacks
@@ -180,7 +241,7 @@ if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; 
             --max-time 30 \
             --header 'accept: application/json' \
             --header "authorization: Bearer $DEVELOCITY_API_ACCESS_KEY" \
-            --header 'content-type: application/json' 2>/dev/null | jq '.' &> .failed-test-history.json; then
+            --header 'content-type: application/json' 2>/dev/null | jq --arg testseed "${TESTS_SEED:-}" '. + {testseed: $testseed}' &> .failed-test-history.json; then
 
             # Set secure file permissions
             chmod 600 .failed-test-history.json
@@ -196,7 +257,7 @@ if [[ "${SMART_RETRIES:-}" == "true" && "${BUILDKITE_RETRY_COUNT:-0}" -gt 0 ]]; 
               ORIGIN_JOB_NAME="previous attempt"
             fi
 
-            echo "✓ Smart retry enabled: filtering to $FILTERED_WORK_UNITS work units"
+            echo "Smart retry enabled: filtering to $FILTERED_WORK_UNITS work units"
 
             # Create Buildkite annotation for visibility
             # Use unique context per job to support multiple retries

--- a/.buildkite/hooks/pre-command.bat
+++ b/.buildkite/hooks/pre-command.bat
@@ -28,7 +28,70 @@ for /f "delims=" %%i in ('vault read -field^=token secret/ci/elastic-elasticsear
 
 bash.exe -c "nohup bash .buildkite/scripts/setup-monitoring.sh </dev/null >/dev/null 2>&1 &"
 
-REM Smart retries implementation
+REM =============================================================================
+REM PART 1: Test seed retrieval for ANY retry
+REM =============================================================================
+REM When a job is retried (regardless of SMART_RETRIES setting), retrieve and use
+REM the same test seed from the original job to ensure reproducible test failures.
+REM =============================================================================
+set ORIGIN_JOB_ID=
+set BUILD_SCAN_ID=
+set BUILD_SCAN_URL=
+set TESTS_SEED=
+
+if defined BUILDKITE_RETRY_COUNT (
+  if %BUILDKITE_RETRY_COUNT% GTR 0 (
+    echo --- Retrieving test seed from original job
+
+    REM Fetch build information from Buildkite API
+    curl --max-time 30 -H "Authorization: Bearer %BUILDKITE_API_TOKEN%" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/%BUILDKITE_PIPELINE_SLUG%/builds/%BUILDKITE_BUILD_NUMBER%?include_retried_jobs=true" -o .build-info.json 2>nul
+
+    if exist .build-info.json (
+      REM Extract origin job ID
+      for /f "delims=" %%i in ('jq -r --arg jobId "%BUILDKITE_JOB_ID%" ".jobs[] | select(.id == $jobId) | .retry_source.job_id" .build-info.json 2^>nul') do set ORIGIN_JOB_ID=%%i
+
+      if defined ORIGIN_JOB_ID (
+        if not "!ORIGIN_JOB_ID!"=="null" (
+          REM Retrieve test seed directly from Buildkite metadata
+          for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"tests-seed-\" + $job_id]" .build-info.json 2^>nul') do set TESTS_SEED=%%i
+
+          REM Retrieve build scan URL and ID for smart retry (reused in Part 2)
+          for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_URL=%%i
+          for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-id-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_ID=%%i
+
+          if defined TESTS_SEED (
+            if not "!TESTS_SEED!"=="null" (
+              echo Using test seed !TESTS_SEED! from original job !ORIGIN_JOB_ID!
+            ) else (
+              echo Warning: Could not find test seed in metadata for original job.
+              echo Tests will use a new random seed.
+              set TESTS_SEED=
+            )
+          ) else (
+            echo Warning: Could not find test seed in metadata for original job.
+            echo Tests will use a new random seed.
+          )
+        ) else (
+          echo Warning: Could not find origin job ID for retry.
+          echo Tests will use a new random seed.
+        )
+      ) else (
+        echo Warning: Could not find origin job ID for retry.
+        echo Tests will use a new random seed.
+      )
+    ) else (
+      echo Warning: Failed to fetch build information from Buildkite API
+      echo Tests will use a new random seed.
+    )
+  )
+)
+
+REM =============================================================================
+REM PART 2: Smart retry test filtering (only when SMART_RETRIES=true)
+REM =============================================================================
+REM When smart retries are enabled, fetch the list of failed tests from the
+REM original job and filter this retry to only run those tests.
+REM =============================================================================
 if "%SMART_RETRIES%"=="true" (
   if defined BUILDKITE_RETRY_COUNT (
     if %BUILDKITE_RETRY_COUNT% GTR 0 (
@@ -36,20 +99,24 @@ if "%SMART_RETRIES%"=="true" (
       set SMART_RETRY_STATUS=disabled
       set SMART_RETRY_DETAILS=
 
-      REM Fetch build information from Buildkite API
-      curl --max-time 30 -H "Authorization: Bearer %BUILDKITE_API_TOKEN%" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/%BUILDKITE_PIPELINE_SLUG%/builds/%BUILDKITE_BUILD_NUMBER%?include_retried_jobs=true" -o .build-info.json 2>nul
+      REM Check if we need to fetch build info (should already exist from Part 1)
+      if not exist .build-info.json (
+        curl --max-time 30 -H "Authorization: Bearer %BUILDKITE_API_TOKEN%" -X GET "https://api.buildkite.com/v2/organizations/elastic/pipelines/%BUILDKITE_PIPELINE_SLUG%/builds/%BUILDKITE_BUILD_NUMBER%?include_retried_jobs=true" -o .build-info.json 2>nul
+      )
 
       if exist .build-info.json (
-        REM Extract origin job ID
-        for /f "delims=" %%i in ('jq -r --arg jobId "%BUILDKITE_JOB_ID%" ".jobs[] | select(.id == $jobId) | .retry_source.job_id" .build-info.json 2^>nul') do set ORIGIN_JOB_ID=%%i
+        REM Get origin job ID if not already set
+        if not defined ORIGIN_JOB_ID (
+          for /f "delims=" %%i in ('jq -r --arg jobId "%BUILDKITE_JOB_ID%" ".jobs[] | select(.id == $jobId) | .retry_source.job_id" .build-info.json 2^>nul') do set ORIGIN_JOB_ID=%%i
+        )
 
         if defined ORIGIN_JOB_ID (
           if not "!ORIGIN_JOB_ID!"=="null" (
-            REM Extract build scan ID directly (new way)
-            for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-id-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_ID=%%i
-
-            REM Retrieve build scan URL for annotation
-            for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_URL=%%i
+            REM Get build scan ID if not already set
+            if not defined BUILD_SCAN_ID (
+              for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-id-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_ID=%%i
+              for /f "delims=" %%i in ('jq -r --arg job_id "!ORIGIN_JOB_ID!" ".meta_data[\"build-scan-\" + $job_id]" .build-info.json 2^>nul') do set BUILD_SCAN_URL=%%i
+            )
 
             if defined BUILD_SCAN_ID (
               if not "!BUILD_SCAN_ID!"=="null" (

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -8,12 +8,17 @@
  */
 
 
+import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 
 import java.lang.management.ManagementFactory
 import java.time.LocalDateTime
-import org.elasticsearch.gradle.Architecture
+import java.util.concurrent.TimeUnit
 
+import static org.elasticsearch.gradle.internal.util.CiUtils.runBuildkiteAgent
+import static org.elasticsearch.gradle.internal.util.CiUtils.safeName
+
+// Resolving this early to avoid issues with the build scan plugin in combination with the configuration cache usage
 def taskNames = gradle.startParameter.taskNames.join(' ')
 
 develocity {
@@ -37,6 +42,7 @@ develocity {
 
     def fips = buildParams.inFipsJvm
     def gitRevision = buildParams.gitRevision
+    def testSeed = buildParams.testSeed
 
     background {
       tag OS.current().name()
@@ -63,6 +69,8 @@ develocity {
 
         value 'Pipeline', System.getenv('BUILDKITE_PIPELINE_SLUG')
         tag System.getenv('BUILDKITE_PIPELINE_SLUG')
+
+        value 'tests.seed', testSeed
 
         value 'Job Name', jobName
         tag jobName
@@ -109,37 +117,45 @@ develocity {
           link 'Source', "https://github.com/${repository}/tree/${gitRevision.get()}"
         }
 
+        // Store test seed in Buildkite metadata so it can be retrieved by retries or other steps in the pipeline
+        // strictly speaking this is not build scan specific, but it's a convenient place and the one place
+        // where we deal with build metadata within the gradle build.
+        def jobId = System.getenv('BUILDKITE_JOB_ID')
+        if (jobId) {
+          // Explicitly convert to String to avoid Groovy/Java array type mismatch
+          runBuildkiteAgent(
+            ['meta-data', 'set', "tests-seed-${jobId}".toString(), testSeed.toString()],
+            "storing test seed in Buildkite metadata"
+          )
+        }
+
         buildFinished { result ->
 
-          buildScanPublished { scan
-            ->
+          buildScanPublished { scan ->
             // Attach build scan link as build metadata
             // See: https://buildkite.com/docs/pipelines/build-meta-data
-            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
-              .start()
-              .waitFor()
+            runBuildkiteAgent(
+              ['meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}".toString(), "${scan.buildScanUri}".toString()],
+              "storing build scan link in Buildkite metadata"
+            )
 
             // Attach build scan ID as build metadata
-            new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-id-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanId}")
-              .start()
-              .waitFor()
+            runBuildkiteAgent(
+              ['meta-data', 'set', "build-scan-id-${System.getenv('BUILDKITE_JOB_ID')}".toString(), "${scan.buildScanId}".toString()],
+              "storing build scan ID in Buildkite metadata"
+            )
 
             // Add a build annotation
             // See: https://buildkite.com/docs/agent/v3/cli-annotate
-            def jobRetryLabel = Integer.parseInt(System.getenv('BUILDKITE_RETRY_COUNT')?:"0") > 0 ? " (retry #${System.getenv('BUILDKITE_RETRY_COUNT')})" : ""
+            def jobRetryLabel = Integer.parseInt(System.getenv('BUILDKITE_RETRY_COUNT') ?: "0") >
+              0 ? " (retry #${System.getenv('BUILDKITE_RETRY_COUNT')})" : ""
             def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}${jobRetryLabel}</span> :gradle: ${result.failures ? 'failed' : 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${taskNames}</code></a></div>"""
-            def process = [
-              'buildkite-agent',
-              'annotate',
-              '--context',
-              result.failures ? 'gradle-build-scans-failed' : 'gradle-build-scans',
-              '--append',
-              '--style',
-              result.failures ? 'error' : 'info'
-            ].execute()
-            process.withWriter { it.write(body) }
             // passing the body in as an argument has issues on Windows, so let's use stdin of the process instead
-            process.waitFor()
+            runBuildkiteAgent(
+              ['annotate', '--context', result.failures ? 'gradle-build-scans-failed' : 'gradle-build-scans', '--append', '--style', result.failures ? 'error' : 'info'],
+              "adding build annotation",
+              { it.write(body) }
+            )
           }
         }
       } else {
@@ -150,8 +166,4 @@ develocity {
       }
     }
   }
-}
-
-static def safeName(String string) {
-  return string.replaceAll(/[^a-zA-Z0-9_\-\.]+/, ' ').trim().replaceAll(' ', '_').toLowerCase()
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/CiUtils.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/CiUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.util;
+
+import groovy.lang.Closure;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class CiUtils {
+
+    private static final Logger logger = Logging.getLogger(CiUtils.class);
+
+    public static String safeName(String input) {
+        return input.replaceAll("[^a-zA-Z0-9_\\-\\.]+", " ").trim().replaceAll(" ", "_").toLowerCase();
+    }
+
+    /**
+     * Executes a buildkite-agent command with timeout and exit code checking.
+     * Failures are logged as warnings but do not fail the build.
+     */
+    public static void runBuildkiteAgent(List<String> args, String description, Closure<?> stdinWriter) {
+        try {
+            List<String> command = new ArrayList<>();
+            command.add("buildkite-agent");
+            command.addAll(args);
+            Process process = new ProcessBuilder(command).start();
+            if (stdinWriter != null) {
+                try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
+                    stdinWriter.call(writer);
+                }
+            }
+            boolean completed = process.waitFor(30, TimeUnit.SECONDS);
+            if (completed == false) {
+                logger.warn("Timeout {}", description);
+                process.destroyForcibly();
+            } else if (process.exitValue() != 0) {
+                logger.warn("Failed {}: exit code {}", description, process.exitValue());
+            }
+        } catch (Exception e) {
+            logger.warn("Failed {}: {}", description, e.getMessage());
+        }
+    }
+
+    /**
+     * Executes a buildkite-agent command with timeout and exit code checking.
+     * Failures are logged as warnings but do not fail the build.
+     */
+    public static void runBuildkiteAgent(List<String> args, String description) {
+        runBuildkiteAgent(args, description, null);
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Use same test seed for all Buildkite job retries (#143090)](https://github.com/elastic/elasticsearch/pull/143090)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)