### PR TITLE
Prevent closing wrong search contexts in compute service

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,12 +342,6 @@ tests:
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/142440
-- class: org.elasticsearch.xpack.esql.action.EsqlRetryIT
-  method: testQueryWhileDeletingIndices
-  issue: https://github.com/elastic/elasticsearch/issues/143639
-- class: org.elasticsearch.xpack.esql.action.EsqlRetryIT
-  method: testRetryOnShardFailures
-  issue: https://github.com/elastic/elasticsearch/issues/143640
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {stats.StatsByMvFieldAggExpr}
   issue: https://github.com/elastic/elasticsearch/issues/141835

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -335,8 +335,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             }
             final var doAcquire = ActionRunnable.supply(listener, () -> {
                 final List<SearchContext> searchContexts = new ArrayList<>(targetShards.size());
-                SearchContext context = null;
                 for (IndexShard shard : targetShards) {
+                    SearchContext context = null;
                     try {
                         var aliasFilter = aliasFilters.getOrDefault(shard.shardId().getIndex(), AliasFilter.EMPTY);
                         var shardRequest = new ShardSearchRequest(


### PR DESCRIPTION
Backport of #128222 to 8.19


The search context variable should be inside the loop, not outside; otherwise, it may close the previous search context when the target shard is unavailable, potentially leaving search contexts without references. This bug was introduced in unreleased versions (9.1 and 8.19). I think we need to refactor DataNodeComputeHandler to allow writing unit tests for these cases easier, but testSearchWhileRelocating should cover this issue.

Closes #143639
Closes #143640
Closes #143647