### PR TITLE
ESQL: Auto create capabilites from functions

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -208,7 +208,7 @@ public class CsvTestsDataLoader {
         ).withRequiredCapabilities(EsqlCapabilities.Cap.HISTOGRAM_RELEASE_VERSION),
         new TestDataset("many_numbers"),
         new TestDataset("mmr_text_vector_keyword"),
-        new TestDataset("json_logs").withRequiredCapabilities(EsqlCapabilities.Cap.FN_JSON_EXTRACT)
+        new TestDataset("json_logs")
     ).collect(toMap(TestDataset::indexName, Function.identity()));
 
     public static final Map<String, EnrichConfig> ENRICH_POLICIES = Stream.of(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -14,11 +14,11 @@ import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.action.admin.cluster.RestNodesCapabilitiesAction;
 import org.elasticsearch.xpack.core.esql.EsqlFeatureFlags;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredOrNullAggWithEval;
 import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
@@ -27,7 +27,60 @@ import java.util.Set;
  * and {@link RestEsqlAsyncQueryAction} APIs. These are exposed over the
  * {@link RestNodesCapabilitiesAction} and we use them to enable tests.
  */
-public class EsqlCapabilities {
+public record EsqlCapabilities(Set<String> capabilities) {
+    /**
+     * ESQL capabilities.
+     *
+     * @param all if {@code false} then only <strong>enabled</strong> capabilities are returned,
+     *            otherwise <strong>all</strong> known capabilities are returned.
+     */
+    public static EsqlCapabilities capabilities(EsqlFunctionRegistry functions, boolean all) {
+        Builder builder = new Builder(all);
+        for (Cap cap : Cap.values()) {
+            builder.add(cap.capabilityName(), cap.isEnabled());
+        }
+
+        /*
+         * Add all of our cluster features without the leading "esql."
+         */
+        for (NodeFeature feature : new EsqlFeatures().getFeatures()) {
+            builder.add(cap(feature), true);
+        }
+
+        if (all) {
+            functions = functions.snapshotRegistry();
+        }
+        functions.addCapabilities(builder);
+        return builder.build();
+    }
+
+    public static class Builder {
+        private final Set<String> capabilities = new HashSet<>();
+        private final boolean all;
+
+        public Builder(boolean all) {
+            this.all = all;
+        }
+
+        public boolean all() {
+            return all;
+        }
+
+        public void add(String cap, boolean enabled) {
+            if (all || enabled) {
+                System.err.println("adding " + cap);
+                boolean firstTime = capabilities.add(cap);
+                if (firstTime == false) {
+                    throw new IllegalStateException("duplicate capability [" + cap + "]");
+                }
+            }
+        }
+
+        public EsqlCapabilities build() {
+            return new EsqlCapabilities(Set.copyOf(capabilities));
+        }
+    }
+
     public enum Cap {
         /**
          * Introduction of {@code MV_SORT}, {@code MV_SLICE}, and {@code MV_ZIP}.
@@ -196,61 +249,11 @@ public class EsqlCapabilities {
         COUNTER_TYPES,
 
         /**
-         * Support for function {@code BIT_LENGTH}. Done in #115792
-         */
-        FN_BIT_LENGTH,
-
-        /**
-         * Support for function {@code BYTE_LENGTH}.
-         */
-        FN_BYTE_LENGTH,
-
-        /**
-         * Support for function {@code REVERSE}.
-         */
-        FN_REVERSE,
-
-        /**
          * Support for reversing whole grapheme clusters. This is not supported
          * on JDK versions less than 20 which are not supported in ES 9.0.0+ but this
          * exists to keep the {@code 8.x} branch similar to the {@code main} branch.
          */
         FN_REVERSE_GRAPHEME_CLUSTERS,
-
-        /**
-         * Support for function {@code CONTAINS}. Done in <a href="https://github.com/elastic/elasticsearch/pull/133016">#133016.</a>
-         */
-        FN_CONTAINS,
-
-        /**
-         * Support for function {@code CBRT}. Done in #108574.
-         */
-        FN_CBRT,
-
-        /**
-         * Support for function {@code HYPOT}.
-         */
-        FN_HYPOT,
-
-        /**
-         * Support for {@code MV_APPEND} function. #107001
-         */
-        FN_MV_APPEND,
-
-        /**
-         * Support for {@code MV_MEDIAN_ABSOLUTE_DEVIATION} function.
-         */
-        FN_MV_MEDIAN_ABSOLUTE_DEVIATION,
-
-        /**
-         * Support for {@code MV_PERCENTILE} function.
-         */
-        FN_MV_PERCENTILE,
-
-        /**
-         * Support for function {@code IP_PREFIX}.
-         */
-        FN_IP_PREFIX,
 
         /**
          * Fix a bug leading to the scratch leaking data to other rows.
@@ -268,30 +271,10 @@ public class EsqlCapabilities {
         FN_ROUND_UL_FIXES,
 
         /**
-         * Support for function {@code SCALB}.
-         */
-        FN_SCALB,
-
-        /**
-         * Support for function DAY_NAME
-         */
-        FN_DAY_NAME,
-
-        /**
-         * Support for function MONTH_NAME
-         */
-        FN_MONTH_NAME,
-
-        /**
          * support for MV_CONTAINS function
          * <a href="https://github.com/elastic/elasticsearch/pull/133099/">Add MV_CONTAINS function #133099</a>
          */
         FN_MV_CONTAINS_V1,
-
-        /**
-         * support for MV_INTERSECTS function
-         */
-        FN_MV_INTERSECTS,
 
         /**
          * Fixes for multiple functions not serializing their source, and emitting warnings with wrong line number and text.
@@ -1588,11 +1571,6 @@ public class EsqlCapabilities {
         ENABLE_FORK_FOR_REMOTE_INDICES_V2,
 
         /**
-         * Support for the Present function
-         */
-        FN_PRESENT,
-
-        /**
          * Bugfix for STATS {{expression}} WHERE {{condition}} when the
          * expression is replaced by something else on planning
          * e.g. STATS SUM(1) WHERE x==3 is replaced by
@@ -1616,11 +1594,6 @@ public class EsqlCapabilities {
         QUERY_PARAMS_MULTI_VALUES(),
 
         FIX_PERCENTILE_PRECISION(),
-
-        /**
-         * Support for the Absent function
-         */
-        FN_ABSENT,
 
         /** INLINE STATS supports remote indices */
         INLINE_STATS_SUPPORTS_REMOTE(INLINESTATS_V11.enabled),
@@ -1836,11 +1809,6 @@ public class EsqlCapabilities {
         HANDLE_DETERMINIZATION_COMPLEXITY,
 
         /**
-         * Support for the TRANGE function
-         */
-        FN_TRANGE,
-
-        /**
          * https://github.com/elastic/elasticsearch/issues/136851
          */
         INLINE_STATS_WITH_NO_COLUMNS(INLINE_STATS.enabled),
@@ -2031,16 +1999,6 @@ public class EsqlCapabilities {
          * {@link org.elasticsearch.xpack.esql.expression.function.aggregate.Absent}
          */
         FIX_PRESENT_AND_ABSENT_ON_STATS_WITH_FALSE_FILTER,
-
-        /**
-         * Support for the MV_INTERSECTION function which returns the set intersection of two multivalued fields
-         */
-        FN_MV_INTERSECTION,
-
-        /**
-         * Support for the MV_UNION function which returns the set union of two multivalued fields
-         */
-        FN_MV_UNION,
 
         /**
          * Enables late materialization on node reduce. See also QueryPragmas.NODE_LEVEL_REDUCTION
@@ -2239,11 +2197,6 @@ public class EsqlCapabilities {
         INLINE_STATS_WITH_CONSTANTS(INLINE_STATS.enabled),
 
         /**
-         * Support for function {@code JSON_EXTRACT}.
-         */
-        FN_JSON_EXTRACT,
-
-        /**
          * Fix for an ArrayIndexOutOfBoundsException in the aggregation framework when the same field is passed twice.
          * https://github.com/elastic/elasticsearch/issues/142180
          */
@@ -2300,30 +2253,6 @@ public class EsqlCapabilities {
         public String capabilityName() {
             return name().toLowerCase(Locale.ROOT);
         }
-    }
-
-    public static final Set<String> CAPABILITIES = capabilities(false);
-
-    /**
-     * Get a {@link Set} of all capabilities. If the {@code all} parameter is {@code false}
-     * then only <strong>enabled</strong> capabilities are returned - otherwise <strong>all</strong>
-     * known capabilities are returned.
-     */
-    public static Set<String> capabilities(boolean all) {
-        List<String> caps = new ArrayList<>();
-        for (Cap cap : Cap.values()) {
-            if (all || cap.isEnabled()) {
-                caps.add(cap.capabilityName());
-            }
-        }
-
-        /*
-         * Add all of our cluster features without the leading "esql."
-         */
-        for (NodeFeature feature : new EsqlFeatures().getFeatures()) {
-            caps.add(cap(feature));
-        }
-        return Set.copyOf(caps);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * and {@link RestEsqlAsyncQueryAction} APIs. These are exposed over the
  * {@link RestNodesCapabilitiesAction} and we use them to enable tests.
  */
-public record EsqlCapabilities(Set<String> capabilities) {
+public class EsqlCapabilities {
     /**
      * ESQL capabilities.
      *
@@ -68,7 +68,6 @@ public record EsqlCapabilities(Set<String> capabilities) {
 
         public void add(String cap, boolean enabled) {
             if (all || enabled) {
-                System.err.println("adding " + cap);
                 boolean firstTime = capabilities.add(cap);
                 if (firstTime == false) {
                     throw new IllegalStateException("duplicate capability [" + cap + "]");
@@ -2262,5 +2261,15 @@ public record EsqlCapabilities(Set<String> capabilities) {
     public static String cap(NodeFeature feature) {
         assert feature.id().startsWith("esql.") : "node feature must start with 'esql.' but was " + feature.id();
         return feature.id().substring("esql.".length());
+    }
+
+    private final Set<String> capabilities;
+
+    private EsqlCapabilities(Set<String> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public Set<String> capabilities() {
+        return capabilities;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlAsyncQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlAsyncQueryAction.java
@@ -28,6 +28,12 @@ import static org.elasticsearch.xpack.esql.formatter.TextFormat.URL_PARAM_DELIMI
 public class RestEsqlAsyncQueryAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(RestEsqlAsyncQueryAction.class);
 
+    private final EsqlCapabilities capabilities;
+
+    public RestEsqlAsyncQueryAction(EsqlCapabilities capabilities) {
+        this.capabilities = capabilities;
+    }
+
     @Override
     public String getName() {
         return "esql_async_query";
@@ -40,7 +46,7 @@ public class RestEsqlAsyncQueryAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return EsqlCapabilities.CAPABILITIES;
+        return capabilities.capabilities();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -28,6 +28,12 @@ import static org.elasticsearch.xpack.esql.formatter.TextFormat.URL_PARAM_DELIMI
 public class RestEsqlQueryAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(RestEsqlQueryAction.class);
 
+    private final EsqlCapabilities capabilities;
+
+    public RestEsqlQueryAction(EsqlCapabilities capabilities) {
+        this.capabilities = capabilities;
+    }
+
     @Override
     public String getName() {
         return "esql_query";
@@ -40,7 +46,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return EsqlCapabilities.CAPABILITIES;
+        return capabilities.capabilities();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function;
 import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
@@ -241,10 +242,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -317,6 +320,7 @@ public class EsqlFunctionRegistry {
 
     @SuppressWarnings("this-escape")
     public EsqlFunctionRegistry() {
+        // TODO build this one time in plugin construction and pass it in
         register(functions());
         buildDataTypesForStringLiteralConversion(functions());
         nameSurrogates();
@@ -1015,6 +1019,33 @@ public class EsqlFunctionRegistry {
 
     protected interface FunctionBuilder {
         Function build(Source source, List<Expression> children, Configuration cfg);
+    }
+
+    /**
+     * Add capabilities for registered functions to the set of capabilities.
+     */
+    public void addCapabilities(EsqlCapabilities.Builder capabilities) {
+        Set<String> filterAliases = new HashSet<>();
+        EsqlFunctionRegistry snapshots = snapshotRegistry();
+        if (snapshots != null) {
+            snapshots.addCapabilities(filterAliases, capabilities, true);
+        } else {
+            addCapabilities(filterAliases, capabilities, true);
+            if (capabilities.all()) {
+                new SnapshotFunctionRegistry().addCapabilities(filterAliases, capabilities, false);
+            }
+        }
+    }
+
+    protected final void addCapabilities(Set<String> filterAliases, EsqlCapabilities.Builder capabilities, boolean enabled) {
+        for (FunctionDefinition def : defs.values()) {
+            System.err.println("checking " + def.name());
+            if (false == filterAliases.add(def.name())) {
+                continue;
+            }
+            String name = "fn_" + def.name();
+            capabilities.add(name, enabled);
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -1039,7 +1039,6 @@ public class EsqlFunctionRegistry {
 
     protected final void addCapabilities(Set<String> filterAliases, EsqlCapabilities.Builder capabilities, boolean enabled) {
         for (FunctionDefinition def : defs.values()) {
-            System.err.println("checking " + def.name());
             if (false == filterAliases.add(def.name())) {
                 continue;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
@@ -199,11 +199,11 @@
  *         Let’s finish up the code by making the tests backwards compatible. Since this is a new
  *         feature we just have to convince the tests not to run in a cluster that includes older
  *         versions of Elasticsearch. We do that with a {@link org.elasticsearch.rest.RestHandler#supportedCapabilities capability}
- *         on the REST handler. ESQL has a <strong>ton</strong> of capabilities so we list them
- *         all in {@link org.elasticsearch.xpack.esql.action.EsqlCapabilities}. Add a new one
- *         for your function. Now add something like {@code required_capability: my_function}
- *         to all of your csv-spec tests. Run those csv-spec tests as integration tests to double
- *         check that they run on the main branch.
+ *         on the REST handler. Your new function automatically created a capability when it was
+ *         registered in the {@link org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry}.
+ *         So you can add {@code required_capability: fn_my_function} to all of your csv-spec
+ *         tests. Run those csv-spec tests as integration tests to double-check that they run on
+ *         the main branch.
  *         <br><br>
  *         NOTE: You may notice tests gated based on Elasticsearch version. This was the old way
  *         of doing things. Now, we use specific capabilities for each function.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ViewMetadata;
@@ -61,6 +62,7 @@ import org.elasticsearch.xpack.esql.EsqlInfoTransportAction;
 import org.elasticsearch.xpack.esql.EsqlUsageTransportAction;
 import org.elasticsearch.xpack.esql.action.EsqlAsyncGetResultAction;
 import org.elasticsearch.xpack.esql.action.EsqlAsyncStopAction;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.action.EsqlGetQueryAction;
 import org.elasticsearch.xpack.esql.action.EsqlListQueriesAction;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
@@ -86,6 +88,7 @@ import org.elasticsearch.xpack.esql.enrich.LookupFromIndexOperator;
 import org.elasticsearch.xpack.esql.enrich.StreamingLookupFromIndexOperator;
 import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.expression.ExpressionWritables;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.inference.InferenceSettings;
 import org.elasticsearch.xpack.esql.io.stream.ExpressionQueryBuilder;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamWrapperQueryBuilder;
@@ -204,6 +207,8 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
     private final List<PlanCheckerProvider> extraCheckerProviders = new ArrayList<>();
     private final List<DataSourcePlugin> dataSourcePlugins = new ArrayList<>();
 
+    private final SetOnce<EsqlCapabilities> capabilities = new SetOnce<>();
+
     @Override
     public Collection<?> createComponents(PluginServices services) {
         Settings settings = services.clusterService().getSettings();
@@ -237,17 +242,20 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         }
 
         // Build capabilities from plugin declarations (cheap -- no I/O, no heavy deps)
-        DataSourceCapabilities capabilities = DataSourceCapabilities.build(allDataSourcePlugins);
+        DataSourceCapabilities dataSourceCapabilities = DataSourceCapabilities.build(allDataSourcePlugins);
 
         // Create DataSourceModule with all discovered plugins
         // Pass GENERIC executor for plugins that need async I/O (e.g. HTTP storage provider)
         DataSourceModule dataSourceModule = new DataSourceModule(
             allDataSourcePlugins,
-            capabilities,
+            dataSourceCapabilities,
             settings,
             blockFactoryProvider.blockFactory(),
             services.threadPool().executor(ThreadPool.Names.GENERIC)
         );
+
+        EsqlFunctionRegistry functionRegistry = new EsqlFunctionRegistry();
+        capabilities.set(EsqlCapabilities.capabilities(functionRegistry, false));
 
         List<Object> components = new ArrayList<>(
             List.of(
@@ -273,7 +281,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         if (ESQL_VIEWS_FEATURE_FLAG.isEnabled()) {
             components = new ArrayList<>(components);
             components.add(new ViewResolver(services.clusterService(), services.projectResolver(), services.client()));
-            components.add(new ViewService(services.clusterService()));
+            components.add(new ViewService(services.clusterService(), functionRegistry));
         }
         return components;
     }
@@ -366,9 +374,10 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
+        EsqlCapabilities capabilities = this.capabilities.get();
         List<RestHandler> releasedRestHandlers = List.of(
-            new RestEsqlQueryAction(),
-            new RestEsqlAsyncQueryAction(),
+            new RestEsqlQueryAction(capabilities),
+            new RestEsqlAsyncQueryAction(capabilities),
             new RestEsqlGetAsyncResultAction(),
             new RestEsqlStopAsyncAction(),
             new RestEsqlDeleteAsyncResultAction(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
@@ -68,14 +68,14 @@ public class ViewService {
     private volatile int maxViewsCount;
     private volatile int maxViewLength;
 
-    public ViewService(ClusterService clusterService) {
+    public ViewService(ClusterService clusterService, EsqlFunctionRegistry functionRegistry) {
         this.clusterService = clusterService;
         this.taskQueue = clusterService.createTaskQueue(
             "update-esql-view-metadata",
             Priority.NORMAL,
             new SequentialAckingBatchedTaskExecutor<>()
         );
-        this.telemetry = new PlanTelemetry(new EsqlFunctionRegistry());
+        this.telemetry = new PlanTelemetry(functionRegistry);
         clusterService.getClusterSettings().initializeAndWatch(MAX_VIEWS_COUNT_SETTING, v -> this.maxViewsCount = v);
         clusterService.getClusterSettings().initializeAndWatch(MAX_VIEW_LENGTH_SETTING, v -> this.maxViewLength = v);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -135,7 +135,6 @@ import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.xpack.esql.CsvSpecReader.specParser;
@@ -199,11 +198,11 @@ import static org.mockito.Mockito.mock;
 // @TestLogging(value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE", reason = "debug")
 public class CsvTests extends ESTestCase {
 
-    private static final Set<String> ALL_ESQL_CAPABILITIES = Stream.of(EsqlCapabilities.Cap.values())
-        .map(EsqlCapabilities.Cap::capabilityName)
-        .collect(toSet());
-
     private static final Logger LOGGER = LogManager.getLogger(CsvTests.class);
+
+    private static final EsqlFunctionRegistry FUNCTION_REGISTRY = new EsqlFunctionRegistry();
+    private static final EsqlCapabilities ENABLED_CAPS = EsqlCapabilities.capabilities(FUNCTION_REGISTRY, false);
+    private static final EsqlCapabilities ALL_CAPS = EsqlCapabilities.capabilities(FUNCTION_REGISTRY, true);
 
     private final String fileName;
     private final String groupName;
@@ -219,7 +218,6 @@ public class CsvTests extends ESTestCase {
      * </p>
      */
     private Configuration configuration;
-    private final EsqlFunctionRegistry functionRegistry = new EsqlFunctionRegistry();
     private final Mapper mapper = new Mapper();
     private ThreadPool threadPool;
     private Executor executor;
@@ -285,9 +283,6 @@ public class CsvTests extends ESTestCase {
 
     public final void test() throws Throwable {
         try {
-            for (String capability : testCase.requiredCapabilities) {
-                assertTrue("Requested capability does not exist: " + capability, ALL_ESQL_CAPABILITIES.contains(capability));
-            }
             assumeTrueLogging("Test " + testName + " is not enabled", isEnabled(testName, instructions, Version.CURRENT));
             /*
              * The csv tests support all but a few features. The unsupported features
@@ -398,11 +393,11 @@ public class CsvTests extends ESTestCase {
                 assertThat(
                     "Capability is not included in the enabled list capabilities on a snapshot build. Spelling mistake?",
                     testCase.requiredCapabilities,
-                    everyItem(in(EsqlCapabilities.capabilities(true)))
+                    everyItem(in(ALL_CAPS.capabilities()))
                 );
                 assumeTrueLogging(
                     "Capability not supported in this build",
-                    EsqlCapabilities.capabilities(false).containsAll(testCase.requiredCapabilities)
+                    ENABLED_CAPS.capabilities().containsAll(testCase.requiredCapabilities)
                 );
             } else {
                 for (EsqlCapabilities.Cap c : EsqlCapabilities.Cap.values()) {
@@ -631,7 +626,7 @@ public class CsvTests extends ESTestCase {
         var analyzer = new Analyzer(
             new AnalyzerContext(
                 configuration,
-                functionRegistry,
+                FUNCTION_REGISTRY,
                 indexResolution,
                 Map.of(),
                 enrichPolicies,
@@ -682,7 +677,7 @@ public class CsvTests extends ESTestCase {
             query,
             new QueryParams(),
             new SettingsValidationContext(false, false),
-            new PlanTelemetry(functionRegistry),
+            new PlanTelemetry(FUNCTION_REGISTRY),
             new InferenceSettings(Settings.EMPTY),
             viewName
         ).plan();
@@ -776,11 +771,11 @@ public class CsvTests extends ESTestCase {
             null,
             null,
             new PreAnalyzer(),
-            functionRegistry,
+            FUNCTION_REGISTRY,
             mapper,
             TEST_VERIFIER,
             null,
-            new PlanTelemetry(functionRegistry),
+            new PlanTelemetry(FUNCTION_REGISTRY),
             null,
             null,
             PlannerSettings.DEFAULTS,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -70,7 +71,7 @@ public class InMemoryViewService extends ViewService implements Closeable {
     }
 
     private InMemoryViewService(ClusterService clusterService, ThreadPool threadPool, ViewMetadata metadata) {
-        super(clusterService);
+        super(clusterService, new EsqlFunctionRegistry());
         this.threadPool = threadPool;
         this.viewMetadata = metadata;
     }


### PR DESCRIPTION
Automatically register a capability for every function. We want to register a capability for every function anyway, let's do it automatically.

This removes all duplicates from `EsqlCapabilities.Cap`.

I've not tried to take handle capabilites we've built for bug fixes. That'll be later.

We can't rename any existing capabilities. Those are used for backwards compatibility. They can just stick around.

