### PR TITLE
Add documentation for new queryDSL aggs on exponential_histogram fields

### DIFF
--- a/docs/reference/aggregations/search-aggregations-bucket-range-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-bucket-range-aggregation.md
@@ -296,7 +296,7 @@ Response:
 
 ## Histogram fields [search-aggregations-bucket-range-aggregation-histogram-fields]
 
-Running a range aggregation over histogram fields computes the total number of counts for each configured range.
+Running a range aggregation over histogram fields computes the total number of counts for each configured range. The same applies to [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4`.
 
 This is done without interpolating between the histogram field values. Consequently, it is possible to have a range that is "in-between" two histogram values. The resulting range bucket would have a zero doc count.
 

--- a/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Boxplot aggregation [search-aggregations-metrics-boxplot-aggregation]
 
 
-A `boxplot` metrics aggregation that computes boxplot of numeric values extracted from the aggregated documents. These values can be generated from specific numeric or [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md) in the documents.
+A `boxplot` metrics aggregation that computes boxplot of numeric values extracted from the aggregated documents. These values can be generated from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
 
 The `boxplot` aggregation returns essential information for making a [box plot](https://en.wikipedia.org/wiki/Box_plot): minimum, maximum, median, first quartile (25th percentile)  and third quartile (75th percentile) values.
 

--- a/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Boxplot aggregation [search-aggregations-metrics-boxplot-aggregation]
 
 
-A `boxplot` metrics aggregation that computes boxplot of numeric values extracted from the aggregated documents. These values can be generated from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
+A `boxplot` metrics aggregation that computes boxplot of numeric values extracted from the aggregated documents. These values can be generated from specific numeric, [histogram](/reference/elasticsearch/mapping-reference/histogram.md) or [exponential histogram](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` fields in the documents.
 
 The `boxplot` aggregation returns essential information for making a [box plot](https://en.wikipedia.org/wiki/Box_plot): minimum, maximum, median, first quartile (25th percentile)  and third quartile (75th percentile) values.
 

--- a/docs/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Percentiles aggregation [search-aggregations-metrics-percentile-aggregation]
 
 
-A `multi-value` metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
+A `multi-value` metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram](/reference/elasticsearch/mapping-reference/histogram.md) or [exponential histogram](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` fields in the documents.
 
 Percentiles show the point at which a certain percentage of observed values occur. For example, the 95th percentile is the value which is greater than 95% of the observed values.
 

--- a/docs/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Percentiles aggregation [search-aggregations-metrics-percentile-aggregation]
 
 
-A `multi-value` metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric or [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md) in the documents.
+A `multi-value` metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
 
 Percentiles show the point at which a certain percentage of observed values occur. For example, the 95th percentile is the value which is greater than 95% of the observed values.
 

--- a/docs/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Percentile ranks aggregation [search-aggregations-metrics-percentile-rank-aggregation]
 
 
-A `multi-value` metrics aggregation that calculates one or more percentile ranks over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
+A `multi-value` metrics aggregation that calculates one or more percentile ranks over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram](/reference/elasticsearch/mapping-reference/histogram.md) or [exponential histogram](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` fields in the documents.
 
 ::::{note}
 Please see [Percentiles are (usually) approximate](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-approximation), [Compression](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-compression) and [Execution hint](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-execution-hint) for advice regarding approximation, performance and memory use of the percentile ranks aggregation

--- a/docs/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Percentile ranks aggregation [search-aggregations-metrics-percentile-rank-aggregation]
 
 
-A `multi-value` metrics aggregation that calculates one or more percentile ranks over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric or [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md) in the documents.
+A `multi-value` metrics aggregation that calculates one or more percentile ranks over numeric values extracted from the aggregated documents. These values can be extracted from specific numeric, [histogram fields](/reference/elasticsearch/mapping-reference/histogram.md), or [exponential histogram fields](/reference/elasticsearch/mapping-reference/exponential-histogram.md) {applies_to}`stack: ga 9.4` in the documents.
 
 ::::{note}
 Please see [Percentiles are (usually) approximate](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-approximation), [Compression](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-compression) and [Execution hint](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md#search-aggregations-metrics-percentile-aggregation-execution-hint) for advice regarding approximation, performance and memory use of the percentile ranks aggregation

--- a/docs/reference/elasticsearch/mapping-reference/exponential-histogram.md
+++ b/docs/reference/elasticsearch/mapping-reference/exponential-histogram.md
@@ -76,6 +76,12 @@ In Query DSL, because the data is not indexed, you can use `exponential_histogra
 - [avg](/reference/aggregations/search-aggregations-metrics-avg-aggregation.md) aggregation
 - [value_count](/reference/aggregations/search-aggregations-metrics-valuecount-aggregation.md) aggregation
 - [histogram](/reference/aggregations/search-aggregations-bucket-histogram-aggregation.md) aggregation
+- [min](/reference/aggregations/search-aggregations-metrics-min-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
+- [max](/reference/aggregations/search-aggregations-metrics-max-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
+- [percentiles](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
+- [percentile ranks](/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
+- [boxplot](/reference/aggregations/search-aggregations-metrics-boxplot-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
+- [range](/reference/aggregations/search-aggregations-bucket-range-aggregation.md) aggregation {applies_to}`stack: ga 9.4`
 
 ## Synthetic `_source` [exponential-histogram-synthetic-source]
 


### PR DESCRIPTION
Closes #135625.
Documents the newly added support for queryDSL aggs on exponential_histogram.
