### PR TITLE
[Docs] Clarify wait for snapshot action in documentation

### DIFF
--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-wait-for-snapshot.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-wait-for-snapshot.md
@@ -7,7 +7,9 @@ mapped_pages:
 
 Phases allowed: delete.
 
-Waits for the specified {{slm-init}} policy to be executed before removing the index. This ensures that a snapshot of the deleted index is available.
+Waits for the specified {{slm-init}} policy to be executed before removing the index.
+This only checks that an SLM policy has had a successful execution at some point after the wait action has started.
+It does not ensure that a snapshot of the index is available before deletion.
 
 ## Options [ilm-wait-for-snapshot-options]
 


### PR DESCRIPTION
The current description of wait for snapshot was deemed misleading/ambiguous.

This PR recreates the changes in https://github.com/elastic/elasticsearch/pull/99934

[Docs preview](https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/143595/reference/elasticsearch/index-lifecycle-actions/ilm-wait-for-snapshot)

Ref: https://github.com/elastic/elasticsearch/issues/57809
