### PR TITLE
ESQL: External source parallel execution and distribution

### DIFF
--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightSplitCollectionSerializationTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightSplitCollectionSerializationTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.grpc;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies that a collection of {@link FlightSplit} instances survives a
+ * {@code writeNamedWriteableCollection} / {@code readNamedWriteableCollectionAsList}
+ * round-trip, which is the same serialization path used by {@code DataNodeRequest}.
+ */
+public class FlightSplitCollectionSerializationTests extends ESTestCase {
+
+    private final NamedWriteableRegistry registry = new NamedWriteableRegistry(List.of(FlightSplit.ENTRY));
+
+    public void testCollectionRoundTrip() throws IOException {
+        List<ExternalSplit> original = new ArrayList<>();
+        original.add(new FlightSplit("employees-part-0".getBytes(StandardCharsets.UTF_8), "grpc://host1:9090", 25));
+        original.add(new FlightSplit("employees-part-1".getBytes(StandardCharsets.UTF_8), "grpc://host2:9090", 25));
+        original.add(new FlightSplit("employees-part-2".getBytes(StandardCharsets.UTF_8), null, 50));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteableCollection(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        List<ExternalSplit> deserialized = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
+
+        assertEquals(original.size(), deserialized.size());
+        for (int i = 0; i < original.size(); i++) {
+            FlightSplit orig = (FlightSplit) original.get(i);
+            FlightSplit deser = (FlightSplit) deserialized.get(i);
+            assertEquals(orig, deser);
+            assertArrayEquals(orig.ticketBytes(), deser.ticketBytes());
+            assertEquals(orig.location(), deser.location());
+            assertEquals(orig.estimatedRows(), deser.estimatedRows());
+        }
+    }
+
+    public void testEmptyCollectionRoundTrip() throws IOException {
+        List<ExternalSplit> original = List.of();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteableCollection(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        List<ExternalSplit> deserialized = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
+
+        assertEquals(0, deserialized.size());
+    }
+
+    public void testSingleSplitCollectionRoundTrip() throws IOException {
+        List<ExternalSplit> original = List.of(new FlightSplit("ticket-abc".getBytes(StandardCharsets.UTF_8), "grpc://remote:47470", 1000));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteableCollection(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        List<ExternalSplit> deserialized = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
+
+        assertEquals(1, deserialized.size());
+        assertEquals(original.get(0), deserialized.get(0));
+    }
+
+    public void testLargeTicketRoundTrip() throws IOException {
+        byte[] largeTicket = new byte[FlightSplit.MAX_TICKET_SIZE];
+        for (int i = 0; i < largeTicket.length; i++) {
+            largeTicket[i] = (byte) (i % 256);
+        }
+        List<ExternalSplit> original = List.of(new FlightSplit(largeTicket, "grpc://host:1234", 999));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteableCollection(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        List<ExternalSplit> deserialized = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
+
+        assertEquals(1, deserialized.size());
+        FlightSplit deser = (FlightSplit) deserialized.get(0);
+        assertArrayEquals(largeTicket, deser.ticketBytes());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
@@ -256,6 +256,9 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
         private CloseableIterator<Page> openFileSplit(ExternalSplit split) throws IOException {
             if (split instanceof FileSplit fileSplit) {
                 StorageObject obj = storageProvider.newObject(fileSplit.path(), fileSplit.length());
+                if (fileSplit.offset() > 0) {
+                    obj = new RangeStorageObject(obj, fileSplit.offset(), fileSplit.length());
+                }
                 return formatReader.read(obj, projectedColumns, batchSize);
             }
             throw new IllegalArgumentException("Unsupported split type: " + split.getClass().getName());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -38,6 +38,18 @@ import java.util.function.BiFunction;
  */
 public class FileSplitProvider implements SplitProvider {
 
+    static final long DEFAULT_TARGET_SPLIT_SIZE = -1;
+
+    private final long targetSplitSizeBytes;
+
+    public FileSplitProvider() {
+        this(DEFAULT_TARGET_SPLIT_SIZE);
+    }
+
+    public FileSplitProvider(long targetSplitSizeBytes) {
+        this.targetSplitSizeBytes = targetSplitSizeBytes;
+    }
+
     @Override
     public List<ExternalSplit> discoverSplits(SplitDiscoveryContext context) {
         FileSet fileSet = context.fileSet();
@@ -76,10 +88,30 @@ public class FileSplitProvider implements SplitProvider {
                 }
             }
 
-            splits.add(new FileSplit("file", filePath, 0, entry.length(), format, config, partitionValues));
+            long fileLength = entry.length();
+            if (targetSplitSizeBytes > 0 && fileLength > targetSplitSizeBytes && isSplittableFormat(format)) {
+                long offset = 0;
+                while (offset < fileLength) {
+                    long chunkLength = Math.min(targetSplitSizeBytes, fileLength - offset);
+                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, config, partitionValues));
+                    offset += chunkLength;
+                }
+            } else {
+                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues));
+            }
         }
 
         return List.copyOf(splits);
+    }
+
+    static boolean isSplittableFormat(String format) {
+        if (format == null) {
+            return false;
+        }
+        return switch (format) {
+            case ".csv", ".tsv", ".ndjson", ".jsonl", ".txt" -> true;
+            default -> false;
+        };
     }
 
     static boolean matchesPartitionFilters(Map<String, Object> partitionValues, List<Expression> filters) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+
+/**
+ * A view over a byte range of a delegate {@link StorageObject}.
+ * Used when a {@link FileSplit} has a non-zero offset, so that format readers
+ * see only the relevant portion of the file.
+ */
+class RangeStorageObject implements StorageObject {
+
+    private final StorageObject delegate;
+    private final long offset;
+    private final long length;
+
+    RangeStorageObject(StorageObject delegate, long offset, long length) {
+        Check.notNull(delegate, "delegate must not be null");
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be >= 0, got: " + offset);
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be >= 0, got: " + length);
+        }
+        this.delegate = delegate;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    @Override
+    public InputStream newStream() throws IOException {
+        return delegate.newStream(offset, length);
+    }
+
+    @Override
+    public InputStream newStream(long position, long rangeLength) throws IOException {
+        return delegate.newStream(Math.addExact(offset, position), rangeLength);
+    }
+
+    @Override
+    public long length() {
+        return length;
+    }
+
+    @Override
+    public Instant lastModified() throws IOException {
+        return delegate.lastModified();
+    }
+
+    @Override
+    public boolean exists() throws IOException {
+        return delegate.exists();
+    }
+
+    @Override
+    public StoragePath path() {
+        return delegate.path();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
@@ -60,6 +60,16 @@ public final class AdaptiveStrategy implements ExternalDistributionStrategy {
         boolean manySplits = splits.size() > nodes.size();
 
         if (hasAggregation || manySplits) {
+            boolean allHaveSize = true;
+            for (ExternalSplit split : splits) {
+                if (split.estimatedSizeInBytes() <= 0) {
+                    allHaveSize = false;
+                    break;
+                }
+            }
+            if (allHaveSize) {
+                return WeightedRoundRobinStrategy.assignByWeight(splits, nodes);
+            }
             return RoundRobinStrategy.assignRoundRobin(splits, nodes);
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -247,6 +247,7 @@ public class ComputeService {
             case "", "adaptive" -> new AdaptiveStrategy();
             case "coordinator_only" -> CoordinatorOnlyStrategy.INSTANCE;
             case "round_robin" -> new RoundRobinStrategy();
+            case "weighted_round_robin" -> new WeightedRoundRobinStrategy();
             default -> {
                 LOGGER.warn("unknown external_distribution pragma value [{}]; falling back to adaptive", value);
                 yield new AdaptiveStrategy();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -256,27 +256,40 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         ComputeListener parentComputeListener
     ) {
         var queryPragmas = configuration.pragmas();
+        boolean allowPartial = configuration.allowPartialResults();
         boolean sentAny = false;
+        int nodesWithSplits = 0;
+        AtomicInteger failedNodes = new AtomicInteger(0);
+
         for (Map.Entry<String, List<ExternalSplit>> entry : distributionPlan.nodeAssignments().entrySet()) {
             String nodeId = entry.getKey();
             List<ExternalSplit> nodeSplits = entry.getValue();
             if (nodeSplits.isEmpty()) {
                 continue;
             }
+            nodesWithSplits++;
 
             DiscoveryNode node = clusterService.state().nodes().get(nodeId);
             if (node == null) {
+                var nodeError = new IllegalStateException(
+                    "node [" + nodeId + "] assigned [" + nodeSplits.size() + "] external splits not found in cluster state"
+                );
+                if (allowPartial) {
+                    LOGGER.warn(
+                        "node [{}] assigned {} external splits is no longer in the cluster state; skipping (partial results enabled)",
+                        nodeId,
+                        nodeSplits.size()
+                    );
+                    failedNodes.incrementAndGet();
+                    parentComputeListener.acquireCompute().onResponse(DriverCompletionInfo.EMPTY);
+                    continue;
+                }
                 LOGGER.warn(
                     "node [{}] assigned {} external splits is no longer in the cluster state; failing external distribution",
                     nodeId,
                     nodeSplits.size()
                 );
-                parentComputeListener.acquireCompute()
-                    .onFailure(
-                        new IllegalStateException(
-                            "node [" + nodeId + "] assigned [" + nodeSplits.size() + "] external splits not found in cluster state"
-                        )
-                    );
+                parentComputeListener.acquireCompute().onFailure(nodeError);
                 return;
             }
 
@@ -284,6 +297,18 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             try {
                 connection = transportService.getConnection(node);
             } catch (Exception e) {
+                if (allowPartial) {
+                    LOGGER.warn(
+                        "failed to connect to node [{}] ({}) for external source execution with {} splits; skipping (partial results)",
+                        nodeId,
+                        node.getName(),
+                        nodeSplits.size(),
+                        e
+                    );
+                    failedNodes.incrementAndGet();
+                    parentComputeListener.acquireCompute().onResponse(DriverCompletionInfo.EMPTY);
+                    continue;
+                }
                 LOGGER.warn(
                     "failed to connect to node [{}] ({}) for external source execution with {} splits",
                     nodeId,
@@ -304,46 +329,73 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 queryPragmas.exchangeBufferSize(),
                 esqlExecutor,
                 parentComputeListener.acquireAvoid().delegateFailureAndWrap((l, unused) -> {
-                    var computeListener = parentComputeListener;
-                    var dataNodeRequest = new DataNodeRequest(
-                        childSessionId,
-                        configuration,
-                        "",
-                        List.of(),
-                        Map.of(),
-                        dataNodePlan,
-                        new String[0],
-                        IndicesOptions.STRICT_EXPAND_OPEN,
-                        queryPragmas.nodeLevelReduction(),
-                        false,
-                        nodeSplits
-                    );
-                    transportService.sendChildRequest(
-                        connection,
-                        ComputeService.DATA_ACTION_NAME,
-                        dataNodeRequest,
-                        parentTask,
-                        TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(
-                            computeListener.acquireCompute().map(r -> r.completionInfo()),
-                            DataNodeComputeResponse::new,
-                            esqlExecutor
-                        )
-                    );
-                    var remoteSink = exchangeService.newRemoteSink(parentTask, childSessionId, transportService, connection);
-                    exchangeSource.addRemoteSink(
-                        remoteSink,
-                        configuration.allowPartialResults() == false,
-                        () -> {},
-                        queryPragmas.concurrentExchangeClients(),
-                        computeListener.acquireAvoid()
-                    );
-                    l.onResponse(null);
+                    final Runnable onGroupFailure;
+                    final CancellableTask groupTask;
+                    if (allowPartial) {
+                        try {
+                            groupTask = computeService.createGroupTask(
+                                parentTask,
+                                () -> "compute group: external data-node [" + node.getName() + "], splits [" + nodeSplits.size() + "]"
+                            );
+                        } catch (TaskCancelledException e) {
+                            l.onFailure(e);
+                            return;
+                        }
+                        onGroupFailure = computeService.cancelQueryOnFailure(groupTask);
+                        l = ActionListener.runAfter(l, () -> transportService.getTaskManager().unregister(groupTask));
+                    } else {
+                        groupTask = parentTask;
+                        onGroupFailure = runOnTaskFailure;
+                    }
+                    try (var computeListener = new ComputeListener(threadPool, onGroupFailure, l.map(ignored -> null))) {
+                        var dataNodeRequest = new DataNodeRequest(
+                            childSessionId,
+                            configuration,
+                            "",
+                            List.of(),
+                            Map.of(),
+                            dataNodePlan,
+                            new String[0],
+                            IndicesOptions.STRICT_EXPAND_OPEN,
+                            queryPragmas.nodeLevelReduction(),
+                            false,
+                            nodeSplits
+                        );
+                        transportService.sendChildRequest(
+                            connection,
+                            ComputeService.DATA_ACTION_NAME,
+                            dataNodeRequest,
+                            groupTask,
+                            TransportRequestOptions.EMPTY,
+                            new ActionListenerResponseHandler<>(
+                                computeListener.acquireCompute().map(r -> r.completionInfo()),
+                                DataNodeComputeResponse::new,
+                                esqlExecutor
+                            )
+                        );
+                        var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, connection);
+                        exchangeSource.addRemoteSink(
+                            remoteSink,
+                            allowPartial == false,
+                            () -> {},
+                            queryPragmas.concurrentExchangeClients(),
+                            computeListener.acquireAvoid()
+                        );
+                    }
                 })
             );
         }
         if (sentAny == false) {
-            parentComputeListener.acquireCompute().onResponse(DriverCompletionInfo.EMPTY);
+            if (failedNodes.get() > 0 && failedNodes.get() >= nodesWithSplits) {
+                parentComputeListener.acquireCompute()
+                    .onFailure(
+                        new IllegalStateException(
+                            "all [" + failedNodes.get() + "] nodes assigned external splits failed; cannot serve partial results"
+                        )
+                    );
+            } else {
+                parentComputeListener.acquireCompute().onResponse(DriverCompletionInfo.EMPTY);
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategy.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Distributes external splits across data nodes using a Longest Processing Time (LPT)
+ * algorithm that considers {@link ExternalSplit#estimatedSizeInBytes()} for load balancing.
+ * When all splits report size information, larger splits are assigned first to the node
+ * with the least accumulated load. Falls back to plain round-robin when size info is absent.
+ */
+public final class WeightedRoundRobinStrategy implements ExternalDistributionStrategy {
+
+    private final NodeEligibilityStrategy eligibility;
+
+    public WeightedRoundRobinStrategy(NodeEligibilityStrategy eligibility) {
+        if (eligibility == null) {
+            throw new IllegalArgumentException("eligibility must not be null");
+        }
+        this.eligibility = eligibility;
+    }
+
+    public WeightedRoundRobinStrategy() {
+        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+    }
+
+    @Override
+    public ExternalDistributionPlan planDistribution(ExternalDistributionContext context) {
+        List<ExternalSplit> splits = context.splits();
+        if (splits.isEmpty()) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        List<DiscoveryNode> nodes = eligibility.eligibleNodes(context.availableNodes());
+        if (nodes.isEmpty()) {
+            return ExternalDistributionPlan.LOCAL;
+        }
+
+        boolean allHaveSize = true;
+        for (ExternalSplit split : splits) {
+            if (split.estimatedSizeInBytes() <= 0) {
+                allHaveSize = false;
+                break;
+            }
+        }
+
+        if (allHaveSize == false) {
+            return RoundRobinStrategy.assignRoundRobin(splits, nodes);
+        }
+
+        return assignByWeight(splits, nodes);
+    }
+
+    static ExternalDistributionPlan assignByWeight(List<ExternalSplit> splits, List<DiscoveryNode> nodes) {
+        List<ExternalSplit> sorted = new ArrayList<>(splits);
+        sorted.sort(Comparator.comparingLong(ExternalSplit::estimatedSizeInBytes).reversed());
+
+        Map<String, List<ExternalSplit>> assignments = new LinkedHashMap<>();
+        long[] nodeLoads = new long[nodes.size()];
+        for (DiscoveryNode node : nodes) {
+            assignments.put(node.getId(), new ArrayList<>());
+        }
+
+        for (ExternalSplit split : sorted) {
+            int minIdx = 0;
+            for (int i = 1; i < nodeLoads.length; i++) {
+                if (nodeLoads[i] < nodeLoads[minIdx]) {
+                    minIdx = i;
+                }
+            }
+            assignments.get(nodes.get(minIdx).getId()).add(split);
+            nodeLoads[minIdx] += split.estimatedSizeInBytes();
+        }
+
+        return new ExternalDistributionPlan(assignments, true);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -339,6 +339,104 @@ public class FileSplitProviderTests extends ESTestCase {
         assertNull(FileSplitProvider.evaluateFilter(new Literal(SRC, true, DataType.BOOLEAN), Map.of("year", 2024)));
     }
 
+    // -- sub-file splitting --
+
+    public void testLargeCsvFileIsSplitIntoChunks() {
+        long targetSize = 1000;
+        FileSplitProvider splitter = new FileSplitProvider(targetSize);
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/big.csv"), 3500, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.csv");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals(4, splits.size());
+        FileSplit s0 = (FileSplit) splits.get(0);
+        assertEquals(0, s0.offset());
+        assertEquals(1000, s0.length());
+        FileSplit s1 = (FileSplit) splits.get(1);
+        assertEquals(1000, s1.offset());
+        assertEquals(1000, s1.length());
+        FileSplit s2 = (FileSplit) splits.get(2);
+        assertEquals(2000, s2.offset());
+        assertEquals(1000, s2.length());
+        FileSplit s3 = (FileSplit) splits.get(3);
+        assertEquals(3000, s3.offset());
+        assertEquals(500, s3.length());
+    }
+
+    public void testSmallFileIsNotSplit() {
+        long targetSize = 1000;
+        FileSplitProvider splitter = new FileSplitProvider(targetSize);
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/small.csv"), 500, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.csv");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals(1, splits.size());
+        FileSplit fs = (FileSplit) splits.get(0);
+        assertEquals(0, fs.offset());
+        assertEquals(500, fs.length());
+    }
+
+    public void testParquetFileIsNotSplit() {
+        long targetSize = 100;
+        FileSplitProvider splitter = new FileSplitProvider(targetSize);
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.parquet"), 5000, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.parquet");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals(1, splits.size());
+        assertEquals(0, ((FileSplit) splits.get(0)).offset());
+        assertEquals(5000, ((FileSplit) splits.get(0)).length());
+    }
+
+    public void testDefaultProviderDoesNotSplit() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/big.csv"), 10_000_000, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.csv");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals(1, splits.size());
+        assertEquals(0, ((FileSplit) splits.get(0)).offset());
+    }
+
+    public void testIsSplittableFormat() {
+        assertTrue(FileSplitProvider.isSplittableFormat(".csv"));
+        assertTrue(FileSplitProvider.isSplittableFormat(".tsv"));
+        assertTrue(FileSplitProvider.isSplittableFormat(".ndjson"));
+        assertTrue(FileSplitProvider.isSplittableFormat(".jsonl"));
+        assertTrue(FileSplitProvider.isSplittableFormat(".txt"));
+        assertFalse(FileSplitProvider.isSplittableFormat(".parquet"));
+        assertFalse(FileSplitProvider.isSplittableFormat(".avro"));
+        assertFalse(FileSplitProvider.isSplittableFormat(null));
+    }
+
+    public void testFileSplitSizeMatchesOriginal() {
+        long targetSize = 1000;
+        long fileSize = 2500;
+        FileSplitProvider splitter = new FileSplitProvider(targetSize);
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), fileSize, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.ndjson");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        long totalBytes = 0;
+        for (ExternalSplit split : splits) {
+            totalBytes += ((FileSplit) split).length();
+        }
+        assertEquals(fileSize, totalBytes);
+    }
+
     // -- helpers --
 
     private static final Source SRC = Source.EMPTY;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+public class RangeStorageObjectTests extends ESTestCase {
+
+    private static final byte[] FILE_BYTES = "Hello, World! This is test data for range reads.".getBytes(StandardCharsets.UTF_8);
+
+    public void testNewStreamReadsFromOffset() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        try (InputStream stream = range.newStream()) {
+            byte[] result = stream.readAllBytes();
+            assertEquals("World!", new String(result, StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testNewStreamWithPositionAddsToOffset() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 20);
+
+        try (InputStream stream = range.newStream(7, 4)) {
+            byte[] result = stream.readAllBytes();
+            assertEquals("This", new String(result, StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testLengthReturnsRangeLength() {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 10, 25);
+        assertEquals(25, range.length());
+    }
+
+    public void testPathDelegates() {
+        StoragePath path = StoragePath.of("s3://bucket/file.csv");
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES, path);
+        RangeStorageObject range = new RangeStorageObject(delegate, 0, 10);
+        assertEquals(path, range.path());
+    }
+
+    public void testExistsDelegates() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 0, 10);
+        assertTrue(range.exists());
+    }
+
+    public void testLastModifiedDelegates() throws IOException {
+        Instant now = Instant.now();
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES, StoragePath.of("s3://bucket/test"), now);
+        RangeStorageObject range = new RangeStorageObject(delegate, 0, 10);
+        assertEquals(now, range.lastModified());
+    }
+
+    public void testZeroOffsetFullLength() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 0, FILE_BYTES.length);
+
+        try (InputStream stream = range.newStream()) {
+            byte[] result = stream.readAllBytes();
+            assertArrayEquals(FILE_BYTES, result);
+        }
+    }
+
+    public void testNegativeOffsetThrows() {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RangeStorageObject(delegate, -1, 10));
+        assertTrue(e.getMessage().contains("offset must be >= 0"));
+    }
+
+    public void testNegativeLengthThrows() {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RangeStorageObject(delegate, 0, -1));
+        assertTrue(e.getMessage().contains("length must be >= 0"));
+    }
+
+    private static class InMemoryStorageObject implements StorageObject {
+        private final byte[] data;
+        private final StoragePath path;
+        private final Instant lastModified;
+
+        InMemoryStorageObject(byte[] data) {
+            this(data, StoragePath.of("s3://bucket/test"), Instant.EPOCH);
+        }
+
+        InMemoryStorageObject(byte[] data, StoragePath path) {
+            this(data, path, Instant.EPOCH);
+        }
+
+        InMemoryStorageObject(byte[] data, StoragePath path, Instant lastModified) {
+            this.data = data;
+            this.path = path;
+            this.lastModified = lastModified;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(data, (int) position, (int) length);
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return lastModified;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return path;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategyTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+
+public class WeightedRoundRobinStrategyTests extends ESTestCase {
+
+    private final WeightedRoundRobinStrategy strategy = new WeightedRoundRobinStrategy();
+
+    public void testBalancedAssignmentBySize() {
+        List<ExternalSplit> splits = List.of(
+            createSplit("file1.parquet", 1000),
+            createSplit("file2.parquet", 500),
+            createSplit("file3.parquet", 300),
+            createSplit("file4.parquet", 200)
+        );
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(2), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        assertEquals(2, plan.nodeAssignments().size());
+
+        long[] loads = new long[2];
+        int idx = 0;
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            for (ExternalSplit s : assigned) {
+                loads[idx] += s.estimatedSizeInBytes();
+            }
+            idx++;
+        }
+        long maxLoad = Math.max(loads[0], loads[1]);
+        long minLoad = Math.min(loads[0], loads[1]);
+        assertTrue("max load imbalance too high: " + maxLoad + " vs " + minLoad, maxLoad <= minLoad * 2);
+    }
+
+    public void testSingleLargeFilePlacedFirst() {
+        List<ExternalSplit> splits = List.of(
+            createSplit("small1.parquet", 100),
+            createSplit("small2.parquet", 100),
+            createSplit("large.parquet", 10000),
+            createSplit("small3.parquet", 100)
+        );
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        int totalAssigned = 0;
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            totalAssigned += assigned.size();
+        }
+        assertEquals(4, totalAssigned);
+    }
+
+    public void testAllEqualSizesDegradesToEvenDistribution() {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            splits.add(createSplit("file" + i + ".parquet", 1024));
+        }
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            assertEquals(2, assigned.size());
+        }
+    }
+
+    public void testNoSizeInfoFallsBackToRoundRobin() {
+        List<ExternalSplit> splits = createSplitsWithoutSize(4);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, createNodes(2), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertTrue(plan.distributed());
+        int totalAssigned = 0;
+        for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
+            totalAssigned += assigned.size();
+        }
+        assertEquals(4, totalAssigned);
+    }
+
+    public void testEmptySplitsReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), List.of(), createNodes(3), QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testNoNodesReturnsLocal() {
+        ExternalDistributionContext context = new ExternalDistributionContext(
+            createPlan(),
+            List.of(createSplit("file.parquet", 1024)),
+            DiscoveryNodes.builder().build(),
+            QueryPragmas.EMPTY
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testDeterministic() {
+        List<ExternalSplit> splits = List.of(createSplit("a.parquet", 500), createSplit("b.parquet", 300), createSplit("c.parquet", 200));
+        DiscoveryNodes nodes = createNodes(2);
+        ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), splits, nodes, QueryPragmas.EMPTY);
+
+        ExternalDistributionPlan plan1 = strategy.planDistribution(context);
+        ExternalDistributionPlan plan2 = strategy.planDistribution(context);
+
+        assertEquals(plan1.nodeAssignments(), plan2.nodeAssignments());
+    }
+
+    private static ExternalSplit createSplit(String name, long sizeBytes) {
+        return new FileSplit("parquet", StoragePath.of("s3://bucket/" + name), 0, sizeBytes, ".parquet", Map.of(), Map.of());
+    }
+
+    private static List<ExternalSplit> createSplitsWithoutSize(int count) {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, -1, ".parquet", Map.of(), Map.of())
+            );
+        }
+        return splits;
+    }
+
+    private static PhysicalPlan createPlan() {
+        ExternalSourceExec source = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/*.parquet",
+            "parquet",
+            List.of(),
+            Map.of(),
+            Map.of(),
+            null
+        );
+        return new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.SINGLE, List.of(), null);
+    }
+
+    private static DiscoveryNodes createNodes(int count) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < count; i++) {
+            builder.add(DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build());
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Adds parallel execution, graceful degradation, cost-aware distribution,
and sub-file splitting for external data sources. This enables ESQL to
distribute external source queries across data nodes with resilience
and load balancing.

Arrow Flight connectors can now discover multiple endpoints and read
partitions in parallel. When nodes fail during distributed execution,
partial results are returned instead of failing the entire query.
The adaptive strategy automatically selects weighted round-robin
distribution when split size information is available, balancing load
across nodes proportionally. Large row-based files (CSV, NDJSON) can
be split into byte-range chunks for finer-grained parallelism.

Relates #143327