### PR TITLE
Fix ESQL division overflow error message

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Div.java
@@ -126,16 +126,30 @@ public class Div extends DenseVectorArithmeticOperation implements BinaryCompari
     @Evaluator(extraName = "Doubles", warnExceptions = { ArithmeticException.class })
     static double processDoubles(double lhs, double rhs) {
         double value = lhs / rhs;
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
-            throw new ArithmeticException("/ by zero");
+        if (Double.isNaN(value)) {
+            throw new ArithmeticException("result is NaN");
+        }
+        if (Double.isInfinite(value)) {
+            if (rhs == 0.0) {
+                throw new ArithmeticException("/ by zero");
+            } else {
+                throw new ArithmeticException("result overflows double precision");
+            }
         }
         return value;
     }
 
     private static float divDenseVectorElements(float lhs, float rhs) {
         float value = lhs / rhs;
-        if (Float.isNaN(value) || Float.isInfinite(value)) {
-            throw new ArithmeticException("/ by zero");
+        if (Float.isNaN(value)) {
+            throw new ArithmeticException("result is NaN");
+        }
+        if (Float.isInfinite(value)) {
+            if (rhs == 0.0f) {
+                throw new ArithmeticException("/ by zero");
+            } else {
+                throw new ArithmeticException("result overflows float precision");
+            }
         }
         return value;
     }


### PR DESCRIPTION
## Summary
Fixes incorrect error message when ESQL division overflows double/float precision.

## Problem
When dividing large numbers that overflow (e.g., `1e308 / 0.1`), ESQL returns `null` (correct) but the error message incorrectly states `/ by zero`. The actual issue is exceeding the numeric type's maximum value, not division by zero.

## Root Cause
In `Div.java`, both `processDoubles()` and `divDenseVectorElements()` catch `NaN` and `Infinity` but throw a generic `/ by zero` `ArithmeticException` for all cases.

## Solution
Distinguish between three cases:
1. **Division by zero** (rhs == 0) → `/ by zero`
2. **Overflow** (result is POSITIVE_INFINITY) → `result overflows double/float precision`
3. **Invalid/NaN** → `result is NaN`

## Changes
- `processDoubles()`: Check for actual division by zero vs overflow
- `divDenseVectorElements()`: Same fix for float division
- Provides accurate error messages for debugging

## Testing
Manual testing with ESQL queries:
```
ROW x = 1e308 / 0.1  // Should show overflow error, not / by zero
ROW x = 1.0 / 0.0    // Should show / by zero error
ROW x = 0.0 / 0.0    // Should show NaN error
```

Fixes #138798