### PR TITLE
[8.19] Fix off-by-one error in HyperLogLogPlusPlus LinearCounting (#143110)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,6 +342,3 @@ tests:
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/142440
-- class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
-  method: testSimple
-  issue: https://github.com/elastic/elasticsearch/issues/142408

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -491,7 +491,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
 
         long maxOrd() {
-            return cells.size() - 1;
+            return cells.size();
         }
 
         @Override


### PR DESCRIPTION
Backport of #143110 to `8.19`.


Seems relevant to a rare (locally un-reproduced) test failure, see https://github.com/elastic/elasticsearch/issues/142408#issuecomment-3973575905