### PR TITLE
Fix a typo in ES|QL CHUNK and TOP_SNIPPETS docs

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/description/chunk.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/chunk.md
@@ -4,7 +4,7 @@
 
 Use `CHUNK` to split a text field into smaller chunks.
 
-Chunk can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
+Chunk can be used on fields from the text family like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
     Chunk will split a text field into smaller chunks, using a sentence-based chunking strategy.
     The number of chunks returned, and the length of the sentences used to create the chunks can be specified.
 

--- a/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
@@ -4,6 +4,6 @@
 
 Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.
 
-`TOP_SNIPPETS` can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
+`TOP_SNIPPETS` can be used on fields from the text family like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
     `TOP_SNIPPETS` will extract the best snippets for a given query string.
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
@@ -73,7 +73,7 @@ public class Chunk extends EsqlScalarFunction implements OptionalArgument {
         description = """
             Use `CHUNK` to split a text field into smaller chunks.""",
         detailedDescription = """
-                Chunk can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
+                Chunk can be used on fields from the text family like <<text, text>> and <<semantic-text, semantic_text>>.
                 Chunk will split a text field into smaller chunks, using a sentence-based chunking strategy.
                 The number of chunks returned, and the length of the sentences used to create the chunks can be specified.
             """,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
@@ -80,7 +80,7 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
         preview = true,
         description = "Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.",
         detailedDescription = """
-                `TOP_SNIPPETS` can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
+                `TOP_SNIPPETS` can be used on fields from the text family like <<text, text>> and <<semantic-text, semantic_text>>.
                 `TOP_SNIPPETS` will extract the best snippets for a given query string.
             """,
         examples = {


### PR DESCRIPTION
It's `family` not `famiy` 🙂 