### PR TITLE
Fix off-by-one error in HyperLogLogPlusPlus LinearCounting (#143110)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -489,7 +489,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
 
         long maxOrd() {
-            return cells.size() - 1;
+            return cells.size();
         }
 
         @Override


### PR DESCRIPTION
LinearCounting.maxOrd() was returning an inclusive upper bound, 
rather than an exclusive.  This could cause CardinalityAggregator 
to mistakenly create an empty bucket instead of correctly reporting 
the cardinality if the number of buckets happened to coincide exactly 
with an oversized bucket allocation.

Fixes #142484