### PR TITLE
[9.3] Fix MemorySegmentUtilsTests (#143391)

### DIFF
--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/MemorySegmentUtilsTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/MemorySegmentUtilsTests.java
@@ -18,6 +18,7 @@ import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.lang.foreign.ValueLayout;
@@ -32,6 +33,11 @@ import static org.hamcrest.Matchers.startsWith;
 @LuceneTestCase.SuppressFileSystems("*") // we do our own mocking
 public class MemorySegmentUtilsTests extends ESTestCase {
 
+    @BeforeClass
+    public static void beforeClass() {
+        assumeTrue("needs final FFI API", Runtime.version().feature() >= 22);
+    }
+
     private FSDirectory newRandomDirectory() throws IOException {
         return randomBoolean() ? new MMapDirectory(createTempDir()) : new NIOFSDirectory(createTempDir());
     }
@@ -41,18 +47,18 @@ public class MemorySegmentUtilsTests extends ESTestCase {
         var data = randomByteArrayOfLength(dataSize);
 
         try (FSDirectory dir = newRandomDirectory()) {
-            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexOutput out = dir.createOutput("tests.bin1", IOContext.DEFAULT)) {
                 out.writeBytes(data, 0, dataSize);
             }
 
-            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexInput in = dir.openInput("tests.bin1", IOContext.DEFAULT)) {
                 if (rarely()) {
                     in.seek(randomIntBetween(0, dataSize - 1));
                 }
 
                 var initialPosition = in.getFilePointer();
 
-                var tempFilePath = MemorySegmentUtils.copyInputToTempFile(in, dir, "tests.bin");
+                var tempFilePath = MemorySegmentUtils.copyInputToTempFile(in, dir, "tests.bin3");
 
                 assertThat(
                     tempFilePath.toString(),
@@ -74,7 +80,7 @@ public class MemorySegmentUtilsTests extends ESTestCase {
         var scratch = new byte[paddingSize];
 
         try (FSDirectory dir = newRandomDirectory()) {
-            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexOutput out = dir.createOutput("tests.bin4", IOContext.DEFAULT)) {
                 for (int i = 0; i < rows; ++i) {
                     out.writeBytes(data, i * rowSize, rowSize);
                     randomBytesBetween(scratch, (byte) 0, (byte) 127);
@@ -82,14 +88,21 @@ public class MemorySegmentUtilsTests extends ESTestCase {
                 }
             }
 
-            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexInput in = dir.openInput("tests.bin4", IOContext.DEFAULT)) {
                 if (rarely()) {
                     in.seek(randomIntBetween(0, data.length - 1));
                 }
 
                 var initialPosition = in.getFilePointer();
 
-                var tempFilePath = MemorySegmentUtils.copyInputToTempFilePacked(in, dir, "tests.bin", rows, rowSize + paddingSize, rowSize);
+                var tempFilePath = MemorySegmentUtils.copyInputToTempFilePacked(
+                    in,
+                    dir,
+                    "tests.bin6",
+                    rows,
+                    rowSize + paddingSize,
+                    rowSize
+                );
 
                 assertThat(
                     tempFilePath.toString(),
@@ -119,14 +132,14 @@ public class MemorySegmentUtilsTests extends ESTestCase {
         var data = randomByteArrayOfLength(dataSize);
 
         try (FSDirectory dir = new MMapDirectory(createTempDir(), maxChunkSize)) {
-            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexOutput out = dir.createOutput("tests.bin7", IOContext.DEFAULT)) {
                 out.writeBytes(data, 0, dataSize);
             }
 
-            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexInput in = dir.openInput("tests.bin7", IOContext.DEFAULT)) {
 
                 var msai = (MemorySegmentAccessInput) in;
-                var holder = MemorySegmentUtils.getContiguousMemorySegment(msai, dir, "tests.bin");
+                var holder = MemorySegmentUtils.getContiguousMemorySegment(msai, dir, "tests.bin9");
 
                 assertThat(holder, isA(MemorySegmentUtils.DirectMemorySegmentHolder.class));
                 assertNotNull(holder.memorySegment());
@@ -142,19 +155,19 @@ public class MemorySegmentUtilsTests extends ESTestCase {
         var data = randomByteArrayOfLength(dataSize);
 
         try (FSDirectory dir = new MMapDirectory(createTempDir(), maxChunkSize)) {
-            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+            try (IndexOutput out = dir.createOutput("tests.bin10", IOContext.DEFAULT)) {
                 out.writeBytes(data, 0, dataSize);
             }
 
-            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
-
+            try (IndexInput in = dir.openInput("tests.bin10", IOContext.DEFAULT)) {
                 var msai = (MemorySegmentAccessInput) in;
-                var holder = MemorySegmentUtils.getContiguousMemorySegment(msai, dir, "tests.bin");
+                try (var holder = MemorySegmentUtils.getContiguousMemorySegment(msai, dir, "tests.bin12")) {
 
-                assertThat(holder, isA(MemorySegmentUtils.FileBackedMemorySegmentHolder.class));
-                assertNotNull(holder.memorySegment());
-                assertThat(holder.memorySegment().address(), is(not(0)));
-                assertArrayEquals(data, holder.memorySegment().toArray(ValueLayout.JAVA_BYTE));
+                    assertThat(holder, isA(MemorySegmentUtils.FileBackedMemorySegmentHolder.class));
+                    assertNotNull(holder.memorySegment());
+                    assertThat(holder.memorySegment().address(), is(not(0)));
+                    assertArrayEquals(data, holder.memorySegment().toArray(ValueLayout.JAVA_BYTE));
+                }
             }
         }
     }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/143391

Fixes https://github.com/elastic/elasticsearch/issues/143542