### PR TITLE
Tests: StoreDirectoryMetricsIT.testDirectoryMetrics

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -264,7 +264,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/TS Command grouping on text field}
   issue: https://github.com/elastic/elasticsearch/issues/142544
->>>>>>> 0a8c2ab30cc (Tests: StoreDirectoryMetricsIT.testDirectoryMetrics)
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/143551

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -264,6 +264,25 @@ tests:
 - class: org.elasticsearch.index.store.StoreDirectoryMetricsIT
   method: testDirectoryMetrics
   issue: https://github.com/elastic/elasticsearch/issues/143419
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/143023
+- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
+  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=STORED]}
+  issue: https://github.com/elastic/elasticsearch/issues/143412
+- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
+  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=NONE]}
+  issue: https://github.com/elastic/elasticsearch/issues/143413
+- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
+  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=DOC_VALUES]}
+  issue: https://github.com/elastic/elasticsearch/issues/143414
+- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/143023
+- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
+  method: test {p0=esql/40_tsdb/TS Command grouping on text field}
+  issue: https://github.com/elastic/elasticsearch/issues/142544
+>>>>>>> 0a8c2ab30cc (Tests: StoreDirectoryMetricsIT.testDirectoryMetrics)
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/143551

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -261,9 +261,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/143407
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/40_tsdb/TS Command grouping on text field}
-  issue: https://github.com/elastic/elasticsearch/issues/142544
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/143551

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -261,24 +261,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/143407
-- class: org.elasticsearch.index.store.StoreDirectoryMetricsIT
-  method: testDirectoryMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/143419
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/143023
-- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=STORED]}
-  issue: https://github.com/elastic/elasticsearch/issues/143412
-- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=NONE]}
-  issue: https://github.com/elastic/elasticsearch/issues/143413
-- class: org.elasticsearch.index.mapper.blockloader.FlattenedFieldRootBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=false, preference=DOC_VALUES]}
-  issue: https://github.com/elastic/elasticsearch/issues/143414
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/143023
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/TS Command grouping on text field}
   issue: https://github.com/elastic/elasticsearch/issues/142544

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class StoreDirectoryMetricsIT extends ESIntegTestCase {
     public void testDirectoryMetrics() throws IOException {
-        assumeTrue("feature flag must be enabled for test", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
+        assumeTrue("directry metrics feature flag must be enabled for test", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
 
         final String indexName = randomIndexName();
         createIndex(indexName, 1, 0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
@@ -28,10 +28,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class StoreDirectoryMetricsIT extends ESIntegTestCase {
     public void testDirectoryMetrics() throws IOException {
+        assumeTrue("feature flag must be enabled for test", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
+
         final String indexName = randomIndexName();
         createIndex(indexName, 1, 0);
         IntStream.range(0, between(10, 100)).forEach(i -> indexDoc(indexName, "id " + i, "f", i));
         flushAndRefresh(indexName);
+        forceMerge(true);
 
         String node = internalCluster().nodesInclude(indexName).iterator().next();
 
@@ -61,12 +64,6 @@ public class StoreDirectoryMetricsIT extends ESIntegTestCase {
         });
         DirectoryMetrics metrics = tuple.v2();
         StoreMetrics storeMetrics = metrics.metrics("store").cast(StoreMetrics.class);
-        // In release builds the directory_metrics feature flag is disabled by default, so the store directory is not
-        // wrapped with StoreMetricsDirectory and bytes read are not tracked.
-        if (Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled()) {
-            assertThat(storeMetrics.getBytesRead(), equalTo(tuple.v1()));
-        } else {
-            assertThat(storeMetrics.getBytesRead(), equalTo(0L));
-        }
+        assertThat(storeMetrics.getBytesRead(), equalTo(tuple.v1()));
     }
 }


### PR DESCRIPTION
In order to not trigger any accidental background flushes, that may delete segment files, force merging down to a single segment before accessing the directory will prevent any changes to the directory in the background.

Closes #143419