### PR TITLE
Correctly include endpoint id in log msg in AuthorizationPoller

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
@@ -356,7 +356,7 @@ public class AuthorizationPoller extends AllocatedPersistentTask {
         if (existingEndpoint == null) {
             logger.debug(
                 () -> Strings.format(
-                    "[{}] selected for persistence, because it currently does not exist",
+                    "[%s] selected for persistence, because it currently does not exist",
                     newEndpoint.getInferenceEntityId()
                 )
             );
@@ -367,7 +367,7 @@ public class AuthorizationPoller extends AllocatedPersistentTask {
         if (existingMetadata.fingerprintMatches(newEndpoint.getConfigurations().getEndpointMetadata()) == false) {
             logger.debug(
                 () -> Strings.format(
-                    "[{}] selected for persistence, because its fingerprint has changed",
+                    "[%s] selected for persistence, because its fingerprint has changed",
                     newEndpoint.getInferenceEntityId()
                 )
             );
@@ -375,7 +375,7 @@ public class AuthorizationPoller extends AllocatedPersistentTask {
         }
         if (newEndpoint.getConfigurations().getEndpointMetadata().hasNewerVersionThan(existingMetadata)) {
             logger.debug(
-                () -> Strings.format("[{}] selected for persistence, because its version is higher", newEndpoint.getInferenceEntityId())
+                () -> Strings.format("[%s] selected for persistence, because its version is higher", newEndpoint.getInferenceEntityId())
             );
             return true;
         }


### PR DESCRIPTION
This fixes debug log messages added in #143567 where the endpoint id is not correctly included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated logging format consistency in authorization-related debug messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->