### PR TITLE
Improve CPS cluster exclusion handling

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/CCSFieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/CCSFieldCapabilitiesIT.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
@@ -342,19 +343,7 @@ public class CCSFieldCapabilitiesIT extends AbstractMultiClustersTestCase {
 
         Map<String, ResolvedIndexExpressions> remote = response.getResolvedRemotely();
         assertThat(remote, notNullValue());
-        assertThat(remote, aMapWithSize(1));
-        assertThat(remote.keySet(), contains(remoteClusterAlias));
-
-        ResolvedIndexExpressions remoteResponse = remote.get(remoteClusterAlias);
-        List<String> remoteIndicesList = remoteResponse.getLocalIndicesList();
-        assertThat(remoteIndicesList, hasSize(0));
-        List<ResolvedIndexExpression> remoteResolvedExpressions = remoteResponse.expressions();
-        assertEquals(1, remoteResolvedExpressions.size());
-        assertEquals(
-            remoteResolvedExpressions.get(0).localExpressions().localIndexResolutionResult(),
-            ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE
-        );
-        assertEquals(0, remoteIndicesList.size());
+        assertThat(remote, anEmptyMap());
     }
 
     public void testResolvedToMatchingRemotelyOnly() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -63,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -632,6 +633,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                 final int remoteRequests = remoteClusterIndices.size();
                 final CountDown completionCounter = new CountDown(remoteRequests);
                 final SortedMap<String, Response> remoteResponses = Collections.synchronizedSortedMap(new TreeMap<>());
+                final var remoteExceptions = Collections.synchronizedMap(new HashMap<String, Exception>());
                 final Runnable terminalHandler = () -> {
                     if (completionCounter.countDown()) {
                         if (resolveCrossProject) {
@@ -639,7 +641,8 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                                 originalIndicesOptions,
                                 request.getProjectRouting(),
                                 localResolvedIndexExpressions,
-                                getResolvedExpressionsByRemote(remoteResponses)
+                                getResolvedExpressionsByRemote(remoteResponses),
+                                remoteExceptions
                             );
                             if (ex != null) {
                                 listener.onFailure(ex);
@@ -666,6 +669,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                         terminalHandler.run();
                     }, failure -> {
                         logger.info("failed to resolve indices on remote cluster [" + clusterAlias + "]", failure);
+                        remoteExceptions.put(clusterAlias, failure);
                         terminalHandler.run();
                     }));
                 }
@@ -677,6 +681,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                         originalIndicesOptions,
                         request.getProjectRouting(),
                         localResolvedIndexExpressions,
+                        Map.of(),
                         Map.of()
                     );
                     if (ex != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -633,7 +633,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                 final int remoteRequests = remoteClusterIndices.size();
                 final CountDown completionCounter = new CountDown(remoteRequests);
                 final SortedMap<String, Response> remoteResponses = Collections.synchronizedSortedMap(new TreeMap<>());
-                final var remoteExceptions = Collections.synchronizedMap(new HashMap<String, Exception>());
+                final Map<String, Exception> remoteExceptions = Collections.synchronizedMap(new HashMap<>());
                 final Runnable terminalHandler = () -> {
                     if (completionCounter.countDown()) {
                         if (resolveCrossProject) {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -265,6 +265,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     request.indicesOptions(),
                     request.getProjectRouting(),
                     request.getResolvedIndexExpressions(),
+                    Map.of(),
                     Map.of()
                 );
                 if (ex != null) {
@@ -366,7 +367,8 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                         request.indicesOptions(),
                         request.getProjectRouting(),
                         resolvedLocally,
-                        resolvedRemotely
+                        resolvedRemotely,
+                        Map.of()
                     );
                     if (ex != null) {
                         listener.onFailure(ex);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -293,10 +293,8 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             indexResponses.clear();
             indexMappingHashToResponses.clear();
         };
-        Map<String, ResolvedIndexExpressions.Builder> resolvedRemotelyBuilder = new ConcurrentHashMap<>();
-        for (String clusterAlias : remoteClusterIndices.keySet()) {
-            resolvedRemotelyBuilder.put(clusterAlias, ResolvedIndexExpressions.builder());
-        }
+        Map<String, ResolvedIndexExpressions> resolvedRemotely = new ConcurrentHashMap<>();
+        Map<String, Exception> remoteExceptions = new ConcurrentHashMap<>();
         final Consumer<FieldCapabilitiesIndexResponse> handleIndexResponse = resp -> {
             if (fieldCapTask.isCancelled()) {
                 releaseResourcesOnCancel.run();
@@ -358,9 +356,6 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             if (fieldCapTask.notifyIfCancelled(listener)) {
                 releaseResourcesOnCancel.run();
             } else {
-                Map<String, ResolvedIndexExpressions> resolvedRemotely = resolvedRemotelyBuilder.entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().build()));
                 ResolvedIndexExpressions resolvedLocally = new ResolvedIndexExpressions(resolvedLocallyList);
                 if (resolveCrossProject) {
                     final Exception ex = CrossProjectIndexResolutionValidator.validate(
@@ -368,7 +363,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                         request.getProjectRouting(),
                         resolvedLocally,
                         resolvedRemotely,
-                        Map.of()
+                        remoteExceptions
                     );
                     if (ex != null) {
                         listener.onFailure(ex);
@@ -423,12 +418,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                         ResolvedIndexExpressions resolvedOnRemoteProject = response.getResolvedLocally();
                         // for bwc we need to check that resolvedOnRemoteProject Exists in the response
                         if (resolvedOnRemoteProject != null) {
-                            for (ResolvedIndexExpression remoteResolvedExpression : resolvedOnRemoteProject.expressions()) {
-                                resolvedRemotelyBuilder.computeIfPresent(clusterAlias, (k, v) -> {
-                                    v.addExpression(remoteResolvedExpression);
-                                    return v;
-                                });
-                            }
+                            resolvedRemotely.put(clusterAlias, resolvedOnRemoteProject);
                         }
 
                     }
@@ -450,19 +440,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                         for (String index : failure.getIndices()) {
                             handleIndexFailure.accept(RemoteClusterAware.buildRemoteIndexName(clusterAlias, index), ex);
                             if (request.includeResolvedTo()) {
-                                ResolvedIndexExpression err = new ResolvedIndexExpression(
-                                    index,
-                                    new ResolvedIndexExpression.LocalExpressions(
-                                        Set.of(),
-                                        ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE,
-                                        null
-                                    ),
-                                    Set.of()
-                                );
-                                resolvedRemotelyBuilder.computeIfPresent(clusterAlias, (k, v) -> {
-                                    v.addExpression(err);
-                                    return v;
-                                });
+                                remoteExceptions.put(clusterAlias, ex);
                             }
                         }
                     }
@@ -476,19 +454,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     for (String index : originalIndices.indices()) {
                         handleIndexFailure.accept(RemoteClusterAware.buildRemoteIndexName(clusterAlias, index), ex);
                         if (request.includeResolvedTo()) {
-                            ResolvedIndexExpression err = new ResolvedIndexExpression(
-                                index,
-                                new ResolvedIndexExpression.LocalExpressions(
-                                    Set.of(),
-                                    ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE,
-                                    null
-                                ),
-                                Set.of()
-                            );
-                            resolvedRemotelyBuilder.computeIfPresent(clusterAlias, (k, v) -> {
-                                v.addExpression(err);
-                                return v;
-                            });
+                            remoteExceptions.put(clusterAlias, ex);
                         }
                     }
                 });

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -246,14 +246,14 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                 l.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
             })
                 .delegateFailure(
-                    (ignored, connection) -> transportService.sendRequest(
+                    (delegate, connection) -> transportService.sendRequest(
                         connection,
                         ResolveIndexAction.REMOTE_TYPE.name(),
                         remoteRequest,
                         TransportRequestOptions.EMPTY,
                         new ActionListenerResponseHandler<>(groupedListener.delegateResponse((l, failure) -> {
                             logger.info("Error occurred on remote cluster [" + clusterAlias + "]", failure);
-                            l.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
+                            delegate.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
                         })
                             .map(
                                 resolveIndexResponse -> Map.entry(

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -187,12 +187,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             .delegateFailureAndWrap((l, responses) -> {
                 Map<String, ResolvedIndexExpressions> resolvedRemoteExpressions = responses.stream()
                     .filter(e -> e.getValue().response() instanceof ResolveIndexAction.Response)
-                    .collect(
-                        Collectors.toMap(
-                            Map.Entry::getKey,
-                            e -> ((ResolveIndexAction.Response) e.getValue().response()).getResolvedIndexExpressions()
-                        )
-                    );
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> ((ResolveIndexAction.Response) e.getValue().response()).getResolvedIndexExpressions()));
                 final Exception ex = CrossProjectIndexResolutionValidator.validate(
                     originalIndicesOptions,
                     request.getProjectRouting(),

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -64,6 +64,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -181,6 +182,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
 
         // CPS
         final int linkedProjectsToQuery = indicesPerCluster.size();
+        Map<String, Exception> remoteClusterExceptions = new ConcurrentHashMap<>();
         ActionListener<Collection<Map.Entry<String, SearchPlanningPhaseResolutionResult>>> responsesListener = listener
             .delegateFailureAndWrap((l, responses) -> {
                 Map<String, ResolvedIndexExpressions> resolvedRemoteExpressions = responses.stream()
@@ -196,7 +198,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                     request.getProjectRouting(),
                     localResolvedIndexExpressions,
                     resolvedRemoteExpressions,
-                    Map.of()
+                    remoteClusterExceptions
                 );
                 if (ex != null) {
                     listener.onFailure(ex);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -168,6 +168,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                 originalIndicesOptions,
                 request.getProjectRouting(),
                 localResolvedIndexExpressions,
+                Map.of(),
                 Map.of()
             );
             if (ex != null) {
@@ -194,7 +195,8 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                     originalIndicesOptions,
                     request.getProjectRouting(),
                     localResolvedIndexExpressions,
-                    resolvedRemoteExpressions
+                    resolvedRemoteExpressions,
+                    Map.of()
                 );
                 if (ex != null) {
                     listener.onFailure(ex);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -60,11 +60,11 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -182,18 +182,24 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
 
         // CPS
         final int linkedProjectsToQuery = indicesPerCluster.size();
-        Map<String, Exception> remoteClusterExceptions = new ConcurrentHashMap<>();
         ActionListener<Collection<Map.Entry<String, SearchPlanningPhaseResolutionResult>>> responsesListener = listener
             .delegateFailureAndWrap((l, responses) -> {
-                Map<String, ResolvedIndexExpressions> resolvedRemoteExpressions = responses.stream()
-                    .filter(e -> e.getValue().response() instanceof ResolveIndexAction.Response)
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> ((ResolveIndexAction.Response) e.getValue().response()).getResolvedIndexExpressions()));
+                Map<String, ResolvedIndexExpressions> resolvedRemoteExpressions = new HashMap<>();
+                Map<String, Exception> remoteExceptions = new HashMap<>();
+
+                for (var entry : responses) {
+                    if (entry.getValue().response() instanceof ResolveIndexAction.Response response) {
+                        resolvedRemoteExpressions.put(entry.getKey(), response.getResolvedIndexExpressions());
+                    } else {
+                        remoteExceptions.put(entry.getKey(), entry.getValue().error());
+                    }
+                }
                 final Exception ex = CrossProjectIndexResolutionValidator.validate(
                     originalIndicesOptions,
                     request.getProjectRouting(),
                     localResolvedIndexExpressions,
                     resolvedRemoteExpressions,
-                    remoteClusterExceptions
+                    remoteExceptions
                 );
                 if (ex != null) {
                     listener.onFailure(ex);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1338,56 +1338,55 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     ) {
         RemoteClusterService remoteClusterService = transportService.getRemoteClusterService();
         final CountDown responsesCountDown = new CountDown(remoteIndicesByCluster.size());
-        final Map<String, SearchPlanningPhaseResolutionResult> searchShardsResponses = new ConcurrentHashMap<>();
+        final Map<String, SearchShardsResponse> searchShardsResponses = new ConcurrentHashMap<>();
+        final Map<String, Exception> remoteExceptions = new ConcurrentHashMap<>();
         final AtomicReference<Exception> exceptions = new AtomicReference<>();
         for (Map.Entry<String, OriginalIndices> entry : remoteIndicesByCluster.entrySet()) {
             final String clusterAlias = entry.getKey();
             boolean shouldSkipOnFailure = remoteClusterService.shouldSkipOnFailure(clusterAlias, allowPartialResults);
-            CCSActionListener<SearchPlanningPhaseResolutionResult, Map<String, SearchShardsResponse>> singleListener =
-                new CCSActionListener<>(clusterAlias, shouldSkipOnFailure, responsesCountDown, exceptions, clusters, listener) {
-                    @Override
-                    void innerOnResponse(SearchPlanningPhaseResolutionResult searchShardsResponse) {
-                        if (searchShardsResponse.response() instanceof SearchShardsResponse response) {
-                            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
-                            ccsClusterInfoUpdate(response, clusters, clusterAlias, timeProvider);
-                        }
-                        searchShardsResponses.put(clusterAlias, searchShardsResponse);
-                    }
+            CCSActionListener<SearchShardsResponse, Map<String, SearchShardsResponse>> singleListener = new CCSActionListener<>(
+                clusterAlias,
+                shouldSkipOnFailure,
+                responsesCountDown,
+                exceptions,
+                remoteExceptions,
+                clusters,
+                listener
+            ) {
+                @Override
+                void innerOnResponse(SearchShardsResponse searchShardsResponse) {
+                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
+                    ccsClusterInfoUpdate(searchShardsResponse, clusters, clusterAlias, timeProvider);
+                    searchShardsResponses.put(clusterAlias, searchShardsResponse);
+                }
 
-                    @Override
-                    Map<String, SearchShardsResponse> createFinalResponse() {
-                        Map<String, SearchShardsResponse> actualSearchShardsResponses = new HashMap<>();
-                        if (resolvesCrossProject && originResolvedIdxExpressions != null) {
-                            Map<String, ResolvedIndexExpressions> resolvedIndexExpressions = new HashMap<>();
-                            Map<String, Exception> remoteExceptions = new HashMap<>();
-                            for (var entry : searchShardsResponses.entrySet()) {
-                                if (entry.getValue().response() instanceof SearchShardsResponse response) {
-                                    if (response.getResolvedIndexExpressions() == null) {
-                                        throw new IllegalArgumentException(
-                                            "Failed to get resolved index expressions for cluster [" + entry.getKey() + "]"
-                                        );
-                                    }
-                                    resolvedIndexExpressions.put(entry.getKey(), response.getResolvedIndexExpressions());
-                                    actualSearchShardsResponses.put(entry.getKey(), response);
-                                } else if (entry.getValue().error() != null) {
-                                    remoteExceptions.put(entry.getKey(), entry.getValue().error());
-                                }
+                @Override
+                Map<String, SearchShardsResponse> createFinalResponse() {
+                    if (resolvesCrossProject && originResolvedIdxExpressions != null) {
+                        Map<String, ResolvedIndexExpressions> resolvedIndexExpressions = new HashMap<>();
+                        for (Map.Entry<String, SearchShardsResponse> entry : searchShardsResponses.entrySet()) {
+                            if (entry.getValue().getResolvedIndexExpressions() == null) {
+                                throw new IllegalArgumentException(
+                                    "Failed to get resolved index expressions for cluster [" + entry.getKey() + "]"
+                                );
                             }
-                            // We do not use the relaxed index options here when validating indices' existence.
-                            ElasticsearchException validationEx = CrossProjectIndexResolutionValidator.validate(
-                                originalIdxOpts,
-                                projectRouting,
-                                originResolvedIdxExpressions,
-                                resolvedIndexExpressions,
-                                remoteExceptions
-                            );
-                            if (validationEx != null) {
-                                throw validationEx;
-                            }
+                            resolvedIndexExpressions.put(entry.getKey(), entry.getValue().getResolvedIndexExpressions());
                         }
-                        return actualSearchShardsResponses;
+                        // We do not use the relaxed index options here when validating indices' existence.
+                        ElasticsearchException validationEx = CrossProjectIndexResolutionValidator.validate(
+                            originalIdxOpts,
+                            projectRouting,
+                            originResolvedIdxExpressions,
+                            resolvedIndexExpressions,
+                            remoteExceptions
+                        );
+                        if (validationEx != null) {
+                            throw validationEx;
+                        }
                     }
-                };
+                    return searchShardsResponses;
+                }
+            };
 
             var threadPool = transportService.getThreadPool();
             var connectionListener = getListenerWithOptionalTimeout(
@@ -1396,10 +1395,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION)
             );
 
-            connectionListener.addListener(singleListener.delegateResponse((responseListener, ex) -> {
-                logger.debug("Failed to communicate with the linked project [{}], error: {}", clusterAlias, ex);
-                responseListener.onResponse(new SearchPlanningPhaseResolutionResult(null, ex));
-            }).delegateFailure((responseListener, connection) -> {
+            connectionListener.addListener(singleListener.delegateFailure((responseListener, connection) -> {
                 /*
                  * It may be possible that indices do not exist on the project that SearchShards API is targeting.
                  * In such cases, it throws an error because it calls the index resolution APIs underneath. We relax
@@ -1431,11 +1427,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         TransportSearchShardsAction.TYPE.name(),
                         searchShardsRequest,
                         TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(
-                            responseListener.map(response -> new SearchPlanningPhaseResolutionResult(response, null)),
-                            SearchShardsResponse::new,
-                            responseExecutor
-                        )
+                        new ActionListenerResponseHandler<>(responseListener, SearchShardsResponse::new, responseExecutor)
                     );
                 } else {
                     // does not do a can-match
@@ -1451,12 +1443,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         searchShardsRequest,
                         TransportRequestOptions.EMPTY,
                         new ActionListenerResponseHandler<>(
-                            singleListener.map(
-                                legacyResponse -> new SearchPlanningPhaseResolutionResult(
-                                    SearchShardsResponse.fromLegacyResponse(legacyResponse),
-                                    null
-                                )
-                            ),
+                            singleListener.map(SearchShardsResponse::fromLegacyResponse),
                             ClusterSearchShardsResponse::new,
                             responseExecutor
                         )
@@ -1490,6 +1477,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             shouldSkipOnFailure,
             countDown,
             exceptions,
+            new HashMap<>(),
             clusters,
             ActionListener.releaseAfter(originalListener, searchResponseMerger)
         ) {
@@ -2287,6 +2275,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         protected final boolean skipOnFailure;
         private final CountDown countDown;
         private final AtomicReference<Exception> exceptions;
+        private final Map<String, Exception> remoteExceptions;
         protected final SearchResponse.Clusters clusters;
         private final ActionListener<FinalResponse> originalListener;
 
@@ -2298,6 +2287,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             boolean skipOnFailure,
             CountDown countDown,
             AtomicReference<Exception> exceptions,
+            Map<String, Exception> remoteExceptions,
             SearchResponse.Clusters clusters,
             ActionListener<FinalResponse> originalListener
         ) {
@@ -2305,6 +2295,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             this.skipOnFailure = skipOnFailure;
             this.countDown = countDown;
             this.exceptions = exceptions;
+            this.remoteExceptions = remoteExceptions;
             this.clusters = clusters;
             this.originalListener = originalListener;
         }
@@ -2324,6 +2315,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         public final void onFailure(Exception e) {
             ShardSearchFailure f = new ShardSearchFailure(e);
             logCCSError(f, clusterAlias, skipOnFailure);
+            remoteExceptions.put(clusterAlias, e);
             SearchResponse.Cluster cluster = clusters.getCluster(clusterAlias);
             if (skipOnFailure && ExceptionsHelper.isTaskCancelledException(e) == false) {
                 if (cluster != null) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1198,7 +1198,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         IndicesOptions resolutionIdxOpts,
         ActionListener<ResolvedIndices> listener
     ) {
-        Map<String, Exception> unresponsiveProjects = new HashMap<>();
+        Map<String, Exception> remoteExceptions = new HashMap<>();
         HashMap<String, ResolvedIndexExpressions> resolvedExpressions = new HashMap<>();
 
         for (Map.Entry<String, SearchPlanningPhaseResolutionResult> entry : responsesByProject) {
@@ -1210,7 +1210,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 resolvedExpressions.put(projectName, response.getResolvedIndexExpressions());
             } else if (result.error() != null) {
                 // There was an error communicating with the linked project and the error was already logged.
-                unresponsiveProjects.put(projectName, result.error());
+                remoteExceptions.put(projectName, result.error());
             }
         }
 
@@ -1229,7 +1229,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             rewritten.getProjectRouting(),
             rewritten.getResolvedIndexExpressions(),
             resolvedExpressions,
-            unresponsiveProjects
+            remoteExceptions
         );
 
         if (ex != null) {
@@ -1249,7 +1249,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
              * on this info, we can track future connection errors (when fanning out a search op) and display them in the
              * search response's metadata section.
              */
-            for (String unresponsiveProject : unresponsiveProjects.keySet()) {
+            for (String unresponsiveProject : remoteExceptions.keySet()) {
                 participatingLinkedProjects.put(
                     unresponsiveProject,
                     originalResolvedIndices.getRemoteClusterIndices().get(unresponsiveProject)

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1198,7 +1198,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         IndicesOptions resolutionIdxOpts,
         ActionListener<ResolvedIndices> listener
     ) {
-        HashSet<String> unresponsiveProjects = new HashSet<>();
+        Map<String, Exception> unresponsiveProjects = new HashMap<>();
         HashMap<String, ResolvedIndexExpressions> resolvedExpressions = new HashMap<>();
 
         for (Map.Entry<String, SearchPlanningPhaseResolutionResult> entry : responsesByProject) {
@@ -1210,7 +1210,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 resolvedExpressions.put(projectName, response.getResolvedIndexExpressions());
             } else if (result.error() != null) {
                 // There was an error communicating with the linked project and the error was already logged.
-                unresponsiveProjects.add(projectName);
+                unresponsiveProjects.put(projectName, result.error());
             }
         }
 
@@ -1229,7 +1229,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             rewritten.getProjectRouting(),
             rewritten.getResolvedIndexExpressions(),
             resolvedExpressions,
-            Map.of()
+            unresponsiveProjects
         );
 
         if (ex != null) {
@@ -1249,7 +1249,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
              * on this info, we can track future connection errors (when fanning out a search op) and display them in the
              * search response's metadata section.
              */
-            for (String unresponsiveProject : unresponsiveProjects) {
+            for (String unresponsiveProject : unresponsiveProjects.keySet()) {
                 participatingLinkedProjects.put(
                     unresponsiveProject,
                     originalResolvedIndices.getRemoteClusterIndices().get(unresponsiveProject)

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1338,53 +1338,56 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     ) {
         RemoteClusterService remoteClusterService = transportService.getRemoteClusterService();
         final CountDown responsesCountDown = new CountDown(remoteIndicesByCluster.size());
-        final Map<String, SearchShardsResponse> searchShardsResponses = new ConcurrentHashMap<>();
+        final Map<String, SearchPlanningPhaseResolutionResult> searchShardsResponses = new ConcurrentHashMap<>();
         final AtomicReference<Exception> exceptions = new AtomicReference<>();
         for (Map.Entry<String, OriginalIndices> entry : remoteIndicesByCluster.entrySet()) {
             final String clusterAlias = entry.getKey();
             boolean shouldSkipOnFailure = remoteClusterService.shouldSkipOnFailure(clusterAlias, allowPartialResults);
-            CCSActionListener<SearchShardsResponse, Map<String, SearchShardsResponse>> singleListener = new CCSActionListener<>(
-                clusterAlias,
-                shouldSkipOnFailure,
-                responsesCountDown,
-                exceptions,
-                clusters,
-                listener
-            ) {
-                @Override
-                void innerOnResponse(SearchShardsResponse searchShardsResponse) {
-                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
-                    ccsClusterInfoUpdate(searchShardsResponse, clusters, clusterAlias, timeProvider);
-                    searchShardsResponses.put(clusterAlias, searchShardsResponse);
-                }
-
-                @Override
-                Map<String, SearchShardsResponse> createFinalResponse() {
-                    if (resolvesCrossProject && originResolvedIdxExpressions != null) {
-                        Map<String, ResolvedIndexExpressions> resolvedIndexExpressions = new HashMap<>();
-                        for (Map.Entry<String, SearchShardsResponse> entry : searchShardsResponses.entrySet()) {
-                            if (entry.getValue().getResolvedIndexExpressions() == null) {
-                                throw new IllegalArgumentException(
-                                    "Failed to get resolved index expressions for cluster [" + entry.getKey() + "]"
-                                );
-                            }
-                            resolvedIndexExpressions.put(entry.getKey(), entry.getValue().getResolvedIndexExpressions());
+            CCSActionListener<SearchPlanningPhaseResolutionResult, Map<String, SearchShardsResponse>> singleListener =
+                new CCSActionListener<>(clusterAlias, shouldSkipOnFailure, responsesCountDown, exceptions, clusters, listener) {
+                    @Override
+                    void innerOnResponse(SearchPlanningPhaseResolutionResult searchShardsResponse) {
+                        if (searchShardsResponse.response() instanceof SearchShardsResponse response) {
+                            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
+                            ccsClusterInfoUpdate(response, clusters, clusterAlias, timeProvider);
                         }
-                        // We do not use the relaxed index options here when validating indices' existence.
-                        ElasticsearchException validationEx = CrossProjectIndexResolutionValidator.validate(
-                            originalIdxOpts,
-                            projectRouting,
-                            originResolvedIdxExpressions,
-                            resolvedIndexExpressions,
-                            Map.of()
-                        );
-                        if (validationEx != null) {
-                            throw validationEx;
-                        }
+                        searchShardsResponses.put(clusterAlias, searchShardsResponse);
                     }
-                    return searchShardsResponses;
-                }
-            };
+
+                    @Override
+                    Map<String, SearchShardsResponse> createFinalResponse() {
+                        Map<String, SearchShardsResponse> actualSearchShardsResponses = new HashMap<>();
+                        if (resolvesCrossProject && originResolvedIdxExpressions != null) {
+                            Map<String, ResolvedIndexExpressions> resolvedIndexExpressions = new HashMap<>();
+                            Map<String, Exception> remoteExceptions = new HashMap<>();
+                            for (var entry : searchShardsResponses.entrySet()) {
+                                if (entry.getValue().response() instanceof SearchShardsResponse response) {
+                                    if (response.getResolvedIndexExpressions() == null) {
+                                        throw new IllegalArgumentException(
+                                            "Failed to get resolved index expressions for cluster [" + entry.getKey() + "]"
+                                        );
+                                    }
+                                    resolvedIndexExpressions.put(entry.getKey(), response.getResolvedIndexExpressions());
+                                    actualSearchShardsResponses.put(entry.getKey(), response);
+                                } else if (entry.getValue().error() != null) {
+                                    remoteExceptions.put(entry.getKey(), entry.getValue().error());
+                                }
+                            }
+                            // We do not use the relaxed index options here when validating indices' existence.
+                            ElasticsearchException validationEx = CrossProjectIndexResolutionValidator.validate(
+                                originalIdxOpts,
+                                projectRouting,
+                                originResolvedIdxExpressions,
+                                resolvedIndexExpressions,
+                                remoteExceptions
+                            );
+                            if (validationEx != null) {
+                                throw validationEx;
+                            }
+                        }
+                        return actualSearchShardsResponses;
+                    }
+                };
 
             var threadPool = transportService.getThreadPool();
             var connectionListener = getListenerWithOptionalTimeout(
@@ -1393,7 +1396,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION)
             );
 
-            connectionListener.addListener(singleListener.delegateFailure((responseListener, connection) -> {
+            connectionListener.addListener(singleListener.delegateResponse((responseListener, ex) -> {
+                logger.debug("Failed to communicate with the linked project [{}], error: {}", clusterAlias, ex);
+                responseListener.onResponse(new SearchPlanningPhaseResolutionResult(null, ex));
+            }).delegateFailure((responseListener, connection) -> {
                 /*
                  * It may be possible that indices do not exist on the project that SearchShards API is targeting.
                  * In such cases, it throws an error because it calls the index resolution APIs underneath. We relax
@@ -1425,7 +1431,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         TransportSearchShardsAction.TYPE.name(),
                         searchShardsRequest,
                         TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(responseListener, SearchShardsResponse::new, responseExecutor)
+                        new ActionListenerResponseHandler<>(
+                            responseListener.map(response -> new SearchPlanningPhaseResolutionResult(response, null)),
+                            SearchShardsResponse::new,
+                            responseExecutor
+                        )
                     );
                 } else {
                     // does not do a can-match
@@ -1441,7 +1451,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         searchShardsRequest,
                         TransportRequestOptions.EMPTY,
                         new ActionListenerResponseHandler<>(
-                            singleListener.map(SearchShardsResponse::fromLegacyResponse),
+                            singleListener.map(
+                                legacyResponse -> new SearchPlanningPhaseResolutionResult(
+                                    SearchShardsResponse.fromLegacyResponse(legacyResponse),
+                                    null
+                                )
+                            ),
                             ClusterSearchShardsResponse::new,
                             responseExecutor
                         )

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1228,7 +1228,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             rewritten.indicesOptions(),
             rewritten.getProjectRouting(),
             rewritten.getResolvedIndexExpressions(),
-            resolvedExpressions
+            resolvedExpressions,
+            Map.of()
         );
 
         if (ex != null) {
@@ -1374,7 +1375,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             originalIdxOpts,
                             projectRouting,
                             originResolvedIdxExpressions,
-                            resolvedIndexExpressions
+                            resolvedIndexExpressions,
+                            Map.of()
                         );
                         if (validationEx != null) {
                             throw validationEx;

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -77,6 +77,7 @@ public class CrossProjectIndexResolutionValidator {
      * @param projectRouting            The project routing string from the request, can be null if request does not specify it
      * @param localResolvedExpressions  Resolution results from the origin project
      * @param remoteResolvedExpressions Resolution results from linked projects
+     * @param remoteExceptions          Connection exceptions, etc., from linked projects, should be empty when all remote requests succeed
      * @return a {@link ElasticsearchException} if validation fails, null if validation passes
      */
     public static ElasticsearchException validate(

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -77,7 +77,7 @@ public class CrossProjectIndexResolutionValidator {
      * @param projectRouting            The project routing string from the request, can be null if request does not specify it
      * @param localResolvedExpressions  Resolution results from the origin project
      * @param remoteResolvedExpressions Resolution results from linked projects
-     * @param remoteExceptions          Connection exceptions, etc., from linked projects, should be empty when all remote requests succeed
+     * @param remoteExceptions          Connection exceptions, etc., from linked projects; should be empty when all remote requests succeed
      * @return a {@link ElasticsearchException} if validation fails, null if validation passes
      */
     public static ElasticsearchException validate(

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -83,7 +83,8 @@ public class CrossProjectIndexResolutionValidator {
         IndicesOptions indicesOptions,
         @Nullable String projectRouting,
         ResolvedIndexExpressions localResolvedExpressions,
-        Map<String, ResolvedIndexExpressions> remoteResolvedExpressions
+        Map<String, ResolvedIndexExpressions> remoteResolvedExpressions,
+        Map<String, Exception> remoteExceptions
     ) {
         if (indicesOptions.allowNoIndices() && indicesOptions.ignoreUnavailable()) {
             logger.debug("Skipping index existence check in lenient mode");
@@ -143,6 +144,7 @@ public class CrossProjectIndexResolutionValidator {
                     ElasticsearchException remoteException = checkSingleRemoteExpression(
                         localResolvedExpressions,
                         remoteResolvedExpressions,
+                        remoteExceptions,
                         projectAlias,
                         resource,
                         remoteExpression,
@@ -186,6 +188,7 @@ public class CrossProjectIndexResolutionValidator {
                     ElasticsearchException remoteException = checkSingleRemoteExpression(
                         localResolvedExpressions,
                         remoteResolvedExpressions,
+                        remoteExceptions,
                         projectAlias,
                         resource,
                         remoteExpression,
@@ -302,6 +305,7 @@ public class CrossProjectIndexResolutionValidator {
     private static ElasticsearchException checkSingleRemoteExpression(
         ResolvedIndexExpressions localExpressions,
         Map<String, ResolvedIndexExpressions> remoteResolvedExpressions,
+        Map<String, Exception> remoteExceptions,
         String projectAlias,
         String resource,
         String remoteExpression,
@@ -321,7 +325,12 @@ public class CrossProjectIndexResolutionValidator {
          * is identical to the one where we could not find an index anywhere.
          */
         if (resolvedExpressionsInProject == null) {
-            return new IndexNotFoundException(remoteExpression);
+            // if we're missing results from the remote because of a connection error, report it; else assume we have an exclusion
+            if (remoteExceptions.containsKey(projectAlias)) {
+                return new IndexNotFoundException(remoteExpression);
+            } else {
+                return null;
+            }
         }
 
         ResolvedIndexExpression.LocalExpressions matchingExpression = findMatchingExpression(resolvedExpressionsInProject, resource);

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -330,6 +330,11 @@ public class CrossProjectIndexResolutionValidator {
             if (remoteExceptions.containsKey(projectAlias)) {
                 return new IndexNotFoundException(remoteExpression);
             } else {
+                assert localExpressions.expressions()
+                    .stream()
+                    .anyMatch(e -> e.remoteExpressions().stream().anyMatch(r -> r.equals(Strings.format("-%s:*", projectAlias))))
+                    : Strings.format("Expected cluster exclusion for %s", projectAlias);
+
                 return checkResolutionFailure(
                     new ResolvedIndexExpression.LocalExpressions(Set.of(), SUCCESS, null),
                     remoteExpression,

--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -330,7 +330,11 @@ public class CrossProjectIndexResolutionValidator {
             if (remoteExceptions.containsKey(projectAlias)) {
                 return new IndexNotFoundException(remoteExpression);
             } else {
-                return null;
+                return checkResolutionFailure(
+                    new ResolvedIndexExpression.LocalExpressions(Set.of(), SUCCESS, null),
+                    remoteExpression,
+                    indicesOptions
+                );
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
@@ -1623,7 +1623,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getLenientIndicesOptions(),
                 useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
                 local,
-                remote
+                remote,
+                Map.of()
             )
         );
     }
@@ -1654,7 +1655,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e.getMessage(), equalTo("no such index [P1:logs]"));

--- a/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
@@ -45,7 +45,9 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
 
     public void testLenientIndicesOptions() {
         // with lenient IndicesOptions we early terminate without error
-        assertNull(CrossProjectIndexResolutionValidator.validate(getLenientIndicesOptions(), randomFrom("_alias:*", null), null, null));
+        assertNull(
+            CrossProjectIndexResolutionValidator.validate(getLenientIndicesOptions(), randomFrom("_alias:*", null), null, null, Map.of())
+        );
     }
 
     public void testFlatExpressionWithStrictIgnoreUnavailableMatchingInOriginProject() {
@@ -69,7 +71,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictIgnoreUnavailable(),
                 useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
                 local,
-                null
+                null,
+                Map.of()
             )
         );
     }
@@ -112,7 +115,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictIgnoreUnavailable(),
                 useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
                 local,
-                remote
+                remote,
+                Map.of()
             )
         );
     }
@@ -152,7 +156,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -174,12 +179,15 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
+        var remoteExceptions = Map.of("P1", new Exception("Unable to connect to [P1]"));
+
         // logs does not exist in the remote responses and indices options are strict. We expect an error.
         var e = CrossProjectIndexResolutionValidator.validate(
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            Map.of()
+            Map.of(),
+            remoteExceptions
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -206,6 +214,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getLenientIndicesOptions(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
+            Map.of(),
             Map.of()
         );
         assertNull(e);
@@ -244,12 +253,15 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
+        var remoteExceptions = Map.of("P1", new Exception("Unable to connect to [P1]"));
+
         // Index expression is a wildcard-ed expression but the indices options are strict. We expect an error.
         var e = CrossProjectIndexResolutionValidator.validate(
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            remoteExceptions
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -294,7 +306,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getLenientIndicesOptions(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNull(e);
     }
@@ -322,12 +335,15 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
+        var remoteExceptions = Map.of("P1", new Exception("Unable to connect to [P1]"));
+
         // logs does not exist in the remote responses and indices options are strict. We expect an error.
         var e = CrossProjectIndexResolutionValidator.validate(
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            remoteExceptions
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -362,7 +378,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getLenientIndicesOptions(),
             useProjectRouting ? "_alias:P1" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNull(e);
     }
@@ -404,7 +421,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e.getMessage(), equalTo("authorization errors while resolving [logs]"));
@@ -440,7 +458,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), projectRouting, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), projectRouting, local, remote, Map.of());
         assertNotNull(e);
         assertThat(e.getMessage(), equalTo("authorization errors while resolving [P1:logs]"));
     }
@@ -474,7 +492,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), projectRouting, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), projectRouting, local, remote, Map.of());
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
         assertThat(e.getMessage(), containsString("no such index [P1:logs]"));
@@ -501,7 +519,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictIgnoreUnavailable(),
                 useProjectRouting ? "_alias:_origin" : null, // a redundant project routing has no impact
                 local,
-                null
+                null,
+                Map.of()
             )
         );
     }
@@ -526,7 +545,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:_origin" : null, // a redundant project routing has no impact
             local,
-            null
+            null,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -561,7 +581,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictIgnoreUnavailable(),
                 useProjectRouting ? "_alias:P1" : null, // a redundant project routing has no impact
                 local,
-                remote
+                remote,
+                Map.of()
             )
         );
     }
@@ -599,7 +620,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:P1" : null, // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -633,7 +655,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictIgnoreUnavailable(),
             useProjectRouting ? "_alias:P1" : null, // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e.getMessage(), equalTo("action is unauthorized for indices [P1:logs]"));
@@ -655,7 +678,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
         );
 
         // we matched resource locally thus no error
-        assertNull(CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, null));
+        assertNull(CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, null, Map.of()));
     }
 
     public void testStrictAllowNoIndicesFoundEmptyResultsOnOriginAndLinked() {
@@ -690,7 +713,13 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        ElasticsearchException ex = CrossProjectIndexResolutionValidator.validate(getIndicesOptions(false, false), null, local, remote);
+        ElasticsearchException ex = CrossProjectIndexResolutionValidator.validate(
+            getIndicesOptions(false, false),
+            null,
+            local,
+            remote,
+            Map.of()
+        );
         assertNotNull(ex);
         assertThat(ex, instanceOf(IndexNotFoundException.class));
     }
@@ -728,7 +757,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
         );
 
         // we matched the flat resource in a linked project thus no error
-        assertNull(CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote));
+        assertNull(CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote, Map.of()));
     }
 
     public void testMissingFlatExpressionWithStrictAllowNoIndices() {
@@ -763,7 +792,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote, Map.of());
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
         assertThat(e.getMessage(), containsString("no such index [logs*]"));
@@ -801,7 +830,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictAllowNoIndices(), null, local, remote, Map.of());
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
         assertThat(e.getMessage(), containsString("no such index [logs*]"));
@@ -828,7 +857,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictAllowNoIndices(),
                 useProjectRouting ? "_alias:_origin" : null, // a redundant project routing has no impact
                 local,
-                null
+                null,
+                Map.of()
             )
         );
     }
@@ -852,7 +882,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:_origin" : null, // a redundant project routing has no impact
             local,
-            null
+            null,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -879,6 +910,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                     getIndicesOptions(randomBoolean(), randomBoolean()),
                     useProjectRouting ? "_alias:_origin" : null, // a redundant project routing has no impact
                     local,
+                    Map.of(),
                     Map.of()
                 )
             );
@@ -913,7 +945,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                 getStrictAllowNoIndices(),
                 useProjectRouting ? "_alias:P1" : null,  // a redundant project routing has no impact
                 local,
-                remote
+                remote,
+                Map.of()
             )
         );
     }
@@ -955,7 +988,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:P1" : null, // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -994,7 +1028,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:P1" : null, // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(e);
         assertThat(e, instanceOf(IndexNotFoundException.class));
@@ -1046,7 +1081,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, Map.of());
         assertThat(e, is(nullValue()));
     }
 
@@ -1081,7 +1116,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var remoteExceptions = Map.of("P2", new Exception("Unable to connect to [P2]"));
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, remoteExceptions);
         assertThat(e, instanceOf(ElasticsearchSecurityException.class));
         assertThat(e.getMessage(), containsString("P1:logs"));
     }
@@ -1161,7 +1197,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, Map.of());
         assertThat(e, is(notNullValue()));
         assertThat(e.getMessage(), equalTo("Unauthorized for P1:metrics"));
         assertThat(e.getSuppressed(), emptyArray());
@@ -1242,7 +1278,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, Map.of());
         assertThat(e, is(notNullValue()));
         assertThat(e.getMessage(), equalTo("Unauthorized for P1:metrics,P1:logs"));
         assertThat(e.getSuppressed(), arrayWithSize(1));
@@ -1325,7 +1361,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, Map.of());
         assertThat(e, is(notNullValue()));
         assertThat(e.getMessage(), equalTo("no such index [" + originalExpression + "]"));
         assertThat(e.getSuppressed(), emptyArray());
@@ -1403,7 +1439,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             )
         );
 
-        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
+        var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote, Map.of());
         assertThat(e, is(notNullValue()));
         assertThat(e.getMessage(), equalTo("no such index [P1:metrics]"));
         assertThat(e.getSuppressed(), emptyArray());
@@ -1453,7 +1489,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                     getStrictIgnoreUnavailable(),
                     useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
                     local,
-                    remote
+                    remote,
+                    Map.of()
                 )
             );
         }
@@ -1502,7 +1539,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
                     getStrictAllowNoIndices(),
                     useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
                     local,
-                    remote
+                    remote,
+                    Map.of()
                 )
             );
         }
@@ -1522,7 +1560,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(ex);
         assertThat(ex.getMessage(), equalTo("no such index [" + expression + "]"));
@@ -1550,7 +1589,8 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
             getStrictAllowNoIndices(),
             useProjectRouting ? "_alias:*" : null,  // a redundant project routing has no impact
             local,
-            remote
+            remote,
+            Map.of()
         );
         assertNotNull(ex);
         assertThat(ex.getMessage(), equalTo("no such index [-shared-index-1,-shared-index-2]"));

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -387,7 +387,8 @@ public class IndexResolver {
                     iOpts,
                     projectRouting,
                     resolvedIndexExpressions,
-                    resolvedRemotely
+                    resolvedRemotely,
+                    Map.of()
                 );
                 if (ex != null) {
                     l.onFailure(ex);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -384,7 +384,7 @@ public class IndexResolver {
             if (crossProjectEnabled) {
                 Map<String, ResolvedIndexExpressions> resolvedRemotely = response.getResolvedRemotely();
                 ElasticsearchException ex = CrossProjectIndexResolutionValidator.validate(
-                    indicesOptions,
+                    iOpts,
                     projectRouting,
                     resolvedIndexExpressions,
                     resolvedRemotely,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -384,7 +384,7 @@ public class IndexResolver {
             if (crossProjectEnabled) {
                 Map<String, ResolvedIndexExpressions> resolvedRemotely = response.getResolvedRemotely();
                 ElasticsearchException ex = CrossProjectIndexResolutionValidator.validate(
-                    iOpts,
+                    indicesOptions,
                     projectRouting,
                     resolvedIndexExpressions,
                     resolvedRemotely,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -158,8 +158,7 @@ public class Querier {
             options = IndicesOptions.builder(options).crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true)).build();
         }
         final OpenPointInTimeRequest openPitRequest = new OpenPointInTimeRequest(search.indices()).indicesOptions(options)
-            .keepAlive(cfg.pageTimeout())
-            .allowPartialSearchResults(cfg.allowPartialSearchResults());
+            .keepAlive(cfg.pageTimeout());
         if (cfg.crossProject() && cfg.projectRouting() != null) {
             openPitRequest.projectRouting(cfg.projectRouting());
         }


### PR DESCRIPTION
Allow expressions such as `*:logs,-linked_project:*`.

Assume that missing remote resolution results for a project alias are due to cluster exclusion, unless we have an exception