### PR TITLE
ES|QL codegen: check builder arguments for vector support

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
@@ -71,7 +71,8 @@ public class EvaluatorImplementer {
         );
         this.processOutputsMultivalued = this.processFunction.hasBlockType;
         boolean anyParameterNotSupportingVectors = this.processFunction.args.stream().anyMatch(a -> a.supportsVectorReadAccess() == false);
-        vectorsUnsupported = processOutputsMultivalued || anyParameterNotSupportingVectors;
+        boolean returnTypeWithoutVectorSupport = vectorType(elementType(this.processFunction.resultDataType(true))) == null;
+        vectorsUnsupported = processOutputsMultivalued || anyParameterNotSupportingVectors || returnTypeWithoutVectorSupport;
         this.allNullsIsNull = allNullsIsNull;
     }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
@@ -38,6 +38,7 @@ import static org.elasticsearch.compute.gen.Types.DOUBLE_BLOCK_BUILDER;
 import static org.elasticsearch.compute.gen.Types.DOUBLE_VECTOR;
 import static org.elasticsearch.compute.gen.Types.DOUBLE_VECTOR_BUILDER;
 import static org.elasticsearch.compute.gen.Types.DOUBLE_VECTOR_FIXED_BUILDER;
+import static org.elasticsearch.compute.gen.Types.EXPONENTIAL_HISTOGRAM_BLOCK_BUILDER;
 import static org.elasticsearch.compute.gen.Types.FLOAT_BLOCK_BUILDER;
 import static org.elasticsearch.compute.gen.Types.FLOAT_VECTOR_BUILDER;
 import static org.elasticsearch.compute.gen.Types.FLOAT_VECTOR_FIXED_BUILDER;
@@ -294,6 +295,9 @@ public class Methods {
         }
         if (t.equals(TDIGEST_BLOCK_BUILDER)) {
             return "newTDigestBlockBuilder";
+        }
+        if (t.equals(EXPONENTIAL_HISTOGRAM_BLOCK_BUILDER)) {
+            return "newExponentialHistogramBlockBuilder";
         }
         throw new IllegalArgumentException("unknown build method for [" + t + "]");
     }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
@@ -62,8 +62,8 @@ public class Types {
     static final ClassName LONG_BLOCK_BUILDER = LONG_BLOCK.nestedClass("Builder");
     static final ClassName DOUBLE_BLOCK_BUILDER = DOUBLE_BLOCK.nestedClass("Builder");
     static final ClassName FLOAT_BLOCK_BUILDER = FLOAT_BLOCK.nestedClass("Builder");
-    static final ClassName EXPONENTIAL_HISTOGRAM_BLOCK_BUILDER = ClassName.get(DATA_PACKAGE, "ExponentialHistogramBlockBuilder");
-    static final ClassName TDIGEST_BLOCK_BUILDER = ClassName.get(DATA_PACKAGE, "TDigestBlockBuilder");
+    static final ClassName EXPONENTIAL_HISTOGRAM_BLOCK_BUILDER = EXPONENTIAL_HISTOGRAM_BLOCK.nestedClass("Builder");
+    static final ClassName TDIGEST_BLOCK_BUILDER = TDIGEST_BLOCK.nestedClass("Builder");
 
     static final ClassName ELEMENT_TYPE = ClassName.get(DATA_PACKAGE, "ElementType");
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlock.java
@@ -60,6 +60,11 @@ public sealed interface ExponentialHistogramBlock extends HistogramBlock permits
     sealed interface Builder extends Block.Builder, BlockLoader.ExponentialHistogramBuilder permits ExponentialHistogramBlockBuilder {
 
         /**
+         * Appends the provided histogram to this builder.
+         */
+        Builder append(ExponentialHistogram histogram);
+
+        /**
          * Copy the values in {@code block} from the given positon into this builder.
          */
         Builder copyFrom(ExponentialHistogramBlock block, int position);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlockBuilder.java
@@ -89,6 +89,7 @@ public final class ExponentialHistogramBlockBuilder implements ExponentialHistog
         return encodedHistogramsBuilder;
     }
 
+    @Override
     public ExponentialHistogramBlockBuilder append(ExponentialHistogram histogram) {
         ExponentialHistogramArrayBlock.EncodedHistogramData data = ExponentialHistogramArrayBlock.encode(histogram);
         valueCountsBuilder.appendDouble(data.count());

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlock.java
@@ -34,6 +34,8 @@ public sealed interface TDigestBlock extends HistogramBlock permits ConstantNull
      */
     sealed interface Builder extends Block.Builder, BlockLoader.TDigestBuilder permits TDigestBlockBuilder {
 
+        Block.Builder appendTDigest(TDigestHolder tDigestHolder);
+
         /**
          * Copy the values in {@code block} from the given positon into this builder.
          */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlockBuilder.java
@@ -159,7 +159,8 @@ public final class TDigestBlockBuilder implements TDigestBlock.Builder {
         Releasables.close(encodedDigestsBuilder, minimaBuilder, maximaBuilder, sumsBuilder, valueCountsBuilder);
     }
 
-    public void appendTDigest(TDigestHolder val) {
+    @Override
+    public TDigestBlockBuilder appendTDigest(TDigestHolder val) {
         encodedDigestsBuilder.appendBytesRef(val.getEncodedDigest());
         if (Double.isNaN(val.getMin())) {
             minimaBuilder.appendNull();
@@ -177,6 +178,7 @@ public final class TDigestBlockBuilder implements TDigestBlock.Builder {
             sumsBuilder.appendDouble(val.getSum());
         }
         valueCountsBuilder.appendLong(val.getValueCount());
+        return this;
     }
 
     public void deserializeAndAppend(TDigestBlock.SerializedTDigestInput input) {

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromHistogramEvaluator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.TDigestBlock;
-import org.elasticsearch.compute.data.TDigestBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -54,7 +53,7 @@ public final class ToTDigestFromHistogramEvaluator extends AbstractConvertFuncti
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
     }
-    try (TDigestBlockBuilder builder = driverContext.blockFactory().newTDigestBlockBuilder(positionCount)) {
+    try (TDigestBlock.Builder builder = driverContext.blockFactory().newTDigestBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
           builder.appendTDigest(evalValue(vector, p, scratchPad));
@@ -76,7 +75,7 @@ public final class ToTDigestFromHistogramEvaluator extends AbstractConvertFuncti
   public Block evalBlock(Block b) {
     BytesRefBlock block = (BytesRefBlock) b;
     int positionCount = block.getPositionCount();
-    try (TDigestBlockBuilder builder = driverContext.blockFactory().newTDigestBlockBuilder(positionCount)) {
+    try (TDigestBlock.Builder builder = driverContext.blockFactory().newTDigestBlockBuilder(positionCount)) {
       BytesRef scratchPad = new BytesRef();
       for (int p = 0; p < positionCount; p++) {
         int valueCount = block.getValueCount(p);


### PR DESCRIPTION
I'm currently working on adding a `TO_EXPONENTIAL_HISTOGRAM` ES|QL type conversion function.
To implement it with as little memory allocations, I will be using a builder argument for the evaluator function:

```java
@Evaluator(extraName = "FromTDigest")
static void fromTDigest(ExponentialHistogramBlock.Builder resultBuilder, TDigestHolder in) {
...
}
```

While doing so, I noticed that the code-generator attempts to generate a vectorized code path, even though `ExponentialHistogramBlocks` don't have a vectorized form. This PR fixes this by adding a check to the code generation ensuring that the return type actually support vectors.

It also fixes some inconsistencies with the builder naming used for `TDigest` and `ExponentialHistogram` in the generated code.