### PR TITLE
ESQL: Add split coalescing for many small files

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A composite split that groups multiple child splits into a single scheduling
+ * unit. Reduces per-split overhead when thousands of tiny files (e.g. Iceberg
+ * micro-partitions) would otherwise each become an independent work item.
+ * Operators that encounter a {@code CoalescedSplit} iterate over its children
+ * and process each one individually.
+ */
+public class CoalescedSplit implements ExternalSplit {
+
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        ExternalSplit.class,
+        "CoalescedSplit",
+        CoalescedSplit::new
+    );
+
+    private final String sourceType;
+    private final List<ExternalSplit> children;
+    private final long estimatedSizeInBytes;
+
+    public CoalescedSplit(String sourceType, List<ExternalSplit> children) {
+        if (sourceType == null) {
+            throw new IllegalArgumentException("sourceType cannot be null");
+        }
+        if (children == null || children.isEmpty()) {
+            throw new IllegalArgumentException("children cannot be null or empty");
+        }
+        this.sourceType = sourceType;
+        this.children = List.copyOf(children);
+        this.estimatedSizeInBytes = computeEstimatedSize(this.children);
+    }
+
+    public CoalescedSplit(StreamInput in) throws IOException {
+        this.sourceType = in.readString();
+        this.children = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
+        this.estimatedSizeInBytes = computeEstimatedSize(this.children);
+    }
+
+    private static long computeEstimatedSize(List<ExternalSplit> children) {
+        long total = 0;
+        for (ExternalSplit child : children) {
+            long childSize = child.estimatedSizeInBytes();
+            if (childSize < 0) {
+                return -1;
+            }
+            total = Math.addExact(total, childSize);
+        }
+        return total;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(sourceType);
+        out.writeNamedWriteableCollection(children);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    public String sourceType() {
+        return sourceType;
+    }
+
+    public List<ExternalSplit> children() {
+        return children;
+    }
+
+    @Override
+    public long estimatedSizeInBytes() {
+        return estimatedSizeInBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CoalescedSplit that = (CoalescedSplit) o;
+        return Objects.equals(sourceType, that.sourceType) && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceType, children);
+    }
+
+    @Override
+    public String toString() {
+        return "CoalescedSplit[sourceType="
+            + sourceType
+            + ", children="
+            + children.size()
+            + ", estimatedBytes="
+            + estimatedSizeInBytes
+            + "]";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescer.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Groups many small {@link ExternalSplit}s into {@link CoalescedSplit}s to
+ * reduce scheduling overhead. Uses greedy bin-packing by size when all splits
+ * report a positive {@code estimatedSizeInBytes()}, and falls back to
+ * count-based grouping otherwise.
+ */
+public final class SplitCoalescer {
+
+    public static final long DEFAULT_TARGET_GROUP_SIZE_BYTES = 128 * 1024 * 1024; // 128 MB
+    public static final int DEFAULT_TARGET_GROUP_COUNT = 8;
+    public static final int COALESCING_THRESHOLD = 32;
+
+    private SplitCoalescer() {}
+
+    public static List<ExternalSplit> coalesce(List<ExternalSplit> splits) {
+        return coalesce(splits, DEFAULT_TARGET_GROUP_SIZE_BYTES, DEFAULT_TARGET_GROUP_COUNT);
+    }
+
+    public static List<ExternalSplit> coalesce(List<ExternalSplit> splits, long targetGroupSizeBytes, int targetGroupCount) {
+        if (splits == null) {
+            throw new IllegalArgumentException("splits cannot be null");
+        }
+        if (splits.size() <= COALESCING_THRESHOLD) {
+            return splits;
+        }
+        if (targetGroupCount <= 0) {
+            throw new IllegalArgumentException("targetGroupCount must be positive, got: " + targetGroupCount);
+        }
+        if (targetGroupSizeBytes <= 0) {
+            throw new IllegalArgumentException("targetGroupSizeBytes must be positive, got: " + targetGroupSizeBytes);
+        }
+
+        boolean allHaveSize = true;
+        for (ExternalSplit split : splits) {
+            if (split.estimatedSizeInBytes() < 0) {
+                allHaveSize = false;
+                break;
+            }
+        }
+
+        if (allHaveSize) {
+            return coalesceBySizeGreedy(splits, targetGroupSizeBytes);
+        }
+        return coalesceByCount(splits, targetGroupCount);
+    }
+
+    private static List<ExternalSplit> coalesceBySizeGreedy(List<ExternalSplit> splits, long targetGroupSizeBytes) {
+        List<ExternalSplit> sorted = new ArrayList<>(splits);
+        sorted.sort(Comparator.comparingLong(ExternalSplit::estimatedSizeInBytes).reversed());
+
+        List<List<ExternalSplit>> bins = new ArrayList<>();
+        List<Long> binSizes = new ArrayList<>();
+
+        for (ExternalSplit split : sorted) {
+            long size = split.estimatedSizeInBytes();
+            if (size >= targetGroupSizeBytes) {
+                bins.add(new ArrayList<>(List.of(split)));
+                binSizes.add(size);
+                continue;
+            }
+
+            int bestBin = -1;
+            long bestRemaining = Long.MAX_VALUE;
+            for (int i = 0; i < bins.size(); i++) {
+                long remaining = targetGroupSizeBytes - binSizes.get(i);
+                if (remaining >= size && remaining < bestRemaining) {
+                    bestBin = i;
+                    bestRemaining = remaining;
+                }
+            }
+
+            if (bestBin >= 0) {
+                bins.get(bestBin).add(split);
+                binSizes.set(bestBin, binSizes.get(bestBin) + size);
+            } else {
+                bins.add(new ArrayList<>(List.of(split)));
+                binSizes.add(size);
+            }
+        }
+
+        return buildResult(bins);
+    }
+
+    private static List<ExternalSplit> coalesceByCount(List<ExternalSplit> splits, int targetGroupCount) {
+        int groupSize = Math.max(1, (splits.size() + targetGroupCount - 1) / targetGroupCount);
+        List<List<ExternalSplit>> bins = new ArrayList<>();
+
+        for (int i = 0; i < splits.size(); i += groupSize) {
+            int end = Math.min(i + groupSize, splits.size());
+            bins.add(new ArrayList<>(splits.subList(i, end)));
+        }
+
+        return buildResult(bins);
+    }
+
+    private static List<ExternalSplit> buildResult(List<List<ExternalSplit>> bins) {
+        List<ExternalSplit> result = new ArrayList<>(bins.size());
+        for (List<ExternalSplit> bin : bins) {
+            if (bin.size() == 1) {
+                result.add(bin.get(0));
+            } else {
+                result.add(new CoalescedSplit(bin.get(0).sourceType(), bin));
+            }
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -75,6 +75,7 @@ import org.elasticsearch.xpack.esql.action.RestEsqlStopAsyncAction;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
 import org.elasticsearch.xpack.esql.analysis.PlanCheckerProvider;
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
 import org.elasticsearch.xpack.esql.datasources.DataSourceCapabilities;
 import org.elasticsearch.xpack.esql.datasources.DataSourceModule;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
@@ -419,6 +420,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         entries.add(MMROperator.Status.ENTRY);
 
         entries.add(FileSplit.ENTRY);
+        entries.add(CoalescedSplit.ENTRY);
 
         entries.add(ExpressionQueryBuilder.ENTRY);
         entries.add(PlanStreamWrapperQueryBuilder.ENTRY);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplitSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplitSerializationTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class CoalescedSplitSerializationTests extends ESTestCase {
+
+    private final NamedWriteableRegistry registry = new NamedWriteableRegistry(List.of(FileSplit.ENTRY, CoalescedSplit.ENTRY));
+
+    public void testRoundTripWithFileSplitChildren() throws IOException {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/a.parquet"), 0, 1024, ".parquet", Map.of(), Map.of()),
+            new FileSplit("file", StoragePath.of("s3://bucket/b.parquet"), 0, 2048, ".parquet", Map.of(), Map.of()),
+            new FileSplit("file", StoragePath.of("s3://bucket/c.parquet"), 0, 512, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit original = new CoalescedSplit("file", children);
+
+        CoalescedSplit deserialized = roundTrip(original);
+
+        assertEquals(original, deserialized);
+        assertEquals(original.hashCode(), deserialized.hashCode());
+        assertEquals("file", deserialized.sourceType());
+        assertEquals(3, deserialized.children().size());
+        assertEquals(1024 + 2048 + 512, deserialized.estimatedSizeInBytes());
+    }
+
+    public void testRoundTripSingleChild() throws IOException {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/single.parquet"), 0, 4096, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit original = new CoalescedSplit("file", children);
+
+        CoalescedSplit deserialized = roundTrip(original);
+
+        assertEquals(original, deserialized);
+        assertEquals(1, deserialized.children().size());
+        assertEquals(4096, deserialized.estimatedSizeInBytes());
+    }
+
+    public void testRoundTripNestedCoalesced() throws IOException {
+        List<ExternalSplit> innerChildren = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/x.parquet"), 0, 100, ".parquet", Map.of(), Map.of()),
+            new FileSplit("file", StoragePath.of("s3://bucket/y.parquet"), 0, 200, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit inner = new CoalescedSplit("file", innerChildren);
+
+        List<ExternalSplit> outerChildren = List.of(
+            inner,
+            new FileSplit("file", StoragePath.of("s3://bucket/z.parquet"), 0, 300, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit original = new CoalescedSplit("file", outerChildren);
+
+        CoalescedSplit deserialized = roundTrip(original);
+
+        assertEquals(original, deserialized);
+        assertEquals(2, deserialized.children().size());
+        assertTrue(deserialized.children().get(0) instanceof CoalescedSplit);
+        assertTrue(deserialized.children().get(1) instanceof FileSplit);
+        assertEquals(100 + 200 + 300, deserialized.estimatedSizeInBytes());
+    }
+
+    public void testNullSourceTypeThrows() {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/a.parquet"), 0, 100, ".parquet", Map.of(), Map.of())
+        );
+        expectThrows(IllegalArgumentException.class, () -> new CoalescedSplit(null, children));
+    }
+
+    public void testNullChildrenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new CoalescedSplit("file", null));
+    }
+
+    public void testEmptyChildrenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new CoalescedSplit("file", List.of()));
+    }
+
+    public void testEstimatedSizeWithZeroLengthChildren() throws IOException {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/a.parquet"), 0, 0, ".parquet", Map.of(), Map.of()),
+            new FileSplit("file", StoragePath.of("s3://bucket/b.parquet"), 0, 0, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit original = new CoalescedSplit("file", children);
+
+        assertEquals(0, original.estimatedSizeInBytes());
+
+        CoalescedSplit deserialized = roundTrip(original);
+        assertEquals(0, deserialized.estimatedSizeInBytes());
+    }
+
+    public void testWriteableName() {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/a.parquet"), 0, 100, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit split = new CoalescedSplit("file", children);
+        assertEquals("CoalescedSplit", split.getWriteableName());
+    }
+
+    public void testToString() {
+        List<ExternalSplit> children = List.of(
+            new FileSplit("file", StoragePath.of("s3://bucket/a.parquet"), 0, 100, ".parquet", Map.of(), Map.of()),
+            new FileSplit("file", StoragePath.of("s3://bucket/b.parquet"), 0, 200, ".parquet", Map.of(), Map.of())
+        );
+        CoalescedSplit split = new CoalescedSplit("file", children);
+        String str = split.toString();
+        assertTrue(str.contains("children=2"));
+        assertTrue(str.contains("estimatedBytes=300"));
+    }
+
+    private CoalescedSplit roundTrip(CoalescedSplit original) throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteable(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        ExternalSplit deserialized = in.readNamedWriteable(ExternalSplit.class);
+        assertTrue("Expected CoalescedSplit but got " + deserialized.getClass(), deserialized instanceof CoalescedSplit);
+        return (CoalescedSplit) deserialized;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescerTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.datasources.SplitCoalescer.COALESCING_THRESHOLD;
+
+public class SplitCoalescerTests extends ESTestCase {
+
+    public void testNullInputThrows() {
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(null));
+    }
+
+    public void testEmptyInputReturnsEmpty() {
+        List<ExternalSplit> result = SplitCoalescer.coalesce(List.of());
+        assertTrue(result.isEmpty());
+    }
+
+    public void testBelowThresholdReturnsUnchanged() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD - 1);
+        assertSame(splits, SplitCoalescer.coalesce(splits));
+    }
+
+    public void testExactlyAtThresholdReturnsUnchanged() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD);
+        assertSame(splits, SplitCoalescer.coalesce(splits));
+    }
+
+    public void testSizeBasedGrouping() {
+        int count = 100;
+        long fileSize = 10 * 1024 * 1024; // 10 MB each
+        long targetGroupSize = 128 * 1024 * 1024; // 128 MB
+        List<ExternalSplit> splits = makeSplits(count, fileSize);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, targetGroupSize, 8);
+
+        int totalChildren = countTotalLeaves(result);
+        assertEquals(count, totalChildren);
+        assertTrue("Expected fewer groups than original splits", result.size() < count);
+
+        for (ExternalSplit split : result) {
+            if (split instanceof CoalescedSplit coalesced) {
+                assertTrue(
+                    "Coalesced split should not exceed target size by more than one file",
+                    coalesced.estimatedSizeInBytes() <= targetGroupSize + fileSize
+                );
+            }
+        }
+    }
+
+    public void testCountBasedFallbackWhenNoSizeInfo() {
+        int count = 100;
+        int targetGroupCount = 8;
+        List<ExternalSplit> splits = makeSplitsWithoutSize(count);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, targetGroupCount);
+
+        int totalChildren = countTotalLeaves(result);
+        assertEquals(count, totalChildren);
+        assertTrue("Expected at most targetGroupCount groups", result.size() <= targetGroupCount);
+    }
+
+    public void testSingleLargeFileLeftAlone() {
+        long largeSize = 256 * 1024 * 1024; // 256 MB, larger than target
+        long targetGroupSize = 128 * 1024 * 1024;
+
+        List<ExternalSplit> splits = new ArrayList<>();
+        splits.add(makeFileSplit(0, largeSize));
+        for (int i = 1; i <= COALESCING_THRESHOLD; i++) {
+            splits.add(makeFileSplit(i, 1024));
+        }
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, targetGroupSize, 8);
+
+        boolean foundLarge = false;
+        for (ExternalSplit split : result) {
+            if (split instanceof FileSplit fs && fs.length() == largeSize) {
+                foundLarge = true;
+            }
+        }
+        assertTrue("Large file should remain as standalone split", foundLarge);
+        assertEquals(COALESCING_THRESHOLD + 1, countTotalLeaves(result));
+    }
+
+    public void testPreservesAllChildren() {
+        int count = 64;
+        List<ExternalSplit> splits = makeSplits(count, 10 * 1024 * 1024);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits);
+
+        Set<ExternalSplit> originalSet = new HashSet<>(splits);
+        Set<ExternalSplit> resultLeaves = new HashSet<>();
+        for (ExternalSplit split : result) {
+            if (split instanceof CoalescedSplit coalesced) {
+                resultLeaves.addAll(coalesced.children());
+            } else {
+                resultLeaves.add(split);
+            }
+        }
+        assertEquals(originalSet, resultLeaves);
+    }
+
+    public void testInvalidTargetGroupCountThrows() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD + 1);
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 0));
+    }
+
+    public void testInvalidTargetGroupSizeBytesThrows() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD + 1);
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(splits, 0, 8));
+    }
+
+    public void testMixedSizesProducesReasonableGroups() {
+        List<ExternalSplit> splits = new ArrayList<>();
+        long targetGroupSize = 100 * 1024 * 1024;
+        for (int i = 0; i < 50; i++) {
+            long size = randomLongBetween(1024, 50 * 1024 * 1024);
+            splits.add(makeFileSplit(i, size));
+        }
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, targetGroupSize, 8);
+
+        assertEquals(50, countTotalLeaves(result));
+        assertTrue("Should produce fewer groups", result.size() < 50);
+    }
+
+    private static List<ExternalSplit> makeSplits(int count) {
+        return makeSplits(count, 1024);
+    }
+
+    private static List<ExternalSplit> makeSplits(int count, long fileSize) {
+        List<ExternalSplit> splits = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            splits.add(makeFileSplit(i, fileSize));
+        }
+        return splits;
+    }
+
+    private static List<ExternalSplit> makeSplitsWithoutSize(int count) {
+        List<ExternalSplit> splits = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            splits.add(new UnknownSizeSplit("file"));
+        }
+        return splits;
+    }
+
+    private static class UnknownSizeSplit implements ExternalSplit {
+        private final String sourceType;
+
+        UnknownSizeSplit(String sourceType) {
+            this.sourceType = sourceType;
+        }
+
+        @Override
+        public String sourceType() {
+            return sourceType;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "unknown";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static FileSplit makeFileSplit(int index, long length) {
+        return new FileSplit(
+            "file",
+            StoragePath.of("s3://bucket/data/file" + index + ".parquet"),
+            0,
+            length,
+            ".parquet",
+            Map.of(),
+            Map.of()
+        );
+    }
+
+    private static int countTotalLeaves(List<ExternalSplit> splits) {
+        int count = 0;
+        for (ExternalSplit split : splits) {
+            if (split instanceof CoalescedSplit coalesced) {
+                count += coalesced.children().size();
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.xpack.esql.WriteableExponentialHistogram;
 import org.elasticsearch.xpack.esql.core.tree.Node;
+import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.expression.ExpressionWritables;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
@@ -64,6 +65,7 @@ public abstract class AbstractPhysicalPlanSerializationTests<T extends PhysicalP
         entries.add(WriteableExponentialHistogram.ENTRY);
         entries.add(TDigestHolder.ENTRY);
         entries.add(FileSplit.ENTRY);
+        entries.add(CoalescedSplit.ENTRY);
         return new NamedWriteableRegistry(entries);
     }
 


### PR DESCRIPTION
Reduces scheduling overhead when querying thousands of tiny files
(e.g. Iceberg micro-partitions) by grouping them into composite
CoalescedSplit units. Uses greedy bin-packing by size when file
sizes are known, count-based grouping otherwise.

Currently, each file discovered by `FileSplitProvider` becomes an
independent scheduling unit. For workloads with thousands of small
files (common with Iceberg micro-partitions), this creates excessive
per-split overhead in the slice queue, distribution strategy, and
operator lifecycle. Coalescing groups small splits into composite
units that are scheduled as one but expanded back into individual
file reads at operator execution time.

Coalescing is applied in `ComputeService.discoverSplits()` after
`SplitDiscoveryPhase` completes, keeping the separation clean from
the discovery logic.

Developed using AI-assisted tooling

Relates #143329 