### PR TITLE
Fix zero-size estimate in BytesRefBlock null test

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -738,7 +738,7 @@ public class BasicBlockTests extends ESTestCase {
 
     public void testBytesRefBlockBuilderWithNulls() {
         int positionCount = randomIntBetween(0, 16 * 1024);
-        final int builderEstimateSize = randomBoolean() ? randomIntBetween(1, positionCount) : positionCount;
+        final int builderEstimateSize = positionCount == 0 ? 0 : (randomBoolean() ? randomIntBetween(1, positionCount) : positionCount);
         try (var blockBuilder = blockFactory.newBytesRefBlockBuilder(builderEstimateSize)) {
             BytesRef[] values = new BytesRef[positionCount];
             for (int i = 0; i < positionCount; i++) {


### PR DESCRIPTION
Fixes a test-only edge case in `BasicBlockTests.testBytesRefBlockBuilderWithNulls` where `positionCount` may be `0` but the builder estimate was still randomized using `randomIntBetween(1, positionCount)`.

This causes an invalid range (`1..0`) and a spurious failure in CI (see below). The fix sets estimate size to `0` when `positionCount == 0`.

This bug + fix came up as a coincidental randomized test reproduction while working on #143188