### PR TITLE
handle remote connection failures in PIT

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.crossproject.CrossProjectIndexResolutionValidator;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
+import org.elasticsearch.search.crossproject.SearchPlanningPhaseResolutionResult;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.tasks.Task;
@@ -179,15 +180,14 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
 
         // CPS
         final int linkedProjectsToQuery = indicesPerCluster.size();
-        ActionListener<Collection<Map.Entry<String, ResolveIndexAction.Response>>> responsesListener = listener.delegateFailureAndWrap(
-            (l, responses) -> {
+        ActionListener<Collection<Map.Entry<String, SearchPlanningPhaseResolutionResult>>> responsesListener = listener
+            .delegateFailureAndWrap((l, responses) -> {
                 Map<String, ResolvedIndexExpressions> resolvedRemoteExpressions = responses.stream()
-                    .filter(e -> e.getValue().getResolvedIndexExpressions() != null)
+                    .filter(e -> e.getValue().response() instanceof ResolveIndexAction.Response)
                     .collect(
                         Collectors.toMap(
                             Map.Entry::getKey,
-                            e -> e.getValue().getResolvedIndexExpressions()
-
+                            e -> ((ResolveIndexAction.Response) e.getValue().response()).getResolvedIndexExpressions()
                         )
                     );
                 final Exception ex = CrossProjectIndexResolutionValidator.validate(
@@ -223,9 +223,8 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                 }
                 request.indices(collectedIndices.toArray(String[]::new));
                 executeOpenPit(task, request, listener);
-            }
-        );
-        ActionListener<Map.Entry<String, ResolveIndexAction.Response>> groupedListener = new GroupedActionListener<>(
+            });
+        ActionListener<Map.Entry<String, SearchPlanningPhaseResolutionResult>> groupedListener = new GroupedActionListener<>(
             linkedProjectsToQuery,
             responsesListener
         );
@@ -242,7 +241,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
 
             connectionListener.addListener(groupedListener.delegateResponse((l, failure) -> {
                 logger.info("failed to resolve indices on remote cluster [" + clusterAlias + "]", failure);
-                l.onFailure(failure);
+                l.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
             })
                 .delegateFailure(
                     (ignored, connection) -> transportService.sendRequest(
@@ -252,8 +251,11 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                         TransportRequestOptions.EMPTY,
                         new ActionListenerResponseHandler<>(groupedListener.delegateResponse((l, failure) -> {
                             logger.info("Error occurred on remote cluster [" + clusterAlias + "]", failure);
-                            l.onFailure(failure);
-                        }).map(resolveIndexResponse -> Map.entry(clusterAlias, resolveIndexResponse)),
+                            l.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
+                        }).map(resolveIndexResponse -> Map.entry(
+                            clusterAlias,
+                            new SearchPlanningPhaseResolutionResult(resolveIndexResponse, null)
+                        )),
                             ResolveIndexAction.Response::new,
                             EsExecutors.DIRECT_EXECUTOR_SERVICE
                         )

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -252,13 +252,13 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                         new ActionListenerResponseHandler<>(groupedListener.delegateResponse((l, failure) -> {
                             logger.info("Error occurred on remote cluster [" + clusterAlias + "]", failure);
                             l.onResponse(Map.entry(clusterAlias, new SearchPlanningPhaseResolutionResult(null, failure)));
-                        }).map(resolveIndexResponse -> Map.entry(
-                            clusterAlias,
-                            new SearchPlanningPhaseResolutionResult(resolveIndexResponse, null)
-                        )),
-                            ResolveIndexAction.Response::new,
-                            EsExecutors.DIRECT_EXECUTOR_SERVICE
-                        )
+                        })
+                            .map(
+                                resolveIndexResponse -> Map.entry(
+                                    clusterAlias,
+                                    new SearchPlanningPhaseResolutionResult(resolveIndexResponse, null)
+                                )
+                            ), ResolveIndexAction.Response::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
                     )
                 ));
 


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/143369, we need to gracefully handle PIT requests where a linked project is unavailable. 

Currently, the entire PIT request fails if any remote request fails; this PR changes the error handling so it can be delegated to `CrossProjectIndexResolutionValidator#validate` (we'll adjust the behaviour of `validate` in a separate PR)