### PR TITLE
Fix dynamic mapping with dotted field names for vector types

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
@@ -671,3 +671,52 @@ setup:
   - match: { indices.mappings.field_types.0.indexed_vector_dim_min: 164 }
   - match: { indices.mappings.field_types.0.indexed_vector_dim_max: 1276 }
 
+---
+"Dense vector dynamic template with dotted field name and intermediate object":
+  - requires:
+      cluster_features: "mapper.dense_vector.dynamic_template_dotted_field_fix"
+      reason: "fix for dynamic template with dotted field names"
+  - do:
+      indices.put_template:
+        name: dense-vector-dotted-template
+        body:
+          index_patterns: ["dense-vector-dotted-*"]
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            dynamic_templates:
+              - dense_vector_template:
+                  path_match: "my_vectors.*"
+                  mapping:
+                    similarity: cosine
+                    type: dense_vector
+                    index: true
+                    index_options:
+                      type: hnsw
+
+  - do:
+      index:
+        index: dense-vector-dotted-test
+        id: "1"
+        refresh: true
+        body:
+          my_vectors.vector1: [
+            -0.09274746, 0.048125198, -0.31602416, 0.57141583, -0.34229536,
+            0.15138765, -0.08300583, 0.7065178, 0.14968437, -0.22518804,
+            0.33417892, -0.12654321
+          ]
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
+      indices.get_mapping:
+        index: dense-vector-dotted-test
+
+  - match: { dense-vector-dotted-test.mappings.properties.my_vectors.properties.vector1.type: dense_vector }
+  - match: { dense-vector-dotted-test.mappings.properties.my_vectors.properties.vector1.dims: 12 }
+  - match: { dense-vector-dotted-test.mappings.properties.my_vectors.properties.vector1.index: true }
+  - match: { dense-vector-dotted-test.mappings.properties.my_vectors.properties.vector1.similarity: cosine }
+

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -69,6 +69,9 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.keyword.store_high_cardinality_in_binary_doc_values"
     );
     static final NodeFeature TDIGEST_TYPE = new NodeFeature("mapper.tdigest_type");
+    static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
+        "mapper.dense_vector.dynamic_template_dotted_field_fix"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -119,7 +122,8 @@ public class MapperFeatures implements FeatureSpecification {
             GENERIC_VECTOR_FORMAT,
             EXPONENTIAL_HISTOGRAM_TYPE,
             STORE_HIGH_CARDINALITY_KEYWORDS_IN_BINARY_DOC_VALUES,
-            TDIGEST_TYPE
+            TDIGEST_TYPE,
+            DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -3176,7 +3176,24 @@ public class DenseVectorFieldMapper extends FieldMapper {
             int dims = fieldType().element.parseDimensionCount(context);
             DenseVectorFieldMapper.Builder builder = (Builder) getMergeBuilder();
             builder.dimensions(dims);
-            Mapper update = builder.build(context.createDynamicMapperBuilderContext());
+            // Build the mapper using a context derived from this field's existing fullPath.
+            // The document parser's content path cannot be used here because for dynamically
+            // mapped fields with dotted names (e.g. "a.b"), the content path
+            // includes the field name itself, not just the parent object path.
+            MapperBuilderContext builderContext;
+            String existingFullPath = fullPath();
+            String leaf = leafName();
+            MapperBuilderContext rootCtx = MapperBuilderContext.root(
+                context.mappingLookup().isSourceSynthetic(),
+                context.mappingLookup().isDataStreamTimestampFieldEnabled()
+            );
+            if (existingFullPath.equals(leaf)) {
+                builderContext = rootCtx;
+            } else {
+                String parentPath = existingFullPath.substring(0, existingFullPath.length() - leaf.length() - 1);
+                builderContext = rootCtx.createChildContext(parentPath, context.dynamic());
+            }
+            Mapper update = builder.build(builderContext);
             context.addDynamicMapper(update);
             return;
         }

--- a/x-pack/plugin/rank-vectors/src/main/java/org/elasticsearch/xpack/rank/vectors/RankVectorsFeatures.java
+++ b/x-pack/plugin/rank-vectors/src/main/java/org/elasticsearch/xpack/rank/vectors/RankVectorsFeatures.java
@@ -14,10 +14,13 @@ import java.util.Set;
 
 public class RankVectorsFeatures implements FeatureSpecification {
     public static final NodeFeature RANK_VECTORS_FEATURE = new NodeFeature("rank_vectors");
+    static final NodeFeature RANK_VECTORS_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
+        "mapper.rank_vectors.dynamic_template_dotted_field_fix"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(RANK_VECTORS_FEATURE);
+        return Set.of(RANK_VECTORS_FEATURE, RANK_VECTORS_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX);
     }
 
 }

--- a/x-pack/plugin/rank-vectors/src/main/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapper.java
+++ b/x-pack/plugin/rank-vectors/src/main/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapper.java
@@ -322,7 +322,24 @@ public class RankVectorsFieldMapper extends FieldMapper {
             }
             var builder = (Builder) getMergeBuilder();
             builder.dimensions(currentDims);
-            Mapper update = builder.build(context.createDynamicMapperBuilderContext());
+            // Build the mapper using a context derived from this field's existing fullPath.
+            // The document parser's content path cannot be used here because for dynamically
+            // mapped fields with dotted names (e.g. "image_embedding.clip"), the content path
+            // includes the field name itself, not just the parent object path.
+            MapperBuilderContext builderContext;
+            String existingFullPath = fullPath();
+            String leaf = leafName();
+            MapperBuilderContext rootCtx = MapperBuilderContext.root(
+                context.mappingLookup().isSourceSynthetic(),
+                context.mappingLookup().isDataStreamTimestampFieldEnabled()
+            );
+            if (existingFullPath.equals(leaf)) {
+                builderContext = rootCtx;
+            } else {
+                String parentPath = existingFullPath.substring(0, existingFullPath.length() - leaf.length() - 1);
+                builderContext = rootCtx.createChildContext(parentPath, context.dynamic());
+            }
+            Mapper update = builder.build(builderContext);
             context.addDynamicMapper(update);
             return;
         }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors.yml
@@ -160,3 +160,42 @@ setup:
           properties:
             embedding:
               type: rank_vectors
+
+---
+"Rank vectors dynamic template with dotted field name and intermediate object":
+  - requires:
+      cluster_features: "mapper.rank_vectors.dynamic_template_dotted_field_fix"
+      reason: "fix for dynamic template with dotted field names"
+  - do:
+      indices.put_template:
+        name: rank-vectors-dotted-template
+        body:
+          index_patterns: ["rank-vectors-dotted-*"]
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            dynamic_templates:
+              - rank_vectors_template:
+                  path_match: "my_vectors.*"
+                  mapping:
+                    type: rank_vectors
+
+  - do:
+      index:
+        index: rank-vectors-dotted-test
+        id: "1"
+        refresh: true
+        body:
+          my_vectors.vector1: [[0.12, -0.34, 0.56], [0.78, -0.91, 0.23]]
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
+      indices.get_mapping:
+        index: rank-vectors-dotted-test
+
+  - match: { rank-vectors-dotted-test.mappings.properties.my_vectors.properties.vector1.type: rank_vectors }
+  - match: { rank-vectors-dotted-test.mappings.properties.my_vectors.properties.vector1.dims: 3 }


### PR DESCRIPTION
PR #130540 introduced a bug where indexing a
document with a dotted field name (e.g. "my_vectors.vector1") matched by a dynamic template for dense_vector or rank_vectors without explicit dims would fail with:
IllegalStateException: Missing intermediate object.

The bug only manifests when dims are not set in the mapping or template, triggering the code path that dynamically determines dimensions from the first indexed document.

The root cause is that when DenseVectorFieldMapper and RankVectorsFieldMapper dynamically determine dims, they rebuild the mapper using the document parser's content path. For dynamically mapped fields with dotted names, the content path includes the field name itself rather than just the parent object path, producing a duplicated full path in the rebuilt mapper.

This was fixed on main/9.4 by PR #142754, which refactored dynamic mapper tracking to use Mapper.Builder objects. This commit provides a targeted fix for 9.3.x by deriving the correct parent path from the existing mapper's fullPath instead of relying on the content path.

The same fix is applied to both DenseVectorFieldMapper and RankVectorsFieldMapper, which shared the same bug.