### PR TITLE
[9.2] Disable "Review skipped" comments for PRs without specified labels (#143728)

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  # Do not post "Review skipped" on PRs without the labels below
+  review_status: false
   auto_review:
     labels:
       - "Team:Delivery"


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Disable "Review skipped" comments for PRs without specified labels (#143728)