### PR TITLE
ESQL: Unmute lookup warnings test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -360,10 +360,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests
   method: testOrderByCardinality
   issue: https://github.com/elastic/elasticsearch/issues/142484
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/190_lookup_join/mv-on-query}
-  issue: https://github.com/elastic/elasticsearch/issues/143307
-
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:


### PR DESCRIPTION
The fix is checked in with https://github.com/elastic/elasticsearch/pull/143585. It seems in mixed-cluster tests can somehow pick server which is from main too ( so the fix is on main only as the problem is on main only). 

Closes https://github.com/elastic/elasticsearch/issues/143307