### PR TITLE
[9.3] [ML] Increase timeout on forecast test (#143487)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -253,7 +253,7 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
 
     protected void waitForecastToFinish(String jobId, String forecastId) throws Exception {
         // Forecasts can take an eternity to complete in the FIPS JVM
-        int timeoutSeconds = inFipsJvm() ? 300 : 90;
+        int timeoutSeconds = inFipsJvm() ? 300 : 180;
         // First wait for the forecast document to exist and be in a non-terminal state
         // This handles the race condition where the document may be SCHEDULED or STARTED initially
         waitForecastStatus(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ML] Increase timeout on forecast test (#143487)](https://github.com/elastic/elasticsearch/pull/143487)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)