### PR TITLE
SQL: fix CLI tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -372,9 +372,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/142079
-- class: org.elasticsearch.xpack.sql.qa.security.CliApiKeyIT
-  method: testCliConnectionWithApiKey
-  issue: https://github.com/elastic/elasticsearch/issues/143125
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliApiKeyIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliApiKeyIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.sql.qa.cli.EmbeddedCli.ApiKeySecurityConfig;
 
 import static org.elasticsearch.xpack.sql.qa.security.RestSqlIT.SSL_ENABLED;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Integration tests for CLI connections using API key authentication.
@@ -65,6 +66,7 @@ public class CliApiKeyIT extends SqlApiKeyTestCase {
             cli.readLine(); // separator line
             String valueLine = cli.readLine();
             assertThat(valueLine, containsString("123"));
+            assertEquals("", cli.readLine());
         }
     }
 


### PR DESCRIPTION
Not consuming an empty line apparently leads to a race condition or to some buffering problems, that sometimes result in an incomplete exit message (the CLI close consumes the output too quickly).

Fixes: https://github.com/elastic/elasticsearch/issues/143125