### PR TITLE
Set DocVector.mayContainDuplicates flag to test deduplication

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,9 +399,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.compute.aggregation.TimeSeriesFirstDocIdDeduplicationTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/143128
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/143023

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/TimeSeriesFirstDocIdDeduplicationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/TimeSeriesFirstDocIdDeduplicationTests.java
@@ -327,7 +327,7 @@ public class TimeSeriesFirstDocIdDeduplicationTests extends OperatorTestCase {
                     shardBuilder.build(),
                     segmentBuilder.build(),
                     docBuilder.build(),
-                    DocVector.config()
+                    DocVector.config().mayContainDuplicates()
                 );
 
                 currentPosition += length;


### PR DESCRIPTION
After pull request [#142055](https://github.com/elastic/elasticsearch/pull/142055) was merged, we need to explicitly set the mayContainDuplicates flag to allow duplication in DocVector.

Closes #143128