### PR TITLE
Use cluster feature to safeguard PIT changes

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -45,6 +45,7 @@ import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
@@ -94,7 +95,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.synchronizedList;
 import static org.elasticsearch.common.BackoffPolicy.exponentialBackoff;
 import static org.elasticsearch.index.VersionType.INTERNAL;
-import static org.elasticsearch.reindex.ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED;
+import static org.elasticsearch.reindex.ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE;
 
 public class Reindexer {
 
@@ -109,6 +110,7 @@ public class Reindexer {
     private final ReindexMetrics reindexMetrics;
     private final TransportService transportService;
     private final ReindexRelocationNodePicker relocationNodePicker;
+    private final FeatureService featureService;
 
     Reindexer(
         ClusterService clusterService,
@@ -119,7 +121,8 @@ public class Reindexer {
         ReindexSslConfig reindexSslConfig,
         @Nullable ReindexMetrics reindexMetrics,
         TransportService transportService,
-        ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker,
+        FeatureService featureService
     ) {
         this.clusterService = clusterService;
         this.projectResolver = projectResolver;
@@ -130,6 +133,7 @@ public class Reindexer {
         this.reindexMetrics = reindexMetrics;
         this.transportService = Objects.requireNonNull(transportService);
         this.relocationNodePicker = Objects.requireNonNull(relocationNodePicker);
+        this.featureService = featureService;
     }
 
     public void initTask(BulkByScrollTask task, ReindexRequest request, ActionListener<Void> listener) {
@@ -172,7 +176,7 @@ public class Reindexer {
          * If this is a request to reindex from remote, then we need to determine the remote version prior to execution
          * NB {@link ReindexRequest} forbids remote requests and slices > 1, so we're guaranteed to be running on the only slice
          */
-        if (REINDEX_PIT_SEARCH_ENABLED && request.getRemoteInfo() != null) {
+        if (featureService.clusterHasFeature(clusterService.state(), REINDEX_PIT_SEARCH_FEATURE) && request.getRemoteInfo() != null) {
             lookupRemoteVersionAndExecute(task, request, listenerWithRelocations, workerAction);
         } else {
             BulkByPaginatedSearchParallelizationHelper.executeSlicedAction(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.ReindexAction;
@@ -59,7 +60,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         TransportService transportService,
         ReindexSslConfig sslConfig,
         @Nullable ReindexMetrics reindexMetrics,
-        ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker,
+        FeatureService featureService
     ) {
         this(
             ReindexAction.NAME,
@@ -75,7 +77,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             transportService,
             sslConfig,
             reindexMetrics,
-            relocationNodePicker
+            relocationNodePicker,
+            featureService
         );
     }
 
@@ -93,7 +96,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         TransportService transportService,
         ReindexSslConfig sslConfig,
         @Nullable ReindexMetrics reindexMetrics,
-        ReindexRelocationNodePicker relocationNodePicker
+        ReindexRelocationNodePicker relocationNodePicker,
+        FeatureService featureService
     ) {
         super(name, transportService, actionFilters, ReindexRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;
@@ -113,7 +117,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             sslConfig,
             reindexMetrics,
             transportService,
-            relocationNodePicker
+            relocationNodePicker,
+            featureService
         );
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.PaginatedHitSource;
@@ -309,7 +310,9 @@ public class ReindexerTests extends ESTestCase {
             mock(ReindexSslConfig.class),
             null,
             transportService,
-            mock(ReindexRelocationNodePicker.class)
+            mock(ReindexRelocationNodePicker.class),
+            // Will default REINDEX_PIT_SEARCH_FEATURE to false
+            mock(FeatureService.class)
         );
     }
 
@@ -323,7 +326,9 @@ public class ReindexerTests extends ESTestCase {
             mock(ReindexSslConfig.class),
             metrics,
             mock(TransportService.class),
-            mock(ReindexRelocationNodePicker.class)
+            mock(ReindexRelocationNodePicker.class),
+            // Will default REINDEX_PIT_SEARCH_FEATURE to false
+            mock(FeatureService.class)
         );
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.reindex.ReindexPlugin;
@@ -51,7 +52,8 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
         Client client,
         TransportService transportService,
         Environment environment,
-        ResourceWatcherService watcherService
+        ResourceWatcherService watcherService,
+        FeatureService featureService
     ) {
         super(
             EnrichReindexAction.NAME,
@@ -68,7 +70,8 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
             new ReindexSslConfig(settings, environment, watcherService),
             null,
             // can't be injected due to different classloaders between enrich and reindex (enrich doesn't extend reindex).
-            ReindexPlugin.getReindexRelocationNodePicker(environment)
+            ReindexPlugin.getReindexRelocationNodePicker(environment),
+            featureService
         );
         this.bulkClient = new OriginSettingClient(client, ENRICH_ORIGIN);
     }


### PR DESCRIPTION
Changes the `Reindexer` to use a cluster feature check to guard the PIT changes, rather than a feature flag. This will be safer when rolling out the reindexing changes during a rolling upgrade, so that one node does not begin a reindex using PIT before the other nodes are capable of running the corresponding PIT searches.

Relates: https://github.com/elastic/elasticsearch-team/issues/2088

