### PR TITLE
ignore missing results from remote project exclusion

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -119,8 +120,7 @@ public class CrossProjectIndexResolutionValidator {
             // TODO consider sorting during index re-writing, to avoid sorting here
             var remoteExpressions = localResolvedIndices.remoteExpressions().stream().sorted().toList();
             ResolvedIndexExpression.LocalExpressions localExpressions = localResolvedIndices.localExpressions();
-            ResolvedIndexExpression.LocalIndexResolutionResult result = localExpressions.localIndexResolutionResult();
-            ElasticsearchException localException = checkResolutionFailure(localExpressions, result, originalExpression, indicesOptions);
+            ElasticsearchException localException = checkResolutionFailure(localExpressions, originalExpression, indicesOptions);
 
             if (isQualifiedExpression) {
                 if (localException != null) {
@@ -141,6 +141,7 @@ public class CrossProjectIndexResolutionValidator {
                     var resource = splitResource[1];
 
                     ElasticsearchException remoteException = checkSingleRemoteExpression(
+                        localResolvedExpressions,
                         remoteResolvedExpressions,
                         projectAlias,
                         resource,
@@ -183,6 +184,7 @@ public class CrossProjectIndexResolutionValidator {
                     var resource = splitResource[1];
 
                     ElasticsearchException remoteException = checkSingleRemoteExpression(
+                        localResolvedExpressions,
                         remoteResolvedExpressions,
                         projectAlias,
                         resource,
@@ -298,6 +300,7 @@ public class CrossProjectIndexResolutionValidator {
     }
 
     private static ElasticsearchException checkSingleRemoteExpression(
+        ResolvedIndexExpressions localExpressions,
         Map<String, ResolvedIndexExpressions> remoteResolvedExpressions,
         String projectAlias,
         String resource,
@@ -323,16 +326,15 @@ public class CrossProjectIndexResolutionValidator {
 
         ResolvedIndexExpression.LocalExpressions matchingExpression = findMatchingExpression(resolvedExpressionsInProject, resource);
         if (matchingExpression == null) {
-            assert false : "Expected to find matching expression [" + resource + "] in project [" + projectAlias + "]";
-            return new IndexNotFoundException(remoteExpression);
+            // assume that this is the result of sending an exclusion to the remote
+            return checkResolutionFailure(
+                new ResolvedIndexExpression.LocalExpressions(Set.of(), SUCCESS, null),
+                remoteExpression,
+                indicesOptions
+            );
         }
 
-        return checkResolutionFailure(
-            matchingExpression,
-            matchingExpression.localIndexResolutionResult(),
-            remoteExpression,
-            indicesOptions
-        );
+        return checkResolutionFailure(matchingExpression, remoteExpression, indicesOptions);
     }
 
     public static String[] splitQualifiedResource(String resource) {
@@ -361,12 +363,13 @@ public class CrossProjectIndexResolutionValidator {
 
     private static ElasticsearchException checkResolutionFailure(
         ResolvedIndexExpression.LocalExpressions localExpressions,
-        ResolvedIndexExpression.LocalIndexResolutionResult result,
         String expression,
         IndicesOptions indicesOptions
     ) {
         assert false == (indicesOptions.allowNoIndices() && indicesOptions.ignoreUnavailable())
             : "Should not be checking index existence in lenient mode";
+
+        var result = localExpressions.localIndexResolutionResult();
 
         if (indicesOptions.ignoreUnavailable() == false) {
             if (result == CONCRETE_RESOURCE_NOT_VISIBLE) {

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -327,6 +327,11 @@ public class CrossProjectIndexResolutionValidator {
         ResolvedIndexExpression.LocalExpressions matchingExpression = findMatchingExpression(resolvedExpressionsInProject, resource);
         if (matchingExpression == null) {
             // assume that this is the result of sending an exclusion to the remote
+            assert localExpressions.expressions()
+                .stream()
+                .anyMatch(e -> e.remoteExpressions().stream().anyMatch(r -> r.startsWith(projectAlias + ":-")))
+                : Strings.format("Could not find matching project exclusion for missing remote expression %s", remoteExpression);
+
             return checkResolutionFailure(
                 new ResolvedIndexExpression.LocalExpressions(Set.of(), SUCCESS, null),
                 remoteExpression,

--- a/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
@@ -1556,6 +1556,70 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
         assertThat(ex.getMessage(), equalTo("no such index [-shared-index-1,-shared-index-2]"));
     }
 
+    public void testExplicitProjectInclusionWithProjectExclusionExpressionAndLenientAllowNoIndices() {
+        var local = new ResolvedIndexExpressions(
+            List.of(
+                new ResolvedIndexExpression(
+                    "*:logs",
+                    new ResolvedIndexExpression.LocalExpressions(
+                        Set.of("logs"),
+                        ResolvedIndexExpression.LocalIndexResolutionResult.SUCCESS,
+                        null
+                    ),
+                    Set.of("P1:logs")
+                ),
+                new ResolvedIndexExpression(
+                    randomFrom("P1:-*", "P*:-*"),
+                    new ResolvedIndexExpression.LocalExpressions(Set.of(), ResolvedIndexExpression.LocalIndexResolutionResult.NONE, null),
+                    Set.of()
+                )
+            )
+        );
+
+        var remote = Map.of("P1", new ResolvedIndexExpressions(List.of()));
+
+        assertNull(
+            CrossProjectIndexResolutionValidator.validate(
+                getLenientIndicesOptions(),
+                useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
+                local,
+                remote
+            )
+        );
+    }
+
+    public void testExplicitProjectInclusionWithProjectExclusionExpressionAndStrictAllowNoIndices() {
+        var local = new ResolvedIndexExpressions(
+            List.of(
+                new ResolvedIndexExpression(
+                    "*:logs",
+                    new ResolvedIndexExpression.LocalExpressions(
+                        Set.of("logs"),
+                        ResolvedIndexExpression.LocalIndexResolutionResult.SUCCESS,
+                        null
+                    ),
+                    Set.of("P1:logs")
+                ),
+                new ResolvedIndexExpression(
+                    randomFrom("P1:-*", "P*:-*", "P1:-logs"),
+                    new ResolvedIndexExpression.LocalExpressions(Set.of(), ResolvedIndexExpression.LocalIndexResolutionResult.NONE, null),
+                    Set.of("P1:-*")
+                )
+            )
+        );
+
+        var remote = Map.of("P1", new ResolvedIndexExpressions(List.of()));
+
+        var e = CrossProjectIndexResolutionValidator.validate(
+            getStrictAllowNoIndices(),
+            useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
+            local,
+            remote
+        );
+        assertNotNull(e);
+        assertThat(e.getMessage(), equalTo("no such index [P1:logs]"));
+    }
+
     private IndicesOptions getStrictAllowNoIndices() {
         return getIndicesOptions(true, false);
     }


### PR DESCRIPTION
Fixes resolution of CPS expressions such as `*:logs,linked_project:-*`.

Assume that when a resolution result exists for e.g. `linked_project`, but it doesn't contain `logs`, that this is because of a remote project exclusion expression.