### PR TITLE
ESQL: Add parallel execution for Arrow Flight multi-endpoint sources

### DIFF
--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightConnector.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightConnector.java
@@ -15,6 +15,7 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.Connector;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.QueryRequest;
@@ -45,11 +46,15 @@ class FlightConnector implements Connector {
 
     FlightConnector(String endpoint) {
         URI uri = URI.create(endpoint);
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Invalid endpoint URI: missing host: " + endpoint);
+        }
         int port = uri.getPort() > 0 ? uri.getPort() : FlightConnectorFactory.DEFAULT_FLIGHT_PORT;
-        Location location = Location.forGrpcInsecure(uri.getHost(), port);
+        Location location = Location.forGrpcInsecure(host, port);
         this.allocator = new RootAllocator();
         this.defaultClient = FlightClient.builder(allocator, location).build();
-        this.defaultEndpoint = uri.getHost() + ":" + port;
+        this.defaultEndpoint = host + ":" + port;
     }
 
     @Override
@@ -114,7 +119,7 @@ class FlightConnector implements Connector {
         locationClients.clear();
         toClose.add(asCloseable(defaultClient));
         try {
-            org.elasticsearch.core.IOUtils.close(toClose);
+            IOUtils.close(toClose);
         } finally {
             allocator.close();
         }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceBuffer;
 import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.Connector;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.QueryRequest;
@@ -110,7 +111,7 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                 ResultCursor cursor = connector.execute(request, Split.SINGLE);
                 executor.execute(() -> {
                     try {
-                        org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPages(cursor, buffer);
+                        ExternalSourceDrainUtils.drainPages(cursor, buffer);
                         buffer.finish(false);
                     } catch (Exception e) {
                         buffer.onFailure(e);
@@ -218,7 +219,7 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                         ExternalSplit split;
                         while ((split = sliceQueue.nextSplit()) != null) {
                             try (ResultCursor cursor = connector.execute(request, split)) {
-                                org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPages(cursor, buffer);
+                                ExternalSourceDrainUtils.drainPages(cursor, buffer);
                             }
                         }
                         buffer.finish(false);
@@ -276,7 +277,9 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                 for (ExternalSplit split : splits) {
                     try (ResultCursor cursor = connector.execute(request, split)) {
                         while (cursor.hasNext()) {
-                            totalRows += cursor.next().getPositionCount();
+                            Page page = cursor.next();
+                            totalRows += page.getPositionCount();
+                            page.releaseBlocks();
                         }
                     }
                 }
@@ -309,7 +312,9 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                 for (ExternalSplit split : splits) {
                     try (ResultCursor cursor = connector.execute(request, split)) {
                         while (cursor.hasNext()) {
-                            totalRows += cursor.next().getPositionCount();
+                            Page page = cursor.next();
+                            totalRows += page.getPositionCount();
+                            page.releaseBlocks();
                         }
                     }
                 }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServer.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServer.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.elasticsearch.core.Booleans;
 
 import java.io.BufferedReader;
 import java.io.Closeable;
@@ -149,7 +150,7 @@ public class EmployeeFlightServer implements Closeable {
                 allFirstNames[i] = fields[firstNameIdx].trim();
                 allLastNames[i] = fields[lastNameIdx].trim();
                 allSalaries[i] = Integer.parseInt(fields[salaryIdx].trim());
-                allStillHired[i] = org.elasticsearch.core.Booleans.parseBoolean(fields[stillHiredIdx].trim());
+                allStillHired[i] = Booleans.parseBoolean(fields[stillHiredIdx].trim());
                 allHeights[i] = Double.parseDouble(fields[heightIdx].trim());
             }
         }

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServerTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServerTests.java
@@ -24,7 +24,10 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class EmployeeFlightServerTests extends ESTestCase {
 
@@ -104,8 +107,8 @@ public class EmployeeFlightServerTests extends ESTestCase {
                 VarCharVector lastNameVec = (VarCharVector) root.getVector("last_name");
 
                 assertEquals(10001, empNoVec.get(0));
-                assertEquals("Georgi", new String(firstNameVec.get(0), java.nio.charset.StandardCharsets.UTF_8).trim());
-                assertEquals("Facello", new String(lastNameVec.get(0), java.nio.charset.StandardCharsets.UTF_8).trim());
+                assertEquals("Georgi", new String(firstNameVec.get(0), StandardCharsets.UTF_8).trim());
+                assertEquals("Facello", new String(lastNameVec.get(0), StandardCharsets.UTF_8).trim());
             }
         }
     }
@@ -135,7 +138,7 @@ public class EmployeeFlightServerTests extends ESTestCase {
             assertEquals(numEndpoints, endpoints.size());
 
             int totalRows = 0;
-            java.util.Set<Integer> allEmpNos = new java.util.TreeSet<>();
+            Set<Integer> allEmpNos = new TreeSet<>();
             for (FlightEndpoint ep : endpoints) {
                 try (FlightStream stream = client.getStream(ep.getTicket())) {
                     while (stream.next()) {


### PR DESCRIPTION
FlightConnector always connected to the original endpoint, ignoring
per-split locations returned by getFlightInfo(). When a Flight server
advertises multiple endpoints (each serving a partition of the data),
the connector now creates separate clients for each distinct location,
enabling true parallel reads across drivers.

- FlightConnector: location-aware client routing with per-split clients
- EmployeeFlightServer: multi-endpoint partitioning mode for tests
- FlightSplitProviderTests: split discovery for single and multi-endpoint
- AsyncConnectorFactoryFlightTests: parallel multi-split execution tests

Relates #143327