### PR TITLE
Unset auto-expanding replicas in CloneStep

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/CloneStep.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/CloneStep.java
@@ -409,7 +409,9 @@ public class CloneStep implements DlmStep {
             cloneIndex
         );
         resizeReq.setTargetIndex(createReq);
-        resizeReq.setTargetIndexSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0));
+        resizeReq.setTargetIndexSettings(
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).putNull(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)
+        );
         return resizeReq;
     }
 

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/CloneStepTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/transitions/steps/CloneStepTests.java
@@ -203,6 +203,8 @@ public class CloneStepTests extends ESTestCase {
         assertThat(capturedResizeRequest.get().getSourceIndex(), equalTo(indexName));
         assertThat(capturedResizeRequest.get().getTargetIndexRequest().index(), containsString("dlm-clone-"));
         assertThat(capturedResizeRequest.get().getTargetIndexRequest().settings().get("index.number_of_replicas"), equalTo("0"));
+        assertTrue(capturedResizeRequest.get().getTargetIndexRequest().settings().keySet().contains("index.auto_expand_replicas"));
+        assertNull(capturedResizeRequest.get().getTargetIndexRequest().settings().get("index.auto_expand_replicas"));
     }
 
     public void testExecuteWithSuccessfulCloneResponse() {


### PR DESCRIPTION
We're specifically cloning in order to avoid replicas, so we need to set `index.auto_expand_replicas` to `null` in order to avoid replicas being created on the cloned index.

Relates to #141638
