### PR TITLE
Fix IndexInputUtils.withSlice to produce native-safe MemorySegments on Java 21

### DIFF
--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
@@ -15,7 +15,9 @@ import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.DirectAccessInput;
 
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.function.IntFunction;
 
 /**
@@ -74,6 +76,7 @@ public final class IndexInputUtils {
             @SuppressWarnings("unchecked")
             R[] result = (R[]) new Object[1];
             boolean available = dai.withByteBufferSlice(offset, length, bb -> {
+                assert bb.isDirect();
                 in.skipBytes(length);
                 result[0] = action.apply(MemorySegment.ofBuffer(bb));
             });
@@ -81,7 +84,7 @@ public final class IndexInputUtils {
                 return result[0];
             }
         }
-        return action.apply(copyOnHeap(in, Math.toIntExact(length), scratchSupplier));
+        return copyAndApply(in, Math.toIntExact(length), scratchSupplier, action);
     }
 
     /**
@@ -100,15 +103,29 @@ public final class IndexInputUtils {
         }
     }
 
+    private static final boolean SUPPORTS_HEAP_SEGMENTS = Runtime.version().feature() >= 22;
+
     /**
-     * Reads the given number of bytes from the current position of the
-     * given IndexInput into a heap-backed memory segment. The returned
-     * segment is sliced to exactly {@code bytesToRead} bytes, even if
-     * the underlying array is larger.
+     * Reads bytes from the index input and applies the action to a memory
+     * segment containing the data. On Java 22+ a heap-backed segment is
+     * used directly. On Java 21, where heap segments cannot be passed to
+     * native downcalls, the data is copied into a confined arena.
      */
-    private static MemorySegment copyOnHeap(IndexInput in, int bytesToRead, IntFunction<byte[]> scratchSupplier) throws IOException {
+    private static <R> R copyAndApply(
+        IndexInput in,
+        int bytesToRead,
+        IntFunction<byte[]> scratchSupplier,
+        CheckedFunction<MemorySegment, R, IOException> action
+    ) throws IOException {
         byte[] buf = scratchSupplier.apply(bytesToRead);
         in.readBytes(buf, 0, bytesToRead);
-        return MemorySegment.ofArray(buf).asSlice(0, bytesToRead);
+        if (SUPPORTS_HEAP_SEGMENTS) {
+            return action.apply(MemorySegment.ofArray(buf).asSlice(0, bytesToRead));
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment nativeSegment = arena.allocate(bytesToRead);
+            MemorySegment.copy(buf, 0, nativeSegment, ValueLayout.JAVA_BYTE, 0, bytesToRead);
+            return action.apply(nativeSegment);
+        }
     }
 }

--- a/libs/simdvec/src/test21/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test21/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -21,7 +21,9 @@ import org.elasticsearch.core.DirectAccessInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -68,6 +70,26 @@ public class IndexInputUtilsTests extends ESTestCase {
                 assertFalse(in instanceof MemorySegmentAccessInput);
                 assertFalse(in instanceof DirectAccessInput);
                 verifyWithSlice(in, data);
+            }
+        }
+    }
+
+    public void testPlainInputFallbackProducesNativeSegmentOnJava21() throws Exception {
+        byte[] data = randomByteArrayOfLength(256);
+        try (Directory dir = new NIOFSDirectory(createTempDir())) {
+            writeData(dir, data);
+            try (IndexInput in = dir.openInput(FILE_NAME, IOContext.DEFAULT)) {
+                assertFalse(in instanceof MemorySegmentAccessInput);
+                assertFalse(in instanceof DirectAccessInput);
+                IndexInputUtils.withSlice(in, data.length, byte[]::new, segment -> {
+                    if (Runtime.version().feature() < 22) {
+                        assertTrue("segment should be native-backed on Java 21", segment.heapBase().isEmpty());
+                    }
+                    byte[] buf = new byte[(int) segment.byteSize()];
+                    MemorySegment.ofArray(buf).copyFrom(segment);
+                    assertArrayEquals(data, buf);
+                    return null;
+                });
             }
         }
     }
@@ -167,9 +189,12 @@ public class IndexInputUtilsTests extends ESTestCase {
 
         @Override
         public boolean withByteBufferSlice(long offset, long length, CheckedConsumer<ByteBuffer, IOException> action) throws IOException {
-            ByteBuffer bb = ByteBuffer.wrap(data, (int) offset, (int) length).asReadOnlyBuffer();
-            action.accept(bb);
-            return true;
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment segment = arena.allocate(length);
+                MemorySegment.copy(data, (int) offset, segment, ValueLayout.JAVA_BYTE, 0, (int) length);
+                action.accept(segment.asByteBuffer().asReadOnlyBuffer());
+                return true;
+            }
         }
 
         @Override


### PR DESCRIPTION
On Java 21, FFI disallows passing heap-backed MemorySegments to native downcalls. Java 22+ removes this restriction.

`IndexInputUtils.withSlice` is now the single path through which all simdvec scorers obtain MemorySegments from IndexInput data, and several of those scorers pass the segment directly to native downcalls. Rather than patching each and every call site across scorer classes individually, this fix takes a "safety by design" approach: `withSlice` itself now guarantees that the segment it hands to callers is always native-safe, regardless of Java version. No current or future caller needs to worry about the heap-segment restriction, correctness is enforced at the source.

I also added an assertion to the DirectAccessInput path that the byte buffer is direct, documenting the invariant that real implementations always provide native-backed buffers. 

The tradeoff here is that on Java 21 only, the copyAndApply fallback path incurs an extra native allocation and copy (via a confined Arena) where a heap-backed segment would have sufficed, since a number of call sites only use the Panama Vector API and never touch native downcalls. On Java 22+ the behavior is unchanged. This is an acceptable cost: the fallback path is already the slowest path (mmap and direct buffer paths are preferred), and the alternative - requiring every call site to independently guard against heap segments, is fragile and has already proven easy to miss. We can do some further cleanup at the call site after this fix has been merged.

caused by #141718
closes #143441
