### PR TITLE
Remove unused method on Mapping

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -128,13 +128,6 @@ public final class Mapping implements ToXContentFragment {
     }
 
     /**
-     * Generate a mapping update for the given root object mapper.
-     */
-    Mapping mappingUpdate(RootObjectMapper rootObjectMapper) {
-        return new Mapping(rootObjectMapper, metadataMappers, meta);
-    }
-
-    /**
      * Returns a {@link SourceLoader.SyntheticVectorsLoader} that loads synthetic vector values
      * from a source document, optionally applying a {@link SourceFilter}.
      * <p>


### PR DESCRIPTION
Dynamic mapping updates all go via Builders now, so this method was a leftover.