### PR TITLE
[9.3] ESQL: TS command ignores aliases in BY (#143489)

### DIFF
--- a/docs/changelog/143489.yaml
+++ b/docs/changelog/143489.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143489
+summary: TS command ignores aliases in BY
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -325,6 +325,7 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
                     var unwrapped = Alias.unwrap(g);
                     if (unwrapped instanceof Attribute a) {
                         addAttribute(
+                            g,
                             a,
                             firstPassAggs,
                             secondPassGroupings,
@@ -431,7 +432,8 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
     }
 
     private void addAttribute(
-        Attribute g,
+        NamedExpression group,
+        Attribute attribute,
         List<NamedExpression> firstPassAggs,
         List<Expression> secondPassGroupings,
         InternalNames internalNames,
@@ -441,27 +443,27 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
         boolean[] packPositions,
         int position
     ) {
-        var valuesAgg = new Alias(g.source(), g.name(), valuesAggregate(context, g));
+        var valuesAgg = new Alias(group.source(), group.name(), valuesAggregate(context, attribute));
         firstPassAggs.add(valuesAgg);
-        if (g.isDimension()) {
+        if (attribute.isDimension()) {
             Alias pack = new Alias(
-                g.source(),
-                internalNames.next("pack_" + g.name()),
-                new PackDimension(g.source(), valuesAgg.toAttribute())
+                group.source(),
+                internalNames.next("pack_" + group.name()),
+                new PackDimension(group.source(), valuesAgg.toAttribute())
             );
             packDimensions.add(pack);
-            Alias grouping = new Alias(g.source(), internalNames.next("group_" + g.name()), pack.toAttribute());
-            secondPassGroupings.add(grouping);
+            Alias packedGrouping = new Alias(group.source(), internalNames.next("group_" + group.name()), pack.toAttribute());
+            secondPassGroupings.add(packedGrouping);
             Alias unpack = new Alias(
-                g.source(),
-                g.name(),
-                new UnpackDimension(g.source(), grouping.toAttribute(), g.dataType().noText()),
-                g.id()
+                group.source(),
+                group.name(),
+                new UnpackDimension(group.source(), packedGrouping.toAttribute(), attribute.dataType().noText()),
+                group.id()
             );
             unpackDimensions.add(unpack);
             packPositions[position] = true;
         } else {
-            secondPassGroupings.add(new Alias(g.source(), g.name(), valuesAgg.toAttribute(), g.id()));
+            secondPassGroupings.add(new Alias(group.source(), group.name(), valuesAgg.toAttribute(), group.id()));
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -9722,20 +9722,20 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
         // Project[[max(max_over_time(network.bytes_in)){r}#420, pod{r}#426, bucket(@timestamp, 1 minute){r}#418]]
         var project = as(plan, Project.class);
-        // Eval[[UNPACKDIMENSION(group_pod_$1{r}#454) AS pod#426]]
+        // Eval[[UNPACKDIMENSION(group_p_$1{r}#454) AS p#426]]
         var eval = as(project.child(), Eval.class);
         assertThat(eval.fields(), hasSize(1));
         var unpackAlias = as(eval.fields().getFirst(), Alias.class);
-        assertThat(unpackAlias.name(), equalTo("pod"));
+        assertThat(unpackAlias.name(), equalTo("p"));
         var unpack = as(unpackAlias.child(), UnpackDimension.class);
         var unpackField = as(unpack.field(), ReferenceAttribute.class);
-        assertThat(unpackField.name(), equalTo("group_pod_$1"));
+        assertThat(unpackField.name(), equalTo("group_p_$1"));
         // Limit[1000000[INTEGER],false,false]
         var limit = as(eval.child(), Limit.class);
-        // Aggregate[[pack_pod_$1{r}#453,
+        // Aggregate[[pack_p_$1{r}#453,
         // bucket(@timestamp, 1 minute){r}#418],
         // [MAX(MAXOVERTIME_$1{r}#451,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(max_over_time(network.bytes_in))#420,
-        // pack_pod_$1{r}#453 AS group_pod_$1#454,
+        // pack_p_$1{r}#453 AS group_p_$1#454,
         // bucket(@timestamp, 1 minute){r}#418 AS bucket(@timestamp, 1 minute)#418]]
         var aggregate = as(limit.child(), Aggregate.class);
         assertThat(aggregate.groupings(), hasSize(2));
@@ -9743,19 +9743,19 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         as(Alias.unwrap(aggregate.aggregates().get(0)), Max.class);
         var podAlias = as(aggregate.aggregates().get(1), Alias.class);
         var podAttribute = as(podAlias.child(), ReferenceAttribute.class);
-        assertThat(podAttribute.name(), equalTo("pack_pod_$1"));
+        assertThat(podAttribute.name(), equalTo("pack_p_$1"));
         assertThat(aggregate.groupings().get(0), is(podAttribute));
         var bucket = as(Alias.unwrap(aggregate.aggregates().get(2)), ReferenceAttribute.class);
         assertThat(aggregate.groupings().get(1), is(bucket));
 
-        // Eval[[PACKDIMENSION(pod{r}#452) AS pack_pod_$1#453]]
+        // Eval[[PACKDIMENSION(p{r}#452) AS pack_p_$1#453]]
         var eval2 = as(aggregate.child(), Eval.class);
         assertThat(eval2.fields(), hasSize(1));
         var packAlias = as(eval2.fields().getFirst(), Alias.class);
-        assertThat(packAlias.name(), equalTo("pack_pod_$1"));
+        assertThat(packAlias.name(), equalTo("pack_p_$1"));
         var pack = as(packAlias.child(), PackDimension.class);
         var packField = as(pack.field(), ReferenceAttribute.class);
-        assertThat(packField.name(), equalTo("pod"));
+        assertThat(packField.name(), equalTo("p"));
 
         // TimeSeriesAggregate[[_tsid{m}#450,
         // bucket(@timestamp, 1 minute){r}#418],

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -277,6 +277,29 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         );
     }
 
+    public void testAliasedGroupingInTsStatsKeepsAliasName() {
+        assumeTrue("requires metrics command", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL.isEnabled());
+
+        LogicalPlan plan = planK8s("""
+            TS k8s
+            | STATS max_bytes = max(to_long(network.total_bytes_in)) BY foobar = cluster
+            """);
+
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("max_bytes", "foobar")));
+    }
+
+    public void testAliasedGroupingInTsStatsCanBeUsedInKeep() {
+        assumeTrue("requires metrics command", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL.isEnabled());
+
+        LogicalPlan plan = planK8s("""
+            TS k8s
+            | STATS max_bytes = max(to_long(network.total_bytes_in)) BY foobar = cluster
+            | KEEP max_bytes, foobar
+            """);
+
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("max_bytes", "foobar")));
+    }
+
     private TimeSeriesAggregate findTimeSeriesAggregate(LogicalPlan plan) {
         Holder<TimeSeriesAggregate> tsAggregateHolder = new Holder<>();
         plan.forEachDown(TimeSeriesAggregate.class, tsAggregateHolder::set);


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/143489.

This backports the ESQL TS BY alias fix so aliased grouping names are preserved in optimizer output and remain usable by downstream commands (for example `KEEP`).