### PR TITLE
Redirect reference landing page

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -593,3 +593,8 @@ redirects:
     many:
       - to: 'reference/query-languages/esql/functions-operators/search-functions.md'
         anchors: { 'esql-limitations-text-fields' }
+
+  # Related to https://github.com/elastic/docs-content-internal/issues/807 (Elasticsearch Reference Landing Page Redirect)
+  'reference/index.md':
+    to: 'reference/elasticsearch/index.md'
+    anchors: '!'


### PR DESCRIPTION
This PR is redirecting the Elasticsearch reference landing page to https://www.elastic.co/docs/reference/elasticsearch

Connected to: https://github.com/elastic/docs-content-internal/issues/807