### PR TITLE
Deduplicate IndexAccessControl

### DIFF
--- a/docs/changelog/143530.yaml
+++ b/docs/changelog/143530.yaml
@@ -1,0 +1,6 @@
+area: Authorization
+issues:
+ - 2372
+pr: 143530
+summary: Deduplicate `IndexAccessControl`
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
@@ -73,6 +73,8 @@ public final class FieldPermissions implements Accountable, CacheKey {
 
     private final long ramBytesUsed;
 
+    private Integer hashMemo = null;
+
     /** Constructor that does not enable field-level security: all fields are accepted. */
     private FieldPermissions() {
         this(new FieldPermissionsDefinition(null, null), Automatons.MATCH_ALL);
@@ -120,6 +122,8 @@ public final class FieldPermissions implements Accountable, CacheKey {
         ramBytesUsed += permittedFieldsAutomaton.ramBytesUsed();
         ramBytesUsed += runAutomatonRamBytesUsed(permittedFieldsAutomaton);
         ramBytesUsed += fieldPredicate.ramBytesUsed();
+        ramBytesUsed += RamUsageEstimator.sizeOf(hashMemo);
+        ramBytesUsed += Long.BYTES; // for ramBytesUsed itself
         this.ramBytesUsed = ramBytesUsed;
     }
 
@@ -274,6 +278,13 @@ public final class FieldPermissions implements Accountable, CacheKey {
 
     @Override
     public int hashCode() {
+        if (hashMemo == null) {
+            hashMemo = computeHashCode();
+        }
+        return hashMemo;
+    }
+
+    private int computeHashCode() {
         return Objects.hash(fieldPermissionsDefinitions, permittedFieldsAutomatonIsTotal);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -639,6 +639,9 @@ public final class IndicesPermission {
         final Map<String, DocumentLevelPermissions> roleQueriesByIndex = Maps.newMapWithExpectedSize(totalResourceCount);
         final Set<String> grantedResources = Sets.newHashSetWithExpectedSize(totalResourceCount);
 
+        final DocumentLevelPermissionsInterner documentLevelPermissionsInterner = new DocumentLevelPermissionsInterner();
+        final SetInterner<FieldPermissions> fieldPermissionsSetInterner = new SetInterner<>();
+
         final boolean isMappingUpdateAction = isMappingUpdateAction(action);
 
         for (Map.Entry<String, IndexResource> resourceEntry : requestedResources.entrySet()) {
@@ -665,26 +668,37 @@ public final class IndicesPermission {
                                     // Most indices rely on the default (empty) field permissions object, so we optimize for that case
                                     // Using an immutable single item set is significantly faster because it avoids any of the hashing
                                     // and backing set creation.
-                                    return Set.of(group.getFieldPermissions());
-                                } else if (existingSet.size() == 1) {
+                                    return fieldPermissionsSetInterner.getOrCreate(Set.of(group.getFieldPermissions()));
+                                } else {
                                     FieldPermissions fp = group.getFieldPermissions();
                                     if (existingSet.contains(fp)) {
                                         return existingSet;
                                     }
-                                    // This index doesn't have a single field permissions object, replace the singleton with a real Set
+                                    // we have to create a new set because the existing set is shared (interned) and we don't want to modify
+                                    // it. We use a HashSet here because we expect that in most cases there will be very few permissions per
+                                    // index, so the cost of copying is small and the O(1) cost of adding is worth it compared to the O(n)
+                                    // cost of checking for duplicates in a list. Note that hashes in FieldPermissions are cached too.
                                     final Set<FieldPermissions> hashSet = new HashSet<>(existingSet);
                                     hashSet.add(fp);
-                                    return hashSet;
-                                } else {
-                                    existingSet.add(group.getFieldPermissions());
-                                    return existingSet;
+                                    return fieldPermissionsSetInterner.getOrCreate(hashSet);
                                 }
                             });
 
                             DocumentLevelPermissions docPermissions;
                             if (group.hasQuery()) {
-                                docPermissions = roleQueriesByIndex.computeIfAbsent(index, (k) -> new DocumentLevelPermissions());
-                                docPermissions.addAll(group.getQuery());
+                                DocumentLevelPermissions existingDocPermissions = roleQueriesByIndex.getOrDefault(
+                                    index,
+                                    DocumentLevelPermissions.EMPTY
+                                );
+                                docPermissions = DocumentLevelPermissions.merge(
+                                    existingDocPermissions,
+                                    group.getQuery(),
+                                    documentLevelPermissionsInterner
+                                );
+                                if (existingDocPermissions != docPermissions) {
+                                    // only update the map if the permissions have actually changed
+                                    roleQueriesByIndex.put(index, docPermissions);
+                                }
                             } else {
                                 // if more than one permission matches for a concrete index here and if
                                 // a single permission doesn't have a role query then DLS will not be
@@ -718,24 +732,33 @@ public final class IndicesPermission {
         }
 
         Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions = Maps.newMapWithExpectedSize(grantedResources.size());
+        Map<Tuple<DocumentLevelPermissions, Set<FieldPermissions>>, IndicesAccessControl.IndexAccessControl> indexAccessControlCache =
+            new HashMap<>();
         for (String index : grantedResources) {
             final DocumentLevelPermissions permissions = roleQueriesByIndex.get(index);
-            final DocumentPermissions documentPermissions;
-            if (permissions != null && permissions.isAllowAll() == false) {
-                documentPermissions = DocumentPermissions.filteredBy(permissions.queries);
-            } else {
-                documentPermissions = DocumentPermissions.allowAll();
-            }
-            final FieldPermissions fieldPermissions;
             final Set<FieldPermissions> indexFieldPermissions = fieldPermissionsByIndex.get(index);
-            if (indexFieldPermissions != null && indexFieldPermissions.isEmpty() == false) {
-                fieldPermissions = indexFieldPermissions.size() == 1
-                    ? indexFieldPermissions.iterator().next()
-                    : fieldPermissionsCache.union(indexFieldPermissions);
-            } else {
-                fieldPermissions = FieldPermissions.DEFAULT;
-            }
-            indexPermissions.put(index, new IndicesAccessControl.IndexAccessControl(fieldPermissions, documentPermissions));
+            IndicesAccessControl.IndexAccessControl indexAccessControl = indexAccessControlCache.computeIfAbsent(
+                Tuple.tuple(permissions, indexFieldPermissions),
+                documentAndFieldPermissions -> {
+                    final DocumentPermissions documentPermissions;
+                    if (documentAndFieldPermissions.v1() != null && documentAndFieldPermissions.v1().isAllowAll() == false) {
+                        documentPermissions = DocumentPermissions.filteredBy(documentAndFieldPermissions.v1().queries);
+                    } else {
+                        documentPermissions = DocumentPermissions.allowAll();
+                    }
+                    final FieldPermissions fieldPermissions;
+                    if (documentAndFieldPermissions.v2() != null && documentAndFieldPermissions.v2().isEmpty() == false) {
+                        fieldPermissions = documentAndFieldPermissions.v2().size() == 1
+                            ? documentAndFieldPermissions.v2().iterator().next()
+                            : fieldPermissionsCache.union(documentAndFieldPermissions.v2());
+                    } else {
+                        fieldPermissions = FieldPermissions.DEFAULT;
+                    }
+                    return new IndicesAccessControl.IndexAccessControl(fieldPermissions, documentPermissions);
+                }
+            );
+
+            indexPermissions.put(index, indexAccessControl);
         }
         return unmodifiableMap(indexPermissions);
     }
@@ -1060,25 +1083,69 @@ public final class IndicesPermission {
 
     private static class DocumentLevelPermissions {
 
-        public static final DocumentLevelPermissions ALLOW_ALL = new DocumentLevelPermissions();
-        static {
-            ALLOW_ALL.allowAll = true;
+        static final DocumentLevelPermissions ALLOW_ALL = new DocumentLevelPermissions(true);
+        static final DocumentLevelPermissions EMPTY = new DocumentLevelPermissions(false);
+
+        private final Set<BytesReference> queries;
+        private final boolean allowAll;
+
+        private DocumentLevelPermissions(boolean allowAll) {
+            queries = null;
+            this.allowAll = allowAll;
         }
 
-        private Set<BytesReference> queries = null;
-        private boolean allowAll = false;
+        DocumentLevelPermissions(Set<BytesReference> p) {
+            this.queries = p;
+            this.allowAll = false;
+        }
 
-        private void addAll(Set<BytesReference> query) {
-            if (allowAll == false) {
-                if (queries == null) {
-                    queries = Sets.newHashSetWithExpectedSize(query.size());
+        boolean isAllowAll() {
+            return allowAll;
+        }
+
+        static DocumentLevelPermissions merge(
+            DocumentLevelPermissions permissions,
+            Set<BytesReference> newQueries,
+            DocumentLevelPermissionsInterner cache
+        ) {
+            if (permissions.allowAll) {
+                return ALLOW_ALL;
+            } else {
+                var existingSize = permissions.queries == null ? 0 : permissions.queries.size();
+                var expectedSize = existingSize + newQueries.size();
+                Set<BytesReference> mergedQueries = Sets.newHashSetWithExpectedSize(expectedSize);
+                if (permissions.queries != null) {
+                    mergedQueries.addAll(permissions.queries);
                 }
-                queries.addAll(query);
+                mergedQueries.addAll(newQueries);
+                return cache.getOrCreate(mergedQueries, false);
             }
         }
+    }
 
-        private boolean isAllowAll() {
-            return allowAll;
+    private static class DocumentLevelPermissionsInterner {
+        private final Map<Set<BytesReference>, DocumentLevelPermissions> interned = new HashMap<>();
+
+        DocumentLevelPermissions getOrCreate(Set<BytesReference> permissions, boolean allowAll) {
+            if (allowAll) {
+                return DocumentLevelPermissions.ALLOW_ALL;
+            } else {
+                return interned.computeIfAbsent(permissions, p -> new DocumentLevelPermissions(Set.copyOf(p)));
+            }
+        }
+    }
+
+    private static class SetInterner<T> {
+        private final Map<Set<T>, Set<T>> interned = new HashMap<>();
+
+        /**
+         * @param set a set which must not be modified after being passed here
+         */
+        Set<T> getOrCreate(Set<T> set) {
+            // we don't make a copy of the underlying set to avoid the overhead.
+            // Unlike the DocumentLevelPermissionsInterner, the sets passed to his method are created only within IndicesPermission class
+            // where we can assume it will not be modified after being passed to this method
+            return interned.computeIfAbsent(set, Function.identity());
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1101,6 +1102,229 @@ public class IndicesPermissionTests extends ESTestCase {
         );
         assertThat(ex.getMessage(), containsString("index pattern [****a*b?c**d**e*f??*g**h???i??*j*k*l*m*n???o*]"));
         assertThat(ex.getCause(), instanceOf(TooComplexToDeterminizeException.class));
+    }
+
+    public void testIndexAccessControlDeduplicationWithDefaultPermissions() {
+        final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        int numIndices = randomIntBetween(3, 10);
+        Metadata.Builder mdBuilder = new Metadata.Builder();
+        Set<String> indexNames = new HashSet<>();
+        for (int i = 0; i < numIndices; i++) {
+            String name = "index-" + i;
+            indexNames.add(name);
+            mdBuilder.put(new IndexMetadata.Builder(name).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true);
+        }
+        ProjectMetadata pmd = mdBuilder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        IndicesPermission indicesPermission = new IndicesPermission.Builder(RESTRICTED_INDICES).addGroup(
+            IndexPrivilege.ALL,
+            FieldPermissions.DEFAULT,
+            null,
+            randomBoolean(),
+            "*"
+        ).build();
+        IndicesAccessControl iac = indicesPermission.authorize(TransportSearchAction.TYPE.name(), indexNames, pmd, fieldPermissionsCache);
+
+        assertThat(iac.isGranted(), is(true));
+        IndicesAccessControl.IndexAccessControl firstControl = iac.getIndexPermissions("index-0");
+        assertThat(firstControl, notNullValue());
+        for (int i = 1; i < numIndices; i++) {
+            assertSame(
+                "IndexAccessControl should be the same instance for indices with identical default permissions",
+                firstControl,
+                iac.getIndexPermissions("index-" + i)
+            );
+        }
+    }
+
+    public void testIndexAccessControlDeduplicationViaAlias() {
+        final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        AliasMetadata aliasMetadata = AliasMetadata.builder("_alias").build();
+        int numIndices = randomIntBetween(2, 6);
+        Metadata.Builder mdBuilder = new Metadata.Builder();
+        for (int i = 0; i < numIndices; i++) {
+            mdBuilder.put(
+                new IndexMetadata.Builder("index-" + i).settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(aliasMetadata)
+                    .build(),
+                true
+            );
+        }
+        ProjectMetadata pmd = mdBuilder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        Set<BytesReference> query = Collections.singleton(new BytesArray("{\"match_all\":{}}"));
+        String[] fields = new String[] { "allowed_*" };
+        IndicesPermission indicesPermission = new IndicesPermission.Builder(RESTRICTED_INDICES).addGroup(
+            IndexPrivilege.ALL,
+            new FieldPermissions(fieldPermissionDef(fields, null)),
+            query,
+            randomBoolean(),
+            "_alias"
+        ).build();
+        IndicesAccessControl iac = indicesPermission.authorize(
+            TransportSearchAction.TYPE.name(),
+            Sets.newHashSet("_alias"),
+            pmd,
+            fieldPermissionsCache
+        );
+
+        assertThat(iac.isGranted(), is(true));
+        IndicesAccessControl.IndexAccessControl aliasControl = iac.getIndexPermissions("_alias");
+        assertThat(aliasControl, notNullValue());
+        for (int i = 0; i < numIndices; i++) {
+            assertSame(
+                "All backing indices of an alias should share the same IndexAccessControl instance",
+                aliasControl,
+                iac.getIndexPermissions("index-" + i)
+            );
+        }
+    }
+
+    public void testIndexAccessControlDeduplicationWithDifferentPermissionGroups() {
+        final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        Metadata.Builder mdBuilder = new Metadata.Builder();
+        for (String name : List.of("a1", "a2", "a3", "b1", "b2", "b3")) {
+            mdBuilder.put(new IndexMetadata.Builder(name).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true);
+        }
+        ProjectMetadata pmd = mdBuilder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        Set<BytesReference> queryA = Collections.singleton(new BytesArray("{\"term\":{\"group\":\"a\"}}"));
+        Set<BytesReference> queryB = Collections.singleton(new BytesArray("{\"term\":{\"group\":\"b\"}}"));
+        IndicesPermission indicesPermission = new IndicesPermission.Builder(RESTRICTED_INDICES).addGroup(
+            IndexPrivilege.ALL,
+            new FieldPermissions(fieldPermissionDef(new String[] { "field_a" }, null)),
+            queryA,
+            randomBoolean(),
+            "a*"
+        )
+            .addGroup(
+                IndexPrivilege.ALL,
+                new FieldPermissions(fieldPermissionDef(new String[] { "field_b" }, null)),
+                queryB,
+                randomBoolean(),
+                "b*"
+            )
+            .build();
+        IndicesAccessControl iac = indicesPermission.authorize(
+            TransportSearchAction.TYPE.name(),
+            Sets.newHashSet("a1", "a2", "a3", "b1", "b2", "b3"),
+            pmd,
+            fieldPermissionsCache
+        );
+
+        assertThat(iac.isGranted(), is(true));
+
+        IndicesAccessControl.IndexAccessControl a1Control = iac.getIndexPermissions("a1");
+        IndicesAccessControl.IndexAccessControl b1Control = iac.getIndexPermissions("b1");
+        assertThat(a1Control, notNullValue());
+        assertThat(b1Control, notNullValue());
+
+        // Indices within the same group should share the same IndexAccessControl
+        assertSame(a1Control, iac.getIndexPermissions("a2"));
+        assertSame(a1Control, iac.getIndexPermissions("a3"));
+        assertSame(b1Control, iac.getIndexPermissions("b2"));
+        assertSame(b1Control, iac.getIndexPermissions("b3"));
+
+        // Indices in different groups should have different IndexAccessControl
+        assertNotSame(a1Control, b1Control);
+
+        // Verify they have different FLS
+        assertTrue(a1Control.getFieldPermissions().grantsAccessTo("field_a"));
+        assertFalse(a1Control.getFieldPermissions().grantsAccessTo("field_b"));
+        assertTrue(b1Control.getFieldPermissions().grantsAccessTo("field_b"));
+        assertFalse(b1Control.getFieldPermissions().grantsAccessTo("field_a"));
+    }
+
+    public void testIndexAccessControlDeduplicationWithMultipleGroupsSameIndex() {
+        final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        Metadata.Builder mdBuilder = new Metadata.Builder();
+        for (String name : List.of("index-1", "index-2", "index-3")) {
+            mdBuilder.put(new IndexMetadata.Builder(name).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true);
+        }
+        ProjectMetadata pmd = mdBuilder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        Set<BytesReference> query1 = Collections.singleton(new BytesArray("{\"term\":{\"status\":\"published\"}}"));
+        Set<BytesReference> query2 = Collections.singleton(new BytesArray("{\"term\":{\"status\":\"draft\"}}"));
+        FieldPermissions fp1 = new FieldPermissions(fieldPermissionDef(new String[] { "title" }, null));
+        FieldPermissions fp2 = new FieldPermissions(fieldPermissionDef(new String[] { "body" }, null));
+
+        // Two groups both match all indices - each index accumulates the same combined FLS and DLS
+        IndicesPermission indicesPermission = new IndicesPermission.Builder(RESTRICTED_INDICES).addGroup(
+            IndexPrivilege.ALL,
+            fp1,
+            query1,
+            randomBoolean(),
+            "index-*"
+        ).addGroup(IndexPrivilege.ALL, fp2, query2, randomBoolean(), "index-*").build();
+        IndicesAccessControl iac = indicesPermission.authorize(
+            TransportSearchAction.TYPE.name(),
+            Sets.newHashSet("index-1", "index-2", "index-3"),
+            pmd,
+            fieldPermissionsCache
+        );
+
+        assertThat(iac.isGranted(), is(true));
+
+        IndicesAccessControl.IndexAccessControl control1 = iac.getIndexPermissions("index-1");
+        assertThat(control1, notNullValue());
+
+        // All indices should share the same IndexAccessControl since they accumulate the same FLS+DLS
+        assertSame(control1, iac.getIndexPermissions("index-2"));
+        assertSame(control1, iac.getIndexPermissions("index-3"));
+
+        // Verify combined DLS contains both queries
+        assertThat(control1.getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
+        assertThat(control1.getDocumentPermissions().getSingleSetOfQueries(), hasSize(2));
+
+        // Verify combined FLS allows both field groups
+        assertTrue(control1.getFieldPermissions().grantsAccessTo("title"));
+        assertTrue(control1.getFieldPermissions().grantsAccessTo("body"));
+    }
+
+    public void testIndexAccessControlDeduplicationWithIdenticalQueryContent() {
+        final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        Metadata.Builder mdBuilder = new Metadata.Builder();
+        for (String name : List.of("idx-a", "idx-b")) {
+            mdBuilder.put(new IndexMetadata.Builder(name).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true);
+        }
+        ProjectMetadata pmd = mdBuilder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        // Two separate BytesArray instances with identical content
+        Set<BytesReference> queryForA = Collections.singleton(new BytesArray("{\"match_all\":{}}"));
+        Set<BytesReference> queryForB = Collections.singleton(new BytesArray("{\"match_all\":{}}"));
+        assertNotSame("precondition: query sets are distinct objects", queryForA, queryForB);
+
+        IndicesPermission indicesPermission = new IndicesPermission.Builder(RESTRICTED_INDICES).addGroup(
+            IndexPrivilege.ALL,
+            FieldPermissions.DEFAULT,
+            queryForA,
+            randomBoolean(),
+            "idx-a"
+        ).addGroup(IndexPrivilege.ALL, FieldPermissions.DEFAULT, queryForB, randomBoolean(), "idx-b").build();
+        IndicesAccessControl iac = indicesPermission.authorize(
+            TransportSearchAction.TYPE.name(),
+            Sets.newHashSet("idx-a", "idx-b"),
+            pmd,
+            fieldPermissionsCache
+        );
+
+        assertThat(iac.isGranted(), is(true));
+        IndicesAccessControl.IndexAccessControl controlA = iac.getIndexPermissions("idx-a");
+        IndicesAccessControl.IndexAccessControl controlB = iac.getIndexPermissions("idx-b");
+        assertThat(controlA, notNullValue());
+        assertThat(controlB, notNullValue());
+        assertSame(
+            "IndexAccessControl should be interned when DLS queries have equal content even if they are separate objects",
+            controlA,
+            controlB
+        );
     }
 
     private static IndexAbstraction concreteIndexAbstraction(String name) {


### PR DESCRIPTION
While completing the authorize call, each index has its own IndexAccessControl object. This unnecessary produces a big number of duplicates especially in data streams, where almost all these objects are identical. This commit internalizes them, so they can reuse single object. That avoids a lot of memory consumption, which used to occasionally cause OOM on large data streams.

Closes #2372
