### PR TITLE
allocation: don't move shards under min write load threshold

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -594,7 +594,8 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         final BalancedShardsAllocator.Balancer.PrioritiseByShardWriteLoadComparator comparator =
             new BalancedShardsAllocator.Balancer.PrioritiseByShardWriteLoadComparator(
                 desiredBalanceResponse.getClusterInfo(),
-                originalClusterState.getRoutingNodes().node(harness.firstDataNodeId)
+                originalClusterState.getRoutingNodes().node(harness.firstDataNodeId),
+                0.0
             );
 
         final List<ShardRouting> bestShardsToMove = StreamSupport.stream(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -123,6 +123,13 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         Property.Dynamic,
         Property.NodeScope
     );
+    public static final Setting<Double> MINIMUM_SHARD_WRITE_LOAD_TO_MOVE = Setting.doubleSetting(
+        "cluster.routing.allocation.write_load_decider.minimum_shard_write_load_to_move",
+        0.000001,
+        0.000001,
+        Property.Dynamic,
+        Property.NodeScope
+    );
     private static boolean enableInvalidWeightsAssertion = true;
 
     private final BalancerSettings balancerSettings;
@@ -184,7 +191,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             allocation,
             balancingWeights,
             balancerSettings.completeEarlyOnShardAssignmentChange(),
-            logInvalidWeights
+            logInvalidWeights,
+            balancerSettings
         );
 
         boolean shardAssigned = false, shardMoved = false, shardBalanced = false;
@@ -263,7 +271,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             allocation,
             balancingWeightsFactory.create(),
             balancerSettings.completeEarlyOnShardAssignmentChange(),
-            logInvalidWeights
+            logInvalidWeights,
+            balancerSettings
         );
         AllocateUnassignedDecision allocateUnassignedDecision = AllocateUnassignedDecision.NOT_TAKEN;
         MoveDecision moveDecision = MoveDecision.NOT_TAKEN;
@@ -324,13 +333,15 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         private final NodeSorters nodeSorters;
         private final boolean completeEarlyOnShardAssignmentChange;
         private final FrequencyCappedAction logInvalidWeights;
+        private final BalancerSettings balancerSettings;
 
         private Balancer(
             WriteLoadForecaster writeLoadForecaster,
             RoutingAllocation allocation,
             BalancingWeights balancingWeights,
             boolean completeEarlyOnShardAssignmentChange,
-            FrequencyCappedAction logInvalidWeights
+            FrequencyCappedAction logInvalidWeights,
+            BalancerSettings balancerSettings
         ) {
             this.writeLoadForecaster = writeLoadForecaster;
             this.allocation = allocation;
@@ -346,6 +357,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             this.balancingWeights = balancingWeights;
             this.completeEarlyOnShardAssignmentChange = completeEarlyOnShardAssignmentChange;
             this.logInvalidWeights = logInvalidWeights;
+            this.balancerSettings = balancerSettings;
         }
 
         private static long getShardDiskUsageInBytes(ShardRouting shardRouting, IndexMetadata indexMetadata, ClusterInfo clusterInfo) {
@@ -1146,14 +1158,25 @@ public class BalancedShardsAllocator implements ShardsAllocator {
              * @return true if the shard is more desirable to move that the current one we stored for this node, false otherwise.
              */
             public boolean shardIsBetterThanCurrent(ShardRouting shardRouting) {
+                PrioritiseByShardWriteLoadComparator nodeComparator = comparatorCache.computeIfAbsent(
+                    shardRouting.currentNodeId(),
+                    nodeId -> new PrioritiseByShardWriteLoadComparator(
+                        allocation.clusterInfo(),
+                        allocation.routingNodes().node(nodeId),
+                        balancerSettings.getWriteLoadMinimumRelocationThreshold()
+                    )
+                );
+
+                if (nodeComparator.hasAnyShardsToMove() == false) {
+                    return false;
+                }
+
                 final var currentShardForNode = bestShardMovementsByNode.get(shardRouting.currentNodeId());
                 if (currentShardForNode == null) {
                     return true;
                 }
-                int comparison = comparatorCache.computeIfAbsent(
-                    shardRouting.currentNodeId(),
-                    nodeId -> new PrioritiseByShardWriteLoadComparator(allocation.clusterInfo(), allocation.routingNodes().node(nodeId))
-                ).compare(shardRouting, currentShardForNode.shardRouting());
+
+                int comparison = nodeComparator.compare(shardRouting, currentShardForNode.shardRouting());
                 // Ignore inferior non-preferred moves
                 return comparison < 0;
             }
@@ -1199,8 +1222,13 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             private final double maxWriteLoadOnNode;
             private final double threshold;
             private final String nodeId;
+            private final boolean hasAnyShardsToMove;
 
-            public PrioritiseByShardWriteLoadComparator(ClusterInfo clusterInfo, RoutingNode routingNode) {
+            public PrioritiseByShardWriteLoadComparator(
+                ClusterInfo clusterInfo,
+                RoutingNode routingNode,
+                double writeLoadMinimumRelocationThreshold
+            ) {
                 shardWriteLoads = clusterInfo.getShardWriteLoads();
                 double maxWriteLoadOnNode = MISSING_WRITE_LOAD;
                 for (ShardRouting shardRouting : routingNode) {
@@ -1212,6 +1240,27 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                 this.maxWriteLoadOnNode = maxWriteLoadOnNode;
                 threshold = maxWriteLoadOnNode * THRESHOLD_RATIO;
                 nodeId = routingNode.nodeId();
+
+                boolean initHasAnyShardsToMove = false;
+                List<ShardRouting> shardsSorted = new ArrayList<>(shardWriteLoads.size());
+                // create double comparator switched for descending order from index 0
+                Collections.sort(shardsSorted, (lhs, rhs) -> Double.compare(shardWriteLoads.get(rhs), shardWriteLoads.get(lhs)));
+                for (ShardRouting shardRouting : shardsSorted) {
+                    double shardWriteLoad = shardWriteLoads.get(shardRouting);
+                    if (shardWriteLoad >= threshold && shardWriteLoad < maxWriteLoadOnNode) {
+                        initHasAnyShardsToMove = true;
+                        break;
+                    }
+                    if (shardWriteLoad < threshold && shardWriteLoad > writeLoadMinimumRelocationThreshold) {
+                        initHasAnyShardsToMove = true;
+                        break;
+                    }
+                }
+                hasAnyShardsToMove = initHasAnyShardsToMove;
+            }
+
+            public boolean hasAnyShardsToMove() {
+                return hasAnyShardsToMove;
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancerSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancerSettings.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.DISK_USAGE_BALANCE_FACTOR_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.MINIMUM_SHARD_WRITE_LOAD_TO_MOVE;
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.THRESHOLD_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.WRITE_LOAD_BALANCE_FACTOR_SETTING;
@@ -27,6 +28,7 @@ public class BalancerSettings {
     private volatile float writeLoadBalanceFactor;
     private volatile float diskUsageBalanceFactor;
     private volatile float threshold;
+    private volatile double writeLoadRelocateMinThreshold;
     private final boolean completeEarlyOnShardAssignmentChange;
     private final ClusterSettings clusterSettings;
 
@@ -40,6 +42,7 @@ public class BalancerSettings {
         clusterSettings.initializeAndWatch(WRITE_LOAD_BALANCE_FACTOR_SETTING, value -> this.writeLoadBalanceFactor = value);
         clusterSettings.initializeAndWatch(DISK_USAGE_BALANCE_FACTOR_SETTING, value -> this.diskUsageBalanceFactor = value);
         clusterSettings.initializeAndWatch(THRESHOLD_SETTING, value -> this.threshold = value);
+        clusterSettings.initializeAndWatch(MINIMUM_SHARD_WRITE_LOAD_TO_MOVE, value -> this.writeLoadRelocateMinThreshold = value);
         this.completeEarlyOnShardAssignmentChange = ClusterModule.DESIRED_BALANCE_ALLOCATOR.equals(
             clusterSettings.get(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING)
         );
@@ -77,6 +80,10 @@ public class BalancerSettings {
      */
     public float getThreshold() {
         return threshold;
+    }
+
+    public double getWriteLoadMinimumRelocationThreshold() {
+        return writeLoadRelocateMinThreshold;
     }
 
     public boolean completeEarlyOnShardAssignmentChange() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -1154,7 +1154,7 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
             allocatedRoutingNodes.initializeShard(shardRouting, nodeId, null, randomNonNegativeLong(), RoutingChangesObserver.NOOP);
         }
 
-        final var comparator = new PrioritiseByShardWriteLoadComparator(allocation.clusterInfo(), allocatedRoutingNodes.node(nodeId));
+        final var comparator = new PrioritiseByShardWriteLoadComparator(allocation.clusterInfo(), allocatedRoutingNodes.node(nodeId), 0.0);
 
         logger.info("--> testing shard movement priority comparator, maxValue={}, threshold={}", maxWriteLoad, writeLoadThreshold);
         var sortedShards = allocatedRoutingNodes.getAssignedShards().values().stream().flatMap(List::stream).sorted(comparator).toList();


### PR DESCRIPTION
In some situations when trying to fix a hotspot, the allocator can get stuck relocating shards back and forth that have no significant write load. This adds work to a hotspotting node that will not fix the situation. This change adds a minimum threshold for a shard that can be moved, and checks a node for eligibility before trying to sort and search for a shard to move.

Closes: ES-14336
