### PR TITLE
ESQL: Fix an issue with Lookup Join and loading Large Text Fields

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -195,9 +195,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
-  method: testLookupExplosionBigString
-  issue: https://github.com/elastic/elasticsearch/issues/138510
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
@@ -298,7 +298,7 @@ public class LookupExecutionPlanner {
 
         // Create a factory that builds ShardContext and BlockLoader dynamically from LookupDriverContext
         // to avoid caching stale IndexReader references when PhysicalOperation is cached
-        ByteSizeValue jumboSize = ByteSizeValue.ofBytes(Long.MAX_VALUE);
+        ByteSizeValue jumboSize = plannerSettings.valuesLoadingJumboSize();
         return source.with(new OperatorFactory() {
             @Override
             public Operator get(DriverContext driverContext) {


### PR DESCRIPTION
**Fix an issue with Lookup Join and loading Large Text Fields.** 
Now we will split one page into potentially multiple pages in the ValuesFromSingleReader, resulting in no more CircuitBreaker exceptions in the Streaming path. 

Closes https://github.com/elastic/elasticsearch/issues/138510