### PR TITLE
ESQL: Fix and unmute HeapAttack test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -375,9 +375,6 @@ tests:
 - class: org.elasticsearch.index.mapper.DynamicMappingIT
   method: testConcurrentDynamicIgnoreBeyondLimitUpdates
   issue: https://github.com/elastic/elasticsearch/issues/143326
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
-  method: testLookupExplosionManyMatchesManyFields
-  issue: https://github.com/elastic/elasticsearch/issues/143347
 - class: org.elasticsearch.snapshots.ConcurrentSnapshotsIT
   method: testBackToBackQueuedDeletes
   issue: https://github.com/elastic/elasticsearch/issues/143387

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
@@ -66,7 +66,7 @@ public class HeapAttackLookupJoinIT extends HeapAttackTestCase {
         // Streaming lookup processes batches incrementally, keeping memory bounded
         // even with many matches and many fields. Previously threw CircuitBreakerException with the non-streaming path.
         int sensorDataCount = 1500;
-        int lookupEntries = 10000;
+        int lookupEntries = 1000;
         Map<?, ?> map = lookupExplosion(sensorDataCount, lookupEntries, 30, lookupEntries, false);
         assertMap(map, matchesMap().extraOk().entry("values", List.of(List.of(sensorDataCount * lookupEntries))));
     }


### PR DESCRIPTION
Previously with the legacy `LookupFromIndexOperator` this test would throw `CircuitBreakerException` fast. 
With the new `StreamingLookupFromIndexOperator` this test will not throw `CircuitBreakerException` any more. However, as the join is expanding, we are joining on 30 columns and data to join is large, sometimes it will timeout. The fix is to reduce the amount of data to join, so it does not timeout. 

Closes https://github.com/elastic/elasticsearch/issues/143347

Assisted by Cursor