### PR TITLE
[9.3] ESQL: Fix unresolved name pattern (#143210)

### DIFF
--- a/docs/changelog/143210.yaml
+++ b/docs/changelog/143210.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143210
+summary: Fix unresolved name pattern
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
@@ -35,13 +35,15 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
     private final CharacterRunAutomaton automaton;
     private final String pattern;
     // string representation without backquotes
-    private final String name;
+    // Cannot rely on NamedExpression.name: the UnresolvedNamedExpression superclass throws on name()
+    // and stores "<unresolved>" as the internal name field.
+    private final String actualName;
 
     public UnresolvedNamePattern(Source source, CharacterRunAutomaton automaton, String patternString, String name) {
         super(source, emptyList());
         this.automaton = automaton;
         this.pattern = patternString;
-        this.name = name;
+        this.actualName = name;
     }
 
     @Override
@@ -58,9 +60,10 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
         return automaton.run(string);
     }
 
+    // override because the super class throws
     @Override
     public String name() {
-        return name;
+        return actualName;
     }
 
     public String pattern() {
@@ -74,7 +77,7 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
 
     @Override
     protected NodeInfo<UnresolvedNamePattern> info() {
-        return NodeInfo.create(this, UnresolvedNamePattern::new, automaton, pattern, name);
+        return NodeInfo.create(this, UnresolvedNamePattern::new, automaton, pattern, actualName);
     }
 
     @Override
@@ -99,13 +102,13 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
 
     @Override
     protected int innerHashCode(boolean ignoreIds) {
-        return Objects.hash(super.innerHashCode(true), pattern);
+        return Objects.hash(super.innerHashCode(true), pattern, actualName);
     }
 
     @Override
     protected boolean innerEquals(Object o, boolean ignoreIds) {
         var other = (UnresolvedNamePattern) o;
-        return super.innerEquals(other, true) && Objects.equals(pattern, other.pattern);
+        return super.innerEquals(other, true) && Objects.equals(pattern, other.pattern) && Objects.equals(actualName, other.actualName);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePatternTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePatternTests.java
@@ -28,7 +28,7 @@ public class UnresolvedNamePatternTests extends AbstractNamedExpressionSerializa
             case 0 -> name = randomValueOtherThan(name, () -> randomAlphaOfLength(4));
             case 1 -> pattern = randomValueOtherThan(pattern, () -> randomAlphaOfLength(4));
         }
-        return new UnresolvedNamePattern(source, null, name, pattern);
+        return new UnresolvedNamePattern(source, null, pattern, name);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: Fix unresolved name pattern (#143210)