### PR TITLE
fix: replace printStackTrace with proper logging in early startup

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -150,7 +150,8 @@ class Elasticsearch {
             LogConfigurator.configure(nodeEnv, args.quiet() == false);
         } catch (Throwable t) {
             // any exception this early needs to be fully printed and fail startup
-            t.printStackTrace(err);
+            final Logger logger = LogManager.getLogger(Elasticsearch.class);
+            logger.error("Failed to initialize node", t);
             err.flush();
             Bootstrap.exit(1); // mimic JDK exit code on exception
             return null; // unreachable, to satisfy compiler


### PR DESCRIPTION
## Summary
Replace direct `printStackTrace(err)` call with proper Log4j logging to improve error handling and log management during node initialization.

## Changes
- Replace `t.printStackTrace(err)` with proper `logger.error("Failed to initialize node", t)` call
- This ensures logs are properly managed through Log4j configuration

## Why
Using `printStackTrace()` directly to `err` stream is not recommended in production code.