### PR TITLE
[9.3] Fix a typo in ES|QL CHUNK and TOP_SNIPPETS docs (#143614)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/description/chunk.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/chunk.md
@@ -4,7 +4,7 @@
 
 Use `CHUNK` to split a text field into smaller chunks.
 
-Chunk can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
+Chunk can be used on fields from the text family like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
     Chunk will split a text field into smaller chunks, using a sentence-based chunking strategy.
     The number of chunks returned, and the length of the sentences used to create the chunks can be specified.
 

--- a/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
@@ -4,6 +4,6 @@
 
 Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.
 
-TopSnippets can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
+TopSnippets can be used on fields from the text family like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
     TopSnippets will extract the best snippets for a given query string.
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
@@ -73,7 +73,7 @@ public class Chunk extends EsqlScalarFunction implements OptionalArgument {
         description = """
             Use `CHUNK` to split a text field into smaller chunks.""",
         detailedDescription = """
-                Chunk can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
+                Chunk can be used on fields from the text family like <<text, text>> and <<semantic-text, semantic_text>>.
                 Chunk will split a text field into smaller chunks, using a sentence-based chunking strategy.
                 The number of chunks returned, and the length of the sentences used to create the chunks can be specified.
             """,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
@@ -75,7 +75,7 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
         preview = true,
         description = "Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.",
         detailedDescription = """
-                TopSnippets can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
+                TopSnippets can be used on fields from the text family like <<text, text>> and <<semantic-text, semantic_text>>.
                 TopSnippets will extract the best snippets for a given query string.
             """,
         examples = {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix a typo in ES|QL CHUNK and TOP_SNIPPETS docs (#143614)](https://github.com/elastic/elasticsearch/pull/143614)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)