### PR TITLE
Update Gradle toolchain configuration for additional JDK support

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -33,6 +33,9 @@ export JAVA11_HOME
 JAVA16_HOME="$HOME/.java/openjdk16"
 export JAVA16_HOME
 
+JAVA22_HOME="$HOME/.java/openjdk22"
+export JAVA22_HOME
+
 if [[ "${ES_RUNTIME_JAVA:-}" ]]; then
   RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
   export RUNTIME_JAVA_HOME

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,10 @@ org.gradle.java.installations.auto-detect=false
 # log some dependency verification info to console
 org.gradle.dependency.verification.console=verbose
 
-# allow user to specify toolchain via the RUNTIME_JAVA_HOME environment variable
-org.gradle.java.installations.fromEnv=RUNTIME_JAVA_HOME
+# allow user to specify toolchain via environment variables. RUNTIME_JAVA_HOME is the main
+# build JDK; JAVA22_HOME (and similar) let CI point to extra JDKs for tasks requiring other JDKs
+# (e.g. :libs:native:compileMain22Java). If unset, Gradle will try to provision from the net.
+org.gradle.java.installations.fromEnv=RUNTIME_JAVA_HOME,JAVA22_HOME
 
 # if configuration cache enabled then enable parallel support too
 org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
Expand `org.gradle.java.installations.fromEnv` to include `JAVA22_HOME` for tasks requiring JDK 22. Added `JAVA22_HOME` configuration in Buildkite pre-command hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Java 22 support to the build system configuration.
  * Updated build toolchain to recognize and utilize Java 22 as an alternative JDK option for CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->