### PR TITLE
ESQL: Remaining serialization tests

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/ExpressionWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/ExpressionWritables.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToBoolean
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCartesianPoint;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCartesianShape;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateNanos;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateRange;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDatetime;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDegrees;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDenseVector;
@@ -230,6 +231,7 @@ public class ExpressionWritables {
         entries.add(ToCartesianPoint.ENTRY);
         entries.add(ToDatetime.ENTRY);
         entries.add(ToDateNanos.ENTRY);
+        entries.add(ToDateRange.ENTRY);
         entries.add(ToDegrees.ENTRY);
         entries.add(ToDenseVector.ENTRY);
         entries.add(ToDouble.ENTRY);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileOverTime.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Similar to {@link Percentile}, but it is used to calculate the percentile value over a time series of values from the given field.
  */
-public class PercentileOverTime extends TimeSeriesAggregateFunction implements SurrogateExpression, ToAggregator {
+public class PercentileOverTime extends TimeSeriesAggregateFunction implements OnlySurrogateExpression, ToAggregator {
     @FunctionInfo(
         returnType = "double",
         description = "Calculates the percentile over time of a field.",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyList;
 /**
  * Similar to {@link StdDev}, but it is used to calculate the standard deviation over a time series of values from the given field.
  */
-public class StddevOverTime extends TimeSeriesAggregateFunction implements SurrogateExpression, ToAggregator {
+public class StddevOverTime extends TimeSeriesAggregateFunction implements OnlySurrogateExpression, ToAggregator {
     @FunctionInfo(
         returnType = "double",
         description = "Calculates the population standard deviation over time of a numeric field.",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/VarianceOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/VarianceOverTime.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyList;
 /**
  * Similar to {@link Variance}, but it is used to calculate the variance over a time series of values from the given field.
  */
-public class VarianceOverTime extends TimeSeriesAggregateFunction implements SurrogateExpression, ToAggregator {
+public class VarianceOverTime extends TimeSeriesAggregateFunction implements OnlySurrogateExpression, ToAggregator {
     @FunctionInfo(
         returnType = "double",
         description = "Calculates the population variance over time of a numeric field.",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Score.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Score.java
@@ -59,11 +59,7 @@ public class Score extends Function implements EvaluatorMapper {
             description = "Boolean expression that contains full text function(s) to be scored."
         ) Expression scorableQuery
     ) {
-        this(source, List.of(scorableQuery));
-    }
-
-    protected Score(Source source, List<Expression> children) {
-        super(source, children);
+        super(source, List.of(scorableQuery));
     }
 
     @Override
@@ -73,7 +69,7 @@ public class Score extends Function implements EvaluatorMapper {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new Score(source(), newChildren);
+        return new Score(source(), newChildren.getFirst());
     }
 
     @Override
@@ -95,12 +91,26 @@ public class Score extends Function implements EvaluatorMapper {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
-        out.writeNamedWriteableCollection(this.children());
+        out.writeOptionalNamedWriteable(children().getFirst());
     }
 
     private static Expression readFrom(StreamInput in) throws IOException {
         Source source = Source.readFrom((PlanStreamInput) in);
+        /*
+         * This is not truly optional. But when the SCORE scalar was originally
+         * created we serialized it with this pair:
+         *
+         * in.readOptionalNamedWriteable(Expression.class);
+         * out.writeNamedWriteableCollection(this.children());
+         *
+         * This pair *is* compatible if we send a single element list. Single
+         * element lists are serialized as `0x01 <name> <body>`. That's also
+         * how optional named writeables are serialized.
+         */
         Expression query = in.readOptionalNamedWriteable(Expression.class);
+        if (query == null) {
+            throw new IllegalStateException("query isn't really optional");
+        }
         return new Score(source, query);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerSurrogate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerSurrogate.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
@@ -43,7 +43,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
  * </ul>
  */
 
-public class ToIntegerSurrogate extends EsqlScalarFunction implements SurrogateExpression, OptionalArgument, ConvertFunction {
+public class ToIntegerSurrogate extends EsqlScalarFunction implements OnlySurrogateExpression, OptionalArgument, ConvertFunction {
 
     private final Expression field;
     private final Expression base;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIp.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIp.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.MapParam;
@@ -62,7 +62,7 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.Ab
  *     expose a single method to users.
  * </p>
  */
-public class ToIp extends EsqlScalarFunction implements SurrogateExpression, OptionalArgument, ConvertFunction {
+public class ToIp extends EsqlScalarFunction implements OnlySurrogateExpression, OptionalArgument, ConvertFunction {
     private static final String LEADING_ZEROS = "leading_zeros";
     public static final Map<String, DataType> ALLOWED_OPTIONS = Map.ofEntries(Map.entry(LEADING_ZEROS, KEYWORD));
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSurrogate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSurrogate.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
@@ -46,7 +46,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
  * </ul>
  */
 
-public class ToLongSurrogate extends EsqlScalarFunction implements SurrogateExpression, OptionalArgument, ConvertFunction {
+public class ToLongSurrogate extends EsqlScalarFunction implements OnlySurrogateExpression, OptionalArgument, ConvertFunction {
 
     private final Expression field;
     private final Expression base;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
@@ -210,6 +210,22 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
         return ENTRY.name;
     }
 
+    Expression value() {
+        return value;
+    }
+
+    Expression origin() {
+        return origin;
+    }
+
+    Expression scale() {
+        return scale;
+    }
+
+    Expression options() {
+        return options;
+    }
+
     @Override
     protected TypeResolution resolveType() {
         if (childrenResolved() == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -19,7 +19,9 @@ import org.elasticsearch.xpack.esql.core.tree.SourceTests;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
 import org.elasticsearch.xpack.esql.expression.OnlySurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.function.inference.InferenceFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlConfigurationFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.FoldablesConvertFunction;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
@@ -241,7 +243,10 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
         for (FunctionDefinition def : registry.listFunctions()) {
             checkFunctionTestExists(errors, def, "Tests", AbstractFunctionTestCase.class);
             checkFunctionTestExists(errors, def, "ErrorTests", ErrorsForCasesWithoutExamplesTestCase.class);
-            if (false == OnlySurrogateExpression.class.isAssignableFrom(def.clazz())) {
+            boolean isSerializable = false == OnlySurrogateExpression.class.isAssignableFrom(def.clazz())
+                && false == FoldablesConvertFunction.class.isAssignableFrom(def.clazz())
+                && false == InferenceFunction.class.isAssignableFrom(def.clazz());
+            if (isSerializable) {
                 checkFunctionTestExists(errors, def, "SerializationTests", AbstractExpressionSerializationTests.class);
             }
         }
@@ -253,63 +258,38 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
              * while working on something, but released stuff should not have an entry here.
              */
             matchesList().item("org.elasticsearch.xpack.esql.expression.function.aggregate.AbsentOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.AbsentOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.AvgOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.AvgOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinctErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinctOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinctOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.CountOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.CountOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.DeltaErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.DeltaSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.DerivErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.DerivSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.FirstErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.FirstOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.FirstOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.IdeltaErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.IdeltaSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.IrateErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.IrateSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.LastErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTimeSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.MaxOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.MedianAbsoluteDeviationErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.MedianErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.MinOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.PresentOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.PresentOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.RateErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialExtentErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.StdDevErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.StddevOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.StddevOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.SumErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTimeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTimeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTimeSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.WeightedAvgErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.KqlSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhraseErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhraseSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MatchSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MultiMatchErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MultiMatchSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.QueryStringSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.grouping.BucketErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.grouping.TBucketErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.inference.TextEmbeddingSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.ClampErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.ClampTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMaxErrorTests is missing")
@@ -317,21 +297,10 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.conditional.GreatestErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.conditional.LeastErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToAggregateMetricDoubleErrorTests is missing")
-                .item(
-                    "org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToAggregateMetricDoubleSerializationTests is missing"
-                )
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDatePeriodSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateRangeErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateRangeSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateRangeTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDenseVectorErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDenseVectorSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToGeohexErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToIntegerSurrogateSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToIpSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToLongSurrogateSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToTDigestSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToTimeDurationSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToVersionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.date.NowErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.math.AcoshErrorTests is missing")
@@ -345,27 +314,16 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvIntersectionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSortErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvUnionErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvUnionSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.nulls.CoalesceErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecaySerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohexSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeotileSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StNPointsErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StNPointsSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StXMaxSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StXMinSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StYMaxSerializationTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StYMinSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ChunkErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippetsErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippetsSerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarityErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilaritySerializationTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.DotProductErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.HammingErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.KnnErrorTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class AbsentOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<AbsentOverTime> {
+    @Override
+    protected AbsentOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new AbsentOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractTimeSeriesAggregationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractTimeSeriesAggregationSerializationTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+/**
+ * Helper for making serialization tests for time series aggregations that take
+ * {@code field}, {@code filter}, and {@code window}.
+ */
+public abstract class AbstractTimeSeriesAggregationSerializationTests<T extends TimeSeriesAggregateFunction>
+    extends AbstractExpressionSerializationTests<T> {
+
+    protected abstract T create(Source source, Expression field, Expression filter, Expression window);
+
+    @Override
+    protected final T createTestInstance() {
+        return create(randomSource(), randomChild(), randomChild(), randomChild());
+    }
+
+    @Override
+    protected final T mutateInstance(T instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        switch (between(0, 2)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+        }
+        return create(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractTimeSeriesAggregationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbstractTimeSeriesAggregationSerializationTests.java
@@ -17,8 +17,8 @@ import java.io.IOException;
  * Helper for making serialization tests for time series aggregations that take
  * {@code field}, {@code filter}, and {@code window}.
  */
-public abstract class AbstractTimeSeriesAggregationSerializationTests<T extends TimeSeriesAggregateFunction>
-    extends AbstractExpressionSerializationTests<T> {
+public abstract class AbstractTimeSeriesAggregationSerializationTests<T extends TimeSeriesAggregateFunction> extends
+    AbstractExpressionSerializationTests<T> {
 
     protected abstract T create(Source source, Expression field, Expression filter, Expression window);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class AvgOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<AvgOverTime> {
+    @Override
+    protected AvgOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new AvgOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctOverTimeSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class CountDistinctOverTimeSerializationTests extends AbstractExpressionSerializationTests<CountDistinctOverTime> {
+    @Override
+    protected CountDistinctOverTime createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression precision = randomBoolean() ? null : randomChild();
+        return new CountDistinctOverTime(source, field, filter, window, precision);
+    }
+
+    @Override
+    protected CountDistinctOverTime mutateInstance(CountDistinctOverTime instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression precision = instance.parameters().isEmpty() ? null : instance.parameters().getFirst();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> precision = randomValueOtherThan(precision, () -> randomBoolean() ? null : randomChild());
+        }
+        return new CountDistinctOverTime(source, field, filter, window, precision);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class CountOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<CountOverTime> {
+    @Override
+    protected CountOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new CountOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DeltaSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DeltaSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class DeltaSerializationTests extends AbstractExpressionSerializationTests<Delta> {
+    @Override
+    protected Delta createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new Delta(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected Delta mutateInstance(Delta instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Delta(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DerivSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DerivSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class DerivSerializationTests extends AbstractExpressionSerializationTests<Deriv> {
+    @Override
+    protected Deriv createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new Deriv(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected Deriv mutateInstance(Deriv instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Deriv(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class FirstOverTimeSerializationTests extends AbstractExpressionSerializationTests<FirstOverTime> {
+    @Override
+    protected FirstOverTime createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new FirstOverTime(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected FirstOverTime mutateInstance(FirstOverTime instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new FirstOverTime(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IdeltaSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IdeltaSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class IdeltaSerializationTests extends AbstractExpressionSerializationTests<Idelta> {
+    @Override
+    protected Idelta createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new Idelta(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected Idelta mutateInstance(Idelta instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Idelta(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class IrateSerializationTests extends AbstractExpressionSerializationTests<Irate> {
+    @Override
+    protected Irate createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new Irate(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected Irate mutateInstance(Irate instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Irate(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class LastOverTimeSerializationTests extends AbstractExpressionSerializationTests<LastOverTime> {
+    @Override
+    protected LastOverTime createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression filter = randomChild();
+        Expression window = randomChild();
+        Expression timestamp = randomChild();
+        return new LastOverTime(source, field, filter, window, timestamp);
+    }
+
+    @Override
+    protected LastOverTime mutateInstance(LastOverTime instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        Expression timestamp = instance.timestamp();
+        switch (between(0, 3)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new LastOverTime(source, field, filter, window, timestamp);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class MaxOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<MaxOverTime> {
+    @Override
+    protected MaxOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new MaxOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class MinOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<MinOverTime> {
+    @Override
+    protected MinOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new MinOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class PresentOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<PresentOverTime> {
+    @Override
+    protected PresentOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new PresentOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumOverTimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumOverTimeSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class SumOverTimeSerializationTests extends AbstractTimeSeriesAggregationSerializationTests<SumOverTime> {
+    @Override
+    protected SumOverTime create(Source source, Expression field, Expression filter, Expression window) {
+        return new SumOverTime(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/VarianceSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/VarianceSerializationTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class VarianceSerializationTests extends AbstractExpressionSerializationTests<Variance> {
+    @Override
+    protected Variance createTestInstance() {
+        return new Variance(randomSource(), randomChild(), randomChild(), randomChild());
+    }
+
+    @Override
+    protected Variance mutateInstance(Variance instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression filter = instance.filter();
+        Expression window = instance.window();
+        switch (between(0, 2)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> filter = randomValueOtherThan(filter, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> window = randomValueOtherThan(window, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Variance(source, field, filter, window);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/KqlSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/KqlSerializationTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class KqlSerializationTests extends AbstractExpressionSerializationTests<Kql> {
+    @Override
+    protected Kql createTestInstance() {
+        Source source = randomSource();
+        Expression query = randomChild();
+        return new Kql(source, query, null, configuration());
+    }
+
+    @Override
+    protected Kql mutateInstance(Kql instance) throws IOException {
+        Source source = instance.source();
+        Expression query = randomValueOtherThan(instance.query(), AbstractExpressionSerializationTests::randomChild);
+        return new Kql(source, query, null, configuration());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseSerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class MatchPhraseSerializationTests extends AbstractExpressionSerializationTests<MatchPhrase> {
+    @Override
+    protected MatchPhrase createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression query = randomChild();
+        return new MatchPhrase(source, field, query, null);
+    }
+
+    @Override
+    protected MatchPhrase mutateInstance(MatchPhrase instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression query = instance.query();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            query = randomValueOtherThan(query, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new MatchPhrase(source, field, query, null);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchSerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class MatchSerializationTests extends AbstractExpressionSerializationTests<Match> {
+    @Override
+    protected Match createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression query = randomChild();
+        return new Match(source, field, query, null);
+    }
+
+    @Override
+    protected Match mutateInstance(Match instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression query = instance.query();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            query = randomValueOtherThan(query, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Match(source, field, query, null);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MultiMatchSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MultiMatchSerializationTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MultiMatchSerializationTests extends AbstractExpressionSerializationTests<MultiMatch> {
+    @Override
+    protected MultiMatch createTestInstance() {
+        Source source = randomSource();
+        Expression query = randomChild();
+        List<Expression> fields = randomList(1, 5, AbstractExpressionSerializationTests::randomChild);
+        return new MultiMatch(source, query, fields, null);
+    }
+
+    @Override
+    protected MultiMatch mutateInstance(MultiMatch instance) throws IOException {
+        Source source = instance.source();
+        Expression query = instance.query();
+        List<Expression> fields = instance.fields();
+        if (randomBoolean()) {
+            query = randomValueOtherThan(query, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            fields = randomValueOtherThan(fields, () -> randomList(1, 5, AbstractExpressionSerializationTests::randomChild));
+        }
+        return new MultiMatch(source, query, fields, null);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringSerializationTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class QueryStringSerializationTests extends AbstractExpressionSerializationTests<QueryString> {
+    @Override
+    protected QueryString createTestInstance() {
+        Source source = randomSource();
+        Expression query = randomChild();
+        return new QueryString(source, query, null, configuration());
+    }
+
+    @Override
+    protected QueryString mutateInstance(QueryString instance) throws IOException {
+        Source source = instance.source();
+        Expression query = randomValueOtherThan(instance.query(), AbstractExpressionSerializationTests::randomChild);
+        return new QueryString(source, query, null, configuration());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/ScoreSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/ScoreSerializationTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class ScoreSerializationTests extends AbstractExpressionSerializationTests<Score> {
+    @Override
+    protected Score createTestInstance() {
+        Source source = randomSource();
+        Expression query = randomChild();
+        return new Score(source, query);
+    }
+
+    @Override
+    protected Score mutateInstance(Score instance) throws IOException {
+        Source source = instance.source();
+        Expression query = randomValueOtherThan(instance.children().getFirst(), AbstractExpressionSerializationTests::randomChild);
+        return new Score(source, query);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class ToAggregateMetricDoubleSerializationTests extends AbstractUnaryScalarSerializationTests<ToAggregateMetricDouble> {
+    @Override
+    protected ToAggregateMetricDouble create(Source source, Expression child) {
+        return new ToAggregateMetricDouble(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateRangeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateRangeSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class ToDateRangeSerializationTests extends AbstractUnaryScalarSerializationTests<ToDateRange> {
+    @Override
+    protected ToDateRange create(Source source, Expression child) {
+        return new ToDateRange(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDenseVectorSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDenseVectorSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class ToDenseVectorSerializationTests extends AbstractUnaryScalarSerializationTests<ToDenseVector> {
+    @Override
+    protected ToDenseVector create(Source source, Expression child) {
+        return new ToDenseVector(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class ToTDigestSerializationTests extends AbstractUnaryScalarSerializationTests<ToTDigest> {
+    @Override
+    protected ToTDigest create(Source source, Expression child) {
+        return new ToTDigest(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvUnionSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvUnionSerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class MvUnionSerializationTests extends AbstractExpressionSerializationTests<MvUnion> {
+    @Override
+    protected MvUnion createTestInstance() {
+        Source source = randomSource();
+        Expression field1 = randomChild();
+        Expression field2 = randomChild();
+        return new MvUnion(source, field1, field2);
+    }
+
+    @Override
+    protected MvUnion mutateInstance(MvUnion instance) throws IOException {
+        Source source = instance.source();
+        Expression left = instance.left();
+        Expression right = instance.right();
+        if (randomBoolean()) {
+            left = randomValueOtherThan(left, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            right = randomValueOtherThan(right, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new MvUnion(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecaySerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecaySerializationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.score;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.MapExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DecaySerializationTests extends AbstractExpressionSerializationTests<Decay> {
+    @Override
+    protected Decay createTestInstance() {
+        Source source = randomSource();
+        Expression value = randomChild();
+        Expression origin = randomChild();
+        Expression scale = randomChild();
+        Expression options = randomBoolean() ? null : randomOptions();
+        return new Decay(source, value, origin, scale, options);
+    }
+
+    @Override
+    protected Decay mutateInstance(Decay instance) throws IOException {
+        Source source = instance.source();
+        Expression value = instance.value();
+        Expression origin = instance.origin();
+        Expression scale = instance.scale();
+        Expression options = instance.options();
+        switch (between(0, 3)) {
+            case 0 -> value = randomValueOtherThan(value, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> origin = randomValueOtherThan(origin, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> scale = randomValueOtherThan(scale, AbstractExpressionSerializationTests::randomChild);
+            case 3 -> options = randomValueOtherThan(options, () -> randomBoolean() ? null : randomOptions());
+        }
+        return new Decay(source, value, origin, scale, options);
+    }
+
+    private MapExpression randomOptions() {
+        List<Expression> entries = new ArrayList<>();
+        if (randomBoolean()) {
+            entries.add(Literal.keyword(Source.EMPTY, "offset"));
+            entries.add(new Literal(Source.EMPTY, randomDoubleBetween(0, 100, true), DataType.DOUBLE));
+        }
+        if (randomBoolean()) {
+            entries.add(Literal.keyword(Source.EMPTY, "decay"));
+            entries.add(new Literal(Source.EMPTY, randomDoubleBetween(0.01, 0.99, true), DataType.DOUBLE));
+        }
+        if (randomBoolean()) {
+            entries.add(Literal.keyword(Source.EMPTY, "type"));
+            entries.add(Literal.keyword(Source.EMPTY, randomFrom("linear", "exp", "gauss")));
+        }
+        return new MapExpression(Source.EMPTY, entries);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexSerializationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StGeohexSerializationTests extends AbstractExpressionSerializationTests<StGeohex> {
+    @Override
+    protected StGeohex createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression precision = randomChild();
+        Expression bounds = randomBoolean() ? null : randomChild();
+        return new StGeohex(source, field, precision, bounds);
+    }
+
+    @Override
+    protected StGeohex mutateInstance(StGeohex instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.spatialField();
+        Expression precision = instance.parameter();
+        Expression bounds = instance.bounds();
+        switch (between(0, 2)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> precision = randomValueOtherThan(precision, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> bounds = randomValueOtherThan(bounds, () -> randomBoolean() ? null : randomChild());
+        }
+        return new StGeohex(source, field, precision, bounds);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileSerializationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StGeotileSerializationTests extends AbstractExpressionSerializationTests<StGeotile> {
+    @Override
+    protected StGeotile createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression precision = randomChild();
+        Expression bounds = randomBoolean() ? null : randomChild();
+        return new StGeotile(source, field, precision, bounds);
+    }
+
+    @Override
+    protected StGeotile mutateInstance(StGeotile instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.spatialField();
+        Expression precision = instance.parameter();
+        Expression bounds = instance.bounds();
+        switch (between(0, 2)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> precision = randomValueOtherThan(precision, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> bounds = randomValueOtherThan(bounds, () -> randomBoolean() ? null : randomChild());
+        }
+        return new StGeotile(source, field, precision, bounds);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StNPointsSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StNPointsSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StNPointsSerializationTests extends AbstractExpressionSerializationTests<StNPoints> {
+    @Override
+    protected StNPoints createTestInstance() {
+        return new StNPoints(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StNPoints mutateInstance(StNPoints instance) throws IOException {
+        return new StNPoints(
+            instance.source(),
+            randomValueOtherThan(instance.spatialField(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StXMaxSerializationTests extends AbstractExpressionSerializationTests<StXMax> {
+    @Override
+    protected StXMax createTestInstance() {
+        return new StXMax(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StXMax mutateInstance(StXMax instance) throws IOException {
+        return new StXMax(
+            instance.source(),
+            randomValueOtherThan(instance.spatialField(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StXMinSerializationTests extends AbstractExpressionSerializationTests<StXMin> {
+    @Override
+    protected StXMin createTestInstance() {
+        return new StXMin(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StXMin mutateInstance(StXMin instance) throws IOException {
+        return new StXMin(
+            instance.source(),
+            randomValueOtherThan(instance.spatialField(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StYMaxSerializationTests extends AbstractExpressionSerializationTests<StYMax> {
+    @Override
+    protected StYMax createTestInstance() {
+        return new StYMax(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StYMax mutateInstance(StYMax instance) throws IOException {
+        return new StYMax(
+            instance.source(),
+            randomValueOtherThan(instance.spatialField(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StYMinSerializationTests extends AbstractExpressionSerializationTests<StYMin> {
+    @Override
+    protected StYMin createTestInstance() {
+        return new StYMin(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StYMin mutateInstance(StYMin instance) throws IOException {
+        return new StYMin(
+            instance.source(),
+            randomValueOtherThan(instance.spatialField(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsSerializationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.MapExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TopSnippetsSerializationTests extends AbstractExpressionSerializationTests<TopSnippets> {
+    @Override
+    protected TopSnippets createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression query = randomChild();
+        Expression options = randomBoolean() ? null : randomOptions();
+        return new TopSnippets(source, field, query, options);
+    }
+
+    @Override
+    protected TopSnippets mutateInstance(TopSnippets instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression query = instance.query();
+        Expression options = instance.options();
+        switch (between(0, 2)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> query = randomValueOtherThan(query, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> options = randomValueOtherThan(options, () -> randomBoolean() ? null : randomOptions());
+        }
+        return new TopSnippets(source, field, query, options);
+    }
+
+    private MapExpression randomOptions() {
+        List<Expression> entries = new ArrayList<>();
+        if (randomBoolean()) {
+            entries.add(Literal.keyword(Source.EMPTY, "num_snippets"));
+            entries.add(new Literal(Source.EMPTY, randomIntBetween(1, 20), DataType.INTEGER));
+        }
+        if (randomBoolean()) {
+            entries.add(Literal.keyword(Source.EMPTY, "num_words"));
+            entries.add(new Literal(Source.EMPTY, randomIntBetween(1, 1000), DataType.INTEGER));
+        }
+        return new MapExpression(Source.EMPTY, entries);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilaritySerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilaritySerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.vector;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class CosineSimilaritySerializationTests extends AbstractVectorSimilaritySerializationTests<CosineSimilarity> {
+    @Override
+    protected CosineSimilarity create(Source source, Expression left, Expression right) {
+        return new CosineSimilarity(source, left, right);
+    }
+}


### PR DESCRIPTION
This adds the remaining serialization tests. It makes a few production code changes:
1. Registers `TO_DATE_RANGE` for serialization. It was serializable and not registered.
2. Normalizes the serialization of `SCORE` and explains how it used to work. It was not broken but held together strangely.
3. Replaces implementing `SurrogateExpression` with `OnlySurrogateExpression` in a few more cases so we don't expect serialization to work.
4. Adds some package private accessors so we can refer to children by name in serialization tests.
