### PR TITLE
Fixed logsdb rolling upgrade test failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -429,9 +429,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/TS Command grouping on text field}
   issue: https://github.com/elastic/elasticsearch/issues/142544
-- class: org.elasticsearch.xpack.logsdb.StandardToLogsDbIndexModeRollingUpgradeIT
-  method: testIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/143426
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:lookup-join.MvJoinKeyOnFromAfterStats}
   issue: https://github.com/elastic/elasticsearch/issues/143427

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -642,11 +642,14 @@ public abstract class ESRestTestCase extends ESTestCase {
     @After
     public final void cleanUpCluster() throws Exception {
         if (previousFailureSkipsRemaining() == false && preserveClusterUponCompletion() == false) {
-            ensureNoInitializingShards();
-            wipeCluster();
-            waitForClusterStateUpdatesToFinish();
-            checkForUnexpectedlyRecreatedObjects();
-            logIfThereAreRunningTasks();
+            // Skip cleanup when there is no client (e.g. test failed during rolling upgrade after closeClients() but before initClient()).
+            if (cleanupClient != null) {
+                ensureNoInitializingShards();
+                wipeCluster();
+                waitForClusterStateUpdatesToFinish();
+                checkForUnexpectedlyRecreatedObjects();
+                logIfThereAreRunningTasks();
+            }
         }
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -320,11 +320,12 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
             queryMessages.add(message);
         }
 
-        // verify that every message in the messages list is present in the query response
+        // STATS BY message returns one row per distinct message, so compare against distinct messages
+        List<String> distinctMessages = messages.stream().distinct().toList();
         assertThat(
-            "Expected messages: " + messages + "\nActual messages: " + queryMessages,
+            "Expected messages: " + distinctMessages + "\nActual messages: " + queryMessages,
             queryMessages,
-            containsInAnyOrder(messages.toArray())
+            containsInAnyOrder(distinctMessages.toArray())
         );
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringWithIgnoreAboveRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringWithIgnoreAboveRollingUpgradeTestCase.java
@@ -89,8 +89,10 @@ public abstract class AbstractStringWithIgnoreAboveRollingUpgradeTestCase extend
             }
         }
 
+        // STATS BY message returns one row per distinct message, so compare against distinct messages
+        List<String> messages = getMessages(dataStreamName).stream().distinct().toList();
+
         // block loaders do not return ignored fields, so we need to filter out all generated messages that would've been ignored
-        List<String> messages = getMessages(dataStreamName);
         List<String> expectedMessages = ignoreAbove.isSet()
             ? messages.stream().filter(msg -> ignoreAbove.isIgnored(msg) == false).toList()
             : messages;


### PR DESCRIPTION
These tests generate random strings to use as a field's values during indexing. In the rare case the same string is generated twice and indexed, the test fails an assertion during querying. This happens because `stats` aggregates duplicate message into a single row. As a result, comparing generated messages against the list return by the query will fail.

Fixes:
- https://github.com/elastic/elasticsearch/issues/143426
- https://github.com/elastic/elasticsearch-serverless/issues/5720
- https://github.com/elastic/elasticsearch-serverless/issues/5721
- https://github.com/elastic/elasticsearch-serverless/issues/5722