### PR TITLE
[9.2] [ML] Fix flaky ForecastIT#testOverflowToDisk (#137452)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -70,9 +70,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
   issue: https://github.com/elastic/elasticsearch/issues/119508
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/117740
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Fix flaky ForecastIT#testOverflowToDisk (#137452)](https://github.com/elastic/elasticsearch/pull/137452)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)