### PR TITLE
[DOCS] Fix ES|QL function and commands lists versioning metadata

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
@@ -2,13 +2,15 @@
 * [`AVG`](../../functions-operators/aggregation-functions/avg.md)
 * [`COUNT`](../../functions-operators/aggregation-functions/count.md)
 * [`COUNT_DISTINCT`](../../functions-operators/aggregation-functions/count_distinct.md)
+* [`FIRST`](../../functions-operators/aggregation-functions/first.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`LAST`](../../functions-operators/aggregation-functions/last.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * [`MAX`](../../functions-operators/aggregation-functions/max.md)
 * [`MEDIAN`](../../functions-operators/aggregation-functions/median.md)
 * [`MEDIAN_ABSOLUTE_DEVIATION`](../../functions-operators/aggregation-functions/median_absolute_deviation.md)
 * [`MIN`](../../functions-operators/aggregation-functions/min.md)
 * [`PERCENTILE`](../../functions-operators/aggregation-functions/percentile.md)
 * [`PRESENT`](../../functions-operators/aggregation-functions/present.md) {applies_to}`stack: ga 9.2`
-* [`SAMPLE`](../../functions-operators/aggregation-functions/sample.md)
+* [`SAMPLE`](../../functions-operators/aggregation-functions/sample.md) {applies_to}`stack: ga 9.1`
 * [`ST_CENTROID_AGG`](../../functions-operators/aggregation-functions/st_centroid_agg.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * [`ST_EXTENT_AGG`](../../functions-operators/aggregation-functions/st_extent_agg.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * [`STD_DEV`](../../functions-operators/aggregation-functions/std_dev.md)
@@ -17,5 +19,3 @@
 * [`VALUES`](../../functions-operators/aggregation-functions/values.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * [`VARIANCE`](../../functions-operators/aggregation-functions/variance.md)
 * [`WEIGHTED_AVG`](../../functions-operators/aggregation-functions/weighted_avg.md)
-* [`FIRST`](../../functions-operators/aggregation-functions/first.md)
-* [`LAST`](../../functions-operators/aggregation-functions/last.md)

--- a/docs/reference/query-languages/esql/_snippets/lists/date-time-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/date-time-functions.md
@@ -3,7 +3,7 @@
 * [`DATE_FORMAT`](../../functions-operators/date-time-functions/date_format.md)
 * [`DATE_PARSE`](../../functions-operators/date-time-functions/date_parse.md)
 * [`DATE_TRUNC`](../../functions-operators/date-time-functions/date_trunc.md)
-* [`DAY_NAME`](../../functions-operators/date-time-functions/day_name.md)
-* [`MONTH_NAME`](../../functions-operators/date-time-functions/month_name.md)
+* [`DAY_NAME`](../../functions-operators/date-time-functions/day_name.md) {applies_to}`stack: ga 9.2`
+* [`MONTH_NAME`](../../functions-operators/date-time-functions/month_name.md) {applies_to}`stack: ga 9.2`
 * [`NOW`](../../functions-operators/date-time-functions/now.md)
-* [`TRANGE`](../../functions-operators/date-time-functions/trange.md)
+* [`TRANGE`](../../functions-operators/date-time-functions/trange.md) {applies_to}`stack: ga 9.3`

--- a/docs/reference/query-languages/esql/_snippets/lists/dense-vector-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/dense-vector-functions.md
@@ -1,10 +1,10 @@
 * Dense vector functions
-  * [`KNN`](../../functions-operators/dense-vector-functions/knn.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
-  * [`TEXT_EMBEDDING`](../../functions-operators/dense-vector-functions/text_embedding.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
+  * [`KNN`](../../functions-operators/dense-vector-functions/knn.md) {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.4`
+  * [`TEXT_EMBEDDING`](../../functions-operators/dense-vector-functions/text_embedding.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
 * Vector similarity functions
-  * [`V_COSINE`](../../functions-operators/dense-vector-functions/v_cosine.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
-  * [`V_DOT_PRODUCT`](../../functions-operators/dense-vector-functions/v_dot_product.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
-  * [`V_HAMMING`](../../functions-operators/dense-vector-functions/v_hamming.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
-  * [`V_L1_NORM`](../../functions-operators/dense-vector-functions/v_l1_norm.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
-  * [`V_L2_NORM`](../../functions-operators/dense-vector-functions/v_l2_norm.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
+  * [`V_COSINE`](../../functions-operators/dense-vector-functions/v_cosine.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
+  * [`V_DOT_PRODUCT`](../../functions-operators/dense-vector-functions/v_dot_product.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
+  * [`V_HAMMING`](../../functions-operators/dense-vector-functions/v_hamming.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
+  * [`V_L1_NORM`](../../functions-operators/dense-vector-functions/v_l1_norm.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
+  * [`V_L2_NORM`](../../functions-operators/dense-vector-functions/v_l2_norm.md) {applies_to}`stack: preview 9.3` {applies_to}`stack: ga 9.4`
 % * [`V_MAGNITUDE`](../../functions-operators/dense-vector-functions/v_magnitude.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/esql/_snippets/lists/grouping-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/grouping-functions.md
@@ -1,3 +1,3 @@
 * [`BUCKET`](../../functions-operators/grouping-functions/bucket.md)
-* [`TBUCKET`](../../functions-operators/grouping-functions/tbucket.md)
-* [`CATEGORIZE`](../../functions-operators/grouping-functions/categorize.md)
+* [`CATEGORIZE`](../../functions-operators/grouping-functions/categorize.md) {applies_to}`stack: preview 9.0` {applies_to}`stack: ga 9.1`
+* [`TBUCKET`](../../functions-operators/grouping-functions/tbucket.md) {applies_to}`stack: ga 9.2`

--- a/docs/reference/query-languages/esql/_snippets/lists/math-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/math-functions.md
@@ -8,7 +8,7 @@
 * [`ATANH`](../../functions-operators/math-functions/atanh.md)
 * [`CBRT`](../../functions-operators/math-functions/cbrt.md)
 * [`CEIL`](../../functions-operators/math-functions/ceil.md)
-* [`COPY_SIGN`](../../functions-operators/math-functions/copy_sign.md)
+* [`COPY_SIGN`](../../functions-operators/math-functions/copy_sign.md) {applies_to}`stack: ga 9.1`
 * [`COS`](../../functions-operators/math-functions/cos.md)
 * [`COSH`](../../functions-operators/math-functions/cosh.md)
 * [`E`](../../functions-operators/math-functions/e.md)
@@ -20,8 +20,8 @@
 * [`PI`](../../functions-operators/math-functions/pi.md)
 * [`POW`](../../functions-operators/math-functions/pow.md)
 * [`ROUND`](../../functions-operators/math-functions/round.md)
-* [`ROUND_TO`](../../functions-operators/math-functions/round_to.md)
-* [`SCALB`](../../functions-operators/math-functions/scalb.md)
+* [`ROUND_TO`](../../functions-operators/math-functions/round_to.md) {applies_to}`stack: preview 9.1` {applies_to}`serverless: preview`
+* [`SCALB`](../../functions-operators/math-functions/scalb.md) {applies_to}`stack: ga 9.1`
 * [`SIGNUM`](../../functions-operators/math-functions/signum.md)
 * [`SIN`](../../functions-operators/math-functions/sin.md)
 * [`SINH`](../../functions-operators/math-functions/sinh.md)

--- a/docs/reference/query-languages/esql/_snippets/lists/mv-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/mv-functions.md
@@ -1,12 +1,12 @@
 * [`MV_APPEND`](../../functions-operators/mv-functions/mv_append.md)
 * [`MV_AVG`](../../functions-operators/mv-functions/mv_avg.md)
 * [`MV_CONCAT`](../../functions-operators/mv-functions/mv_concat.md)
-* [`MV_CONTAINS`](../../functions-operators/mv-functions/mv_contains.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`MV_CONTAINS`](../../functions-operators/mv-functions/mv_contains.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`MV_COUNT`](../../functions-operators/mv-functions/mv_count.md)
 * [`MV_DEDUPE`](../../functions-operators/mv-functions/mv_dedupe.md)
 * [`MV_FIRST`](../../functions-operators/mv-functions/mv_first.md)
 * [`MV_INTERSECTION`](../../functions-operators/mv-functions/mv_intersection.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
-* [`MV_INTERSECTS`](../../functions-operators/mv-functions/mv_intersects.md) {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+* [`MV_INTERSECTS`](../../functions-operators/mv-functions/mv_intersects.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
 * [`MV_LAST`](../../functions-operators/mv-functions/mv_last.md)
 * [`MV_MAX`](../../functions-operators/mv-functions/mv_max.md)
 * [`MV_MEDIAN`](../../functions-operators/mv-functions/mv_median.md)

--- a/docs/reference/query-languages/esql/_snippets/lists/processing-commands.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/processing-commands.md
@@ -1,21 +1,21 @@
-* [`CHANGE_POINT`](/reference/query-languages/esql/commands/change-point.md)
-* [`COMPLETION`](/reference/query-languages/esql/commands/completion.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`CHANGE_POINT`](/reference/query-languages/esql/commands/change-point.md) {applies_to}`stack: preview 9.1` {applies_to}`stack: ga 9.2`
+* [`COMPLETION`](/reference/query-languages/esql/commands/completion.md) {applies_to}`stack: preview 9.1` {applies_to}`stack: ga 9.3`
 * [`DISSECT`](/reference/query-languages/esql/commands/dissect.md)
 * [`DROP`](/reference/query-languages/esql/commands/drop.md)
 * [`ENRICH`](/reference/query-languages/esql/commands/enrich.md)
 * [`EVAL`](/reference/query-languages/esql/commands/eval.md)
 * [`GROK`](/reference/query-languages/esql/commands/grok.md)
-* [`FORK`](/reference/query-languages/esql/commands/fork.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-* [`FUSE`](/reference/query-languages/esql/commands/fuse.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`FORK`](/reference/query-languages/esql/commands/fork.md) {applies_to}`stack: preview 9.1` {applies_to}`serverless: preview`
+* [`FUSE`](/reference/query-languages/esql/commands/fuse.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`KEEP`](/reference/query-languages/esql/commands/keep.md)
 * [`LIMIT`](/reference/query-languages/esql/commands/limit.md)
-* [`LOOKUP JOIN`](/reference/query-languages/esql/commands/lookup-join.md)
-* [`INLINE STATS`](/reference/query-languages/esql/commands/inlinestats-by.md)
+* [`LOOKUP JOIN`](/reference/query-languages/esql/commands/lookup-join.md) {applies_to}`stack: preview 9.0` {applies_to}`stack: ga 9.1`
+* [`INLINE STATS`](/reference/query-languages/esql/commands/inlinestats-by.md) {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.3`
 * [`MV_EXPAND`](/reference/query-languages/esql/commands/mv_expand.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 % * [`REGISTERED_DOMAIN`](/reference/query-languages/esql/commands/registered-domain.md) {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
 * [`RENAME`](/reference/query-languages/esql/commands/rename.md)
-* [`RERANK`](/reference/query-languages/esql/commands/rerank.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-* [`SAMPLE`](/reference/query-languages/esql/commands/sample.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`RERANK`](/reference/query-languages/esql/commands/rerank.md) {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.4`
+* [`SAMPLE`](/reference/query-languages/esql/commands/sample.md) {applies_to}`stack: preview 9.1` {applies_to}`serverless: preview`
 * [`SORT`](/reference/query-languages/esql/commands/sort.md)
 * [`STATS`](/reference/query-languages/esql/commands/stats-by.md)
 % * [`URI_PARTS`](/reference/query-languages/esql/commands/uri-parts.md) {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
@@ -1,8 +1,8 @@
-* [`DECAY`](../../functions-operators/search-functions/decay.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-* [`KQL`](../../functions-operators/search-functions/kql.md)
-* [`MATCH`](../../functions-operators/search-functions/match.md)
-* [`MATCH_PHRASE`](../../functions-operators/search-functions/match_phrase.md)
-* [`QSTR`](../../functions-operators/search-functions/qstr.md)
-* [`SCORE`](../../functions-operators/search-functions/score.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`DECAY`](../../functions-operators/search-functions/decay.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
+* [`KQL`](../../functions-operators/search-functions/kql.md) {applies_to}`stack: preview 9.0` {applies_to}`stack: ga 9.1`
+* [`MATCH`](../../functions-operators/search-functions/match.md) {applies_to}`stack: preview 9.0` {applies_to}`stack: ga 9.1`
+* [`MATCH_PHRASE`](../../functions-operators/search-functions/match_phrase.md) {applies_to}`stack: ga 9.1`
+* [`QSTR`](../../functions-operators/search-functions/qstr.md) {applies_to}`stack: preview 9.0` {applies_to}`stack: ga 9.1`
+* [`SCORE`](../../functions-operators/search-functions/score.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
 % * [`TERM`](../../functions-operators/search-functions/term.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
-* [`TOP_SNIPPETS`](../../functions-operators/search-functions/top-snippets.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
+* [`TOP_SNIPPETS`](../../functions-operators/search-functions/top-snippets.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/esql/_snippets/lists/source-commands.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/source-commands.md
@@ -1,4 +1,4 @@
 - [`FROM`](/reference/query-languages/esql/commands/from.md)
 - [`ROW`](/reference/query-languages/esql/commands/row.md)
 - [`SHOW`](/reference/query-languages/esql/commands/show.md)
-- [`TS`](/reference/query-languages/esql/commands/ts.md)
+- [`TS`](/reference/query-languages/esql/commands/ts.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/esql/_snippets/lists/string-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/string-functions.md
@@ -1,12 +1,12 @@
 * [`BIT_LENGTH`](../../functions-operators/string-functions/bit_length.md)
 * [`BYTE_LENGTH`](../../functions-operators/string-functions/byte_length.md)
-* [`CHUNK`](../../functions-operators/string-functions/chunk.md)
+* [`CHUNK`](../../functions-operators/string-functions/chunk.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
 * [`CONCAT`](../../functions-operators/string-functions/concat.md)
-* [`CONTAINS`](../../functions-operators/string-functions/contains.md)
+* [`CONTAINS`](../../functions-operators/string-functions/contains.md) {applies_to}`stack: ga 9.2`
 * [`ENDS_WITH`](../../functions-operators/string-functions/ends_with.md)
 * [`FROM_BASE64`](../../functions-operators/string-functions/from_base64.md)
 * [`HASH`](../../functions-operators/string-functions/hash.md)
-* [`JSON_EXTRACT`](../../functions-operators/string-functions/json_extract.md)
+* [`JSON_EXTRACT`](../../functions-operators/string-functions/json_extract.md) {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
 * [`LEFT`](../../functions-operators/string-functions/left.md)
 * [`LENGTH`](../../functions-operators/string-functions/length.md)
 * [`LOCATE`](../../functions-operators/string-functions/locate.md)
@@ -27,6 +27,6 @@
 * [`TO_LOWER`](../../functions-operators/string-functions/to_lower.md)
 * [`TO_UPPER`](../../functions-operators/string-functions/to_upper.md)
 * [`TRIM`](../../functions-operators/string-functions/trim.md)
-* [`URL_ENCODE`](../../functions-operators/string-functions/url_encode.md)
-* [`URL_ENCODE_COMPONENT`](../../functions-operators/string-functions/url_encode_component.md)
-* [`URL_DECODE`](../../functions-operators/string-functions/url_decode.md)
+* [`URL_DECODE`](../../functions-operators/string-functions/url_decode.md) {applies_to}`stack: ga 9.2`
+* [`URL_ENCODE`](../../functions-operators/string-functions/url_encode.md) {applies_to}`stack: ga 9.2`
+* [`URL_ENCODE_COMPONENT`](../../functions-operators/string-functions/url_encode_component.md) {applies_to}`stack: ga 9.2`

--- a/docs/reference/query-languages/esql/_snippets/lists/time-series-aggregation-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/time-series-aggregation-functions.md
@@ -11,7 +11,7 @@
 * [`LAST_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/last_over_time.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`MAX_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/max_over_time.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`MIN_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/min_over_time.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
-* [`PERCENTILE_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/percentile_over_time.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
+* [`PERCENTILE_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/percentile_over_time.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
 * [`PRESENT_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/present_over_time.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`RATE`](../../functions-operators/time-series-aggregation-functions/rate.md) {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
 * [`STDDEV_OVER_TIME`](../../functions-operators/time-series-aggregation-functions/stddev_over_time.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`

--- a/docs/reference/query-languages/esql/_snippets/lists/type-conversion-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/type-conversion-functions.md
@@ -18,7 +18,7 @@
 * [`TO_LONG`](../../functions-operators/type-conversion-functions/to_long.md)
 * [`TO_RADIANS`](../../functions-operators/type-conversion-functions/to_radians.md)
 * [`TO_STRING`](../../functions-operators/type-conversion-functions/to_string.md)
-* [`TO_TDIGEST`](../../functions-operators/type-conversion-functions/to_tdigest.md)
+* [`TO_TDIGEST`](../../functions-operators/type-conversion-functions/to_tdigest.md) {applies_to}`stack: preview 9.3` {applies_to}`serverless: preview`
 * [`TO_TIMEDURATION`](../../functions-operators/type-conversion-functions/to_timeduration.md)
 * [`TO_UNSIGNED_LONG`](../../functions-operators/type-conversion-functions/to_unsigned_long.md) {applies_to}`stack: preview` {applies_to}`serverless: preview`
 * [`TO_VERSION`](../../functions-operators/type-conversion-functions/to_version.md)

--- a/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
@@ -1,4 +1,7 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 navigation_title: "Time series aggregation functions"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-functions-operators.html#esql-time-series-agg-functions


### PR DESCRIPTION
Makes sure the lists of functions and commands are up to date versioning and availability wise

## tl:dr

- Some lists were out of sync with the true version availability and lifecycles (preview or GA) of functions 
- **NOTE**: If something doesn't have a tag in a list, it's GA
  - For example:
    -  if there's no serverless tag on a list item it's GA on serverless
    -  if there's no stack tag, the thing was GA already by 9.0

## Methodology

1. Listed all files in `_snippets/lists/`
2. Read the `@FunctionInfo` / `@FunctionAppliesTo` annotation system in Java:
   - `FunctionInfo.java` — annotation on function constructors; has `preview = true` and `appliesTo[]` fields
   - `FunctionAppliesTo.java` — `lifeCycle` (PREVIEW, GA, DEVELOPMENT, COMING, ...) and `version` fields
3. Ran a broad `grep` across all `x-pack/plugin/esql/src/main/java/` for `preview = true` and `appliesTo` to get a complete list of every function with non-default lifecycle metadata
4. Cross-checked each result against the corresponding entry in the list files
5. Applied corrections

## Not covered / out of scope

- **`NETWORK_DIRECTION`**: has `preview = true` in Java but is not listed in `ip-functions.md` (presumably intentionally unlisted)
- **`TO_DATE_RANGE`**: has `preview = true` in Java but is not listed in `type-conversion-functions.md`
- **`MULTI_MATCH`**: has `COMING` lifecycle in Java and is not listed in any list file
- **`V_MAGNITUDE`**: `DEVELOPMENT` lifecycle in Java, correctly commented out (`%`) in the list
- **Individual function `.md` pages**: function pages are generated (via `DocsV3Support.java` from `@FunctionInfo` annotations), so their `applies_to` front matter is kept in sync automatically and was not audited
