### PR TITLE
[8.19] Remove LifecyclePolicyUsageCalculator's assertion that a data stream has a template (#143710)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculator.java
@@ -82,7 +82,6 @@ public class LifecyclePolicyUsageCalculator {
             // Find the index template with the highest priority that matches this data stream's name.
             String indexTemplate = MetadataIndexTemplateService.findV2TemplateFromSortedList(metadata, indexTemplates, dataStream, false);
             if (indexTemplate == null) {
-                assert false : "Data stream [" + dataStream + "] has no matching template";
                 continue;
             }
             final var policyName = templateToPolicy.get(indexTemplate);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
@@ -247,4 +247,27 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
             equalTo(new ItemUsage(List.of("myindex"), null, List.of("mytemplate")))
         );
     }
+
+    public void testGetUsageWhenDataStreamHasNoTemplate() {
+        IndexMetadata index = IndexMetadata.builder("myindex")
+            .settings(indexSettings(IndexVersion.current(), 1, 0).put(LifecycleSettings.LIFECYCLE_NAME, "mypolicy"))
+            .build();
+        final var project = ProjectMetadata.builder(randomProjectIdOrDefault())
+            .put(index, false)
+            .put(DataStreamTestHelper.newInstance("myds", List.of(index.getIndex())))
+            .putCustom(
+                IndexLifecycleMetadata.TYPE,
+                new IndexLifecycleMetadata(
+                    Map.of("mypolicy", LifecyclePolicyMetadataTests.createRandomPolicyMetadata("mypolicy")),
+                    OperationMode.RUNNING
+                )
+            )
+            .build();
+
+        // Test where policy exists and is used by an index, datastream, but no template
+        assertThat(
+            new LifecyclePolicyUsageCalculator(iner, project, List.of("mypolicy")).retrieveCalculatedUsage("mypolicy"),
+            equalTo(new ItemUsage(List.of("myindex"), null, null))
+        );
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUsageCalculatorTests.java
@@ -252,15 +252,19 @@ public class LifecyclePolicyUsageCalculatorTests extends ESTestCase {
         IndexMetadata index = IndexMetadata.builder("myindex")
             .settings(indexSettings(IndexVersion.current(), 1, 0).put(LifecycleSettings.LIFECYCLE_NAME, "mypolicy"))
             .build();
-        final var project = ProjectMetadata.builder(randomProjectIdOrDefault())
-            .put(index, false)
-            .put(DataStreamTestHelper.newInstance("myds", List.of(index.getIndex())))
-            .putCustom(
-                IndexLifecycleMetadata.TYPE,
-                new IndexLifecycleMetadata(
-                    Map.of("mypolicy", LifecyclePolicyMetadataTests.createRandomPolicyMetadata("mypolicy")),
-                    OperationMode.RUNNING
-                )
+        final var project = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(
+                Metadata.builder()
+                    .put(index, false)
+                    .put(DataStreamTestHelper.newInstance("myds", List.of(index.getIndex())))
+                    .putCustom(
+                        IndexLifecycleMetadata.TYPE,
+                        new IndexLifecycleMetadata(
+                            Map.of("mypolicy", LifecyclePolicyMetadataTests.createRandomPolicyMetadata("mypolicy")),
+                            OperationMode.RUNNING
+                        )
+                    )
+                    .build()
             )
             .build();
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove LifecyclePolicyUsageCalculator's assertion that a data stream has a template (#143710)