### PR TITLE
ESQL: Add parallel execution for Arrow Flight multi-endpoint sources

### DIFF
--- a/docs/changelog/143345.yaml
+++ b/docs/changelog/143345.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143345
+summary: Add parallel execution for Arrow Flight multi-endpoint sources
+type: enhancement

--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightConnector.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightConnector.java
@@ -21,24 +21,35 @@ import org.elasticsearch.xpack.esql.datasources.spi.QueryRequest;
 import org.elasticsearch.xpack.esql.datasources.spi.ResultCursor;
 import org.elasticsearch.xpack.esql.datasources.spi.Split;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Connector for Apache Arrow Flight endpoints.
- * Maintains a persistent {@link FlightClient} connection for the duration of the query.
+ * Maintains a default {@link FlightClient} for the configured endpoint and
+ * creates additional clients on demand when a {@link FlightSplit} specifies
+ * a different location (as returned by multi-endpoint {@code getFlightInfo}).
  */
 class FlightConnector implements Connector {
 
     private final BufferAllocator allocator;
-    private final FlightClient client;
+    private final FlightClient defaultClient;
+    private final String defaultEndpoint;
+    private final Map<String, FlightClient> locationClients = new ConcurrentHashMap<>();
+    private volatile boolean closed = false;
 
     FlightConnector(String endpoint) {
         URI uri = URI.create(endpoint);
         int port = uri.getPort() > 0 ? uri.getPort() : FlightConnectorFactory.DEFAULT_FLIGHT_PORT;
         Location location = Location.forGrpcInsecure(uri.getHost(), port);
         this.allocator = new RootAllocator();
-        this.client = FlightClient.builder(allocator, location).build();
+        this.defaultClient = FlightClient.builder(allocator, location).build();
+        this.defaultEndpoint = uri.getHost() + ":" + port;
     }
 
     @Override
@@ -53,9 +64,12 @@ class FlightConnector implements Connector {
 
     private ResultCursor doExecute(QueryRequest request, FlightSplit flightSplit) {
         Ticket ticket;
+        FlightClient client;
         if (flightSplit != null) {
             ticket = new Ticket(flightSplit.ticketBytes());
+            client = clientForSplit(flightSplit);
         } else {
+            client = defaultClient;
             FlightInfo info = client.getInfo(FlightDescriptor.path(request.target()));
             if (info.getEndpoints().isEmpty()) {
                 throw new IllegalStateException("Flight server returned no endpoints for target: " + request.target());
@@ -66,16 +80,55 @@ class FlightConnector implements Connector {
         return new FlightResultCursor(stream, request.attributes(), request.blockFactory());
     }
 
+    private FlightClient clientForSplit(FlightSplit split) {
+        if (closed) {
+            throw new IllegalStateException("Connector is closed");
+        }
+        String loc = split.location();
+        if (loc == null) {
+            return defaultClient;
+        }
+        URI uri = URI.create(loc);
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Invalid location URI: missing host: " + loc);
+        }
+        int port = uri.getPort() > 0 ? uri.getPort() : FlightConnectorFactory.DEFAULT_FLIGHT_PORT;
+        String key = host + ":" + port;
+        if (key.equals(defaultEndpoint)) {
+            return defaultClient;
+        }
+        return locationClients.computeIfAbsent(key, k -> {
+            Location location = Location.forGrpcInsecure(host, port);
+            return FlightClient.builder(allocator, location).build();
+        });
+    }
+
     @Override
     public void close() throws IOException {
+        closed = true;
+        List<Closeable> toClose = new ArrayList<>(locationClients.size() + 1);
+        for (FlightClient client : locationClients.values()) {
+            toClose.add(asCloseable(client));
+        }
+        locationClients.clear();
+        toClose.add(asCloseable(defaultClient));
         try {
-            client.close();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted while closing FlightClient", e);
+            org.elasticsearch.core.IOUtils.close(toClose);
         } finally {
             allocator.close();
         }
+    }
+
+    private static Closeable asCloseable(FlightClient client) {
+        return () -> {
+            try {
+                client.close();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while closing FlightClient", e);
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
@@ -17,15 +17,19 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceBuffer;
+import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
 import org.elasticsearch.xpack.esql.datasources.spi.Connector;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.QueryRequest;
 import org.elasticsearch.xpack.esql.datasources.spi.ResultCursor;
 import org.elasticsearch.xpack.esql.datasources.spi.Split;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -70,16 +74,13 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                 }
                 assertEquals(100, totalRows);
 
-                // Verify first page has correct data
                 Page firstPage = pages.get(0);
                 assertTrue(firstPage.getPositionCount() > 0);
                 assertEquals(6, firstPage.getBlockCount());
 
-                // emp_no of first row should be 10001
                 IntBlock empNoBlock = firstPage.getBlock(0);
                 assertEquals(10001, empNoBlock.getInt(0));
 
-                // first_name of first row should be "Georgi"
                 BytesRefBlock firstNameBlock = firstPage.getBlock(1);
                 assertEquals(new BytesRef("Georgi"), firstNameBlock.getBytesRef(0, new BytesRef()));
 
@@ -130,7 +131,6 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                         Thread.sleep(10);
                     }
                 }
-                // Drain remaining
                 Page page;
                 while ((page = buffer.pollPage()) != null) {
                     totalRows += page.getPositionCount();
@@ -142,6 +142,179 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
         } finally {
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testMultiSplitParallelExecution() throws Exception {
+        int numEndpoints = 4;
+        try (EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints)) {
+            String endpoint = "flight://localhost:" + server.port();
+            FlightConnectorFactory factory = new FlightConnectorFactory();
+
+            List<Attribute> attributes = FlightTypeMapping.toAttributes(EmployeeFlightServer.SCHEMA);
+            List<String> projectedColumns = new ArrayList<>();
+            for (Attribute attr : attributes) {
+                projectedColumns.add(attr.name());
+            }
+
+            List<ExternalSplit> splits = new ArrayList<>(numEndpoints);
+            String loc = "grpc://localhost:" + server.port();
+            for (int i = 0; i < numEndpoints; i++) {
+                byte[] ticket = ("employees-part-" + i).getBytes(StandardCharsets.UTF_8);
+                splits.add(new FlightSplit(ticket, loc, 100 / numEndpoints));
+            }
+
+            try (Connector connector = factory.open(Map.of("endpoint", endpoint))) {
+                QueryRequest request = new QueryRequest("employees", projectedColumns, attributes, Map.of(), 1000, blockFactory);
+
+                int totalRows = 0;
+                TreeSet<Integer> allEmpNos = new TreeSet<>();
+                for (ExternalSplit split : splits) {
+                    try (ResultCursor cursor = connector.execute(request, split)) {
+                        while (cursor.hasNext()) {
+                            Page page = cursor.next();
+                            IntBlock empNoBlock = page.getBlock(0);
+                            for (int i = 0; i < page.getPositionCount(); i++) {
+                                allEmpNos.add(empNoBlock.getInt(i));
+                            }
+                            totalRows += page.getPositionCount();
+                            page.releaseBlocks();
+                        }
+                    }
+                }
+                assertEquals(100, totalRows);
+                assertEquals(100, allEmpNos.size());
+            }
+        }
+    }
+
+    public void testMultiSplitWithSliceQueue() throws Exception {
+        int numEndpoints = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints)) {
+            String endpoint = "flight://localhost:" + server.port();
+            FlightConnectorFactory factory = new FlightConnectorFactory();
+
+            List<Attribute> attributes = FlightTypeMapping.toAttributes(EmployeeFlightServer.SCHEMA);
+            List<String> projectedColumns = new ArrayList<>();
+            for (Attribute attr : attributes) {
+                projectedColumns.add(attr.name());
+            }
+
+            List<ExternalSplit> splits = new ArrayList<>(numEndpoints);
+            String loc = "grpc://localhost:" + server.port();
+            for (int i = 0; i < numEndpoints; i++) {
+                byte[] ticket = ("employees-part-" + i).getBytes(StandardCharsets.UTF_8);
+                splits.add(new FlightSplit(ticket, loc, 100 / numEndpoints));
+            }
+
+            ExternalSliceQueue sliceQueue = new ExternalSliceQueue(splits);
+            try (Connector connector = factory.open(Map.of("endpoint", endpoint))) {
+                QueryRequest request = new QueryRequest("employees", projectedColumns, attributes, Map.of(), 1000, blockFactory);
+                AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(20);
+
+                executor.execute(() -> {
+                    try {
+                        ExternalSplit split;
+                        while ((split = sliceQueue.nextSplit()) != null) {
+                            try (ResultCursor cursor = connector.execute(request, split)) {
+                                org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPages(cursor, buffer);
+                            }
+                        }
+                        buffer.finish(false);
+                    } catch (Exception e) {
+                        buffer.onFailure(e);
+                    }
+                });
+
+                int totalRows = 0;
+                while (buffer.noMoreInputs() == false || buffer.size() > 0) {
+                    Page page = buffer.pollPage();
+                    if (page != null) {
+                        totalRows += page.getPositionCount();
+                        page.releaseBlocks();
+                    } else if (buffer.noMoreInputs() == false) {
+                        Thread.sleep(10);
+                    }
+                }
+                Page page;
+                while ((page = buffer.pollPage()) != null) {
+                    totalRows += page.getPositionCount();
+                    page.releaseBlocks();
+                }
+
+                assertEquals(100, totalRows);
+            }
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testMultiSplitWithNullLocationUsesDefaultClient() throws Exception {
+        int numEndpoints = 3;
+        try (EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints)) {
+            String endpoint = "flight://localhost:" + server.port();
+            FlightConnectorFactory factory = new FlightConnectorFactory();
+
+            List<Attribute> attributes = FlightTypeMapping.toAttributes(EmployeeFlightServer.SCHEMA);
+            List<String> projectedColumns = new ArrayList<>();
+            for (Attribute attr : attributes) {
+                projectedColumns.add(attr.name());
+            }
+
+            List<ExternalSplit> splits = new ArrayList<>(numEndpoints);
+            for (int i = 0; i < numEndpoints; i++) {
+                byte[] ticket = ("employees-part-" + i).getBytes(StandardCharsets.UTF_8);
+                splits.add(new FlightSplit(ticket, null, 100 / numEndpoints));
+            }
+
+            try (Connector connector = factory.open(Map.of("endpoint", endpoint))) {
+                QueryRequest request = new QueryRequest("employees", projectedColumns, attributes, Map.of(), 1000, blockFactory);
+
+                int totalRows = 0;
+                for (ExternalSplit split : splits) {
+                    try (ResultCursor cursor = connector.execute(request, split)) {
+                        while (cursor.hasNext()) {
+                            totalRows += cursor.next().getPositionCount();
+                        }
+                    }
+                }
+                assertEquals(100, totalRows);
+            }
+        }
+    }
+
+    public void testMultiSplitAcrossDifferentServers() throws Exception {
+        try (EmployeeFlightServer server1 = new EmployeeFlightServer(0, 2); EmployeeFlightServer server2 = new EmployeeFlightServer(0, 2)) {
+            String endpoint = "flight://localhost:" + server1.port();
+            FlightConnectorFactory factory = new FlightConnectorFactory();
+
+            List<Attribute> attributes = FlightTypeMapping.toAttributes(EmployeeFlightServer.SCHEMA);
+            List<String> projectedColumns = new ArrayList<>();
+            for (Attribute attr : attributes) {
+                projectedColumns.add(attr.name());
+            }
+
+            List<ExternalSplit> splits = new ArrayList<>(4);
+            splits.add(new FlightSplit("employees-part-0".getBytes(StandardCharsets.UTF_8), "grpc://localhost:" + server1.port(), 25));
+            splits.add(new FlightSplit("employees-part-1".getBytes(StandardCharsets.UTF_8), "grpc://localhost:" + server1.port(), 25));
+            splits.add(new FlightSplit("employees-part-0".getBytes(StandardCharsets.UTF_8), "grpc://localhost:" + server2.port(), 25));
+            splits.add(new FlightSplit("employees-part-1".getBytes(StandardCharsets.UTF_8), "grpc://localhost:" + server2.port(), 25));
+
+            try (Connector connector = factory.open(Map.of("endpoint", endpoint))) {
+                QueryRequest request = new QueryRequest("employees", projectedColumns, attributes, Map.of(), 1000, blockFactory);
+
+                int totalRows = 0;
+                for (ExternalSplit split : splits) {
+                    try (ResultCursor cursor = connector.execute(request, split)) {
+                        while (cursor.hasNext()) {
+                            totalRows += cursor.next().getPositionCount();
+                        }
+                    }
+                }
+                assertEquals(200, totalRows);
+            }
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServerTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServerTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.grpc;
 
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Location;
@@ -23,6 +24,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.List;
 
 public class EmployeeFlightServerTests extends ESTestCase {
 
@@ -104,6 +106,69 @@ public class EmployeeFlightServerTests extends ESTestCase {
                 assertEquals(10001, empNoVec.get(0));
                 assertEquals("Georgi", new String(firstNameVec.get(0), java.nio.charset.StandardCharsets.UTF_8).trim());
                 assertEquals("Facello", new String(lastNameVec.get(0), java.nio.charset.StandardCharsets.UTF_8).trim());
+            }
+        }
+    }
+
+    public void testMultiEndpointReturnsCorrectEndpointCount() throws Exception {
+        int numEndpoints = 4;
+        try (
+            EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints);
+            BufferAllocator allocator = new RootAllocator();
+            FlightClient client = FlightClient.builder(allocator, Location.forGrpcInsecure("localhost", server.port())).build()
+        ) {
+            FlightInfo info = client.getInfo(FlightDescriptor.path("employees"));
+            assertEquals(numEndpoints, info.getEndpoints().size());
+            assertEquals(100, info.getRecords());
+        }
+    }
+
+    public void testMultiEndpointPartitionsAreDisjointAndComplete() throws Exception {
+        int numEndpoints = 4;
+        try (
+            EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints);
+            BufferAllocator allocator = new RootAllocator();
+            FlightClient client = FlightClient.builder(allocator, Location.forGrpcInsecure("localhost", server.port())).build()
+        ) {
+            FlightInfo info = client.getInfo(FlightDescriptor.path("employees"));
+            List<FlightEndpoint> endpoints = info.getEndpoints();
+            assertEquals(numEndpoints, endpoints.size());
+
+            int totalRows = 0;
+            java.util.Set<Integer> allEmpNos = new java.util.TreeSet<>();
+            for (FlightEndpoint ep : endpoints) {
+                try (FlightStream stream = client.getStream(ep.getTicket())) {
+                    while (stream.next()) {
+                        VectorSchemaRoot root = stream.getRoot();
+                        IntVector empNoVec = (IntVector) root.getVector("emp_no");
+                        for (int i = 0; i < root.getRowCount(); i++) {
+                            assertTrue("Duplicate emp_no: " + empNoVec.get(i), allEmpNos.add(empNoVec.get(i)));
+                        }
+                        totalRows += root.getRowCount();
+                    }
+                }
+            }
+            assertEquals(100, totalRows);
+            assertEquals(100, allEmpNos.size());
+        }
+    }
+
+    public void testMultiEndpointEachPartitionHasRows() throws Exception {
+        int numEndpoints = 5;
+        try (
+            EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints);
+            BufferAllocator allocator = new RootAllocator();
+            FlightClient client = FlightClient.builder(allocator, Location.forGrpcInsecure("localhost", server.port())).build()
+        ) {
+            FlightInfo info = client.getInfo(FlightDescriptor.path("employees"));
+            for (FlightEndpoint ep : info.getEndpoints()) {
+                int partRows = 0;
+                try (FlightStream stream = client.getStream(ep.getTicket())) {
+                    while (stream.next()) {
+                        partRows += stream.getRoot().getRowCount();
+                    }
+                }
+                assertTrue("Each partition must have rows, got: " + partRows, partRows > 0);
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightSplitProviderTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightSplitProviderTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.grpc;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.FileSet;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class FlightSplitProviderTests extends ESTestCase {
+
+    public void testSingleEndpointProducesOneSplit() throws IOException {
+        try (EmployeeFlightServer server = new EmployeeFlightServer(0)) {
+            FlightSplitProvider provider = new FlightSplitProvider();
+            String endpoint = "flight://localhost:" + server.port();
+            Map<String, Object> config = Map.of("endpoint", endpoint, "target", "employees");
+            SplitDiscoveryContext context = new SplitDiscoveryContext(null, FileSet.UNRESOLVED, config, null, null);
+
+            List<ExternalSplit> splits = provider.discoverSplits(context);
+            assertEquals(1, splits.size());
+
+            FlightSplit split = (FlightSplit) splits.get(0);
+            assertEquals("flight", split.sourceType());
+            assertNotNull(split.ticketBytes());
+            assertTrue(split.ticketBytes().length > 0);
+            assertEquals(100, split.estimatedRows());
+        }
+    }
+
+    public void testMultiEndpointProducesMultipleSplits() throws IOException {
+        int numEndpoints = 4;
+        try (EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints)) {
+            FlightSplitProvider provider = new FlightSplitProvider();
+            String endpoint = "flight://localhost:" + server.port();
+            Map<String, Object> config = Map.of("endpoint", endpoint, "target", "employees");
+            SplitDiscoveryContext context = new SplitDiscoveryContext(null, FileSet.UNRESOLVED, config, null, null);
+
+            List<ExternalSplit> splits = provider.discoverSplits(context);
+            assertEquals(numEndpoints, splits.size());
+
+            long totalEstimated = 0;
+            for (ExternalSplit s : splits) {
+                FlightSplit fs = (FlightSplit) s;
+                assertEquals("flight", fs.sourceType());
+                assertNotNull(fs.ticketBytes());
+                assertTrue(fs.ticketBytes().length > 0);
+                assertNotNull(fs.location());
+                assertTrue(fs.estimatedRows() > 0);
+                totalEstimated += fs.estimatedRows();
+            }
+            assertEquals(100, totalEstimated);
+        }
+    }
+
+    public void testMissingEndpointReturnsEmpty() {
+        FlightSplitProvider provider = new FlightSplitProvider();
+        Map<String, Object> config = Map.of("target", "employees");
+        SplitDiscoveryContext context = new SplitDiscoveryContext(null, FileSet.UNRESOLVED, config, null, null);
+
+        List<ExternalSplit> splits = provider.discoverSplits(context);
+        assertEquals(0, splits.size());
+    }
+
+    public void testMissingTargetReturnsEmpty() {
+        FlightSplitProvider provider = new FlightSplitProvider();
+        Map<String, Object> config = Map.of("endpoint", "flight://localhost:12345");
+        SplitDiscoveryContext context = new SplitDiscoveryContext(null, FileSet.UNRESOLVED, config, null, null);
+
+        List<ExternalSplit> splits = provider.discoverSplits(context);
+        assertEquals(0, splits.size());
+    }
+}


### PR DESCRIPTION
FlightConnector always connected to the original endpoint, ignoring
per-split locations returned by getFlightInfo(). When a Flight server
advertises multiple endpoints (each serving a partition of the data),
the connector now creates separate clients for each distinct location,
enabling true parallel reads across drivers.

Relates #143327