### PR TITLE
ES|QL: Add note of future removal of FORK implicit LIMIT

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -21,6 +21,10 @@ Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) com
 
 ::::{note}
 `FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
+
+In a future release, no implicit `LIMIT` will be added to `FORK` branches.
+To maintain the current behavior of the queries using `FORK`, it is recommended
+to include a `LIMIT` in each `FORK` branch.
 ::::
 
 ## Output behavior

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -19,12 +19,18 @@ on the same input data and combines the results in a single output table. A disc
 
 Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) command, `FORK` enables hybrid search to combine and score results from multiple queries. To learn more about using {{esql}} for search, refer to [ES|QL for search](docs-content://solutions/search/esql-for-search.md).
 
-::::{note}
-`FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
+::::{applies-switch}
 
+:::{applies-item} { serverless: , stack: preview 9.4+ }
 In a future release, no implicit `LIMIT` will be added to `FORK` branches.
 To maintain the current behavior of the queries using `FORK`, it is recommended
 to include a `LIMIT` in each `FORK` branch.
+:::
+
+:::{applies-item} stack: preview 9.1-9.3
+`FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
+:::
+
 ::::
 
 ## Output behavior

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -19,17 +19,15 @@ on the same input data and combines the results in a single output table. A disc
 
 Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) command, `FORK` enables hybrid search to combine and score results from multiple queries. To learn more about using {{esql}} for search, refer to [ES|QL for search](docs-content://solutions/search/esql-for-search.md).
 
-::::{applies-switch}
 
-:::{applies-item} { serverless: , stack: preview 9.4+ }
+% Use applies-switch tabs once we remove the implicit limit.
+
+::::{note}
+
+`FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
 In a future release, no implicit `LIMIT` will be added to `FORK` branches.
 To maintain the current behavior of the queries using `FORK`, it is recommended
 to include a `LIMIT` in each `FORK` branch.
-:::
-
-:::{applies-item} stack: preview 9.1-9.3
-`FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
-:::
 
 ::::
 


### PR DESCRIPTION
As part of making FORK GA, in the following weeks we want to remove the implicit LIMIT we add to each FORK branch.
This adds a note in the documentation that this change is coming, with a recommendation to add a LIMIT to each FORK branch, in case users want to maintain the current behaviour of the queries after upgrading.

