### PR TITLE
[9.1] [Transform] Stop transforms at the end of tests (#139783)

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -340,6 +340,11 @@ public class TransformUpdateIT extends TransformRestTestCase {
             Map<?, ?> transformStatsAsMap = getTransformStateAndStats(transformIdCloned);
             assertThat(XContentMapValues.extractValue("stats.documents_indexed", transformStatsAsMap), equalTo(27));
         }, 15, TimeUnit.SECONDS);
+
+        stopTransform(transformId, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1, true, false);
+        stopTransform(transformIdCloned, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1, true, false);
+        deleteTransform(transformId);
+        deleteTransform(transformIdCloned);
     }
 
     private void deleteUser(String user) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [Transform] Stop transforms at the end of tests (#139783)