### PR TITLE
ES|QL: Update docs for TOP_SNIPPETS and DECAY

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/examples/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/top_snippets.md
@@ -34,4 +34,23 @@ FROM books
 | 2714 | Return of the King Being the Third Part of The Lord of the Rings | [Concluding the story begun in The Hobbit\, this is the final part of Tolkien s epic masterpiece\, The Lord of the Rings\, featuring an exclusive, Tolkien s epic masterpiece\, The Lord of the Rings\, featuring an exclusive cover image from the film\, the definitive text\, and a detailed map of, Tolkien s classic tale of magic and adventure\, begun in The Fellowship of the Ring and The Two Towers\, features the definitive edition of the] |
 | 7350 | Return of the Shadow | [Tolkien for long believed would be a far shorter book\, 'a sequel to The Hobbit'., In The Return of the Shadow (an abandoned title for the first volume) Christopher Tolkien describes\, with full citation of the earliest notes\, outline plans, ) Christopher Tolkien describes\, with full citation of the earliest notes\, outline plans\, and narrative drafts\, the intricate evolution of The Fellowship of the Ring and] |
 
+```{applies_to}
+stack: preview 9.3.0
+```
+
+```esql
+FROM books
+| WHERE MATCH(title, "return")
+| RERANK "Tolkien" ON TOP_SNIPPETS(description, "Tolkien", { "num_snippets": 3, "num_words": 25 }) WITH { "inference_id" : "test_reranker" }
+```
+
+| book_no:keyword | title:text | _score:double |
+| --- | --- | --- |
+| 2714 | Return of the King Being the Third Part of The Lord of the Rings | 0.007092198356986046 |
+| 7350 | Return of the Shadow | 0.012500000186264515 |
+
+
+This examples demonstrates how to use `TOP_SNIPPETS` with `RERANK`. By returning a fixed number of snippets with a limited
+size, we have more control over the number of tokens that are used for semantic reranking.
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/functionNamedParams/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/functionNamedParams/top_snippets.md
@@ -4,7 +4,6 @@
 
 `num_words`
 :   (integer) The maximum number of words to return in each snippet.
-This allows better control of inference costs by limiting the size of tokens per snippet.
 
 
 `num_snippets`

--- a/docs/reference/query-languages/esql/_snippets/functions/parameters/decay.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/parameters/decay.md
@@ -12,5 +12,5 @@
 :   Distance from the origin where the function returns the decay value.
 
 `options`
-:   
+:   (Optional) Additional options such as `decay`, `offset` and `type`.
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/decay.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/decay.json
@@ -29,7 +29,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -60,7 +60,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -91,7 +91,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -122,7 +122,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -153,7 +153,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -184,7 +184,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -215,7 +215,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,
@@ -246,7 +246,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='offset', values=[], description='Distance from the origin where no decay occurs.', type=[double, integer, long, time_duration, keyword, text]}, {name='type', values=[], description='Decay function to use: linear, exponential or gaussian.', type=[keyword]}, {name='decay', values=[], description='Multiplier value returned at the scale distance from the origin.', type=[double]}",
           "optional" : true,
-          "description" : ""
+          "description" : "(Optional) Additional options such as `decay`, `offset` and `type`."
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
@@ -39,7 +39,7 @@
         {
           "name" : "options",
           "type" : "function_named_parameters",
-          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
+          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
           "optional" : true,
           "description" : "(Optional) `TOP_SNIPPETS` additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
         }
@@ -82,7 +82,7 @@
         {
           "name" : "options",
           "type" : "function_named_parameters",
-          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
+          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
           "optional" : true,
           "description" : "(Optional) `TOP_SNIPPETS` additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
         }
@@ -93,7 +93,8 @@
   ],
   "examples" : [
     "FROM books\n| EVAL snippets = TOP_SNIPPETS(description, \"Tolkien\")",
-    "FROM books\n| WHERE MATCH(title, \"Return\")\n| EVAL snippets = TOP_SNIPPETS(description, \"Tolkien\", { \"num_snippets\": 3, \"num_words\": 25 })"
+    "FROM books\n| WHERE MATCH(title, \"Return\")\n| EVAL snippets = TOP_SNIPPETS(description, \"Tolkien\", { \"num_snippets\": 3, \"num_words\": 25 })",
+    "FROM books\n| WHERE MATCH(title, \"return\")\n| RERANK \"Tolkien\" ON TOP_SNIPPETS(description, \"Tolkien\", { \"num_snippets\": 3, \"num_words\": 25 }) WITH { \"inference_id\" : \"test_reranker\" }"
   ],
   "preview" : true,
   "snapshot_only" : false

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
@@ -159,6 +159,7 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
         ) Expression scale,
         @MapParam(
             name = "options",
+            description = "(Optional) Additional options such as `decay`, `offset` and `type`.",
             params = {
                 @MapParam.MapParamEntry(
                     name = OFFSET,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
@@ -85,7 +85,11 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
             """,
         examples = {
             @Example(file = "top-snippets", tag = "top-snippets-with-field", applies_to = "stack: preview 9.3.0"),
-            @Example(file = "top-snippets", tag = "top-snippets-with-options", applies_to = "stack: preview 9.3.0") }
+            @Example(file = "top-snippets", tag = "top-snippets-with-options", applies_to = "stack: preview 9.3.0"),
+            @Example(file = "rerank", tag = "rerank-top-snippets", applies_to = "stack: preview 9.3.0", explanation = """
+                This examples demonstrates how to use `TOP_SNIPPETS` with `RERANK`. By returning a fixed number of snippets with a limited
+                size, we have more control over the number of tokens that are used for semantic reranking.
+                """) }
     )
     public TopSnippets(
         Source source,
@@ -116,7 +120,6 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
                 ),
                 @MapParam.MapParamEntry(name = "num_words", type = "integer", description = """
                     The maximum number of words to return in each snippet.
-                    This allows better control of inference costs by limiting the size of tokens per snippet.
                     """, valueHint = { "300" }) }
         ) Expression options
     ) {


### PR DESCRIPTION
# Changes in Decay docs

`Decay` docs are missing a description for options:

<img width="858" height="901" alt="Screenshot 2026-03-06 at 13 45 15" src="https://github.com/user-attachments/assets/8ee3b70c-5753-4eee-9bfb-19a30336f95c" />

# Changes in `TOP_SNIPPETS` docs

`TOP_SNIPPETS` has a seemingly random note about controlling the cost of inference using `num_words` - but we lack any context of what this means, so I added an example using RERANK:

<img width="776" height="283" alt="Screenshot 2026-03-06 at 13 46 11" src="https://github.com/user-attachments/assets/15b437ff-495b-42c2-8cf5-14a5b97f1a64" />
