### PR TITLE
Don't run seq_no pruning tests in release CI

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -372,6 +372,8 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         final boolean pruneSequenceNumber,
         final boolean useSyntheticRecoverySource
     ) throws IOException {
+        assumeTrue("Sequence number pruning requires a feature flag",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false);
         try (var dir = newDirectory()) {
             dir.setCheckIndexOnClose(false);
 
@@ -574,6 +576,8 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         boolean syntheticRecoverySource = randomBoolean();
         boolean pruneIdField = randomBoolean();
         boolean pruneSequenceNumber = randomBoolean();
+        assumeTrue("Sequence number pruning requires a feature flag",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false);
         String pruneStoredFieldName = syntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME;
         String pruneNumericDVFieldName = syntheticRecoverySource
             ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -372,8 +372,10 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         final boolean pruneSequenceNumber,
         final boolean useSyntheticRecoverySource
     ) throws IOException {
-        assumeTrue("Sequence number pruning requires a feature flag",
-            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false);
+        assumeTrue(
+            "Sequence number pruning requires a feature flag",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false
+        );
         try (var dir = newDirectory()) {
             dir.setCheckIndexOnClose(false);
 
@@ -576,8 +578,10 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         boolean syntheticRecoverySource = randomBoolean();
         boolean pruneIdField = randomBoolean();
         boolean pruneSequenceNumber = randomBoolean();
-        assumeTrue("Sequence number pruning requires a feature flag",
-            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false);
+        assumeTrue(
+            "Sequence number pruning requires a feature flag",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false
+        );
         String pruneStoredFieldName = syntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME;
         String pruneNumericDVFieldName = syntheticRecoverySource
             ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME


### PR DESCRIPTION
These tests require a feature flag to be enabled to pass, which is 
not available in nightly builds.

Fixes #143718 
Fixes #143717 