### PR TITLE
Added a no-op multi_value parameter to doc values

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -108,7 +108,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     private static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
         false,
-        FieldMapper.DocValuesParameter.Values.Cardinality.HIGH
+        FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+        FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
     );
 
     public static class Defaults {
@@ -129,7 +130,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
-        private final FieldMapper.DocValuesParameter docValuesParameters = new FieldMapper.DocValuesParameter(
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.arraysWithCardinality(
             DEFAULT_DOC_VALUES_PARAMS,
             m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters
         );
@@ -147,6 +148,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             boolean usesBinaryDocValuesForFallbackFields
         ) {
             super(name, indexCreatedVersion, isWithinMultiField);
+
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
                 m -> ((MatchOnlyTextFieldMapper) m).indexAnalyzer,

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.support.AbstractXContentParser;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -1268,6 +1269,11 @@ public abstract class FieldMapper extends Mapper {
                 for (T t : enumSet) {
                     // the string representation may differ from the actual name of the enum type (e.g. lowercase vs uppercase)
                     if (t.toString().equals(o.toString())) {
+                        if (acceptedValues.contains(t) == false) {
+                            throw new MapperParsingException(
+                                "Unknown value [" + o + "] for field [" + name + "] - accepted values are " + acceptedValues
+                            );
+                        }
                         return t;
                     }
                 }
@@ -1448,7 +1454,7 @@ public abstract class FieldMapper extends Mapper {
 
         public static FeatureFlag EXTENDED_DOC_VALUES_PARAMS_FF = new FeatureFlag("extended_doc_values_options");
 
-        public record Values(boolean enabled, Cardinality cardinality) {
+        public record Values(boolean enabled, Cardinality cardinality, MultiValue multiValue) {
             public enum Cardinality {
                 LOW,
                 HIGH;
@@ -1459,20 +1465,105 @@ public abstract class FieldMapper extends Mapper {
                 }
             }
 
-            public static Values DISABLED = new Values(false, Cardinality.LOW);
+            /**
+             * Controls how multiple values per document are handled in doc values.
+             * <p>
+             * {@code NO} restricts the field to a single value per document.
+             * {@code SORTED} stores multiple values sorted per document (numeric types).
+             * {@code SORTED_SET} stores multiple values sorted and deduplicated per document (keyword/IP types).
+             * {@code ARRAYS} allows multiple values and keeps original ordering.
+             */
+            public enum MultiValue {
+                NO,
+                SORTED,
+                SORTED_SET,
+                ARRAYS;
+
+                @Override
+                public String toString() {
+                    return name().toLowerCase(Locale.ROOT);
+                }
+            }
+
+            public static Values DISABLED = new Values(false, Cardinality.LOW, MultiValue.SORTED);
         }
 
-        public final Parameter<Values.Cardinality> cardinalityParameter;
+        public final Optional<Parameter<Values.Cardinality>> cardinalityParameter;
+        public final Parameter<Values.MultiValue> multiValueParameter;
 
-        public DocValuesParameter(Values defaultValue, Function<FieldMapper, Values> initializer) {
+        /**
+         * Factory for field types that do not support cardinality. Use for numeric types that use {@code SortedNumericDocValuesField}.
+         */
+        public static DocValuesParameter sorted(Values defaultValue, Function<FieldMapper, Values> initializer) {
+            return new DocValuesParameter(
+                defaultValue,
+                initializer,
+                false,
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED, Values.MultiValue.ARRAYS)
+            );
+        }
+
+        /**
+         * Factory for field types that do not support cardinality. Use for types that use {@code SortedSetDocValuesField}
+         * (e.g. IP, flattened).
+         */
+        public static DocValuesParameter sortedSet(Values defaultValue, Function<FieldMapper, Values> initializer) {
+            return new DocValuesParameter(
+                defaultValue,
+                initializer,
+                false,
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
+            );
+        }
+
+        /**
+         * Factory for field types that support cardinality. Use for keyword fields.
+         */
+        public static DocValuesParameter sortedSetWithCardinality(Values defaultValue, Function<FieldMapper, Values> initializer) {
+            return new DocValuesParameter(
+                defaultValue,
+                initializer,
+                true,
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
+            );
+        }
+
+        /**
+         * Factory for field types that support cardinality. Use for text-family fields (text, match_only_text).
+         */
+        public static DocValuesParameter arraysWithCardinality(Values defaultValue, Function<FieldMapper, Values> initializer) {
+            return new DocValuesParameter(defaultValue, initializer, true, EnumSet.of(Values.MultiValue.NO, Values.MultiValue.ARRAYS));
+        }
+
+        private DocValuesParameter(
+            Values defaultValue,
+            Function<FieldMapper, Values> initializer,
+            boolean supportsCardinality,
+            Set<Values.MultiValue> allowedMultiValues
+        ) {
             super(PARAMETER_NAME, false, () -> defaultValue, null, initializer, null, Values::toString);
 
-            cardinalityParameter = Parameter.enumParam(
-                "cardinality",
+            if (supportsCardinality) {
+                cardinalityParameter = Optional.of(
+                    Parameter.enumParam(
+                        "cardinality",
+                        false,
+                        m -> initializer.apply(m).cardinality,
+                        defaultValue.cardinality,
+                        Values.Cardinality.class
+                    )
+                );
+            } else {
+                cardinalityParameter = Optional.empty();
+            }
+
+            multiValueParameter = Parameter.restrictedEnumParam(
+                "multi_value",
                 false,
-                m -> initializer.apply(m).cardinality,
-                defaultValue.cardinality,
-                Values.Cardinality.class
+                m -> initializer.apply(m).multiValue,
+                defaultValue.multiValue,
+                Values.MultiValue.class,
+                allowedMultiValues
             );
         }
 
@@ -1482,25 +1573,36 @@ public abstract class FieldMapper extends Mapper {
          * Doc values can be configured in the following ways:
          * <ul>
          *   <li>{@code "doc_values": false} - doc_values disabled</li>
-         *   <li>{@code "doc_values": true} - doc_values enabled with the default cardinality</li>
-         *   <li>{@code "doc_values": { "cardinality": "low" }} - doc_values enabled with LOW cardinality
-         *   <li>{@code "doc_values": { "cardinality": "high" }} - doc_values enabled with HIGH cardinality
+         *   <li>{@code "doc_values": true} - doc_values enabled with defaults</li>
+         *   <li>{@code "doc_values": { "cardinality": "low" }} - doc_values enabled with LOW cardinality</li>
+         *   <li>{@code "doc_values": { "cardinality": "high" }} - doc_values enabled with HIGH cardinality</li>
+         *   <li>{@code "doc_values": { "multi_value": "no" }} - single value enforced per document</li>
+         *   <li>{@code "doc_values": { "multi_value": "sorted" }} - multiple values sorted per document</li>
+         *   <li>{@code "doc_values": { "multi_value": "sorted_set" }} - multiple values sorted and deduplicated per document</li>
+         *   <li>{@code "doc_values": { "multi_value": "arrays" }} - multiple values stored as-is (no sorting or deduplication)</li>
          * </ul>
          * <p>
-         * The presence of {@code doc_values} as a map indicates the user wants doc_values enabled. The map format allows specifying an
-         * additional cardinality setting.
+         * Not all {@code multi_value} options are supported by every field type; unsupported options are rejected at mapping parse time.
+         * <p>
+         * The presence of {@code doc_values} as a map indicates the user wants doc_values enabled. The map format allows specifying
+         * additional cardinality and multi_value settings.
          */
         @Override
         public void parse(String field, MappingParserContext context, Object value) {
-            // if doc_values are given as a map, then parse cardinality
             if (value instanceof Map<?, ?> valueMap && EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()) {
-                cardinalityParameter.parse(field, context, valueMap.get(cardinalityParameter.name));
+                cardinalityParameter.ifPresent(p -> p.parse(field, context, valueMap.get(p.name)));
+                multiValueParameter.parse(field, context, valueMap.get(multiValueParameter.name));
 
-                setValue(new Values(true, cardinalityParameter.getValue()));
+                setValue(
+                    new Values(
+                        true,
+                        cardinalityParameter.map(Parameter::getValue).orElse(getDefaultValue().cardinality()),
+                        multiValueParameter.getValue()
+                    )
+                );
             } else {
-                // otherwise, parse the boolean value from the mapping, but set the cardinality ourselves to ensure bwc
                 if (XContentMapValues.nodeBooleanValue(value, name)) {
-                    setValue(new Values(true, getDefaultValue().cardinality()));
+                    setValue(new Values(true, getDefaultValue().cardinality(), getDefaultValue().multiValue()));
                 } else {
                     setValue(Values.DISABLED);
                 }
@@ -1510,7 +1612,8 @@ public abstract class FieldMapper extends Mapper {
         @Override
         public void setValue(Values value) {
             super.setValue(value);
-            cardinalityParameter.setValue(value.cardinality);
+            cardinalityParameter.ifPresent(p -> p.setValue(value.cardinality));
+            multiValueParameter.setValue(value.multiValue);
         }
 
         protected void toXContent(XContentBuilder builder, boolean includeDefaults) throws IOException {
@@ -1521,9 +1624,27 @@ public abstract class FieldMapper extends Mapper {
                 } else if (EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled() == false) {
                     builder.field(name, true);
                 } else {
-                    builder.startObject(name);
-                    builder.field(cardinalityParameter.name, value.cardinality);
-                    builder.endObject();
+                    boolean cardinalityConfigured = cardinalityParameter.map(Parameter::isConfigured).orElse(false);
+                    boolean multiValueConfigured = multiValueParameter.isConfigured();
+                    if (includeDefaults == false && cardinalityConfigured == false && multiValueConfigured == false) {
+                        // no sub-parameters were explicitly set; use the boolean shorthand to match the original source
+                        builder.field(name, true);
+                    } else {
+                        builder.startObject(name);
+                        cardinalityParameter.ifPresent(p -> {
+                            if (includeDefaults || p.isConfigured()) {
+                                try {
+                                    builder.field(p.name, value.cardinality);
+                                } catch (IOException e) {
+                                    throw new UncheckedIOException(e);
+                                }
+                            }
+                        });
+                        if (includeDefaults || multiValueConfigured) {
+                            builder.field(multiValueParameter.name, value.multiValue);
+                        }
+                        builder.endObject();
+                    }
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1471,7 +1471,7 @@ public abstract class FieldMapper extends Mapper {
              * {@code NO} restricts the field to a single value per document.
              * {@code SORTED} stores multiple values sorted per document (numeric types).
              * {@code SORTED_SET} stores multiple values sorted and deduplicated per document (keyword/IP types).
-             * {@code ARRAYS} allows multiple values and keeps original ordering.
+             * {@code ARRAYS} allows multiple values, keeps original ordering, and supports null values.
              */
             public enum MultiValue {
                 NO,

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -125,7 +125,8 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
         true,
-        DocValuesParameter.Values.Cardinality.LOW
+        DocValuesParameter.Values.Cardinality.LOW,
+        DocValuesParameter.Values.MultiValue.SORTED_SET
     );
 
     public static class Defaults {
@@ -191,7 +192,7 @@ public final class KeywordFieldMapper extends FieldMapper {
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final Parameter<Boolean> indexed;
-        private final DocValuesParameter docValuesParameters = new DocValuesParameter(
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.sortedSetWithCardinality(
             DEFAULT_DOC_VALUES_PARAMS,
             m -> toType(m).docValuesParameters()
         );
@@ -336,7 +337,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         public Builder docValues(DocValuesParameter.Values.Cardinality cardinality) {
-            this.docValuesParameters.setValue(new DocValuesParameter.Values(true, cardinality));
+            this.docValuesParameters.setValue(new DocValuesParameter.Values(true, cardinality, DEFAULT_DOC_VALUES_PARAMS.multiValue()));
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -77,6 +77,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_dotted_field_fix"
     );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -77,8 +77,6 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_dotted_field_fix"
     );
-    public static final NodeFeature DOC_VALUES_MULTI_VALUE = new NodeFeature("mapper.doc_values.multi_value");
-
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
@@ -132,8 +130,7 @@ public class MapperFeatures implements FeatureSpecification {
             MV_MIN_FUNCTION_FUSE_TO_LOAD,
             TDIGEST_TYPE,
             TEXT_FIELD_DOC_VALUES,
-            DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
-            DOC_VALUES_MULTI_VALUE
+            DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -77,6 +77,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_dotted_field_fix"
     );
+    public static final NodeFeature DOC_VALUES_MULTI_VALUE = new NodeFeature("mapper.doc_values.multi_value");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -131,7 +132,8 @@ public class MapperFeatures implements FeatureSpecification {
             MV_MIN_FUNCTION_FUSE_TO_LOAD,
             TDIGEST_TYPE,
             TEXT_FIELD_DOC_VALUES,
-            DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX
+            DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
+            DOC_VALUES_MULTI_VALUE
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -113,7 +113,8 @@ public final class TextFieldMapper extends FieldMapper {
 
     public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
         false,
-        DocValuesParameter.Values.Cardinality.HIGH
+        DocValuesParameter.Values.Cardinality.HIGH,
+        DocValuesParameter.Values.MultiValue.ARRAYS
     );
 
     public static class Defaults {
@@ -265,7 +266,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> ((TextFieldMapper) m).index, true);
 
-        final DocValuesParameter docValuesParameters = new DocValuesParameter(
+        final DocValuesParameter docValuesParameters = DocValuesParameter.arraysWithCardinality(
             DEFAULT_DOC_VALUES_PARAMS,
             m -> ((TextFieldMapper) m).docValuesParameters
         );
@@ -330,6 +331,7 @@ public final class TextFieldMapper extends FieldMapper {
 
             this.indexMode = indexMode;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
+
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
                 m -> ((TextFieldMapper) m).indexAnalyzer,

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DocValuesParameterTests extends MapperServiceTestCase {
+
+    // -----------------------------------------------------------------------
+    // Null-fallback: omitting one sub-parameter falls back to the field-type default
+    // -----------------------------------------------------------------------
+
+    public void testMultiValueWithoutCardinalityUsesDefault() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "sorted_set").endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters(),
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                )
+            )
+        );
+    }
+
+    public void testCardinalityWithoutMultiValueUsesDefault() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("cardinality", "high").endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters(),
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                )
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Unknown-value rejection
+    // -----------------------------------------------------------------------
+
+    public void testInvalidCardinality() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("cardinality", "invalid").endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("Unknown value [invalid] for field [cardinality] - accepted values are [low, high]"));
+    }
+
+    public void testInvalidMultiValue() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "invalid").endObject())
+            )
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Boolean shorthand: doc_values: true / false still works alongside map form
+    // -----------------------------------------------------------------------
+
+    public void testDocValuesTrueShorthand() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", true)));
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().enabled(), equalTo(true));
+    }
+
+    public void testDocValuesFalseShorthand() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)));
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -947,7 +947,13 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
             mapper.docValuesParameters(),
-            equalTo(new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW))
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                )
+            )
         );
         assertScriptDocValues(mapperService, List.of("bar", "foo"), equalTo(List.of("bar", "foo")));
     }
@@ -960,20 +966,61 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
             mapper.docValuesParameters(),
-            equalTo(new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH))
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                )
+            )
         );
         assertScriptDocValues(mapperService, List.of("bar", "foo"), equalTo(List.of("bar", "foo")));
     }
 
-    public void testDocValuesInvalidCardinality() throws IOException {
+    public void testMultiValueSortedSet() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createSytheticSourceMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword")
+                    .startObject("doc_values")
+                    .field("multi_value", "sorted_set")
+                    .field("cardinality", "low")
+                    .endObject()
+            )
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters(),
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                )
+            )
+        );
+        assertScriptDocValues(mapperService, List.of("foo", "bar", "foo"), equalTo(List.of("bar", "foo")));
+    }
+
+    public void testMultiValueDefaultIsSortedSet() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET));
+    }
+
+    public void testMultiValueSortedNotAllowed() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         var e = expectThrows(
             MapperParsingException.class,
             () -> createMapperService(
-                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("cardinality", "invalid").endObject())
+                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "sorted").endObject())
             )
         );
-        assertThat(e.getMessage(), containsString("Unknown value [invalid] for field [cardinality] - accepted values are [low, high]"));
+        assertThat(
+            e.getMessage(),
+            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+        );
     }
 
     public void testFieldTypeWithSkipDocValues_LogsDbModeDisabledSetting() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -317,11 +317,13 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             return ESTestCase.randomBoolean();
         }
 
-        return switch (ESTestCase.randomInt(3)) {
+        return switch (ESTestCase.randomInt(5)) {
             case 0 -> false;
             case 1 -> Map.of("cardinality", "low");
             case 2 -> Map.of("cardinality", "high");
             case 3 -> true;
+            case 4 -> Map.of("cardinality", "low", "multi_value", "arrays");
+            case 5 -> Map.of("cardinality", "high", "multi_value", "arrays");
             default -> throw new IllegalStateException();
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
@@ -50,13 +50,25 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
             if (allowIgnoredSource && ESTestCase.randomBoolean()) {
                 return FieldMapper.DocValuesParameter.Values.DISABLED;
             } else {
-                return new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW);
+                return new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                );
             }
         }
 
         return switch (ESTestCase.randomInt(allowIgnoredSource ? 2 : 1)) {
-            case 0 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW);
-            case 1 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH);
+            case 0 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+            );
+            case 1 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+            );
             case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
             default -> throw new IllegalStateException();
         };

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
@@ -67,8 +67,16 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
         }
 
         return switch (randomInt(2)) {
-            case 0 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.LOW);
-            case 1 -> new FieldMapper.DocValuesParameter.Values(true, FieldMapper.DocValuesParameter.Values.Cardinality.HIGH);
+            case 0 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
+            );
+            case 1 -> new FieldMapper.DocValuesParameter.Values(
+                true,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
+            );
             case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
             default -> throw new IllegalStateException();
         };


### PR DESCRIPTION
This is a first of several changes for https://github.com/elastic/logs-program/issues/18.

This PR adds `multi_value` as a parameter for doc values with the following options: `no | sorted | sorted_set | arrays`. At this time, `multi_value` is a no-op. Adding support for all multi value options in a single PR to all field types would resulted in too many changes to review. The follow up PRs will add support for each `multi_value` option respectively.

Note, `multi_value` is added under the same feature flag that the `cardinality` parameter uses.