### PR TITLE
[ML] Increase timeout on forecast test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -174,9 +174,6 @@ tests:
 - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
   method: testUpdateMappingConcurrently
   issue: https://github.com/elastic/elasticsearch/issues/137758
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/138055
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/138128

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -253,7 +253,7 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
 
     protected void waitForecastToFinish(String jobId, String forecastId) throws Exception {
         // Forecasts can take an eternity to complete in the FIPS JVM
-        int timeoutSeconds = inFipsJvm() ? 300 : 90;
+        int timeoutSeconds = inFipsJvm() ? 300 : 180;
         // First wait for the forecast document to exist and be in a non-terminal state
         // This handles the race condition where the document may be SCHEDULED or STARTED initially
         waitForecastStatus(


### PR DESCRIPTION
This issue has happened before: https://github.com/elastic/elasticsearch/pull/108183


Looks like 90s is still not enough time for the job to finish. Looks like the job is killed ~90s while it's still ongoing
```
4312:[2025-11-13T19:41:23,728][INFO ][o.e.x.m.p.l.CppLogMessageHandler] [javaRestTest-2] [forecast-it-test-overflow-to-disk] [autodetect/219442] [CForecastRunner.cc@111] Start forecasting from 2025-11-13T17:00:00+0000 to 2025-11-13T18:00:00+0000
4313:[2025-11-13T19:42:54,147][INFO ][o.e.x.m.a.TransportKillProcessAction] [javaRestTest-2] [forecast-it-test-overflow-to-disk] Killing job
4314:[2025-11-13T19:42:54,148][INFO ][o.e.x.m.j.p.a.ProcessContext] [javaRestTest-2] Killing job [forecast-it-test-overflow-to-disk], because [kill process (api)]
4315:[2025-11-13T19:42:54,578][WARN ][o.e.x.m.j.p.a.o.AutodetectResultProcessor] [javaRestTest-2] [forecast-it-test-overflow-to-disk] some results not processed due to the process being killed
4316:[2025-11-13T19:42:54,579][WARN ][o.e.x.m.j.p.a.o.AutodetectResultProcessor] [javaRestTest-2] [forecast-it-test-overflow-to-disk] still had forecasts [FEW8fpoBWoaCCwOPhkYb] executing. Attempting to set them to failed.
4317:[2025-11-13T19:42:54,580][WARN ][o.e.x.m.j.p.a.o.AutodetectResultProcessor] [javaRestTest-2] [forecast-it-test-overflow-to-disk] failure setting running forecasts to failed. org.elasticsearch.ElasticsearchStatusException: Bulk indexing has failed as machine learning feature is being reset.
```