### PR TITLE
Fix SQL client parsing of array header values

### DIFF
--- a/docs/changelog/143408.yaml
+++ b/docs/changelog/143408.yaml
@@ -1,0 +1,7 @@
+area: SQL
+issues:
+ - 143018
+ - 143019
+pr: 143408
+summary: Fix SQL client parsing of array header values
+type: bug

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
@@ -269,10 +269,20 @@ public class RemoteFailure {
             }
             String name = parser.getText();
             token = parser.nextToken();
-            if (token != JsonToken.VALUE_STRING) {
+            String value;
+            if (token == JsonToken.VALUE_STRING) {
+                value = parser.getText();
+            } else if (token == JsonToken.START_ARRAY) {
+                List<String> values = new ArrayList<>();
+                while ((token = parser.nextToken()) != JsonToken.END_ARRAY) {
+                    if (token == JsonToken.VALUE_STRING) {
+                        values.add(parser.getText());
+                    }
+                }
+                value = String.join(", ", values);
+            } else {
                 throw new IOException("expected header value but was [" + token + "][" + parser.getText() + "]");
             }
-            String value = parser.getText();
             headers.put(name, value);
         }
 

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
@@ -64,6 +64,18 @@ public class RemoteFailureTests extends ESTestCase {
         assertEquals(singletonMap("WWW-Authenticate", "Basic realm=\"security\", charset=\"UTF-8\""), failure.headers());
     }
 
+    public void testParseMissingAuthMultipleSchemes() throws IOException {
+        RemoteFailure failure = parse("missing_auth_multiple_schemes.json");
+        assertEquals("security_exception", failure.type());
+        assertEquals(
+            "unable to authenticate with provided credentials and anonymous access is not allowed for this request",
+            failure.reason()
+        );
+        assertThat(failure.remoteTrace(), containsString("AuthenticationService.authenticate"));
+        assertNull(failure.cause());
+        assertEquals(singletonMap("WWW-Authenticate", "Basic realm=\"security\", charset=\"UTF-8\", ApiKey"), failure.headers());
+    }
+
     public void testNoError() {
         IOException e = expectThrows(IOException.class, () -> parse("no_error.json"));
         assertEquals(

--- a/x-pack/plugin/sql/sql-client/src/test/resources/remote_failure/missing_auth_multiple_schemes.json
+++ b/x-pack/plugin/sql/sql-client/src/test/resources/remote_failure/missing_auth_multiple_schemes.json
@@ -1,0 +1,23 @@
+{
+  "error" : {
+    "root_cause" : [
+      {
+        "type" : "security_exception",
+        "reason" : "unable to authenticate with provided credentials and anonymous access is not allowed for this request",
+        "additional_unsuccessful_credentials" : "API key: Illegal base64 character 5f",
+        "header" : {
+          "WWW-Authenticate" : ["Basic realm=\"security\", charset=\"UTF-8\"", "ApiKey"]
+        },
+        "stack_trace" : "ElasticsearchSecurityException[unable to authenticate]\n\tat org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:99)"
+      }
+    ],
+    "type" : "security_exception",
+    "reason" : "unable to authenticate with provided credentials and anonymous access is not allowed for this request",
+    "additional_unsuccessful_credentials" : "API key: Illegal base64 character 5f",
+    "header" : {
+      "WWW-Authenticate" : ["Basic realm=\"security\", charset=\"UTF-8\"", "ApiKey"]
+    },
+    "stack_trace" : "ElasticsearchSecurityException[unable to authenticate]\n\tat org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:99)"
+  },
+  "status" : 401
+}


### PR DESCRIPTION
`RemoteFailure.parseHeaders()` only handled string header values, causing parsing failures in the SQL CLI when authentication errors included array headers.

With this one, I'm handling parsing of array headers.

Fixes: https://github.com/elastic/elasticsearch/issues/143018
Fixes: https://github.com/elastic/elasticsearch/issues/143019
