### PR TITLE
[9.3] fix: `_resolve/index API` should be able to accept an empty body (#143159)

### DIFF
--- a/docs/changelog/143159.yaml
+++ b/docs/changelog/143159.yaml
@@ -1,0 +1,5 @@
+area: CCS
+issues: []
+pr: 143159
+summary: "Fix: `_resolve/index API` should be able to accept an empty body"
+type: bug

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestResolveIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestResolveIndexActionTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -15,12 +16,15 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentType;
+import org.hamcrest.Matchers;
 
 import java.util.List;
 
@@ -29,12 +33,12 @@ import static org.mockito.Mockito.mock;
 
 public class RestResolveIndexActionTests extends ESTestCase {
 
-    public void testAddResolveCrossProjectBasedOnSettingValue() throws Exception {
-        final boolean cpsEnabled = randomBoolean();
+    private void executeRequest(BytesArray body, boolean cpsEnabled) throws Exception {
         final Settings settings = Settings.builder().put("serverless.cross_project.enabled", cpsEnabled).build();
         final var action = new RestResolveIndexAction(settings);
         final var request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
             .withPath("/_resolve/index/foo")
+            .withContent(body, XContentType.JSON)
             .build();
 
         final NodeClient nodeClient = new NodeClient(settings, mock(ThreadPool.class), TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
@@ -54,5 +58,41 @@ public class RestResolveIndexActionTests extends ESTestCase {
         final var restChannel = new FakeRestChannel(request, true, 1);
         action.handleRequest(request, restChannel, nodeClient);
         assertThat(restChannel.responses().get(), equalTo(1));
+    }
+
+    public void testAddResolveCrossProjectBasedOnSettingValue() throws Exception {
+        // Empty body is always fine irrespective of CPS status.
+        executeRequest(randomBoolean() ? new BytesArray("{}") : new BytesArray(""), randomBoolean());
+    }
+
+    public void testResolveIndexWithInvalidBody() {
+        // Invalid request body.
+        ElasticsearchException error = assertThrows(ElasticsearchException.class, () -> executeRequest(new BytesArray("""
+            {
+              "foo": "bar"
+            }
+            """), randomBoolean()));
+        assertThat(error.getMessage(), equalTo("Couldn't parse request body"));
+        assertThat(error.getCause().toString(), Matchers.containsString("request does not support [foo]"));
+    }
+
+    public void testResolveIndexWithProjectRoutingForCps() throws Exception {
+        // Project routing is allowed when CPS is turned on.
+        executeRequest(new BytesArray("""
+            {
+              "project_routing": "_alias:_origin"
+            }
+            """), true);
+    }
+
+    public void testResolveIndexWithProjectRoutingForNonCps() {
+        // Project routing is disallowed when CPS is turned off and is treated as an invalid request body.
+        ElasticsearchException error = assertThrows(ElasticsearchException.class, () -> executeRequest(new BytesArray("""
+            {
+              "project_routing": "_alias:_origin"
+            }
+            """), false));
+        assertThat(error.getMessage(), equalTo("Couldn't parse request body"));
+        assertThat(error.getCause().toString(), Matchers.containsString("request does not support [project_routing]"));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix: `_resolve/index API` should be able to accept an empty body (#143159)](https://github.com/elastic/elasticsearch/pull/143159)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)