### PR TITLE
[9.3] apm-data: explicit map of timestamp.us to long (#143173)

### DIFF
--- a/docs/changelog/143173.yaml
+++ b/docs/changelog/143173.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 143173
+summary: "Apm-data: explicit map of `timestamp.us` to long"
+type: bug

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
@@ -17,3 +17,7 @@ template:
         type: constant_keyword
       data_stream.namespace:
         type: constant_keyword
+      timestamp:
+        properties:
+          us:
+            type: long

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 102
+version: 103
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
@@ -18,6 +18,36 @@ setup:
   - contains: {index_templates: {name: traces-apm.sampled@template}}
 
 ---
+# This is a regression test to avoid incurring in APM Server bug https://github.com/elastic/apm-server/issues/20496
+"Test apm timestamp.us mapping":
+  - do:
+      cluster.get_component_template:
+        name: apm@mappings
+  - match:
+      component_templates.0.component_template.template.mappings.properties.timestamp.properties.us.type: long
+
+---
+"Test apm timestamp.us coercion":
+  - do:
+      index:
+        index: traces-apm-timestampus
+        refresh: true
+        body:
+          "@timestamp": "2017-06-22T00:00:00Z"
+          data_stream.type: traces
+          data_stream.dataset: apm
+          data_stream.namespace: testing
+          timestamp:
+            us: 1772469840000000.0
+  - do:
+      search:
+        index: traces-apm-timestampus
+        body:
+          fields: ["timestamp.us"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.timestamp\.us: [1772469840000000] }
+
+---
 "Test metrics-apm* template installation":
   - skip:
       reason: contains is a newly added assertion


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [apm-data: explicit map of timestamp.us to long (#143173)](https://github.com/elastic/elasticsearch/pull/143173)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)