### PR TITLE
ESQL: Fix flaky EmployeeFlightServerTests shutdown race

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -387,9 +387,30 @@ tests:
 - class: org.elasticsearch.index.query.PrefixQueryBuilderTests
   method: testPrefixCircuitBreakerTripsWithLowLimit
   issue: https://github.com/elastic/elasticsearch/issues/143548
-- class: org.elasticsearch.xpack.esql.datasource.grpc.EmployeeFlightServerTests
-  method: testMultiEndpointReturnsCorrectEndpointCount
-  issue: https://github.com/elastic/elasticsearch/issues/143636
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-irate.Irate_of_ratio_promql}
+  issue: https://github.com/elastic/elasticsearch/issues/143616
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-irate.Irate_of_ratio}
+  issue: https://github.com/elastic/elasticsearch/issues/143617
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-irate.Irate_of_double_no_grouping_promql}
+  issue: https://github.com/elastic/elasticsearch/issues/143624
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-irate.Irate_of_double_no_grouping}
+  issue: https://github.com/elastic/elasticsearch/issues/143625
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_aggregate_metric_double}
+  issue: https://github.com/elastic/elasticsearch/issues/143631
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-delta.Delta_of_double_no_grouping}
+  issue: https://github.com/elastic/elasticsearch/issues/143632
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_aggregate_metric_double_grouping}
+  issue: https://github.com/elastic/elasticsearch/issues/143633
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:k8s-timeseries-delta.Delta_of_double_no_grouping_promql}
+  issue: https://github.com/elastic/elasticsearch/issues/143634
 - class: org.elasticsearch.search.SearchLoggingIT
   method: testSearchLogShardInfoPartialFailure
   issue: https://github.com/elastic/elasticsearch/issues/143638

--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServer.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/EmployeeFlightServer.java
@@ -40,7 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * In-memory Arrow Flight server that serves employee data from the employees.csv test fixture.
@@ -249,8 +248,15 @@ public class EmployeeFlightServer implements Closeable {
     @Override
     public void close() throws IOException {
         try {
-            server.shutdown();
-            server.awaitTermination(5, TimeUnit.SECONDS);
+            // Use FlightServer.close() which provides a robust shutdown sequence:
+            // graceful shutdown → awaitTermination → shutdownNow fallback.
+            // After close() returns, the gRPC server is terminated but Netty's event loop may still
+            // have pending ChannelFutureListener callbacks (e.g. NettyServerHandler.closeStreamWhenDone)
+            // that can throw if the HTTP/2 stream was already closed. Netty's DefaultPromise logs
+            // these as WARN which ESTestCase.checkStaticState() treats as a test failure.
+            // A brief sleep lets those callbacks drain on the event loop thread before the test ends.
+            server.close();
+            Thread.sleep(50);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Interrupted while closing FlightServer", e);


### PR DESCRIPTION
Fixes a flaky test failure in `EmployeeFlightServerTests.testMultiEndpointReturnsCorrectEndpointCount` caused by a race condition during gRPC/Netty server shutdown.

When the test's `FlightClient` closes, gRPC's `NettyServerHandler` processes the disconnect asynchronously on Netty's event loop. A `ChannelFutureListener` callback (`closeStreamWhenDone`) can throw if the HTTP/2 stream was already closed by the time it fires. Netty's `DefaultPromise` logs this as a WARN, which `ESTestCase.checkStaticState()` captures and treats as a test failure.

The fix replaces the manual `shutdown()` + `awaitTermination()` with `FlightServer.close()` which provides a more robust shutdown sequence (graceful shutdown → `awaitTermination` → `shutdownNow` fallback), and adds a brief sleep to let any remaining Netty event loop callbacks drain before the test framework checks for logged warnings.

Closes #143636