### PR TITLE
Add support for rolling upgrade to LocalClusterHandle.

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -191,6 +191,15 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
         waitUntilReady();
     }
 
+    @Override
+    public void upgradeToVersion(Version version, Runnable onNodeUpgradeComplete) {
+        int numNodes = getNumNodes();
+        for (int index = 0; index < numNodes; index++) {
+            upgradeNodeToVersion(index, version);
+            onNodeUpgradeComplete.run();
+        }
+    }
+
     public String getName(int index) {
         return nodes.get(index).getName();
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalElasticsearchCluster.java
@@ -165,6 +165,12 @@ public class DefaultLocalElasticsearchCluster<S extends LocalClusterSpec, H exte
     }
 
     @Override
+    public void upgradeToVersion(Version version, Runnable onNodeUpgradeComplete) {
+        checkHandle();
+        handle.upgradeToVersion(version, onNodeUpgradeComplete);
+    }
+
+    @Override
     public InputStream getNodeLog(int index, LogType logType) {
         checkHandle();
         return handle.getNodeLog(index, logType);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -14,7 +14,6 @@ import org.elasticsearch.test.cluster.LogType;
 import org.elasticsearch.test.cluster.MutableSettingsProvider;
 import org.elasticsearch.test.cluster.util.Version;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -17,7 +17,6 @@ import org.elasticsearch.test.cluster.util.Version;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.function.Consumer;
 
 public interface LocalClusterHandle extends ClusterHandle {
 
@@ -99,24 +98,18 @@ public interface LocalClusterHandle extends ClusterHandle {
     void upgradeNodeToVersion(int index, Version version);
 
     /**
-     * Perform a rolling upgrade to the given version.
-     * @param version               The version to upgrade to.
-     * @param onNodeUpgradeComplete A callback that is invoked after each node is upgraded.
-     */
-    default void rollingUpgradeToVersion(Version version, Runnable onNodeUpgradeComplete) {
-        int numNodes = getNumNodes();
-        for (int index = 0; index < numNodes; index++) {
-            upgradeNodeToVersion(index, version);
-            onNodeUpgradeComplete.run();
-        }
-    }
-
-    /**
      * Performs a "full cluster restart" upgrade to the given version. Method blocks until the cluster is restarted and available.
      *
      * @param version version to upgrade to
      */
     void upgradeToVersion(Version version);
+
+    /**
+     * Perform a rolling upgrade to the given version.
+     * @param version               The version to upgrade to.
+     * @param onNodeUpgradeComplete A callback that is invoked after each node is upgraded.
+     */
+    void upgradeToVersion(Version version, Runnable onNodeUpgradeComplete);
 
     /**
      * Returns an {@link InputStream} for the given node log.

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -103,11 +103,11 @@ public interface LocalClusterHandle extends ClusterHandle {
      * @param version               The version to upgrade to.
      * @param onNodeUpgradeComplete A callback that is invoked after each node is upgraded.
      */
-    default void rollingUpgradeToVersion(Version version, Consumer<Integer> onNodeUpgradeComplete) {
+    default void rollingUpgradeToVersion(Version version, Runnable onNodeUpgradeComplete) {
         int numNodes = getNumNodes();
         for (int index = 0; index < numNodes; index++) {
             upgradeNodeToVersion(index, version);
-            onNodeUpgradeComplete.accept(index);
+            onNodeUpgradeComplete.run();
         }
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -14,9 +14,11 @@ import org.elasticsearch.test.cluster.LogType;
 import org.elasticsearch.test.cluster.MutableSettingsProvider;
 import org.elasticsearch.test.cluster.util.Version;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface LocalClusterHandle extends ClusterHandle {
 
@@ -96,6 +98,19 @@ public interface LocalClusterHandle extends ClusterHandle {
      * @param version version to upgrade to
      */
     void upgradeNodeToVersion(int index, Version version);
+
+    /**
+     * Perform a rolling upgrade to the given version.
+     * @param version               The version to upgrade to.
+     * @param onNodeUpgradeComplete A callback that is invoked after each node is upgraded.
+     */
+    default void rollingUpgradeToVersion(Version version, Consumer<Integer> onNodeUpgradeComplete) {
+        int numNodes = getNumNodes();
+        for (int index = 0; index < numNodes; index++) {
+            upgradeNodeToVersion(index, version);
+            onNodeUpgradeComplete.accept(index);
+        }
+    }
 
     /**
      * Performs a "full cluster restart" upgrade to the given version. Method blocks until the cluster is restarted and available.

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.util.Version;
@@ -66,7 +67,7 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
         return Settings.builder().put(super.restClientSettings()).put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    protected void upgradeNode(int n) throws IOException {
+    protected void clusterRollingUpgrade(CheckedConsumer<Integer, Exception> onNodeUpgradeComplete) throws IOException {
         closeClients();
 
         var serverlessBwcStackVersion = System.getProperty("tests.serverless.bwc_stack_version");
@@ -75,9 +76,14 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
         logger.info("serverlessBwcStackVersion={}, bwcTag={}, newClusterVersion={}", serverlessBwcStackVersion, bwcTag, newClusterVersion);
 
         var upgradeVersion = newClusterVersion != null ? Version.fromString(newClusterVersion) : Version.CURRENT;
-        logger.info("Upgrading node {} to version {}", n, upgradeVersion);
-        getCluster().upgradeNodeToVersion(n, upgradeVersion);
-        initClient();
+        getCluster().rollingUpgradeToVersion(upgradeVersion, (index) -> {
+            try {
+                initClient();
+                onNodeUpgradeComplete.accept(index);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     protected ElasticsearchCluster getCluster() {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -77,7 +77,7 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
 
         int[] count = new int[1];
         var upgradeVersion = newClusterVersion != null ? Version.fromString(newClusterVersion) : Version.CURRENT;
-        getCluster().rollingUpgradeToVersion(upgradeVersion, () -> {
+        getCluster().upgradeToVersion(upgradeVersion, () -> {
             try {
                 initClient();
                 onNodeUpgradeComplete.accept(count[0]++);

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -75,11 +75,12 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
         var newClusterVersion = System.getProperty("tests.new_cluster_version");
         logger.info("serverlessBwcStackVersion={}, bwcTag={}, newClusterVersion={}", serverlessBwcStackVersion, bwcTag, newClusterVersion);
 
+        int[] count = new int[1];
         var upgradeVersion = newClusterVersion != null ? Version.fromString(newClusterVersion) : Version.CURRENT;
-        getCluster().rollingUpgradeToVersion(upgradeVersion, (index) -> {
+        getCluster().rollingUpgradeToVersion(upgradeVersion, () -> {
             try {
                 initClient();
-                onNodeUpgradeComplete.accept(index);
+                onNodeUpgradeComplete.accept(count[0]++);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -120,12 +120,11 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
         verifyIndexMode(IndexMode.LOGSDB, templates.get(0).dataStreamName());
 
         // during upgrade
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
+        clusterRollingUpgrade(index -> {
             for (TemplateConfig config : templates) {
                 indexDocumentsAndVerifyResults(config);
             }
-        }
+        });
 
         // after everything is upgraded
         for (TemplateConfig config : templates) {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/FlattenedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/FlattenedRollingUpgradeIT.java
@@ -263,11 +263,8 @@ public class FlattenedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTestC
         List<FlattenedData> indexedData = new ArrayList<>();
         indexDocumentsAndVerifyResults(spec, settings, indexedData);
 
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
-            indexDocumentsAndVerifyResults(spec, settings, indexedData);
-        }
+        Settings.Builder finalSettings = settings;
+        clusterRollingUpgrade(index -> { indexDocumentsAndVerifyResults(spec, finalSettings, indexedData); });
     }
 
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbIndexingRollingUpgradeIT.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -82,14 +83,13 @@ public class LogsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgrade
             search(dataStreamName);
             query(dataStreamName);
         }
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
-            time = time.plusNanos(60 * 30);
-            bulkIndex(dataStreamName, 4, 1024, time, LogsdbIndexingRollingUpgradeIT::docSupplier);
+        AtomicReference<Instant> timeRef = new AtomicReference<>(time);
+        clusterRollingUpgrade(index -> {
+            timeRef.set(timeRef.get().plusNanos(60 * 30));
+            bulkIndex(dataStreamName, 4, 1024, timeRef.get(), LogsdbIndexingRollingUpgradeIT::docSupplier);
             search(dataStreamName);
             query(dataStreamName);
-        }
+        });
         {
             var forceMergeRequest = new Request("POST", "/" + dataStreamName + "/_forcemerge");
             forceMergeRequest.addParameter("max_num_segments", "1");

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -150,15 +150,13 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
             indexAndQueryDocuments(indexConfigs[i]);
         }
 
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            flush(indexNameBase + "*", true);
-            upgradeNode(i);
+        flush(indexNameBase + "*", true);
+        clusterRollingUpgrade(index -> {
             ensureGreen(indexNameBase + "*");
             for (int j = 0; j < NUM_INDICES; j++) {
                 indexAndQueryDocuments(indexConfigs[j]);
             }
-        }
+        });
     }
 
     public void testIndexingStandardSource() throws IOException {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/StandardToLogsDbIndexModeRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/StandardToLogsDbIndexModeRollingUpgradeIT.java
@@ -73,12 +73,11 @@ public class StandardToLogsDbIndexModeRollingUpgradeIT extends AbstractStringTyp
         verifyIndexMode(IndexMode.STANDARD, templates.get(0).dataStreamName());
 
         // during upgrade
-        for (int i = 0; i < getNumNodes(); i++) {
-            upgradeNode(i);
+        clusterRollingUpgrade(index -> {
             for (TemplateConfig config : templates) {
                 indexDocumentsAndVerifyResults(config);
             }
-        }
+        });
 
         enableLogsDb();
         for (TemplateConfig config : templates) {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SyntheticSourceRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SyntheticSourceRollingUpgradeIT.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.both;
@@ -82,15 +83,13 @@ public class SyntheticSourceRollingUpgradeIT extends AbstractLogsdbRollingUpgrad
         search(dataStreamName);
         query(dataStreamName);
 
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
-            time = time.plusNanos(60 * 30);
+        AtomicReference<Instant> timeRef = new AtomicReference<>(time);
+        clusterRollingUpgrade(index -> {
+            timeRef.set(timeRef.get().plusNanos(60 * 30));
             bulkIndex(dataStreamName, 4, 1024, time, SyntheticSourceRollingUpgradeIT::docSupplier);
             search(dataStreamName);
             query(dataStreamName);
-
-        }
+        });
 
         var forceMergeRequest = new Request("POST", "/" + dataStreamName + "/_forcemerge");
         forceMergeRequest.addParameter("max_num_segments", "1");

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
@@ -136,11 +136,7 @@ public class TsdbIT extends AbstractLogsdbRollingUpgradeTestCase {
 
         performOldClustertOperations(templateName, dataStreamName);
 
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
-            performMixedClusterOperations(dataStreamName, i == 0);
-        }
+        clusterRollingUpgrade(index -> { performMixedClusterOperations(dataStreamName, index == 0); });
         performUpgradedClusterOperations(dataStreamName);
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.logsdb.TsdbIT.TEMPLATE;
 import static org.elasticsearch.xpack.logsdb.TsdbIT.formatInstant;
@@ -61,14 +62,13 @@ public class TsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTe
         search(dataStreamName);
         query(dataStreamName);
 
-        int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
-        for (int i = 0; i < numNodes; i++) {
-            upgradeNode(i);
-            startTime = startTime.plusNanos(60 * 30);
+        AtomicReference<Instant> startTimeRef = new AtomicReference<>(startTime);
+        clusterRollingUpgrade(index -> {
+            startTimeRef.set(startTimeRef.get().plusNanos(60 * 30));
             bulkIndex(dataStreamName, 4, 1024, startTime, TsdbIndexingRollingUpgradeIT::docSupplier);
             search(dataStreamName);
             query(dataStreamName);
-        }
+        });
 
         var forceMergeRequest = new Request("POST", "/" + dataStreamName + "/_forcemerge");
         forceMergeRequest.addParameter("max_num_segments", "1");


### PR DESCRIPTION
And push logic for logsdb rolling upgrade to  LocalClusterHandle.

Upgrading a statefull cluster doesn't require a special ordering, but a serveless cluster needs to first upgrade search nodes and then other node types. This logic should be stay behind LocalClusterHandle abstraction.