### PR TITLE
[8.19] [ML] Fix flaky ForecastIT#testOverflowToDisk (#137452)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -220,9 +220,6 @@ tests:
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/20_metrics_ingest/Test metrics-apm.app-* setting event.ingested via ingest pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/118875
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/117740
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability
   issue: https://github.com/elastic/elasticsearch/issues/117249


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix flaky ForecastIT#testOverflowToDisk (#137452)](https://github.com/elastic/elasticsearch/pull/137452)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)