### PR TITLE
ESQL: Prevent full-text functions from executing after mv_expand to a…

### DIFF
--- a/docs/changelog/143121.yaml
+++ b/docs/changelog/143121.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues: []
+pr: 143121
+summary: Prevent full-text functions (e.g. multi_match) from executing after mv_expand
+type: bug
+

--- a/docs/changelog/143208.yaml
+++ b/docs/changelog/143208.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues: []
+pr: 143208
+summary: Prevent full-text functions (e.g. multi_match) from executing after mv_expand
+type: bug
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multi-match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multi-match-function.csv-spec
@@ -131,3 +131,17 @@ Return of the King Being the Third Part of The Lord of the Rings
 A Tolkien Compass: Including J. R. R. Tolkien's Guide to the Names in The Lord of the Rings
 The Lord of the Rings Poster Collection: Six Paintings by Alan Lee (No. 1)
 ;
+
+testMultiMatchAfterMvExpandNotAllowed
+required_capability: multi_match_function
+
+FROM languages
+| KEEP language_code_long, language_code
+| MV_EXPAND language_code
+| WHERE MULTI_MATCH("test", language_code_long)
+| KEEP language_code_long
+;
+
+error:
+cannot be used after mv_expand
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
@@ -225,9 +226,32 @@ public abstract class FullTextFunction extends Function
         }
     }
 
-    private static void checkFullTextFunctionsInFilter(Filter filter, Failures failures, boolean checkFullTextFunctionsAboveSubqueries) {
+    private static void checkFullTextFunctionsInFilter(
+        Filter filter,
+        Failures failures,
+        boolean checkFullTextFunctionsAboveSubqueries
+    ) {
         Expression condition = filter.condition();
-        checkFullTextQueryFunctionForCondition(filter, failures, condition, false, checkFullTextFunctionsAboveSubqueries);
+        if (filter.child() instanceof MvExpand mvExpand) {
+            condition.forEachDown(FullTextFunction.class, ftf -> {
+                failures.add(
+                    fail(
+                        ftf,
+                        "[{}] {} cannot be used after mv_expand because it requires document-level execution",
+                        ftf.functionName(),
+                        ftf.functionType()
+                    )
+                );
+            });
+        }
+
+        checkFullTextQueryFunctionForCondition(
+            filter,
+            failures,
+            condition,
+            false,
+            checkFullTextFunctionsAboveSubqueries
+        );
     }
 
     private static void checkFullTextQueryFunctionForCondition(
@@ -496,7 +520,13 @@ public abstract class FullTextFunction extends Function
         // the check for LookupJoin or the score function may fail at LogicalVerifier.
         return (logicalPlan, failures) -> {
             if (logicalPlan instanceof Filter f) {
-                checkFullTextFunctionsInFilter(f, failures, true);
+                checkFullTextQueryFunctionForCondition(
+                    f,
+                    failures,
+                    f.condition(),
+                    false,
+                    true
+                );
             }
         };
     }


### PR DESCRIPTION
## Fix mv_expand + full-text function crash

Running full-text functions (such as `multi_match`) after `mv_expand`
can cause a runtime failure:

AssertionError: LuceneQueryExpressionEvaluator expects a DocBlock

This happens because `mv_expand` breaks the document-level execution
assumption required by LuceneQueryEvaluator.

### Fix

Add validation in `FullTextFunction` to prevent full-text functions
from being used after `mv_expand`.

### Result

Instead of crashing at runtime, the query now fails during
plan verification with a clear error message.

### Testing

Added csv-spec coverage for multi_match usage.