### PR TITLE
[9.2] Add circuit breaker for query construction to prevent OOM from automaton-based queries (#142150)

### DIFF
--- a/docs/changelog/142150.yaml
+++ b/docs/changelog/142150.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues: []
+pr: 142150
+summary: Add circuit breaker for query construction to prevent OOM from automaton-based
+  queries
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.indices.memory.breaker;
+
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.PrefixQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.RegexpQueryBuilder;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntFunction;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Integration tests verifying that Lucene queries implementing {@link org.apache.lucene.util.Accountable}
+ * (wildcard, prefix, regexp, query_string, range) are properly tracked by the request circuit breaker
+ * during query construction, and that the accounted memory is released after the search completes.
+ */
+@ClusterScope(scope = TEST, numClientNodes = 0, maxNumDataNodes = 1)
+public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
+
+    private static final String INDEX_NAME = "cb-accountable-test";
+    private static final String TEXT_FIELD = "text_field";
+    private static final String KEYWORD_FIELD = "keyword_field";
+
+    @Before
+    public void checkBreakerType() {
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
+    }
+
+    @After
+    public void resetBreakerSettings() {
+        updateClusterSettings(
+            Settings.builder()
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey())
+        );
+    }
+
+    public void testWildcardQueryTripsCircuitBreaker() {
+        assertBoolQueryTripsBreaker(100, i -> new WildcardQueryBuilder(TEXT_FIELD, "*pattern*" + i + "*"));
+    }
+
+    public void testPrefixQueryTripsCircuitBreaker() {
+        assertBoolQueryTripsBreaker(100, i -> new PrefixQueryBuilder(TEXT_FIELD, "prefix" + i));
+    }
+
+    public void testRegexpQueryTripsCircuitBreaker() {
+        assertBoolQueryTripsBreaker(50, i -> new RegexpQueryBuilder(TEXT_FIELD, "(pattern" + i + "|alternate" + i + "|option" + i + ").*"));
+    }
+
+    public void testQueryStringTripsCircuitBreaker() {
+        assertBoolQueryTripsBreaker(100, i -> new QueryStringQueryBuilder("*pattern" + i + "*").defaultField(TEXT_FIELD));
+    }
+
+    public void testRangeQueryTripsCircuitBreaker() {
+        assertBoolQueryTripsBreaker(100, i -> new RangeQueryBuilder(KEYWORD_FIELD).gte("key" + i).lte("key" + (i + 100)));
+    }
+
+    public void testWildcardQueryMemoryReleased() throws Exception {
+        assertQueryMemoryReleasedAfterSearch(new WildcardQueryBuilder(TEXT_FIELD, "*test*pattern*"));
+    }
+
+    public void testPrefixQueryMemoryReleased() throws Exception {
+        assertQueryMemoryReleasedAfterSearch(new PrefixQueryBuilder(TEXT_FIELD, "value"));
+    }
+
+    public void testRegexpQueryMemoryReleased() throws Exception {
+        assertQueryMemoryReleasedAfterSearch(new RegexpQueryBuilder(TEXT_FIELD, ".*test.*pattern.*"));
+    }
+
+    public void testQueryStringMemoryReleased() throws Exception {
+        assertQueryMemoryReleasedAfterSearch(new QueryStringQueryBuilder("*test*pattern*").defaultField(TEXT_FIELD));
+    }
+
+    public void testRangeQueryMemoryReleased() throws Exception {
+        assertQueryMemoryReleasedAfterSearch(new RangeQueryBuilder(KEYWORD_FIELD).gte("key0").lte("key999"));
+    }
+
+    private void assertBoolQueryTripsBreaker(int count, IntFunction<QueryBuilder> queryFactory) {
+        createAndPopulateIndex();
+
+        BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+        for (int i = 0; i < count; i++) {
+            boolQuery.should(queryFactory.apply(i));
+        }
+        assertQueryTripsBreaker(boolQuery);
+    }
+
+    private void assertQueryMemoryReleasedAfterSearch(QueryBuilder query) throws Exception {
+        createAndPopulateIndex();
+        assertQueryMemoryReleased(query);
+    }
+
+    private boolean noopBreakerUsed() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        for (NodeStats nodeStats : stats.getNodes()) {
+            if (nodeStats.getBreaker().getStats(CircuitBreaker.REQUEST).getLimit() == NoopCircuitBreaker.LIMIT) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private long getRequestBreakerTrippedCount() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        long tripped = 0;
+        for (NodeStats stat : stats.getNodes()) {
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.REQUEST);
+            if (breakerStats != null) {
+                tripped += breakerStats.getTrippedCount();
+            }
+        }
+        return tripped;
+    }
+
+    private long getRequestBreakerEstimated() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        long estimated = 0;
+        for (NodeStats stat : stats.getNodes()) {
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.REQUEST);
+            if (breakerStats != null) {
+                estimated += breakerStats.getEstimated();
+            }
+        }
+        return estimated;
+    }
+
+    private void createAndPopulateIndex() {
+        assertAcked(
+            prepareCreate(INDEX_NAME, 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))).setMapping(
+                TEXT_FIELD,
+                "type=text",
+                KEYWORD_FIELD,
+                "type=keyword"
+            )
+        );
+        int docCount = scaledRandomIntBetween(100, 500);
+        List<IndexRequestBuilder> reqs = new ArrayList<>();
+        for (long id = 0; id < docCount; id++) {
+            reqs.add(
+                client().prepareIndex(INDEX_NAME).setId(Long.toString(id)).setSource(TEXT_FIELD, "value" + id, KEYWORD_FIELD, "key" + id)
+            );
+        }
+        indexRandom(true, false, true, reqs);
+    }
+
+    private void assertQueryTripsBreaker(QueryBuilder query) {
+        updateClusterSettings(
+            Settings.builder()
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "10b")
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 1.0)
+        );
+
+        SearchRequestBuilder searchRequest = client().prepareSearch(INDEX_NAME).setQuery(query);
+        assertFailures(searchRequest, RestStatus.BAD_REQUEST, containsString("Data too large"));
+        assertThat("Request circuit breaker should have tripped", getRequestBreakerTrippedCount(), greaterThanOrEqualTo(1L));
+    }
+
+    private void assertQueryMemoryReleased(QueryBuilder query) throws Exception {
+        long baseline = getRequestBreakerEstimated();
+        client().prepareSearch(INDEX_NAME).setQuery(query).get().decRef();
+        long estimated = getRequestBreakerEstimated();
+        assertEquals("Request breaker memory should be released after search completes", baseline, estimated);
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.indices.breaker.CircuitBreakerStats;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.rest.RestStatus;
@@ -110,10 +112,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testMemoryBreaker() throws Exception {
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
         assertAcked(
             prepareCreate("cb-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))).setMapping(
                 "test",
@@ -159,10 +158,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testRamAccountingTermsEnum() throws Exception {
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
         final Client client = client();
 
         // Create an index where the mappings have a field data filter
@@ -225,10 +221,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testRequestBreaker() throws Exception {
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
         assertAcked(prepareCreate("cb-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
         Client client = client();
 
@@ -256,10 +249,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testAggTookTooMuch() throws Exception {
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
         assertAcked(prepareCreate("cb-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
         Client client = client();
 
@@ -307,10 +297,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testCanResetUnreasonableSettings() {
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
         updateClusterSettings(
             Settings.builder().put(HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "5b")
         );
@@ -333,10 +320,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
 
     public void testLimitsRequestSize() {
         ByteSizeValue inFlightRequestsLimit = ByteSizeValue.of(8, ByteSizeUnit.KB);
-        if (noopBreakerUsed()) {
-            logger.info("--> noop breakers used, skipping test");
-            return;
-        }
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
 
         internalCluster().ensureAtLeastNumDataNodes(2);
 
@@ -416,6 +400,56 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         checkLimitSize(client, 0.8);
 
         updateClusterSettings(Settings.builder().putNull(totalCircuitBreakerLimitSettingKey).putNull(useRealMemoryUsageSetting));
+    }
+
+    public void testCircuitBreakerDuringQueryConstruction() {
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
+
+        assertAcked(
+            prepareCreate("cb-query-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))).setMapping(
+                "test_field",
+                "type=text"
+            )
+        );
+
+        int docCount = scaledRandomIntBetween(100, 500);
+        List<IndexRequestBuilder> reqs = new ArrayList<>();
+        for (long id = 0; id < docCount; id++) {
+            reqs.add(client().prepareIndex("cb-query-test").setId(Long.toString(id)).setSource("test_field", "value" + id));
+        }
+        indexRandom(true, false, true, reqs);
+
+        updateClusterSettings(
+            Settings.builder()
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "10b")
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 1.0)
+        );
+
+        BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+        for (int i = 0; i < 100; i++) {
+            boolQuery.should(new WildcardQueryBuilder("test_field", "*pattern*" + i + "*"));
+        }
+
+        SearchRequestBuilder searchRequest = client().prepareSearch("cb-query-test").setQuery(boolQuery);
+        // This is one of the cases where a CB-trip does not translate into a 429, but instead a 400, because the query is rejected
+        // at construction time, before it is executed
+        assertFailures(searchRequest, RestStatus.BAD_REQUEST, containsString("Data too large"));
+
+        NodesStatsResponse stats = client().admin().cluster().prepareNodesStats().setBreaker(true).get();
+        long queryConstructionBreaks = 0;
+        for (NodeStats stat : stats.getNodes()) {
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.REQUEST);
+            if (breakerStats != null) {
+                queryConstructionBreaks += breakerStats.getTrippedCount();
+            }
+        }
+        assertThat("Query construction breaker should have tripped", queryConstructionBreaks, greaterThanOrEqualTo(1L));
+
+        updateClusterSettings(
+            Settings.builder()
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey())
+        );
     }
 
     private void checkLimitSize(Client client, double limitRatio) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -35,10 +36,21 @@ import java.util.regex.Pattern;
 
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
-/** Base class for {@link MappedFieldType} implementations that use the same
+/**
+ * Base class for {@link MappedFieldType} implementations that use the same
  * representation for internal index terms as the external representation so
  * that partial matching queries such as prefix, wildcard and fuzzy queries
- * can be implemented. */
+ * can be implemented.
+ *
+ * <p>Circuit breaker accounting for automaton-based queries (prefix, wildcard, regexp, range)
+ * is performed here, at the point each individual Lucene query is created, rather than solely
+ * in {@link SearchExecutionContext#toQuery} after the full query tree is assembled. This is
+ * intentional: compound queries such as a {@code bool} with many wildcard clauses build each
+ * clause sequentially, so by the time the complete tree is available for a post-hoc walk every
+ * automaton has already been allocated. Accounting per-clause lets the circuit breaker trip as
+ * soon as cumulative memory crosses the threshold, preventing the remaining clauses from being
+ * constructed and avoiding a potential OOM.
+ */
 public abstract class StringFieldType extends TermBasedFieldType {
 
     private static final Pattern WILDCARD_PATTERN = Pattern.compile("(\\\\.)|([?*]+)");
@@ -100,10 +112,14 @@ public abstract class StringFieldType extends TermBasedFieldType {
         }
         failIfNotIndexed();
         Term prefix = new Term(name(), indexedValueForSearch(value));
+        AutomatonQuery query;
         if (caseInsensitive) {
-            return method == null ? new CaseInsensitivePrefixQuery(prefix, false) : new CaseInsensitivePrefixQuery(prefix, false, method);
+            query = method == null ? new CaseInsensitivePrefixQuery(prefix, false) : new CaseInsensitivePrefixQuery(prefix, false, method);
+        } else {
+            query = method == null ? new PrefixQuery(prefix) : new PrefixQuery(prefix, method);
         }
-        return method == null ? new PrefixQuery(prefix) : new PrefixQuery(prefix, method);
+        context.addCircuitBreakerMemory(query.ramBytesUsed(), "prefix:" + name());
+        return query;
     }
 
     public static final String normalizeWildcardPattern(String fieldname, String value, Analyzer normalizer) {
@@ -167,10 +183,14 @@ public abstract class StringFieldType extends TermBasedFieldType {
         } else {
             term = new Term(name(), indexedValueForSearch(value));
         }
+        AutomatonQuery query;
         if (caseInsensitive) {
-            return method == null ? new CaseInsensitiveWildcardQuery(term) : new CaseInsensitiveWildcardQuery(term, false, method);
+            query = method == null ? new CaseInsensitiveWildcardQuery(term) : new CaseInsensitiveWildcardQuery(term, false, method);
+        } else {
+            query = method == null ? new WildcardQuery(term) : new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
         }
-        return method == null ? new WildcardQuery(term) : new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
+        context.addCircuitBreakerMemory(query.ramBytesUsed(), "wildcard:" + name());
+        return query;
     }
 
     @Override
@@ -188,7 +208,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
             );
         }
         failIfNotIndexed();
-        return method == null
+        AutomatonQuery query = method == null
             ? new RegexpQuery(new Term(name(), indexedValueForSearch(value)), syntaxFlags, matchFlags, maxDeterminizedStates)
             : new RegexpQuery(
                 new Term(name(), indexedValueForSearch(value)),
@@ -198,6 +218,8 @@ public abstract class StringFieldType extends TermBasedFieldType {
                 maxDeterminizedStates,
                 method
             );
+        context.addCircuitBreakerMemory(query.ramBytesUsed(), "regexp:" + name());
+        return query;
     }
 
     @Override
@@ -216,12 +238,14 @@ public abstract class StringFieldType extends TermBasedFieldType {
             );
         }
         failIfNotIndexed();
-        return new TermRangeQuery(
+        AutomatonQuery query = new TermRangeQuery(
             name(),
             lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
             upperTerm == null ? null : indexedValueForSearch(upperTerm),
             includeLower,
             includeUpper
         );
+        context.addCircuitBreakerMemory(query.ramBytesUsed(), "range:" + name());
+        return query;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
@@ -273,7 +274,6 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewrite, null, LoggingDeprecationHandler.INSTANCE);
 
         int matchFlagsValue = caseInsensitive ? RegExp.ASCII_CASE_INSENSITIVE : 0;
-        Query query = null;
         // For BWC we mask irrelevant bits (RegExp changed ALL from 0xffff to 0xff)
         // We need to preserve the DEPRECATED_COMPLEMENT for now though
         int deprecatedComplementFlag = syntaxFlagsValue & RegExp.DEPRECATED_COMPLEMENT;
@@ -281,25 +281,22 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
 
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType != null) {
-            query = fieldType.regexpQuery(value, sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates, method, context);
+            Query query = fieldType.regexpQuery(value, sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates, method, context);
+            if (query != null) {
+                return query;
+            }
         }
-        if (query == null) {
-            return method == null
-                ? new RegexpQuery(
-                    new Term(fieldName, BytesRefs.toBytesRef(value)),
-                    sanitisedSyntaxFlag,
-                    matchFlagsValue,
-                    maxDeterminizedStates
-                )
-                : new RegexpQuery(
-                    new Term(fieldName, BytesRefs.toBytesRef(value)),
-                    sanitisedSyntaxFlag,
-                    matchFlagsValue,
-                    RegexpQuery.DEFAULT_PROVIDER,
-                    maxDeterminizedStates,
-                    method
-                );
-        }
+        AutomatonQuery query = method == null
+            ? new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates)
+            : new RegexpQuery(
+                new Term(fieldName, BytesRefs.toBytesRef(value)),
+                sanitisedSyntaxFlag,
+                matchFlagsValue,
+                RegexpQuery.DEFAULT_PROVIDER,
+                maxDeterminizedStates,
+                method
+            );
+        context.addCircuitBreakerMemory(query.ramBytesUsed(), "regexp:" + fieldName);
         return query;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
@@ -71,6 +72,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -108,6 +110,9 @@ public class SearchExecutionContext extends QueryRewriteContext {
 
     private final Integer requestSize;
     private final MapperMetrics mapperMetrics;
+    @Nullable
+    private final CircuitBreaker circuitBreaker;
+    private final AtomicLong queryConstructionMemoryUsed = new AtomicLong(0);
 
     private Long rangeTimestampFrom;
 
@@ -209,11 +214,22 @@ public class SearchExecutionContext extends QueryRewriteContext {
             valuesSourceRegistry,
             parseRuntimeMappings(runtimeMappings, mapperService, indexSettings, mappingLookup),
             requestSize,
-            mapperMetrics
+            mapperMetrics,
+            null
         );
     }
 
+    /**
+     * Copy constructor that preserves the circuit breaker from the source context.
+     */
     public SearchExecutionContext(SearchExecutionContext source) {
+        this(source, source.circuitBreaker);
+    }
+
+    /**
+     * Copy constructor that overrides the circuit breaker.
+     */
+    public SearchExecutionContext(SearchExecutionContext source, @Nullable CircuitBreaker circuitBreaker) {
         this(
             source.shardId,
             source.shardRequestIndex,
@@ -236,7 +252,8 @@ public class SearchExecutionContext extends QueryRewriteContext {
             source.getValuesSourceRegistry(),
             source.runtimeMappings,
             source.requestSize,
-            source.mapperMetrics
+            source.mapperMetrics,
+            circuitBreaker
         );
     }
 
@@ -262,7 +279,8 @@ public class SearchExecutionContext extends QueryRewriteContext {
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, MappedFieldType> runtimeMappings,
         Integer requestSize,
-        MapperMetrics mapperMetrics
+        MapperMetrics mapperMetrics,
+        @Nullable CircuitBreaker circuitBreaker
     ) {
         super(
             parserConfig,
@@ -295,6 +313,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         this.searcher = searcher;
         this.requestSize = requestSize;
         this.mapperMetrics = mapperMetrics;
+        this.circuitBreaker = circuitBreaker;
     }
 
     private void reset() {
@@ -761,6 +780,40 @@ public class SearchExecutionContext extends QueryRewriteContext {
             this.rangeTimestampFrom = rangeTimestampFrom;
         } else {
             this.rangeTimestampFrom = Math.min(rangeTimestampFrom, this.rangeTimestampFrom);
+        }
+    }
+
+    /**
+     * Adds memory usage to the circuit breaker for query construction.
+     * <p>
+     * This method tracks memory used during query construction and enforces circuit breaker limits
+     * to prevent excessive memory usage. The tracked memory can later be released using
+     * {@link #releaseQueryConstructionMemory()}.
+     *
+     * @param bytes the number of bytes to add to the circuit breaker
+     * @param label a descriptive label for the memory allocation, used in circuit breaker error messages
+     */
+    public void addCircuitBreakerMemory(long bytes, String label) {
+        if (circuitBreaker != null) {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, label);
+            queryConstructionMemoryUsed.addAndGet(bytes);
+        }
+    }
+
+    /**
+     * Get total query construction memory used.
+     */
+    public long getQueryConstructionMemoryUsed() {
+        return queryConstructionMemoryUsed.get();
+    }
+
+    /**
+     * Release all accumulated query construction memory back to the circuit breaker.
+     */
+    public void releaseQueryConstructionMemory() {
+        long memoryToRelease = queryConstructionMemoryUsed.getAndSet(0);
+        if (memoryToRelease > 0 && circuitBreaker != null) {
+            circuitBreaker.addWithoutBreaking(-memoryToRelease);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -174,7 +174,8 @@ final class DefaultSearchContext extends SearchContext {
         SearchService.ResultsType resultsType,
         boolean enableQueryPhaseParallelCollection,
         int minimumDocsPerSlice,
-        long memoryAccountingBufferSize
+        long memoryAccountingBufferSize,
+        @Nullable CircuitBreaker circuitBreaker
     ) throws IOException {
         this.readerContext = readerContext;
         this.request = request;
@@ -218,7 +219,7 @@ final class DefaultSearchContext extends SearchContext {
             closeFuture.addListener(ActionListener.releasing(Releasables.wrap(engineSearcher, searcher)));
             this.relativeTimeSupplier = relativeTimeSupplier;
             this.timeout = timeout;
-            searchExecutionContext = indexService.newSearchExecutionContext(
+            SearchExecutionContext baseContext = indexService.newSearchExecutionContext(
                 request.shardId().id(),
                 request.shardRequestIndex(),
                 searcher,
@@ -227,6 +228,7 @@ final class DefaultSearchContext extends SearchContext {
                 request.getRuntimeMappings(),
                 request.source() == null ? null : request.source().size()
             );
+            searchExecutionContext = circuitBreaker != null ? new SearchExecutionContext(baseContext, circuitBreaker) : baseContext;
             queryBoost = request.indexBoost();
             this.lowLevelCancellation = lowLevelCancellation;
             success = true;

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -390,7 +390,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         this.scriptService = scriptService;
         this.bigArrays = bigArrays;
         this.fetchPhase = fetchPhase;
-        circuitBreaker = circuitBreakerService.getBreaker(CircuitBreaker.REQUEST);
+        this.circuitBreaker = circuitBreakerService.getBreaker(CircuitBreaker.REQUEST);
         this.multiBucketConsumerService = new MultiBucketConsumerService(clusterService, settings, circuitBreaker);
         this.executorSelector = executorSelector;
         this.tracer = tracer;
@@ -1368,6 +1368,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         checkCancelled(task);
         final DefaultSearchContext context = createSearchContext(readerContext, request, defaultSearchTimeout, resultsType);
         resultsType.addResultsObject(context);
+
+        // Release the memory used for query construction once the search context is closed.
+        context.addReleasable(context.getSearchExecutionContext()::releaseQueryConstructionMemory);
+
         try {
             if (request.scroll() != null) {
                 context.scrollContext().scroll = request.scroll();
@@ -1400,6 +1404,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         try (ReaderContext readerContext = new ReaderContext(id, indexService, indexShard, reader, -1L, true)) {
             DefaultSearchContext searchContext = createSearchContext(readerContext, request, timeout, ResultsType.NONE);
             searchContext.addReleasable(readerContext.markAsUsed(0L));
+            searchContext.addReleasable(searchContext.getSearchExecutionContext()::releaseQueryConstructionMemory);
             return searchContext;
         }
     }
@@ -1431,13 +1436,18 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 resultsType,
                 enableQueryPhaseParallelCollection,
                 minimumDocsPerSlice,
-                memoryAccountingBufferSize
+                memoryAccountingBufferSize,
+                circuitBreaker
             );
             // we clone the query shard context here just for rewriting otherwise we
             // might end up with incorrect state since we are using now() or script services
             // during rewrite and normalized / evaluate templates etc.
             SearchExecutionContext context = new SearchExecutionContext(searchContext.getSearchExecutionContext());
+
             Rewriteable.rewrite(request.getRewriteable(), context, true);
+            assert context.getQueryConstructionMemoryUsed() == 0
+                : "rewrite phase should not build queries; found " + context.getQueryConstructionMemoryUsed() + " bytes tracked";
+
             assert searchContext.getSearchExecutionContext().isCacheable();
             success = true;
         } finally {
@@ -2218,4 +2228,5 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
         };
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -25,6 +25,7 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
 import static org.hamcrest.Matchers.equalTo;
@@ -89,11 +90,16 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     public void testBlendedRewriteMethod() throws IOException {
         String rewrite = "top_terms_blended_freqs_10";
-        Query parsedQuery = parseQuery(prefixQuery(TEXT_FIELD_NAME, "val").rewrite(rewrite)).toQuery(createSearchExecutionContext());
-        assertThat(parsedQuery, instanceOf(PrefixQuery.class));
-        PrefixQuery prefixQuery = (PrefixQuery) parsedQuery;
-        assertThat(prefixQuery.getPrefix(), equalTo(new Term(TEXT_FIELD_NAME, "val")));
-        assertThat(prefixQuery.getRewriteMethod(), instanceOf(MultiTermQuery.TopTermsBlendedFreqScoringRewrite.class));
+        SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext(), createCircuitBreakerService());
+        try {
+            Query parsedQuery = parseQuery(prefixQuery(TEXT_FIELD_NAME, "val").rewrite(rewrite)).toQuery(context);
+            assertThat(parsedQuery, instanceOf(PrefixQuery.class));
+            PrefixQuery prefixQuery = (PrefixQuery) parsedQuery;
+            assertThat(prefixQuery.getPrefix(), equalTo(new Term(TEXT_FIELD_NAME, "val")));
+            assertThat(prefixQuery.getRewriteMethod(), instanceOf(MultiTermQuery.TopTermsBlendedFreqScoringRewrite.class));
+        } finally {
+            context.releaseQueryConstructionMemory();
+        }
     }
 
     public void testFromJson() throws IOException {
@@ -210,4 +216,21 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         assertThat(rewritten, CoreMatchers.instanceOf(MatchNoneQueryBuilder.class));
     }
 
+    public void testPrefixQueryCircuitBreakerAccounting() throws IOException {
+        assertCircuitBreakerAccountsForQuery(new PrefixQueryBuilder(TEXT_FIELD_NAME, "test"));
+    }
+
+    public void testPrefixCircuitBreakerTripsWithLowLimit() {
+        assertCircuitBreakerTripsOnQueryConstruction("500kb", () -> {
+            BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+            IntStream.range(0, 100).forEach(i -> {
+                PrefixQueryBuilder prefixQuery = new PrefixQueryBuilder(TEXT_FIELD_NAME, "prefix" + i);
+                if (randomBoolean()) {
+                    prefixQuery.caseInsensitive(true);
+                }
+                boolQuery.should(prefixQuery);
+            });
+            return boolQuery;
+        });
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -65,6 +65,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
@@ -1433,5 +1435,21 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         b.field("ww_keyword");
         Query q = b.doToQuery(createSearchExecutionContext());
         assertEquals(new TermQuery(new Term("ww_keyword", "query with spaces")), q);
+    }
+
+    public void testQueryStringCircuitBreakerTripsWithManyWildcards() {
+        assertCircuitBreakerTripsOnQueryConstruction("1mb", () -> {
+            StringJoiner joiner = new StringJoiner(" OR ");
+            IntStream.range(0, 100).forEach(i -> joiner.add("*a*b*c*d*e*f*g*h*" + i + "*"));
+            return queryStringQuery(joiner.toString()).defaultField(TEXT_FIELD_NAME);
+        });
+    }
+
+    public void testQueryStringCircuitBreakerTripsWithManyRegexps() {
+        assertCircuitBreakerTripsOnQueryConstruction("500kb", () -> {
+            StringJoiner joiner = new StringJoiner(" OR ");
+            IntStream.range(0, 50).forEach(i -> joiner.add("/(pattern" + i + "|alternate" + i + "|option" + i + ").*/"));
+            return queryStringQuery(joiner.toString()).defaultField(TEXT_FIELD_NAME);
+        });
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -678,4 +678,15 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
+
+    public void testRangeQueryCircuitBreakerAccountingTextFields() throws IOException {
+        assertCircuitBreakerAccountsForQuery(new RangeQueryBuilder(TEXT_FIELD_NAME).gte("aaa").lte("zzz"));
+    }
+
+    public void testRangeQueryCircuitBreakerTripsOnLargeTextRange() {
+        assertCircuitBreakerTripsOnQueryConstruction(
+            "1kb",
+            () -> new RangeQueryBuilder(TEXT_FIELD_NAME).gte("a").lte("zzzzzzzzzzzzzzzzzzzz")
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -144,5 +145,22 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
             }""";
         e = expectThrows(ParsingException.class, () -> parseQuery(shortJson));
         assertEquals("[regexp] query doesn't support multiple fields, found [user1] and [user2]", e.getMessage());
+    }
+
+    public void testRegexpQueryCircuitBreakerAccounting() throws IOException {
+        assertCircuitBreakerAccountsForQuery(new RegexpQueryBuilder(TEXT_FIELD_NAME, ".*test.*pattern.*"));
+    }
+
+    public void testRegexpCircuitBreakerTripsWithLowLimit() {
+        assertCircuitBreakerTripsOnQueryConstruction("500kb", () -> {
+            BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+            IntStream.range(0, 50)
+                .forEach(
+                    i -> boolQuery.should(
+                        new RegexpQueryBuilder(TEXT_FIELD_NAME, "(pattern" + i + "|alternate" + i + "|option" + i + ").*")
+                    )
+                );
+            return boolQuery;
+        });
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -200,5 +201,18 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
         QueryBuilder rewritten = query.rewrite(coordinatorRewriteContext);
         assertThat(rewritten, CoreMatchers.instanceOf(MatchNoneQueryBuilder.class));
+    }
+
+    public void testWildcardQueryCircuitBreakerAccounting() throws IOException {
+        assertCircuitBreakerAccountsForQuery(new WildcardQueryBuilder(TEXT_FIELD_NAME, "test*pattern*with*wildcards*"));
+    }
+
+    public void testCircuitBreakerTripsWithLowLimit() {
+        assertCircuitBreakerTripsOnQueryConstruction("1mb", () -> {
+            BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+            IntStream.range(0, 100)
+                .forEach(i -> boolQuery.should(new WildcardQueryBuilder(TEXT_FIELD_NAME, "*a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*" + i + "*")));
+            return boolQuery;
+        });
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -190,7 +190,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
             contextWithoutScroll.from(300);
             contextWithoutScroll.close();
@@ -233,8 +234,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
-
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
                 context1.from(300);
@@ -317,7 +318,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
 
@@ -360,7 +362,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
                 context3.sliceBuilder(null).parsedQuery(parsedQuery).preProcess();
@@ -392,7 +395,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
                 context4.sliceBuilder(new SliceBuilder(1, 2)).parsedQuery(parsedQuery).preProcess();
@@ -464,7 +468,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
 
             assertThat(context.searcher().hasCancellations(), is(false));
@@ -1084,7 +1089,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -20,8 +20,11 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexMode;
@@ -41,13 +44,17 @@ import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RootObjectMapper;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.CircuitBreakerMetrics;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -369,6 +376,106 @@ public class SearchServiceTests extends IndexShardTestCase {
             // allowing prewarming
             assertThat(isExecutorQueuedBeyondPrewarmingFactor(DIRECT_EXECUTOR_SERVICE, 2), is(false));
         }
+    }
+
+    public void testBuildQueryWithCircuitBreakerAccountsMemory() throws IOException {
+        IndexShard indexShard = newShard(true);
+        try {
+            recoverShardFromStore(indexShard);
+            try (Engine.Searcher searcher = indexShard.acquireSearcher("test")) {
+                CircuitBreaker cb = createQueryConstructionBreaker("100mb");
+                SearchExecutionContext context = new SearchExecutionContext(
+                    createSearchExecutionContext((mappedFieldType, fieldDataContext) -> null, searcher),
+                    cb
+                );
+
+                try {
+                    long cbBefore = cb.getUsed();
+                    assertEquals("Freshly created breaker must start at zero", 0L, cbBefore);
+
+                    WildcardQueryBuilder queryBuilder = new WildcardQueryBuilder("field", "*test*pattern*");
+                    assertNotNull(queryBuilder.toQuery(context));
+
+                    long cbAfter = cb.getUsed();
+                    long tracked = context.getQueryConstructionMemoryUsed();
+
+                    assertTrue("Circuit breaker should have accounted memory", cbAfter > cbBefore);
+                    assertTrue("Context should have tracked memory", tracked > 0);
+                    assertEquals("CB delta must match tracked memory", cbAfter - cbBefore, tracked);
+                } finally {
+                    context.releaseQueryConstructionMemory();
+                }
+            }
+        } finally {
+            closeShards(indexShard);
+        }
+    }
+
+    public void testBuildQueryWithCircuitBreakerTripsOnLimitExceeded() throws IOException {
+        IndexShard indexShard = newShard(true);
+        try {
+            recoverShardFromStore(indexShard);
+            try (Engine.Searcher searcher = indexShard.acquireSearcher("test")) {
+                CircuitBreaker cb = createQueryConstructionBreaker("1kb");
+                SearchExecutionContext context = new SearchExecutionContext(
+                    createSearchExecutionContext((mappedFieldType, fieldDataContext) -> null, searcher),
+                    cb
+                );
+
+                try {
+                    BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+                    for (int i = 0; i < 50; i++) {
+                        boolQuery.should(new WildcardQueryBuilder("field", "*a*b*c*" + i + "*"));
+                    }
+
+                    expectThrows(CircuitBreakingException.class, () -> boolQuery.toQuery(context));
+                } finally {
+                    context.releaseQueryConstructionMemory();
+                }
+            }
+        } finally {
+            closeShards(indexShard);
+        }
+    }
+
+    public void testQueryConstructionMemoryReleasedOnContextClose() throws IOException {
+        IndexShard indexShard = newShard(true);
+        try {
+            recoverShardFromStore(indexShard);
+            try (Engine.Searcher searcher = indexShard.acquireSearcher("test")) {
+                CircuitBreaker cb = createQueryConstructionBreaker("100mb");
+                SearchExecutionContext context = new SearchExecutionContext(
+                    createSearchExecutionContext((mappedFieldType, fieldDataContext) -> null, searcher),
+                    cb
+                );
+
+                for (int i = 0; i < 3; i++) {
+                    new WildcardQueryBuilder("field", "*test" + i + "*").toQuery(context);
+                }
+
+                long cbAfterBuild = cb.getUsed();
+                long tracked = context.getQueryConstructionMemoryUsed();
+                assertTrue("Memory should be accounted before release", cbAfterBuild > 0);
+                assertEquals("Tracked memory should match CB", cbAfterBuild, tracked);
+
+                context.releaseQueryConstructionMemory();
+
+                assertEquals("CB must be fully released", 0L, cb.getUsed());
+                assertEquals("Tracked memory must be zeroed", 0L, context.getQueryConstructionMemoryUsed());
+            }
+        } finally {
+            closeShards(indexShard);
+        }
+    }
+
+    private CircuitBreaker createQueryConstructionBreaker(String limit) {
+        Settings settings = Settings.builder()
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), limit)
+            .put(HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING.getKey(), false)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        return new HierarchyCircuitBreakerService(CircuitBreakerMetrics.NOOP, settings, Collections.emptyList(), clusterSettings)
+            .getBreaker(CircuitBreaker.REQUEST);
     }
 
     private void doTestCanMatch(

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -13,6 +13,8 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.SeedUtils;
 
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.MockResolvedIndices;
@@ -29,6 +31,8 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.regex.Regex;
@@ -55,6 +59,7 @@ import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.CoordinatorRewriteContext;
 import org.elasticsearch.index.query.DataRewriteContext;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
@@ -63,6 +68,9 @@ import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.DateFieldRangeInfo;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerMetrics;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.node.InternalSettingsPreparer;
@@ -108,12 +116,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.containsString;
 
 public abstract class AbstractBuilderTestCase extends ESTestCase {
 
@@ -421,6 +431,86 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
 
     }
 
+    protected static CircuitBreaker createCircuitBreakerService(String limit) {
+        Settings settings = Settings.builder()
+            .put("indices.breaker.request.limit", limit)
+            .put("indices.breaker.request.overhead", "1.0")
+            .build();
+
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            settings,
+            Collections.emptyList(),
+            clusterSettings
+        );
+
+        return service.getBreaker(CircuitBreaker.REQUEST);
+    }
+
+    /**
+     * Creates a circuit breaker for testing query construction with default limit (10% of heap).
+     *
+     * @return a configured CircuitBreaker instance
+     */
+    protected static CircuitBreaker createCircuitBreakerService() {
+        return createCircuitBreakerService("10%");
+    }
+
+    /**
+     * Override this method to provide a custom CircuitBreakerService for tests.
+     * By default, returns NoneCircuitBreakerService for backwards compatibility.
+     *
+     * @param nodeSettings the node settings
+     * @param clusterSettings the cluster settings
+     * @return the CircuitBreakerService to use in tests
+     */
+    protected CircuitBreakerService createCircuitBreakerService(Settings nodeSettings, ClusterSettings clusterSettings) {
+        return new NoneCircuitBreakerService();
+    }
+
+    /**
+     * Asserts that building the supplied query trips the circuit breaker with a "Data too large" message.
+     */
+    protected static void assertCircuitBreakerTripsOnQueryConstruction(String breakerLimit, Supplier<QueryBuilder> querySupplier) {
+        SearchExecutionContext context = new SearchExecutionContext(
+            createSearchExecutionContext(),
+            createCircuitBreakerService(breakerLimit)
+        );
+
+        try {
+            QueryBuilder query = querySupplier.get();
+            CircuitBreakingException exception = expectThrows(CircuitBreakingException.class, () -> query.toQuery(context));
+            assertThat(exception.getMessage(), containsString("Data too large"));
+        } finally {
+            context.releaseQueryConstructionMemory();
+        }
+    }
+
+    /**
+     * Asserts that the circuit breaker correctly accounts for the memory used by the given query.
+     */
+    protected static void assertCircuitBreakerAccountsForQuery(QueryBuilder queryBuilder) throws IOException {
+        CircuitBreaker cb = createCircuitBreakerService();
+        SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext(), cb);
+
+        try {
+            long before = cb.getUsed();
+            Query query = queryBuilder.toQuery(context);
+            long after = cb.getUsed();
+
+            if (query instanceof Accountable accountable) {
+                long queryMemory = accountable.ramBytesUsed();
+                if (queryMemory > 0) {
+                    assertTrue("Circuit breaker should account for query memory", after >= before);
+                    assertEquals("Circuit breaker delta should equal query ramBytesUsed", queryMemory, after - before);
+                }
+            }
+        } finally {
+            context.releaseQueryConstructionMemory();
+        }
+    }
+
     private static class ServiceHolder implements Closeable {
         private final IndexFieldDataService indexFieldDataService;
         private final SearchModule searchModule;
@@ -435,6 +525,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         private final Client client;
         private final long nowInMillis;
         private final IndexMetadata indexMetadata;
+        private final CircuitBreakerService circuitBreakerService;
 
         ServiceHolder(
             Settings nodeSettings,
@@ -451,12 +542,15 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             PluginsService pluginsService;
             pluginsService = new MockPluginsService(nodeSettings, env, plugins);
 
+            ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
             ClusterService clusterService = new ClusterService(
                 Settings.EMPTY,
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                clusterSettings,
                 new DeterministicTaskQueue().getThreadPool(),
                 null
             );
+
+            this.circuitBreakerService = testCase.createCircuitBreakerService(nodeSettings, clusterSettings);
 
             client = (Client) Proxy.newProxyInstance(
                 Client.class.getClassLoader(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -602,6 +602,7 @@ public class ComputeService {
                     return new ReinitializingSourceProvider(super::createSourceProvider);
                 }
             };
+            searchContext.addReleasable(searchExecutionContext::releaseQueryConstructionMemory);
             contexts.add(
                 new EsPhysicalOperationProviders.DefaultShardContext(
                     i,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Add circuit breaker for query construction to prevent OOM from automaton-based queries (#142150)](https://github.com/elastic/elasticsearch/pull/142150)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)