### PR TITLE
Disable "Review skipped" comments for PRs without specified labels

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  # Do not post "Review skipped" on PRs without the labels below
+  review_status: false
   auto_review:
     labels:
       - "Team:Delivery"


### PR DESCRIPTION
Updated `.coderabbit.yml` to add `review_status: false`, preventing unnecessary "Review skipped" comments on pull requests without matching labels.

https://docs.coderabbit.ai/reference/configuration#param-review-status

> `review_status`
> Post review status messages (e.g., when a review is skipped) in the walkthrough summary comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for code review automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->