### PR TITLE
[8.19] [Gradle] Fix some gradle task input caching (#142987)

### DIFF
--- a/.buildkite/scripts/gradle-build-cache-validation.sh
+++ b/.buildkite/scripts/gradle-build-cache-validation.sh
@@ -13,7 +13,7 @@ tmpOutputFile=$(mktemp)
 trap "rm $tmpOutputFile" EXIT
 
 set +e
-gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t precommit --fail-if-not-fully-cacheable | tee $tmpOutputFile
+develocity-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --develocity-server https://gradle-enterprise.elastic.co -t "precommit javadoc" --fail-if-not-fully-cacheable | tee $tmpOutputFile
 # Capture the return value
 retval=$?
 set -e

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -67,7 +67,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
       file(checkstyleConfig),
       file(checkstyleIdeFragment),
       file(checkstylePluginConfigTemplate)
-    )
+    ).withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.files(
       file(checkstyleIdeConfig),
       file(checkstylePluginConfig)

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -57,6 +57,7 @@ public class JavaModulePrecommitTask extends PrecommitTask {
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileCollection getClassesDirs() {
         return this.classesDirs;
     }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -183,8 +183,8 @@ def buildDefaultLog4jConfigTaskProvider = tasks.register("buildDefaultLog4jConfi
     inputFiles = inputFiles + it.fileTree('src/main/config').matching { include 'log4j2.properties' }
   }
 
-  inputs.files(inputFiles)
-  outputs.file outputFile
+  inputs.files(inputFiles).withPathSensitivity(PathSensitivity.RELATIVE)
+  outputs.file(outputFile)
 
   doLast {
     outputFile.setText('', 'UTF-8')

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -551,7 +551,7 @@ void addBuildCloudDockerImageTasks(Architecture architecture) {
       DockerBase base = DockerBase.WOLFI
 
       TaskProvider<DockerBuildTask> buildBaseTask = tasks.named(taskName("build", architecture, base, "DockerImage"))
-      inputs.files(buildBaseTask)
+      inputs.files(buildBaseTask).withPathSensitivity(PathSensitivity.RELATIVE)
 
       dockerContext.fileProvider(buildContextTask.map { it.getDestinationDir() })
 
@@ -633,7 +633,7 @@ subprojects { Project subProject ->
     final String tarFile = "${parent.projectDir}/build/${artifactName}_${VersionProperties.elasticsearch}.${extension}"
 
     def exportTask = tasks.register(exportTaskName, LoggedExec) {
-      inputs.file("${parent.projectDir}/build/markers/${buildTaskName}.marker")
+      inputs.file("${parent.projectDir}/build/markers/${buildTaskName}.marker").withPathSensitivity(PathSensitivity.RELATIVE)
       executable = 'docker'
       outputs.file(tarFile)
       outputs.doNotCacheIf("Build cache is disabled for export tasks") { true }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -2130,7 +2130,7 @@ buildRestTests.teardowns['failure-store-recipes-2-td'] = '''
 
   /* Load the actual events only if we're going to use them. */
   File atomicRedRegsvr32File = new File("$projectDir/src/yamlRestTest/resources/normalized-T1117-AtomicRed-regsvr32.json")
-  inputs.file(atomicRedRegsvr32File)
+  inputs.file(atomicRedRegsvr32File).withPathSensitivity(PathSensitivity.RELATIVE)
 
   doFirst {
     String events = atomicRedRegsvr32File.getText('UTF-8')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Gradle] Fix some gradle task input caching (#142987)](https://github.com/elastic/elasticsearch/pull/142987)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)