### PR TITLE
ESQL: Buffer reuse in ParquetStorageObjectAdapter and StorageObject

### DIFF
--- a/docs/changelog/143700.yaml
+++ b/docs/changelog/143700.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143700
+summary: Buffer reuse in `ParquetStorageObjectAdapter` and `StorageObject`
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -193,22 +193,32 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return 0;
             }
 
-            int bytesToRead = buf.remaining();
-            byte[] temp = new byte[bytesToRead];
-            int bytesRead = read(temp, 0, bytesToRead);
+            if (buf.hasArray()) {
+                int bytesRead = read(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+                if (bytesRead > 0) {
+                    buf.position(buf.position() + bytesRead);
+                }
+                return bytesRead;
+            }
 
+            byte[] temp = new byte[buf.remaining()];
+            int bytesRead = read(temp, 0, temp.length);
             if (bytesRead > 0) {
                 buf.put(temp, 0, bytesRead);
             }
-
             return bytesRead;
         }
 
         @Override
         public void readFully(java.nio.ByteBuffer buf) throws IOException {
-            int remaining = buf.remaining();
-            byte[] temp = new byte[remaining];
-            readFully(temp, 0, remaining);
+            if (buf.hasArray()) {
+                readFully(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+                buf.position(buf.limit());
+                return;
+            }
+
+            byte[] temp = new byte[buf.remaining()];
+            readFully(temp, 0, temp.length);
             buf.put(temp);
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -197,6 +197,84 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         }
     }
 
+    public void testReadByteBufferWithNonZeroPosition() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        StorageObject storageObject = createStorageObject(data);
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            ByteBuffer buffer = ByteBuffer.allocate(10);
+            buffer.position(3);
+            int bytesRead = stream.read(buffer);
+            assertEquals(7, bytesRead);
+            assertEquals(10, buffer.position());
+            buffer.flip();
+            buffer.position(3);
+            assertEquals(1, buffer.get());
+            assertEquals(2, buffer.get());
+            assertEquals(3, buffer.get());
+        }
+    }
+
+    public void testReadFullyByteBufferWithNonZeroPosition() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        StorageObject storageObject = createStorageObject(data);
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            ByteBuffer buffer = ByteBuffer.allocate(8);
+            buffer.position(3);
+            stream.readFully(buffer);
+            assertEquals(8, buffer.position());
+            buffer.flip();
+            buffer.position(3);
+            assertEquals(1, buffer.get());
+            assertEquals(2, buffer.get());
+            assertEquals(3, buffer.get());
+            assertEquals(4, buffer.get());
+            assertEquals(5, buffer.get());
+        }
+    }
+
+    public void testReadDirectByteBuffer() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        StorageObject storageObject = createStorageObject(data);
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(5);
+            assertFalse(buffer.hasArray());
+            int bytesRead = stream.read(buffer);
+            assertEquals(5, bytesRead);
+            buffer.flip();
+            assertEquals(1, buffer.get());
+            assertEquals(2, buffer.get());
+            assertEquals(3, buffer.get());
+        }
+    }
+
+    public void testReadFullyDirectByteBuffer() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        StorageObject storageObject = createStorageObject(data);
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(5);
+            assertFalse(buffer.hasArray());
+            stream.readFully(buffer);
+            buffer.flip();
+            assertEquals(1, buffer.get());
+            assertEquals(2, buffer.get());
+            assertEquals(3, buffer.get());
+            assertEquals(4, buffer.get());
+            assertEquals(5, buffer.get());
+        }
+    }
+
     public void testSeekableInputStreamSkip() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createStorageObject(data);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
@@ -83,6 +83,48 @@ public interface StorageObject {
     }
 
     /**
+     * Async byte read into a caller-provided ByteBuffer.
+     * <p>
+     * Avoids per-call allocation by reading directly into the target buffer.
+     * For heap-backed buffers, reads directly into the backing array.
+     * For direct buffers, falls back to allocating a temporary array.
+     * <p>
+     * The buffer's position is advanced by the number of bytes read.
+     * The listener receives the number of bytes actually read.
+     *
+     * @param position the starting byte position in the storage object
+     * @param target the ByteBuffer to read into; bytes are written starting at {@code target.position()}
+     * @param executor executor for running the async operation
+     * @param listener callback with the number of bytes read, or failure
+     */
+    default void readBytesAsync(long position, ByteBuffer target, Executor executor, ActionListener<Integer> listener) {
+        executor.execute(() -> {
+            int toRead = target.remaining();
+            try (InputStream stream = newStream(position, toRead)) {
+                if (target.hasArray()) {
+                    int totalRead = 0;
+                    int off = target.arrayOffset() + target.position();
+                    while (totalRead < toRead) {
+                        int n = stream.read(target.array(), off + totalRead, toRead - totalRead);
+                        if (n < 0) {
+                            break;
+                        }
+                        totalRead += n;
+                    }
+                    target.position(target.position() + totalRead);
+                    listener.onResponse(totalRead);
+                } else {
+                    byte[] bytes = stream.readAllBytes();
+                    target.put(bytes);
+                    listener.onResponse(bytes.length);
+                }
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
      * Returns true if this object has native async support.
      * <p>
      * Columnar formats (Parquet) can use this to determine whether to use


### PR DESCRIPTION
Two allocation hot spots in the datasource I/O path cause unnecessary garbage and
memory copies on every Parquet read call:

1. `ParquetStorageObjectAdapter`'s `read(ByteBuffer)` and `readFully(ByteBuffer)` allocate
   a temporary `byte[]` the size of the request, read into it, then copy into the caller's
   ByteBuffer. For heap-backed ByteBuffers (the common case with Parquet's column readers),
   this is a pure waste — we can read directly into the backing array.

2. `StorageObject.readBytesAsync` always allocates a fresh `byte[]` via `stream.readAllBytes()`.
   Callers that can reuse buffers across reads (e.g., columnar format readers doing sequential
   chunk reads) have no way to avoid this allocation.

This PR fixes both:
- `ParquetStorageObjectAdapter` now reads directly into heap ByteBuffer backing arrays,
  falling back to temp arrays only for direct ByteBuffers.
- `StorageObject` gains a `readBytesAsync(long, ByteBuffer, Executor, ActionListener<Integer>)`
  overload that fills a caller-provided buffer, enabling buffer reuse across async reads.

Developed using AI-assisted tooling