### PR TITLE
Remove LifecyclePolicyUsageCalculator's assertion that a data stream has a template

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
@@ -80,7 +80,6 @@ public class LifecyclePolicyUsageCalculator {
             // Find the index template with the highest priority that matches this data stream's name.
             String indexTemplate = MetadataIndexTemplateService.findV2TemplateFromSortedList(project, indexTemplates, dataStream, false);
             if (indexTemplate == null) {
-                assert false : "Data stream [" + dataStream + "] has no matching template";
                 continue;
             }
             final var policyName = templateToPolicy.get(indexTemplate);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
@@ -219,4 +219,28 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
             equalTo(new ItemUsage(List.of("myindex"), null, List.of("mytemplate")))
         );
     }
+
+    public void testGetUsageWhenDataStreamHasNoTemplate() {
+        // Test when a data stream does not use the policy anymore because of a higher template
+        IndexMetadata index = IndexMetadata.builder("myindex")
+            .settings(indexSettings(IndexVersion.current(), 1, 0).put(LifecycleSettings.LIFECYCLE_NAME, "mypolicy"))
+            .build();
+        final var project = ProjectMetadata.builder(randomProjectIdOrDefault())
+            .put(index, false)
+            .put(DataStreamTestHelper.newInstance("myds", List.of(index.getIndex())))
+            .putCustom(
+                IndexLifecycleMetadata.TYPE,
+                new IndexLifecycleMetadata(
+                    Map.of("mypolicy", LifecyclePolicyMetadataTests.createRandomPolicyMetadata("mypolicy")),
+                    OperationMode.RUNNING
+                )
+            )
+            .build();
+
+        // Test where policy exists and is used by an index, datastream, but no template
+        assertThat(
+            new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
+            equalTo(new ItemUsage(List.of("myindex"), null, null))
+        );
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
@@ -221,7 +221,6 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
     }
 
     public void testGetUsageWhenDataStreamHasNoTemplate() {
-        // Test when a data stream does not use the policy anymore because of a higher template
         IndexMetadata index = IndexMetadata.builder("myindex")
             .settings(indexSettings(IndexVersion.current(), 1, 0).put(LifecycleSettings.LIFECYCLE_NAME, "mypolicy"))
             .build();


### PR DESCRIPTION
It's possible for a data stream not to have a template. For example, when it is restored from a snapshot without a matching template, or in the event it is a system data stream (which have their own template management).

Resolves #143605
