### PR TITLE
[Test] Add test for sequence number pruning with synthetic ids

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
@@ -10,7 +10,10 @@
 package org.elasticsearch.datastreams;
 
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.DocWriteRequest;
@@ -50,6 +53,7 @@ import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
@@ -59,6 +63,7 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.seqno.RetentionLease;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
@@ -1171,6 +1176,190 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         }
 
         assertShardsHaveNoIdStoredFieldValuesOnDisk(indices);
+    }
+
+    public void testSeqNoFieldsPrunedDuringMerge() throws Exception {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
+        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
+
+        final var dataStreamName = randomIdentifier();
+        putDataStreamTemplate(
+            dataStreamName,
+            1,
+            0,
+            Settings.builder()
+                .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+                .put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), "100ms")
+                .build()
+        );
+
+        final var docsIndexByIds = new ConcurrentHashMap<String, String>();
+        var timestamp = Instant.now();
+        logger.info("--> timestamp is {} (epoch: {})", timestamp, timestamp.toEpochMilli());
+
+        final int nbBulks = randomIntBetween(12, 20);
+        final int nbDocs = randomIntBetween(100, 1_000);
+
+        for (int i = 0; i < nbBulks; i++) {
+            var client = client();
+            var bulkRequest = client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            for (int j = 0; j < nbDocs; j++) {
+                bulkRequest.add(
+                    client.prepareIndex(dataStreamName).setOpType(DocWriteRequest.OpType.CREATE).setSource(String.format(Locale.ROOT, """
+                        {"@timestamp": "%s", "hostname": "%s", "metric": {"field": "metric_%d", "value": %d}}
+                        """, timestamp, "vm-test-" + randomIntBetween(0, 4), randomIntBetween(0, 1), randomInt()), XContentType.JSON)
+                );
+                timestamp = timestamp.plusMillis(10);
+            }
+
+            var bulkResponse = bulkRequest.get();
+            assertNoFailures(bulkResponse);
+            for (var result : bulkResponse.getItems()) {
+                assertThat(result.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
+                assertThat(result.getVersion(), equalTo(1L));
+                docsIndexByIds.put(result.getId(), result.getIndex());
+            }
+        }
+
+        var indices = new HashSet<>(docsIndexByIds.values());
+
+        // Delete some random docs, keeping a mapping of deleted doc id -> index for later assertions
+        var deletedDocIndices = new HashMap<String, String>();
+        var deletedDocs = deleteRandomDocuments(new HashMap<>(docsIndexByIds));
+        for (var docId : deletedDocs) {
+            deletedDocIndices.put(docId, docsIndexByIds.remove(docId));
+        }
+
+        refresh(dataStreamName);
+
+        // Before merge: _seq_no doc values should be present at the Lucene level
+        assertShardsHaveSeqNoFieldOnDisk(indices);
+
+        for (var index : indices) {
+            long segmentsCount = indicesAdmin().prepareStats(index).clear().setSegments(true).get().getPrimaries().getSegments().getCount();
+            assertThat("index [" + index + "] has " + segmentsCount + " segments", segmentsCount, greaterThan(1L));
+        }
+
+        flush(dataStreamName);
+
+        // Wait for the peer recovery retention leases to advance past all indexed documents.
+        // Until these leases advance, the soft-deletes retention query matches all docs and
+        // prevents the merge policy from pruning _seq_no doc values.
+        final long expectedRetainingSeqNo = (long) nbBulks * nbDocs + deletedDocs.size();
+        assertBusy(() -> {
+            for (var indicesServices : internalCluster().getDataNodeInstances(IndicesService.class)) {
+                for (var indexService : indicesServices) {
+                    if (indices.contains(indexService.index().getName())) {
+                        for (var indexShard : indexService) {
+                            for (RetentionLease lease : indexShard.getRetentionLeases().leases()) {
+                                assertThat(
+                                    "retention lease [" + lease.id() + "] should have advanced",
+                                    lease.retainingSequenceNumber(),
+                                    equalTo(expectedRetainingSeqNo)
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        var forceMerge = indicesAdmin().prepareForceMerge(indices.toArray(String[]::new)).setMaxNumSegments(1).get();
+        assertThat(forceMerge.getFailedShards(), equalTo(0));
+
+        for (var index : indices) {
+            long segmentsCount = indicesAdmin().prepareStats(index).clear().setSegments(true).get().getPrimaries().getSegments().getCount();
+            assertThat("index [" + index + "] has " + segmentsCount + " segments", segmentsCount, equalTo(1L));
+        }
+
+        refresh(dataStreamName);
+
+        // After merge: documents should still be accessible via GET
+        var randomDocsAfter = randomSubsetOf(randomIntBetween(1, Math.min(10, docsIndexByIds.size())), docsIndexByIds.keySet());
+        for (var docId : randomDocsAfter) {
+            var getResponse = client().prepareGet(docsIndexByIds.get(docId), docId).setRealtime(false).get();
+            assertThat("Doc [" + docId + "] should still exist after merge", getResponse.isExists(), equalTo(true));
+        }
+
+        // After merge: documents should still be accessible via search
+        assertHitCount(client().prepareSearch(dataStreamName).setTrackTotalHits(true).setSize(0), docsIndexByIds.size());
+
+        // Deleted docs should not be found
+        for (var docId : randomSubsetOf(randomIntBetween(1, Math.min(5, deletedDocs.size())), deletedDocs)) {
+            var getResponse = client().prepareGet(deletedDocIndices.get(docId), docId).setRealtime(false).get();
+            assertThat("Deleted doc [" + docId + "] should not exist", getResponse.isExists(), equalTo(false));
+        }
+
+        // After merge: _seq_no doc values and points should be absent at the Lucene level
+        assertShardsHaveNoIdStoredFieldValuesOnDisk(indices);
+        assertShardsHaveNoSeqNoFieldOnDisk(indices);
+    }
+
+    private static void assertShardsHaveNoSeqNoFieldOnDisk(Set<String> indices) {
+        int nbVisitedShards = 0;
+        for (var indicesServices : internalCluster().getDataNodeInstances(IndicesService.class)) {
+            for (var indexService : indicesServices) {
+                if (indices.contains(indexService.index().getName())) {
+                    for (var indexShard : indexService) {
+                        indexShard.withEngineOrNull(engine -> {
+                            if (engine != null) {
+                                try (var searcher = engine.acquireSearcher("assert_no_seq_no_field")) {
+                                    for (var leaf : searcher.getLeafContexts()) {
+                                        var leafReader = leaf.reader();
+
+                                        NumericDocValues seqNoDV = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                                        if (seqNoDV != null) {
+                                            assertThat(
+                                                "_seq_no doc values should be empty after merge",
+                                                seqNoDV.nextDoc(),
+                                                equalTo(DocIdSetIterator.NO_MORE_DOCS)
+                                            );
+                                        }
+
+                                        PointValues seqNoPoints = leafReader.getPointValues(SeqNoFieldMapper.NAME);
+                                        assertThat("_seq_no point values should be null after merge", seqNoPoints, nullValue());
+                                    }
+                                } catch (IOException ioe) {
+                                    throw new AssertionError(ioe);
+                                }
+                            }
+                            return null;
+                        });
+                        nbVisitedShards++;
+                    }
+                }
+            }
+        }
+        assertThat("Expect at least 1 shard per index to be verified", nbVisitedShards, greaterThanOrEqualTo(indices.size()));
+    }
+
+    private static void assertShardsHaveSeqNoFieldOnDisk(Set<String> indices) {
+        int nbVisitedShards = 0;
+        for (var indicesServices : internalCluster().getDataNodeInstances(IndicesService.class)) {
+            for (var indexService : indicesServices) {
+                if (indices.contains(indexService.index().getName())) {
+                    for (var indexShard : indexService) {
+                        indexShard.withEngineOrNull(engine -> {
+                            if (engine != null) {
+                                try (var searcher = engine.acquireSearcher("assert_has_seq_no_field")) {
+                                    for (var leaf : searcher.getLeafContexts()) {
+                                        var leafReader = leaf.reader();
+                                        NumericDocValues seqNoDV = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                                        assertThat("_seq_no doc values should be present before merge", seqNoDV, notNullValue());
+                                        assertThat(seqNoDV.nextDoc(), not(equalTo(DocIdSetIterator.NO_MORE_DOCS)));
+                                    }
+                                } catch (IOException ioe) {
+                                    throw new AssertionError(ioe);
+                                }
+                            }
+                            return null;
+                        });
+                        nbVisitedShards++;
+                    }
+                }
+            }
+        }
+        assertThat("Expect at least 1 shard per index to be verified", nbVisitedShards, greaterThanOrEqualTo(indices.size()));
     }
 
     private static long documentCount(String dataStreamName) {

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -913,11 +913,12 @@ public abstract class Engine implements Closeable {
 
     protected final GetResult getFromSearcher(Get get, Engine.Searcher searcher, boolean uncachedLookup) throws EngineException {
         final DocIdAndVersion docIdAndVersion;
+        final boolean loadSeqNo = engineConfig.getIndexSettings().sequenceNumbersDisabled() == false;
         try {
             if (uncachedLookup) {
-                docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersionUncached(searcher.getIndexReader(), get.uid(), true);
+                docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersionUncached(searcher.getIndexReader(), get.uid(), loadSeqNo);
             } else {
-                docIdAndVersion = VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(searcher.getIndexReader(), get.uid(), true);
+                docIdAndVersion = VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(searcher.getIndexReader(), get.uid(), loadSeqNo);
             }
         } catch (Exception e) {
             Releasables.closeWhileHandlingException(searcher);

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2805,16 +2805,19 @@ public class InternalEngine extends Engine {
         MergePolicy mergePolicy = config().getMergePolicy();
         // always configure soft-deletes field so an engine with soft-deletes disabled can open a Lucene index with soft-deletes.
         iwc.setSoftDeletesField(Lucene.SOFT_DELETES_FIELD);
+        final boolean pruneSeqNo = engineConfig.getIndexSettings().sequenceNumbersDisabled();
+        final var seqNoIndexOptions = engineConfig.getIndexSettings().seqNoIndexOptions();
         mergePolicy = new RecoverySourcePruneMergePolicy(
             engineConfig.getIndexSettings().isRecoverySourceSyntheticEnabled() ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME,
             engineConfig.getIndexSettings().isRecoverySourceSyntheticEnabled()
                 ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME
                 : SourceFieldMapper.RECOVERY_SOURCE_NAME,
             engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES,
-            () -> softDeletesPolicy.getRetentionQuery(engineConfig.getIndexSettings().seqNoIndexOptions()),
+            pruneSeqNo,
+            () -> softDeletesPolicy.getRetentionQuery(seqNoIndexOptions),
             new SoftDeletesRetentionMergePolicy(
                 Lucene.SOFT_DELETES_FIELD,
-                () -> softDeletesPolicy.getRetentionQuery(engineConfig.getIndexSettings().seqNoIndexOptions()),
+                () -> softDeletesPolicy.getRetentionQuery(seqNoIndexOptions),
                 useTsdbSyntheticId ? mergePolicy : new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME)
             ),
             engineConfig.getIndexSettings().useTimeSeriesSyntheticId()

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.FieldInfo;
@@ -18,6 +19,7 @@ import org.apache.lucene.index.FilterNumericDocValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.OneMergeWrappingMergePolicy;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.search.ConjunctionUtils;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -32,6 +34,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.codec.FilterDocValuesProducer;
 import org.elasticsearch.index.codec.storedfields.TSDBStoredFieldsFormat;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.search.internal.FilterStoredFieldVisitor;
 
 import java.io.IOException;
@@ -43,6 +46,7 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         @Nullable String pruneStoredFieldName,
         String pruneNumericDVFieldName,
         boolean pruneIdField,
+        boolean pruneSeqNo,
         Supplier<Query> retainSourceQuerySupplier,
         MergePolicy in,
         boolean useSyntheticId
@@ -55,6 +59,7 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
                     pruneStoredFieldName,
                     pruneNumericDVFieldName,
                     pruneIdField,
+                    pruneSeqNo,
                     wrapped,
                     retainSourceQuerySupplier,
                     useSyntheticId
@@ -67,16 +72,20 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         String pruneStoredFieldName,
         String pruneNumericDVFieldName,
         boolean pruneIdField,
+        boolean pruneSeqNo,
         CodecReader reader,
         Supplier<Query> retainSourceQuerySupplier,
         boolean useSyntheticId
     ) throws IOException {
         NumericDocValues recoverySource = reader.getNumericDocValues(pruneNumericDVFieldName);
-        if (recoverySource == null || recoverySource.nextDoc() == DocIdSetIterator.NO_MORE_DOCS) {
+        final boolean hasRecoverySource = recoverySource != null && recoverySource.nextDoc() != DocIdSetIterator.NO_MORE_DOCS;
+        NumericDocValues seqNoDocValues = reader.getNumericDocValues(SeqNoFieldMapper.NAME);
+        final boolean hasSeqNo = pruneSeqNo && seqNoDocValues != null && seqNoDocValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS;
+        if (hasRecoverySource == false && hasSeqNo == false) {
             if (useSyntheticId) {
                 return unwrapSyntheticIdStoredFieldsReader(reader);
             }
-            return reader;  // early terminate - nothing to do here since none of the docs has a recovery source anymore.
+            return reader;  // early terminate - nothing to do here
         }
         IndexSearcher s = new IndexSearcher(reader);
         s.setQueryCache(null);
@@ -92,19 +101,21 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
                 }
                 return reader; // keep all source
             }
-            return new SourcePruningFilterCodecReader(
+            return new PruningFilterCodecReader(
                 pruneStoredFieldName,
                 pruneNumericDVFieldName,
                 pruneIdField,
+                pruneSeqNo,
                 reader,
                 recoverySourceToKeep,
                 useSyntheticId
             );
         } else {
-            return new SourcePruningFilterCodecReader(
+            return new PruningFilterCodecReader(
                 pruneStoredFieldName,
                 pruneNumericDVFieldName,
                 pruneIdField,
+                pruneSeqNo,
                 reader,
                 null,
                 useSyntheticId
@@ -112,17 +123,19 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         }
     }
 
-    private static class SourcePruningFilterCodecReader extends FilterCodecReader {
+    private static class PruningFilterCodecReader extends FilterCodecReader {
         private final BitSet recoverySourceToKeep;
         private final String pruneStoredFieldName;
         private final String pruneNumericDVFieldName;
         private final boolean pruneIdField;
+        private final boolean pruneSeqNo;
         private final boolean useSyntheticId;
 
-        SourcePruningFilterCodecReader(
+        PruningFilterCodecReader(
             @Nullable String pruneStoredFieldName,
             String pruneNumericDVFieldName,
             boolean pruneIdField,
+            boolean pruneSeqNo,
             CodecReader reader,
             BitSet recoverySourceToKeep,
             boolean useSyntheticId
@@ -132,7 +145,15 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             this.recoverySourceToKeep = recoverySourceToKeep;
             this.pruneNumericDVFieldName = pruneNumericDVFieldName;
             this.pruneIdField = pruneIdField;
+            this.pruneSeqNo = pruneSeqNo;
             this.useSyntheticId = useSyntheticId;
+        }
+
+        private boolean shouldPruneNumericDocValues(String fieldName) {
+            if (fieldName.equals(pruneNumericDVFieldName)) {
+                return true;
+            }
+            return pruneSeqNo && fieldName.equals(SeqNoFieldMapper.NAME);
         }
 
         @Override
@@ -142,11 +163,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
                 @Override
                 public NumericDocValues getNumeric(FieldInfo field) throws IOException {
                     NumericDocValues numeric = super.getNumeric(field);
-                    if (field.name.equals(pruneNumericDVFieldName)) {
-                        assert numeric != null : pruneNumericDVFieldName + " must have numeric DV but was null";
+                    if (shouldPruneNumericDocValues(field.name)) {
+                        assert numeric != null : field.name + " must have numeric doc values but was null";
                         final DocIdSetIterator intersection;
                         if (recoverySourceToKeep == null) {
-                            // we can't return null here lucenes DocIdMerger expects an instance
+                            // we can't return null here Lucene's DocIdMerger expects an instance
                             intersection = DocIdSetIterator.empty();
                         } else {
                             intersection = ConjunctionUtils.intersectIterators(
@@ -177,6 +198,33 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         }
 
         @Override
+        public PointsReader getPointsReader() {
+            final var pointsReader = super.getPointsReader();
+            if (pruneSeqNo == false || pointsReader == null) {
+                return pointsReader;
+            }
+            return new PointsReader() {
+                @Override
+                public PointValues getValues(String field) throws IOException {
+                    if (SeqNoFieldMapper.NAME.equals(field)) {
+                        return null;
+                    }
+                    return pointsReader.getValues(field);
+                }
+
+                @Override
+                public void checkIntegrity() throws IOException {
+                    pointsReader.checkIntegrity();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    pointsReader.close();
+                }
+            };
+        }
+
+        @Override
         public StoredFieldsReader getFieldsReader() {
             StoredFieldsReader fieldsReader = super.getFieldsReader();
             if (useSyntheticId && fieldsReader instanceof TSDBStoredFieldsFormat.TSDBStoredFieldsReader tsdbReader) {
@@ -185,13 +233,7 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             if (pruneStoredFieldName == null && pruneIdField == false && useSyntheticId == false) {
                 return fieldsReader;
             }
-            return new RecoverySourcePruningStoredFieldsReader(
-                fieldsReader,
-                recoverySourceToKeep,
-                pruneStoredFieldName,
-                pruneIdField,
-                useSyntheticId
-            );
+            return new PruningStoredFieldsReader(fieldsReader, recoverySourceToKeep, pruneStoredFieldName, pruneIdField, useSyntheticId);
         }
 
         @Override
@@ -204,14 +246,14 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             return null;
         }
 
-        private static class RecoverySourcePruningStoredFieldsReader extends FilterStoredFieldsReader {
+        private static class PruningStoredFieldsReader extends FilterStoredFieldsReader {
 
             private final BitSet recoverySourceToKeep;
             private final String recoverySourceField;
             private final boolean pruneIdField;
             private final boolean useSyntheticId;
 
-            RecoverySourcePruningStoredFieldsReader(
+            PruningStoredFieldsReader(
                 StoredFieldsReader in,
                 BitSet recoverySourceToKeep,
                 @Nullable String recoverySourceField,
@@ -252,7 +294,7 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
             @Override
             public StoredFieldsReader getMergeInstance() {
-                return new RecoverySourcePruningStoredFieldsReader(
+                return new PruningStoredFieldsReader(
                     in.getMergeInstance(),
                     recoverySourceToKeep,
                     recoverySourceField,
@@ -263,13 +305,7 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
             @Override
             public StoredFieldsReader clone() {
-                return new RecoverySourcePruningStoredFieldsReader(
-                    in.clone(),
-                    recoverySourceToKeep,
-                    recoverySourceField,
-                    pruneIdField,
-                    useSyntheticId
-                );
+                return new PruningStoredFieldsReader(in.clone(), recoverySourceToKeep, recoverySourceField, pruneIdField, useSyntheticId);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/SeqNoPrimaryTermPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/SeqNoPrimaryTermPhase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.search.fetch.FetchContext;
@@ -49,9 +50,12 @@ public final class SeqNoPrimaryTermPhase implements FetchSubPhase {
                 // we have to check the primary term field as it is only assigned for non-nested documents
                 if (primaryTermField != null && primaryTermField.advanceExact(docId)) {
                     boolean found = seqNoField.advanceExact(docId);
-                    assert found : "found seq no for " + docId + " but not a primary term";
-                    seqNo = seqNoField.longValue();
-                    primaryTerm = primaryTermField.longValue();
+                    assert found || IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
+                        : "found primary term for " + docId + " but no seq no";
+                    if (found) { // TODO This is brittle, use IndexSettings.DISABLE_SEQUENCE_NUMBERS
+                        seqNo = seqNoField.longValue();
+                        primaryTerm = primaryTermField.longValue();
+                    }
                 }
                 hitContext.hit().setSeqNo(seqNo);
                 hitContext.hit().setPrimaryTerm(primaryTerm);

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.NullInfoStream;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.TsidBuilder;
@@ -51,6 +52,7 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.MapperTestUtils;
 import org.elasticsearch.index.codec.LegacyPerFieldMapperCodec;
 import org.elasticsearch.index.codec.storedfields.TSDBStoredFieldsFormat;
@@ -58,6 +60,8 @@ import org.elasticsearch.index.codec.tsdb.ES93TSDBDefaultCompressionLucene103Cod
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdStoredFieldsReader;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.LuceneDocument;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
@@ -65,6 +69,7 @@ import org.elasticsearch.index.mapper.TsidExtractingIdFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.io.IOException;
@@ -81,7 +86,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
@@ -94,6 +102,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         syntheticRecoverySource ? null : "extra_source",
                         syntheticRecoverySource ? "extra_source_size" : "extra_source",
                         pruneIdField,
+                        false,
                         () -> Queries.NO_DOCS_INSTANCE,
                         newLogMergePolicy(),
                         false
@@ -186,6 +195,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                             syntheticRecoverySource ? null : "extra_source",
                             syntheticRecoverySource ? "extra_source_size" : "extra_source",
                             pruneIdField,
+                            false,
                             () -> new TermQuery(new Term("even", "true")),
                             iwc.getMergePolicy(),
                             false
@@ -262,6 +272,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         syntheticRecoverySource ? null : "extra_source",
                         syntheticRecoverySource ? "extra_source_size" : "extra_source",
                         false,
+                        false,
                         () -> Queries.ALL_DOCS_INSTANCE,
                         iwc.getMergePolicy(),
                         false
@@ -304,53 +315,42 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         }
     }
 
-    public void testSkipSyntheticIdStoredFieldValuesDuringMerges() throws IOException {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(true, true, true);
+    public void testTimeSeriesForceMergeToOneSegment() throws IOException {
+        final var values = List.of(true, false);
+        for (boolean useSyntheticId : values) {
+            for (boolean pruneId : values) {
+                for (boolean pruneSequenceNumber : values) {
+                    for (boolean useSyntheticRecoverySource : values) {
+                        runTimeSeriesForceMergeToOneSegment(useSyntheticId, pruneId, pruneSequenceNumber, useSyntheticRecoverySource);
+                    }
+                }
+            }
+        }
     }
 
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoSyntheticRecoverySource() throws IOException {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(true, true, false);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoIdPruning() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(true, false, true);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoIdPruningNoSyntheticRecoverySource() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(true, false, false);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoSyntheticId() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(false, true, true);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoSyntheticIdNoSyntheticRecoverySource() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(false, true, false);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoSyntheticIdNoIdPruning() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(false, false, true);
-    }
-
-    public void testSkipSyntheticIdStoredFieldValuesDuringMergesNoSyntheticIdNoIdPruningNoSyntheticRecoverySource() throws Exception {
-        runTestSkipSyntheticIdStoredFieldValuesDuringMerges(false, false, true);
-    }
-
-    private void runTestSkipSyntheticIdStoredFieldValuesDuringMerges(
+    private void runTimeSeriesForceMergeToOneSegment(
         final boolean useSyntheticId,
-        final boolean pruneIdField,
-        final boolean syntheticRecoverySource
+        final boolean pruneId,
+        final boolean pruneSequenceNumber,
+        final boolean useSyntheticRecoverySource
     ) throws IOException {
         try (var dir = newDirectory()) {
             dir.setCheckIndexOnClose(false);
 
-            var iwc = createIndexWriterConfig(useSyntheticId);
+            final int nbDocs = randomIntBetween(50, 150);
+            final long minRetainedSeqNo = randomInt(nbDocs);
+            final long primaryTerm = randomNonNegativeLong();
+
+            final var indexSettings = timeSeriesIndexSettings(useSyntheticId, pruneSequenceNumber);
+            final var seqNoIndexOptions = IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.get(indexSettings.getSettings());
+            var iwc = createIndexWriterConfig(indexSettings);
             iwc.setMergePolicy(
                 new RecoverySourcePruneMergePolicy(
-                    syntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME,
-                    syntheticRecoverySource ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME : SourceFieldMapper.RECOVERY_SOURCE_NAME,
-                    pruneIdField,
-                    () -> NumericDocValuesField.newSlowExactQuery("retained", 1),
+                    useSyntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME,
+                    useSyntheticRecoverySource ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME : SourceFieldMapper.RECOVERY_SOURCE_NAME,
+                    pruneId,
+                    pruneSequenceNumber,
+                    () -> SeqNoFieldMapper.rangeQueryForSeqNo(seqNoIndexOptions, minRetainedSeqNo, Long.MAX_VALUE),
                     iwc.getMergePolicy(),
                     useSyntheticId
                 )
@@ -360,12 +360,20 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                 final int routingHash = randomIntBetween(0, 10);
                 final Instant now = Instant.now();
 
-                for (int i = 0; i < 100; i++) {
-                    if (i > 0 && randomBoolean()) {
+                for (int seqNo = 0; seqNo < nbDocs; seqNo++) {
+                    if (seqNo > 0 && randomBoolean()) {
                         writer.flush();
                     }
-                    var doc = newDocument(useSyntheticId, syntheticRecoverySource, routingHash, now.plusMillis(i).toEpochMilli());
-                    doc.add(new NumericDocValuesField("retained", randomInt(1)));
+                    var doc = newDocument(
+                        useSyntheticId,
+                        useSyntheticRecoverySource,
+                        seqNoIndexOptions,
+                        seqNo,
+                        primaryTerm,
+                        routingHash,
+                        now.plusMillis(seqNo).toEpochMilli()
+                    );
+                    doc.add(new NumericDocValuesField("retained", seqNo >= minRetainedSeqNo ? 1 : 0));
                     writer.addDocument(doc);
                 }
                 writer.forceMerge(1);
@@ -375,11 +383,33 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                     assertEquals(1, reader.leaves().size());
 
                     final var leafReader = reader.leaves().getFirst().reader();
+                    assertThat(leafReader.numDocs(), equalTo(nbDocs));
+
+                    // Points for _seq_no
+                    final var seqNoPoints = leafReader.getPointValues(SeqNoFieldMapper.NAME);
+                    if (seqNoIndexOptions == SeqNoFieldMapper.SeqNoIndexOptions.POINTS_AND_DOC_VALUES) {
+                        assertThat(seqNoPoints, notNullValue());
+                        assertThat(seqNoPoints.size(), equalTo((long) nbDocs));
+                        assertThat(NumericUtils.sortableBytesToLong(seqNoPoints.getMinPackedValue(), 0), equalTo(0L));
+                        assertThat(NumericUtils.sortableBytesToLong(seqNoPoints.getMaxPackedValue(), 0), equalTo((long) nbDocs - 1L));
+                    } else {
+                        assertThat(seqNoPoints, nullValue());
+                    }
+
+                    // Doc values for _seq_no
+                    final var seqNoDocValues = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                    assertThat(seqNoDocValues, notNullValue());
+
+                    // Doc values for _primary_term
+                    final var primaryTermDocValues = leafReader.getNumericDocValues(SeqNoFieldMapper.PRIMARY_TERM_NAME);
+                    assertNotNull(primaryTermDocValues);
+
                     // Doc values for _recovery_source field
                     final var recoverySourceDocValues = leafReader.getNumericDocValues(
-                        syntheticRecoverySource ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME : SourceFieldMapper.RECOVERY_SOURCE_NAME
+                        useSyntheticRecoverySource ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME : SourceFieldMapper.RECOVERY_SOURCE_NAME
                     );
                     assertNotNull(recoverySourceDocValues);
+
                     // Doc values for "retained" field"
                     var retainedDocValues = leafReader.getNumericDocValues("retained");
                     assertNotNull(retainedDocValues);
@@ -403,30 +433,59 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         // - synthetic id is used, in which case the value is materialized;
                         // - the id is never pruned;
                         // - the id is pruned but retained for the document.
-                        if (useSyntheticId || pruneIdField == false || isRetained) {
+                        if (useSyntheticId || pruneId == false || isRetained) {
                             expectedStoredFields.add(IdFieldMapper.NAME);
                         }
                         // The _recovery_source stored field value must be present when synthetic source is not used and the
                         // document is retained.
-                        if (syntheticRecoverySource == false && isRetained) {
+                        if (useSyntheticRecoverySource == false && isRetained) {
                             expectedStoredFields.add(SourceFieldMapper.RECOVERY_SOURCE_NAME);
                         }
                         assertThat(storedFieldsNames, equalTo(expectedStoredFields));
 
-                        // If the document is retained, we can check the recovery source doc values
+                        // primary term must be present for all docs
+                        assertThat(primaryTermDocValues.nextDoc(), equalTo(docID));
+                        assertThat(primaryTermDocValues.longValue(), equalTo(primaryTerm));
+
+                        // if _seq_no pruning is disabled, _seq_no must be present for all docs
+                        if (pruneSequenceNumber == false) {
+                            assertThat(seqNoDocValues.nextDoc(), equalTo(docID));
+                            assertThat(seqNoDocValues.longValue(), greaterThanOrEqualTo(0L));
+                            assertThat(seqNoDocValues.longValue(), lessThan((long) nbDocs));
+                        }
+
                         if (isRetained) {
+                            // document is retained, it should have a _seq_no doc value
+                            if (seqNoDocValues.docID() < docID) {
+                                seqNoDocValues.advance(docID);
+                            }
+                            assertThat(seqNoDocValues.docID(), equalTo(docID));
+                            assertThat(seqNoDocValues.longValue(), greaterThanOrEqualTo(minRetainedSeqNo));
+
+                            // document is retained, it should have a recovery source doc value
                             recoverySourceDocValues.advance(docID);
-                            if (syntheticRecoverySource) {
+                            assertThat(recoverySourceDocValues.docID(), equalTo(docID));
+                            if (useSyntheticRecoverySource) {
                                 assertThat(recoverySourceDocValues.longValue(), greaterThan(100L));
                             } else {
                                 assertThat(recoverySourceDocValues.longValue(), equalTo(1L));
                             }
+                        } else if (pruneSequenceNumber) {
+                            // document is not retained and _seq_no pruning is enabled, _seq_no doc value must be absent
+                            if (seqNoDocValues.docID() < docID) {
+                                seqNoDocValues.advance(docID);
+                            }
+                            assertThat(seqNoDocValues.docID(), not(equalTo(docID)));
                         }
                     }
+                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, primaryTermDocValues.nextDoc());
                     assertEquals(DocIdSetIterator.NO_MORE_DOCS, retainedDocValues.nextDoc());
 
                     if (recoverySourceDocValues.docID() != DocIdSetIterator.NO_MORE_DOCS) {
                         assertEquals(DocIdSetIterator.NO_MORE_DOCS, recoverySourceDocValues.nextDoc());
+                    }
+                    if (seqNoDocValues != null && seqNoDocValues.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+                        assertEquals(DocIdSetIterator.NO_MORE_DOCS, seqNoDocValues.nextDoc());
                     }
 
                     // Check that _id are not stored at all when synthetic id is used
@@ -460,7 +519,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
                             // The _recovery_source stored field value must be present when synthetic source is not used and the
                             // document is retained.
-                            if (syntheticRecoverySource == false && isRetained) {
+                            if (useSyntheticRecoverySource == false && isRetained) {
                                 expectedStoredFields = Set.of(SourceFieldMapper.RECOVERY_SOURCE_NAME);
                             }
                             assertThat(storedFieldsNames, equalTo(expectedStoredFields));
@@ -476,6 +535,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
     public void testWrapForMergeUnwrapsSyntheticIdStoredFieldsReader() throws IOException {
         boolean syntheticRecoverySource = randomBoolean();
         boolean pruneIdField = randomBoolean();
+        boolean pruneSequenceNumber = randomBoolean();
         String pruneStoredFieldName = syntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME;
         String pruneNumericDVFieldName = syntheticRecoverySource
             ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME
@@ -484,12 +544,20 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         try (var dir = newDirectory()) {
             dir.setCheckIndexOnClose(false);
 
-            var iwc = createIndexWriterConfig(true);
+            final int nbDocs = randomIntBetween(50, 150);
+            final long primaryTerm = randomNonNegativeLong();
+            final int routingHash = randomIntBetween(0, 10);
+
+            final var indexSettings = timeSeriesIndexSettings(true, pruneSequenceNumber);
+            final var seqNoIndexOptions = IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.get(indexSettings.getSettings());
+
+            var iwc = createIndexWriterConfig(indexSettings);
             iwc.setMergePolicy(
                 new RecoverySourcePruneMergePolicy(
                     pruneStoredFieldName,
                     pruneNumericDVFieldName,
                     pruneIdField,
+                    pruneSequenceNumber,
                     () -> Queries.ALL_DOCS_INSTANCE, // Use ALL_DOCS so that all recovery source DV are retained during merges
                     iwc.getMergePolicy(),
                     true
@@ -497,14 +565,23 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
             );
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                final int routingHash = randomIntBetween(0, 10);
                 final Instant now = Instant.now();
 
-                for (int i = 0; i < 100; i++) {
-                    if (i > 0 && randomBoolean()) {
+                for (int seqNo = 0; seqNo < nbDocs; seqNo++) {
+                    if (seqNo > 0 && randomBoolean()) {
                         writer.flush();
                     }
-                    writer.addDocument(newDocument(true, syntheticRecoverySource, routingHash, now.plusMillis(i).toEpochMilli()));
+                    writer.addDocument(
+                        newDocument(
+                            true,
+                            syntheticRecoverySource,
+                            seqNoIndexOptions,
+                            seqNo,
+                            primaryTerm,
+                            routingHash,
+                            now.plusMillis(seqNo).toEpochMilli()
+                        )
+                    );
                 }
                 writer.forceMerge(1);
                 writer.commit();
@@ -512,6 +589,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                 try (DirectoryReader reader = DirectoryReader.open(dir)) {
                     assertEquals(1, reader.leaves().size());
                     final var leafReader = reader.leaves().getFirst().reader();
+                    assertThat(leafReader.numDocs(), equalTo(nbDocs));
                     assertTrue(leafReader instanceof CodecReader);
                     final var codecReader = (CodecReader) leafReader;
 
@@ -522,6 +600,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                             pruneStoredFieldName,
                             pruneNumericDVFieldName,
                             pruneIdField,
+                            pruneSequenceNumber,
                             () -> Queries.ALL_DOCS_INSTANCE,
                             newLogMergePolicy(),
                             true
@@ -538,19 +617,30 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
             // To test the "no recovery source DV" early-return, we need a segment where DV have already been
             // pruned. Re-open the writer with a NO_DOCS policy and force merge again to produce that.
-            var iwc2 = createIndexWriterConfig(true);
+            var iwc2 = createIndexWriterConfig(indexSettings);
             iwc2.setMergePolicy(
                 new RecoverySourcePruneMergePolicy(
                     pruneStoredFieldName,
                     pruneNumericDVFieldName,
                     pruneIdField,
+                    pruneSequenceNumber,
                     () -> Queries.NO_DOCS_INSTANCE,
                     iwc2.getMergePolicy(),
                     true
                 )
             );
             try (IndexWriter writer2 = new IndexWriter(dir, iwc2)) {
-                writer2.addDocument(newDocument(true, syntheticRecoverySource, 0, Instant.now().plusMillis(200).toEpochMilli()));
+                writer2.addDocument(
+                    newDocument(
+                        true,
+                        syntheticRecoverySource,
+                        seqNoIndexOptions,
+                        nbDocs + 1L,
+                        primaryTerm,
+                        routingHash,
+                        Instant.now().plusMillis(200).toEpochMilli()
+                    )
+                );
                 writer2.forceMerge(1);
                 writer2.commit();
             }
@@ -560,6 +650,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
             try (DirectoryReader reader = DirectoryReader.open(dir)) {
                 assertEquals(1, reader.leaves().size());
                 final var leafReader = reader.leaves().getFirst().reader();
+                assertThat(leafReader.numDocs(), equalTo(nbDocs + 1));
                 assertTrue(leafReader instanceof CodecReader);
                 final var codecReader = (CodecReader) leafReader;
 
@@ -567,6 +658,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                     pruneStoredFieldName,
                     pruneNumericDVFieldName,
                     pruneIdField,
+                    pruneSequenceNumber,
                     () -> Queries.ALL_DOCS_INSTANCE,
                     newLogMergePolicy(),
                     true
@@ -579,16 +671,21 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         }
     }
 
-    /**
-     * Creates an {@link IndexWriterConfig} configured for TSDB indices with the appropriate index sort, codec, and no-op segment warmer.
-     * The caller is responsible for setting the merge policy.
-     */
-    private static IndexWriterConfig createIndexWriterConfig(boolean useSyntheticId) throws IOException {
-        final var iwc = newIndexWriterConfig();
-        final var indexSettings = new IndexSettings(
+    private static IndexSettings timeSeriesIndexSettings(boolean useSyntheticId, boolean pruneSequenceNumber) {
+        IndexVersion minVersion;
+        if (pruneSequenceNumber) {
+            minVersion = IndexVersions.DISABLE_SEQUENCE_NUMBERS;
+        } else if (useSyntheticId) {
+            minVersion = IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94;
+        } else {
+            minVersion = IndexVersions.TIME_SERIES_ID_HASHING;
+        }
+        var indexVersion = IndexVersionUtils.randomVersionBetween(minVersion, IndexVersion.current());
+        return new IndexSettings(
             IndexMetadata.builder(randomIdentifier())
                 .settings(
-                    indexSettings(IndexVersion.current(), 1, 0).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+                    indexSettings(indexVersion, 1, 0).put(IndexMetadata.SETTING_VERSION_CREATED, indexVersion)
+                        .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
                         .put(IndexSettings.SYNTHETIC_ID.getKey(), useSyntheticId)
                         .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), List.of("retained"))
                         .build()
@@ -596,13 +693,21 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                 .build(),
             Settings.EMPTY
         );
+    }
+
+    /**
+     * Creates an {@link IndexWriterConfig} configured for TSDB indices with the appropriate index sort, codec, and no-op segment warmer.
+     * The caller is responsible for setting the merge policy.
+     */
+    private static IndexWriterConfig createIndexWriterConfig(final IndexSettings indexSettings) throws IOException {
         final var mapperService = MapperTestUtils.newMapperService(
             new NamedXContentRegistry(CollectionUtils.concatLists(ClusterModule.getNamedXWriteables(), IndicesModule.getNamedXContents())),
             createTempFile(),
             indexSettings.getSettings(),
             indexSettings.getIndex().getName()
         );
-        if (useSyntheticId) {
+        final var iwc = newIndexWriterConfig();
+        if (IndexSettings.SYNTHETIC_ID.get(indexSettings.getSettings())) {
             iwc.setCodec(
                 new ES93TSDBDefaultCompressionLucene103Codec(
                     new LegacyPerFieldMapperCodec(Lucene103Codec.Mode.BEST_SPEED, mapperService, BigArrays.NON_RECYCLING_INSTANCE, null)
@@ -623,8 +728,16 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         return iwc;
     }
 
-    private static Document newDocument(boolean useSyntheticId, boolean syntheticRecoverySource, int routingHash, long timestamp) {
-        Document doc = new Document();
+    private static LuceneDocument newDocument(
+        boolean useSyntheticId,
+        boolean syntheticRecoverySource,
+        SeqNoFieldMapper.SeqNoIndexOptions seqNoIndexOptions,
+        long seqNo,
+        long primaryTerm,
+        int routingHash,
+        long timestamp
+    ) {
+        LuceneDocument doc = new LuceneDocument();
         var hostname = "prod-" + randomInt(4);
         var metricField = randomFrom("uptime", "load");
         var metricValue = randomLongBetween(0, 1_000L);
@@ -647,6 +760,9 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
             doc.add(new StoredField(SourceFieldMapper.RECOVERY_SOURCE_NAME, "test"));
             doc.add(new NumericDocValuesField(SourceFieldMapper.RECOVERY_SOURCE_NAME, 1));
         }
+        var seqNoFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID(seqNoIndexOptions);
+        seqNoFields.set(seqNo, primaryTerm);
+        seqNoFields.addFields(doc);
         return doc;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -338,10 +338,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                             StoredFields storedFields = reader.storedFields();
                             for (int i = 0; i < reader.maxDoc(); i++) {
                                 Document document = storedFields.document(i);
-                                Set<String> collect = document.getFields()
-                                    .stream()
-                                    .map(IndexableField::name)
-                                    .collect(Collectors.toSet());
+                                Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
                                 assertTrue(collect.contains("source"));
                                 assertThat(collect.contains("extra_source"), equalTo(syntheticRecoverySource == false));
                                 assertEquals(i, extra_source.nextDoc());

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -95,88 +95,87 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
     public void testPruneAll() throws IOException {
         for (boolean pruneIdField : List.of(true, false)) {
-            for (boolean syntheticRecoverySource : List.of(true, false)) {
-                try (Directory dir = newDirectory()) {
-                    IndexWriterConfig iwc = newIndexWriterConfig();
-                    RecoverySourcePruneMergePolicy mp = new RecoverySourcePruneMergePolicy(
-                        syntheticRecoverySource ? null : "extra_source",
-                        syntheticRecoverySource ? "extra_source_size" : "extra_source",
-                        pruneIdField,
-                        false,
-                        () -> Queries.NO_DOCS_INSTANCE,
-                        newLogMergePolicy(),
-                        false
-                    );
-                    iwc.setMergePolicy(new ShuffleForcedMergePolicy(mp));
-                    try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                        for (int i = 0; i < 20; i++) {
-                            if (i > 0 && randomBoolean()) {
-                                writer.flush();
-                            }
-                            Document doc = new Document();
-                            doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
-                            doc.add(new StoredField("source", "hello world"));
-                            if (syntheticRecoverySource) {
-                                doc.add(new NumericDocValuesField("extra_source_size", randomIntBetween(10, 10000)));
-                            } else {
-                                doc.add(new StoredField("extra_source", "hello world"));
-                                doc.add(new NumericDocValuesField("extra_source", 1));
-                            }
-                            writer.addDocument(doc);
-                        }
-                        writer.forceMerge(1);
-                        writer.commit();
-                        try (DirectoryReader reader = DirectoryReader.open(writer)) {
-                            StoredFields storedFields = reader.storedFields();
-                            for (int i = 0; i < reader.maxDoc(); i++) {
-                                Document document = storedFields.document(i);
-                                if (pruneIdField) {
-                                    assertEquals(1, document.getFields().size());
-                                    assertEquals("source", document.getFields().get(0).name());
-                                } else {
-                                    assertEquals(2, document.getFields().size());
-                                    assertEquals(IdFieldMapper.NAME, document.getFields().get(0).name());
-                                    assertEquals("source", document.getFields().get(1).name());
+            for (boolean pruneSequenceNumber : List.of(true, false)) {
+                for (boolean syntheticRecoverySource : List.of(true, false)) {
+                    try (Directory dir = newDirectory()) {
+                        IndexWriterConfig iwc = newIndexWriterConfig();
+                        RecoverySourcePruneMergePolicy mp = new RecoverySourcePruneMergePolicy(
+                            syntheticRecoverySource ? null : "extra_source",
+                            syntheticRecoverySource ? "extra_source_size" : "extra_source",
+                            pruneIdField,
+                            pruneSequenceNumber,
+                            () -> Queries.NO_DOCS_INSTANCE,
+                            newLogMergePolicy(),
+                            false
+                        );
+                        iwc.setMergePolicy(new ShuffleForcedMergePolicy(mp));
+                        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                            final int nbDocs = randomIntBetween(10, 100);
+                            for (int i = 0; i < nbDocs; i++) {
+                                if (i > 0 && randomBoolean()) {
+                                    writer.flush();
                                 }
+                                Document doc = new Document();
+                                doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
+                                doc.add(new StoredField("source", "hello world"));
+                                doc.add(new NumericDocValuesField(SeqNoFieldMapper.NAME, i));
+                                if (syntheticRecoverySource) {
+                                    doc.add(new NumericDocValuesField("extra_source_size", randomIntBetween(10, 10000)));
+                                } else {
+                                    doc.add(new StoredField("extra_source", "hello world"));
+                                    doc.add(new NumericDocValuesField("extra_source", 1));
+                                }
+                                writer.addDocument(doc);
                             }
-
-                            assertEquals(1, reader.leaves().size());
-                            LeafReader leafReader = reader.leaves().get(0).reader();
-
-                            NumericDocValues extra_source = leafReader.getNumericDocValues(
-                                syntheticRecoverySource ? "extra_source_size" : "extra_source"
-                            );
-                            if (extra_source != null) {
-                                assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
-                            }
-                            if (leafReader instanceof CodecReader codecReader && reader instanceof StandardDirectoryReader sdr) {
-                                SegmentInfos segmentInfos = sdr.getSegmentInfos();
-                                MergePolicy.MergeSpecification forcedMerges = mp.findForcedDeletesMerges(
-                                    segmentInfos,
-                                    new MergePolicy.MergeContext() {
-                                        @Override
-                                        public int numDeletesToMerge(SegmentCommitInfo info) {
-                                            return info.info.maxDoc() - 1;
-                                        }
-
-                                        @Override
-                                        public int numDeletedDocs(SegmentCommitInfo info) {
-                                            return info.info.maxDoc() - 1;
-                                        }
-
-                                        @Override
-                                        public InfoStream getInfoStream() {
-                                            return new NullInfoStream();
-                                        }
-
-                                        @Override
-                                        public Set<SegmentCommitInfo> getMergingSegments() {
-                                            return Collections.emptySet();
-                                        }
+                            writer.forceMerge(1);
+                            writer.commit();
+                            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                                StoredFields storedFields = reader.storedFields();
+                                for (int i = 0; i < reader.maxDoc(); i++) {
+                                    Document document = storedFields.document(i);
+                                    if (pruneIdField) {
+                                        assertEquals(1, document.getFields().size());
+                                        assertEquals("source", document.getFields().get(0).name());
+                                    } else {
+                                        assertEquals(2, document.getFields().size());
+                                        assertEquals(IdFieldMapper.NAME, document.getFields().get(0).name());
+                                        assertEquals("source", document.getFields().get(1).name());
                                     }
+                                }
+
+                                assertEquals(1, reader.leaves().size());
+                                LeafReader leafReader = reader.leaves().get(0).reader();
+                                assertThat(leafReader.numDocs(), equalTo(nbDocs));
+
+                                NumericDocValues extra_source = leafReader.getNumericDocValues(
+                                    syntheticRecoverySource ? "extra_source_size" : "extra_source"
                                 );
-                                // don't wrap if there is nothing to do
-                                assertSame(codecReader, forcedMerges.merges.get(0).wrapForMerge(codecReader));
+                                if (extra_source != null) {
+                                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
+                                }
+
+                                NumericDocValues seqNoDV = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                                if (pruneSequenceNumber) {
+                                    if (seqNoDV != null) {
+                                        assertEquals(DocIdSetIterator.NO_MORE_DOCS, seqNoDV.nextDoc());
+                                    }
+                                } else {
+                                    assertNotNull(seqNoDV);
+                                    for (int i = 0; i < nbDocs; i++) {
+                                        assertEquals(i, seqNoDV.nextDoc());
+                                    }
+                                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, seqNoDV.nextDoc());
+                                }
+
+                                if (leafReader instanceof CodecReader codecReader && reader instanceof StandardDirectoryReader sdr) {
+                                    SegmentInfos segmentInfos = sdr.getSegmentInfos();
+                                    MergePolicy.MergeSpecification forcedMerges = mp.findForcedDeletesMerges(
+                                        segmentInfos,
+                                        newMergeContext()
+                                    );
+                                    // don't wrap if there is nothing to do
+                                    assertSame(codecReader, forcedMerges.merges.get(0).wrapForMerge(codecReader));
+                                }
                             }
                         }
                     }
@@ -187,6 +186,113 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
     public void testPruneSome() throws IOException {
         for (boolean pruneIdField : List.of(true, false)) {
+            for (boolean pruneSequenceNumber : List.of(true, false)) {
+                for (boolean syntheticRecoverySource : List.of(true, false)) {
+                    try (Directory dir = newDirectory()) {
+                        IndexWriterConfig iwc = newIndexWriterConfig();
+                        iwc.setMergePolicy(
+                            new RecoverySourcePruneMergePolicy(
+                                syntheticRecoverySource ? null : "extra_source",
+                                syntheticRecoverySource ? "extra_source_size" : "extra_source",
+                                pruneIdField,
+                                pruneSequenceNumber,
+                                () -> new TermQuery(new Term("even", "true")),
+                                iwc.getMergePolicy(),
+                                false
+                            )
+                        );
+                        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                            final int nbDocs = randomIntBetween(10, 100);
+                            for (int i = 0; i < nbDocs; i++) {
+                                if (i > 0 && randomBoolean()) {
+                                    writer.flush();
+                                }
+                                Document doc = new Document();
+                                doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
+                                doc.add(new StringField("even", Boolean.toString(i % 2 == 0), Field.Store.YES));
+                                doc.add(new StoredField("source", "hello world"));
+                                doc.add(new NumericDocValuesField(SeqNoFieldMapper.NAME, i));
+                                if (syntheticRecoverySource) {
+                                    doc.add(new NumericDocValuesField("extra_source_size", randomIntBetween(10, 10000)));
+                                } else {
+                                    doc.add(new StoredField("extra_source", "hello world"));
+                                    doc.add(new NumericDocValuesField("extra_source", 1));
+                                }
+                                writer.addDocument(doc);
+                            }
+                            writer.forceMerge(1);
+                            writer.commit();
+                            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                                assertEquals(1, reader.leaves().size());
+                                LeafReader leafReader = reader.leaves().get(0).reader();
+                                assertThat(leafReader.numDocs(), equalTo(nbDocs));
+                                String extraSourceDVName = syntheticRecoverySource ? "extra_source_size" : "extra_source";
+                                NumericDocValues extra_source = leafReader.getNumericDocValues(extraSourceDVName);
+                                assertNotNull(extra_source);
+                                NumericDocValues seqNoDV = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                                assertNotNull(seqNoDV);
+                                StoredFields storedFields = reader.storedFields();
+                                for (int i = 0; i < reader.maxDoc(); i++) {
+                                    Document document = storedFields.document(i);
+                                    Set<String> collect = document.getFields()
+                                        .stream()
+                                        .map(IndexableField::name)
+                                        .collect(Collectors.toSet());
+                                    assertTrue(collect.contains("source"));
+                                    assertTrue(collect.contains("even"));
+                                    boolean isEven = Booleans.parseBoolean(document.getField("even").stringValue());
+                                    if (isEven) {
+                                        assertTrue(collect.contains(IdFieldMapper.NAME));
+                                        assertThat(collect.contains("extra_source"), equalTo(syntheticRecoverySource == false));
+                                        if (extra_source.docID() < i) {
+                                            extra_source.advance(i);
+                                        }
+                                        assertEquals(i, extra_source.docID());
+                                        if (syntheticRecoverySource) {
+                                            assertThat(extra_source.longValue(), greaterThanOrEqualTo(10L));
+                                        } else {
+                                            assertThat(extra_source.longValue(), equalTo(1L));
+                                        }
+                                        if (seqNoDV.docID() < i) {
+                                            seqNoDV.advance(i);
+                                        }
+                                        assertThat(seqNoDV.docID(), equalTo(i));
+                                    } else {
+                                        assertThat(collect.contains(IdFieldMapper.NAME), equalTo(pruneIdField == false));
+                                        assertFalse(collect.contains("extra_source"));
+                                        if (extra_source.docID() < i) {
+                                            extra_source.advance(i);
+                                        }
+                                        assertNotEquals(i, extra_source.docID());
+                                        if (pruneSequenceNumber) {
+                                            if (seqNoDV.docID() < i) {
+                                                seqNoDV.advance(i);
+                                            }
+                                            assertThat(seqNoDV.docID(), not(equalTo(i)));
+                                        } else {
+                                            if (seqNoDV.docID() < i) {
+                                                seqNoDV.advance(i);
+                                            }
+                                            assertThat(seqNoDV.docID(), equalTo(i));
+                                        }
+                                    }
+                                }
+                                if (extra_source.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+                                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
+                                }
+                                if (seqNoDV.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+                                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, seqNoDV.nextDoc());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testPruneNone() throws IOException {
+        for (boolean pruneSequenceNumber : List.of(true, false)) {
             for (boolean syntheticRecoverySource : List.of(true, false)) {
                 try (Directory dir = newDirectory()) {
                     IndexWriterConfig iwc = newIndexWriterConfig();
@@ -194,22 +300,22 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         new RecoverySourcePruneMergePolicy(
                             syntheticRecoverySource ? null : "extra_source",
                             syntheticRecoverySource ? "extra_source_size" : "extra_source",
-                            pruneIdField,
                             false,
-                            () -> new TermQuery(new Term("even", "true")),
+                            pruneSequenceNumber,
+                            () -> Queries.ALL_DOCS_INSTANCE,
                             iwc.getMergePolicy(),
                             false
                         )
                     );
                     try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                        for (int i = 0; i < 20; i++) {
+                        final int nbDocs = randomIntBetween(10, 100);
+                        for (int i = 0; i < nbDocs; i++) {
                             if (i > 0 && randomBoolean()) {
                                 writer.flush();
                             }
                             Document doc = new Document();
-                            doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
-                            doc.add(new StringField("even", Boolean.toString(i % 2 == 0), Field.Store.YES));
                             doc.add(new StoredField("source", "hello world"));
+                            doc.add(new NumericDocValuesField(SeqNoFieldMapper.NAME, i));
                             if (syntheticRecoverySource) {
                                 doc.add(new NumericDocValuesField("extra_source_size", randomIntBetween(10, 10000)));
                             } else {
@@ -222,93 +328,28 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         writer.commit();
                         try (DirectoryReader reader = DirectoryReader.open(writer)) {
                             assertEquals(1, reader.leaves().size());
+                            LeafReader leafReader = reader.leaves().get(0).reader();
+                            assertThat(leafReader.numDocs(), equalTo(nbDocs));
                             String extraSourceDVName = syntheticRecoverySource ? "extra_source_size" : "extra_source";
-                            NumericDocValues extra_source = reader.leaves().get(0).reader().getNumericDocValues(extraSourceDVName);
+                            NumericDocValues extra_source = leafReader.getNumericDocValues(extraSourceDVName);
                             assertNotNull(extra_source);
+                            NumericDocValues seqNoDV = leafReader.getNumericDocValues(SeqNoFieldMapper.NAME);
+                            assertNotNull(seqNoDV);
                             StoredFields storedFields = reader.storedFields();
                             for (int i = 0; i < reader.maxDoc(); i++) {
                                 Document document = storedFields.document(i);
-                                Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
+                                Set<String> collect = document.getFields()
+                                    .stream()
+                                    .map(IndexableField::name)
+                                    .collect(Collectors.toSet());
                                 assertTrue(collect.contains("source"));
-                                assertTrue(collect.contains("even"));
-                                boolean isEven = Booleans.parseBoolean(document.getField("even").stringValue());
-                                if (isEven) {
-                                    assertTrue(collect.contains(IdFieldMapper.NAME));
-                                    assertThat(collect.contains("extra_source"), equalTo(syntheticRecoverySource == false));
-                                    if (extra_source.docID() < i) {
-                                        extra_source.advance(i);
-                                    }
-                                    assertEquals(i, extra_source.docID());
-                                    if (syntheticRecoverySource) {
-                                        assertThat(extra_source.longValue(), greaterThanOrEqualTo(10L));
-                                    } else {
-                                        assertThat(extra_source.longValue(), equalTo(1L));
-                                    }
-                                } else {
-                                    assertThat(collect.contains(IdFieldMapper.NAME), equalTo(pruneIdField == false));
-                                    assertFalse(collect.contains("extra_source"));
-                                    if (extra_source.docID() < i) {
-                                        extra_source.advance(i);
-                                    }
-                                    assertNotEquals(i, extra_source.docID());
-                                }
+                                assertThat(collect.contains("extra_source"), equalTo(syntheticRecoverySource == false));
+                                assertEquals(i, extra_source.nextDoc());
+                                assertEquals(i, seqNoDV.nextDoc());
                             }
-                            if (extra_source.docID() != DocIdSetIterator.NO_MORE_DOCS) {
-                                assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
-                            }
+                            assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
+                            assertEquals(DocIdSetIterator.NO_MORE_DOCS, seqNoDV.nextDoc());
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    public void testPruneNone() throws IOException {
-        for (boolean syntheticRecoverySource : List.of(true, false)) {
-            try (Directory dir = newDirectory()) {
-                IndexWriterConfig iwc = newIndexWriterConfig();
-                iwc.setMergePolicy(
-                    new RecoverySourcePruneMergePolicy(
-                        syntheticRecoverySource ? null : "extra_source",
-                        syntheticRecoverySource ? "extra_source_size" : "extra_source",
-                        false,
-                        false,
-                        () -> Queries.ALL_DOCS_INSTANCE,
-                        iwc.getMergePolicy(),
-                        false
-                    )
-                );
-                try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                    for (int i = 0; i < 20; i++) {
-                        if (i > 0 && randomBoolean()) {
-                            writer.flush();
-                        }
-                        Document doc = new Document();
-                        doc.add(new StoredField("source", "hello world"));
-                        if (syntheticRecoverySource) {
-                            doc.add(new NumericDocValuesField("extra_source_size", randomIntBetween(10, 10000)));
-                        } else {
-                            doc.add(new StoredField("extra_source", "hello world"));
-                            doc.add(new NumericDocValuesField("extra_source", 1));
-                        }
-                        writer.addDocument(doc);
-                    }
-                    writer.forceMerge(1);
-                    writer.commit();
-                    try (DirectoryReader reader = DirectoryReader.open(writer)) {
-                        assertEquals(1, reader.leaves().size());
-                        String extraSourceDVName = syntheticRecoverySource ? "extra_source_size" : "extra_source";
-                        NumericDocValues extra_source = reader.leaves().get(0).reader().getNumericDocValues(extraSourceDVName);
-                        assertNotNull(extra_source);
-                        StoredFields storedFields = reader.storedFields();
-                        for (int i = 0; i < reader.maxDoc(); i++) {
-                            Document document = storedFields.document(i);
-                            Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
-                            assertTrue(collect.contains("source"));
-                            assertThat(collect.contains("extra_source"), equalTo(syntheticRecoverySource == false));
-                            assertEquals(i, extra_source.nextDoc());
-                        }
-                        assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
                     }
                 }
             }


### PR DESCRIPTION
This commit adds an integration test for checking that `_seq_no` fields are correctly pruned after merges in time-series indices with synthetic ids.

Note: the test has been generated by Cursor.

Requires #143575
Requires #143583

Relates #136305
