### PR TITLE
ESQL: Aggregates don't get pushed with splits with external data sources

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalPipelineBreakerComparisonTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalPipelineBreakerComparisonTests.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
+import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
+import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
+import org.elasticsearch.xpack.esql.datasources.FileSet;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.parser.EsqlParser;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.elasticsearch.xpack.esql.session.Versioned;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_SEARCH_STATS;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultEnrichResolution;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.indexResolutions;
+import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
+import static org.elasticsearch.xpack.esql.index.EsIndexGenerator.esIndex;
+
+/**
+ * Side-by-side comparison of the fully resolved physical plans for ES indices vs external sources.
+ * <p>
+ * Each test runs the same ES|QL query through the complete planning pipeline:
+ * parse → analyze → logical optimize → map → physical optimize → local plan (FragmentExec expansion)
+ * <p>
+ * The resulting plans show exactly what the compute engine would receive. For ES indices, the
+ * FragmentExec is expanded into the localized data-node plan (e.g., AggregateExec(INITIAL) →
+ * EsQueryExec). For external sources, no such expansion occurs because there is no FragmentExec.
+ * <p>
+ * These tests are expected to FAIL, demonstrating the gap: external sources lack the ExchangeExec
+ * that enables distributed execution.
+ */
+public class ExternalPipelineBreakerComparisonTests extends ESTestCase {
+
+    private static final String EXTERNAL_LOCATION = "s3://bucket/data/*.parquet";
+    private static final Configuration CONFIG = TEST_CFG;
+
+    // ======================== STATS ========================
+
+    /**
+     * {@code STATS count = COUNT(*) | LIMIT 100}
+     * <p>
+     * ES index:    LimitExec → AggregateExec[FINAL] → ExchangeExec → AggregateExec[INITIAL] → EsQueryExec
+     * External:    LimitExec → AggregateExec[SINGLE] → ExternalSourceExec
+     */
+    public void testStatsShouldDistributeForExternalSource() {
+        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+
+        String suffix = " | STATS count = COUNT(*) | LIMIT 100";
+        PhysicalPlan esPlan = planEs("FROM test" + suffix);
+        PhysicalPlan extPlan = planExternal("EXTERNAL \"" + EXTERNAL_LOCATION + "\"" + suffix);
+
+        assertPlanContainsExchange("STATS count = COUNT(*)", esPlan, extPlan);
+
+        AggregateExec esAgg = findFirst(esPlan, AggregateExec.class);
+        AggregateExec extAgg = findFirst(extPlan, AggregateExec.class);
+        assertNotNull("ES plan should have AggregateExec", esAgg);
+        assertNotNull("External plan should have AggregateExec", extAgg);
+        assertEquals(
+            formatComparison("STATS aggregator mode", esPlan, extPlan)
+                + "\nES index uses FINAL (two-phase), external source should too but uses SINGLE",
+            esAgg.getMode(),
+            extAgg.getMode()
+        );
+    }
+
+    /**
+     * {@code STATS avg = AVG(salary) BY gender | LIMIT 100} — grouped aggregation with surrogate decomposition.
+     */
+    public void testGroupedStatsShouldDistributeForExternalSource() {
+        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+
+        String suffix = " | STATS avg = AVG(salary) BY gender | LIMIT 100";
+        PhysicalPlan esPlan = planEs("FROM test" + suffix);
+        PhysicalPlan extPlan = planExternal("EXTERNAL \"" + EXTERNAL_LOCATION + "\"" + suffix);
+
+        assertPlanContainsExchange("STATS AVG(salary) BY gender", esPlan, extPlan);
+    }
+
+    // ======================== LIMIT ========================
+
+    /**
+     * {@code LIMIT 10}
+     * <p>
+     * ES index:    LimitExec → ExchangeExec → LimitExec → EsQueryExec
+     * External:    LimitExec → ExternalSourceExec
+     */
+    public void testLimitShouldDistributeForExternalSource() {
+        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+
+        PhysicalPlan esPlan = planEs("FROM test | LIMIT 10");
+        PhysicalPlan extPlan = planExternal("EXTERNAL \"" + EXTERNAL_LOCATION + "\" | LIMIT 10");
+
+        assertPlanContainsExchange("LIMIT 10", esPlan, extPlan);
+    }
+
+    // ======================== TopN (SORT + LIMIT) ========================
+
+    /**
+     * {@code SORT emp_no DESC | LIMIT 10}
+     * <p>
+     * ES index:    TopNExec → ExchangeExec → TopNExec → EsQueryExec
+     * External:    TopNExec → ExternalSourceExec
+     */
+    public void testTopNShouldDistributeForExternalSource() {
+        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+
+        PhysicalPlan esPlan = planEs("FROM test | SORT emp_no DESC | LIMIT 10");
+        PhysicalPlan extPlan = planExternal("EXTERNAL \"" + EXTERNAL_LOCATION + "\" | SORT emp_no DESC | LIMIT 10");
+
+        assertPlanContainsExchange("SORT emp_no DESC | LIMIT 10", esPlan, extPlan);
+    }
+
+    // ======================== Full planning pipeline ========================
+
+    private PhysicalPlan planEs(String query) {
+        return fullPlan(query, makeEsAnalyzer());
+    }
+
+    private PhysicalPlan planExternal(String query) {
+        return fullPlan(query, makeExternalAnalyzer());
+    }
+
+    /**
+     * Complete planning pipeline: parse → analyze → logical optimize → map → physical optimize → localize.
+     * <p>
+     * The localize step expands FragmentExec nodes into the actual data-node plan via LocalMapper,
+     * producing the plan exactly as the compute engine would receive it.
+     */
+    private PhysicalPlan fullPlan(String query, Analyzer analyzer) {
+        // 1. Parse
+        LogicalPlan parsed = EsqlParser.INSTANCE.parseQuery(query);
+
+        // 2. Analyze
+        LogicalPlan analyzed = analyzer.analyze(parsed);
+
+        // 3. Logical optimize
+        TransportVersion version = analyzer.context().minimumVersion();
+        LogicalPlanOptimizer logicalOptimizer = new LogicalPlanOptimizer(new LogicalOptimizerContext(CONFIG, FoldContext.small(), version));
+        LogicalPlan optimized = logicalOptimizer.optimize(analyzed);
+
+        // 4. Map (logical → physical)
+        PhysicalPlan physical = new Mapper().map(new Versioned<>(optimized, version));
+
+        // 5. Physical optimize + row size estimation
+        PhysicalPlanOptimizer physicalOptimizer = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(CONFIG, version));
+        PhysicalPlan optimizedPhysical = EstimatesRowSize.estimateRowSize(0, physicalOptimizer.optimize(physical));
+
+        // 6. Localize — expand FragmentExec into the actual data-node plan (LocalMapper + local optimizers).
+        // This is the plan that the compute engine receives.
+        PhysicalPlan localized = optimizedPhysical.transformUp(FragmentExec.class, fragment -> {
+            var flags = new EsqlFlags(true);
+            var localPlan = PlannerUtils.localPlan(
+                PlannerSettings.DEFAULTS,
+                flags,
+                CONFIG,
+                FoldContext.small(),
+                fragment,
+                TEST_SEARCH_STATS,
+                null
+            );
+            return EstimatesRowSize.estimateRowSize(fragment.estimatedRowSize(), localPlan);
+        });
+
+        // 7. Align local reduction outputs with exchange expectations
+        return localized.transformUp(ExchangeExec.class, exg -> {
+            if (exg.inBetweenAggs() && exg.child() instanceof LocalSourceExec lse) {
+                var output = exg.output();
+                if (lse.output().equals(output) == false) {
+                    return exg.replaceChild(new LocalSourceExec(lse.source(), output, lse.supplier()));
+                }
+            }
+            return exg;
+        });
+    }
+
+    // ======================== Analyzer setup ========================
+
+    private static Analyzer makeEsAnalyzer() {
+        var mapping = loadMapping("mapping-basic.json");
+        var index = esIndex("test", mapping, Map.of("test", org.elasticsearch.index.IndexMode.STANDARD));
+        return new Analyzer(
+            new AnalyzerContext(
+                CONFIG,
+                new EsqlFunctionRegistry(),
+                null,
+                indexResolutions(index),
+                Map.of(),
+                defaultEnrichResolution(),
+                emptyInferenceResolution(),
+                ExternalSourceResolution.EMPTY,
+                TransportVersion.current(),
+                UnmappedResolution.FAIL
+            ),
+            TEST_VERIFIER
+        );
+    }
+
+    private static Analyzer makeExternalAnalyzer() {
+        List<Attribute> schema = List.of(
+            new FieldAttribute(EMPTY, "emp_no", new EsField("emp_no", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)),
+            new FieldAttribute(EMPTY, "salary", new EsField("salary", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)),
+            new FieldAttribute(EMPTY, "gender", new EsField("gender", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+        );
+
+        ExternalSourceMetadata metadata = new ExternalSourceMetadata() {
+            @Override
+            public String location() {
+                return EXTERNAL_LOCATION;
+            }
+
+            @Override
+            public List<Attribute> schema() {
+                return schema;
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+        };
+
+        var resolvedSource = new ExternalSourceResolution.ResolvedSource(metadata, FileSet.UNRESOLVED);
+        var externalResolution = new ExternalSourceResolution(Map.of(EXTERNAL_LOCATION, resolvedSource));
+
+        return new Analyzer(
+            new AnalyzerContext(
+                CONFIG,
+                new EsqlFunctionRegistry(),
+                null,
+                Map.of(),
+                Map.of(),
+                new EnrichResolution(),
+                emptyInferenceResolution(),
+                externalResolution,
+                TransportVersion.current(),
+                UnmappedResolution.FAIL
+            ),
+            TEST_VERIFIER
+        );
+    }
+
+    // ======================== Assertions & formatting ========================
+
+    private static boolean containsExchange(PhysicalPlan plan) {
+        return plan.anyMatch(node -> node instanceof ExchangeExec);
+    }
+
+    private static void assertPlanContainsExchange(String query, PhysicalPlan esPlan, PhysicalPlan extPlan) {
+        assertTrue(
+            "BUG IN TEST: ES index plan for [" + query + "] should contain ExchangeExec but doesn't:\n" + esPlan,
+            containsExchange(esPlan)
+        );
+
+        assertTrue(
+            formatComparison(query, esPlan, extPlan)
+                + "\nExternal source plan should contain ExchangeExec for distributed execution, like ES indices",
+            containsExchange(extPlan)
+        );
+    }
+
+    private static String formatComparison(String query, PhysicalPlan esPlan, PhysicalPlan extPlan) {
+        return "\n========================================\n"
+            + "  Query: "
+            + query
+            + "\n========================================\n"
+            + "\n--- ES Index (FROM test) ---\n"
+            + esPlan
+            + "\n\n--- External Source (EXTERNAL \"s3://...\") ---\n"
+            + extPlan
+            + "\n";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T findFirst(PhysicalPlan plan, Class<T> type) {
+        var holder = new Object() {
+            T found = null;
+        };
+        plan.forEachDown(node -> {
+            if (holder.found == null && type.isInstance(node)) {
+                holder.found = type.cast(node);
+            }
+        });
+        return holder.found;
+    }
+}


### PR DESCRIPTION
## Problem

### How ES indices distribute pipeline breakers

The physical planning pipeline has three stages:

1. **Mapper (coordinator)** — converts the logical plan into a physical plan. For ES indices, the leaf node (`EsRelation`) becomes a `FragmentExec` — a placeholder that carries the logical subtree to data nodes. When a pipeline breaker (STATS, LIMIT, TopN) sits above a `FragmentExec`, the Mapper wraps it in an `ExchangeExec`, creating the coordinator/data-node boundary:

    ```java
    private PhysicalPlan addExchangeForFragment(LogicalPlan logical, PhysicalPlan child) {
        if (child instanceof FragmentExec) {
            child = new FragmentExec(logical);         // include the breaker in the fragment
            child = new ExchangeExec(child.source(), child);  // mark the boundary
        }
        return child;
    }
    ```

    After this stage, the plan looks like:
    ```
    AggregateExec[FINAL] → ExchangeExec → FragmentExec(Aggregate → EsRelation)
    ```

2. **Plan breaking (coordinator)** — `breakPlanBetweenCoordinatorAndDataNode` splits the plan at the `ExchangeExec`. The subtree below it (containing the `FragmentExec`) is sent to data nodes.

3. **Local planning (data node)** — each data node receives the `FragmentExec` and expands it via `LocalMapper` into concrete physical operators — e.g., `AggregateExec(INITIAL)` and `EsQueryExec`. `FragmentExec` disappears at this point; it was the vehicle that carried the pipeline breaker to the data node.

The plan examples below show the result after all three stages — the fully expanded plans that the compute engine executes.

### How external sources differ

`ExternalRelation` maps directly to `ExternalSourceExec` — a concrete physical operator, not a `FragmentExec` placeholder. The `instanceof FragmentExec` check is always false, the exchange is never inserted, and pipeline breakers stay on the coordinator:

```
PipelineBreaker → ExternalSourceExec
```

External sources distribute their **read work** across data nodes via splits and the adaptive strategy, but this distribution is encapsulated inside `ExternalSourceExec` — invisible to the plan structure above it. Pipeline breakers sit above the source and execute as single coordinator-only operations.

### Plan examples

These are the fully expanded physical plans after all three stages — `FragmentExec` has been replaced by the concrete data-node operators it carried. This is what the compute engine executes.

**`STATS count = COUNT(*)`**

ES Index:
```
LimitExec[100]
\_AggregateExec[FINAL]                          ← coordinator merges partial counts
  \_ExchangeExec                                 ← coordinator/data-node boundary
    \_EsStatsQueryExec[test, COUNT]              ← data node: count pushed to Lucene
```

External Source:
```
LimitExec[100]
\_AggregateExec[SINGLE]                          ← coordinator does everything
  \_ExternalSourceExec[s3://bucket/data/*.parquet]
```

**`STATS avg = AVG(salary) BY gender`**

ES Index:
```
ProjectExec → EvalExec[SUM/COUNT] → LimitExec
\_AggregateExec[FINAL]                           ← coordinator merges partials
  \_ExchangeExec                                  ← coordinator/data-node boundary
    \_AggregateExec[INITIAL]                      ← data node: partial SUM + COUNT
      \_FieldExtractExec → EsQueryExec
```

External Source:
```
ProjectExec → EvalExec[SUM/COUNT] → LimitExec
\_AggregateExec[SINGLE]                           ← coordinator does full aggregation
  \_ExternalSourceExec[s3://bucket/data/*.parquet]
```

**`SORT emp_no DESC | LIMIT 10`**

ES Index:
```
TopNExec[emp_no DESC, 10]                        ← coordinator merges top-10s
\_ExchangeExec                                    ← coordinator/data-node boundary
  \_ProjectExec → FieldExtractExec
    \_EsQueryExec[limit=10, sort=emp_no DESC]     ← data node: local top-10
```

External Source:
```
TopNExec[emp_no DESC, 10]                        ← coordinator sorts everything
\_ExternalSourceExec[s3://bucket/data/*.parquet]
```

**`LIMIT 10`**

ES Index:
```
LimitExec[10]
\_ExchangeExec                                    ← coordinator/data-node boundary
  \_ProjectExec → FieldExtractExec
    \_EsQueryExec[limit=10]                       ← data node: reads only 10 rows
```

External Source:
```
LimitExec[10]
\_ExternalSourceExec[s3://bucket/data/*.parquet]
```

### Consequences

**STATS with GROUP BY** runs in `SINGLE` mode on the coordinator instead of `INITIAL`/`FINAL` across data nodes. In SINGLE mode, `HashAggregationOperator.shouldEmitPartialResultsPeriodically()` is disabled (`isOutputPartial()` returns false), so all group keys and accumulator state are held in coordinator memory until the query completes. For high-cardinality groupings on large external datasets, this leads to OOM. In INITIAL mode (ES indices), the operator periodically flushes and reinitializes its state, bounding memory usage.

**STATS without GROUP BY** has no OOM risk (fixed-size accumulator state regardless of mode), but all data still streams through a single node with no parallelism.

**LIMIT** is memory-safe (the `LimitOperator` stops consuming once the limit is reached), but without an exchange there is no data-node-side limit to cap reads early. `LIMIT 10` on a large dataset reads all data from object storage, deserializes it, and discards everything beyond 10 rows.

**TopN (SORT + LIMIT)** is memory-safe (fixed-size min-heap bounded by the limit), but without distribution every row flows through the coordinator for heap comparison. Each data node could sort locally and send only the top N rows; instead, the coordinator processes all rows single-threaded.

### Suggested approach

The Mapper should produce two-phase physical plans for external sources directly, without using `FragmentExec`. When a pipeline breaker's child is an `ExternalSourceExec`, the Mapper creates the INITIAL-mode operator below an `ExchangeExec` and the FINAL-mode operator above it — the same plan structure as ES indices, but built in one step rather than deferring to `LocalMapper` on data nodes. For LIMIT and TopN, it pushes a copy of the operator below the exchange.

`FragmentExec` is not needed here because external sources don't require per-node re-planning. Unlike ES shards, there is no per-split variation in capabilities that would change the plan structure — the coordinator knows everything it needs to build the data-node plan upfront.

The existing `collapseExternalSourceExchanges` method already handles the non-distributed fallback: when the adaptive strategy decides not to distribute (single split, small dataset), it strips the exchange and the plan collapses back to coordinator-only execution.

### Tests

The attached `ExternalPipelineBreakerComparisonTests` demonstrate the problem. Each test runs the same ES|QL query through the complete planning pipeline for both `FROM test` (ES index) and `EXTERNAL "s3://..."` (external source), using the same field schema, and asserts the external source plan should contain an `ExchangeExec`.

The tests intentionally fail. Run with:

```
./gradlew :x-pack:plugin:esql:test --tests "org.elasticsearch.xpack.esql.plugin.ExternalPipelineBreakerComparisonTests"
```

## Test plan

- [x] `ExternalDistributionTests` (existing, 11 tests) — still pass
- [x] `ExternalPipelineBreakerComparisonTests` (new, 4 tests) — intentionally fail, demonstrating the gap
