### PR TITLE
fix: content parser returns null on keywords fields encoded with SMILE

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -277,7 +277,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public final XContentString optimizedTextOrNull() throws IOException {
-        if (currentToken() == Token.VALUE_NULL) {
+        if (currentToken() == Token.VALUE_NULL || currentToken() == Token.VALUE_EMBEDDED_OBJECT) {
             return null;
         }
         return optimizedText();

--- a/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.common.xcontent.smile;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.BaseXContentTestCase;
 import org.elasticsearch.xcontent.XContentGenerator;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.smile.SmileXContent;
 
@@ -33,6 +35,29 @@ public class SmileXContentTests extends BaseXContentTestCase {
     public void testAllowsDuplicates() throws Exception {
         try (XContentParser xParser = createParser(builder().startObject().endObject())) {
             expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
+    }
+
+    /**
+     * Binary SMILE values (VALUE_EMBEDDED_OBJECT tokens) have no text representation.
+     * {@code optimizedTextOrNull()} must return {@code null} for them, not {@code Text}
+     * object with null internals, to avoid a NullPointerException when callers access the
+     * string content (e.g. via {@code stringLength()}).
+     */
+    public void testOptimizedTextOrNullReturnNullForBinaryValue() throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (XContentGenerator generator = SmileXContent.smileXContent.createGenerator(os)) {
+            generator.writeStartObject();
+            generator.writeBinaryField("field", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+            generator.writeEndObject();
+        }
+        try (XContentParser parser = createParser(SmileXContent.smileXContent, new BytesArray(os.toByteArray()))) {
+            assertSame(Token.START_OBJECT, parser.nextToken());
+            assertSame(Token.FIELD_NAME, parser.nextToken());
+            assertSame(Token.VALUE_EMBEDDED_OBJECT, parser.nextToken());
+            // Binary SMILE values have no text representation; optimizedTextOrNull() must return null,
+            // not new Text(null), which would NPE when stringLength() is called on it.
+            assertNull(parser.optimizedTextOrNull());
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
@@ -45,8 +46,11 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentGenerator;
+import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.Matchers;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -1251,5 +1255,31 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     @Override
     protected List<SortShortcutSupport> getSortShortcutSupport() {
         return List.of(new SortShortcutSupport(this::minimalMapping, this::writeField, true));
+    }
+
+    /**
+     * Parsing a keyword field that contains a SMILE binary value (VALUE_EMBEDDED_OBJECT token)
+     * must not throw a NullPointerException. Binary values have no text representation and should
+     * be treated as null by the parser, so the field must be skipped rather than indexed.
+     *
+     * Regression test for when {@code KeywordFieldMapper.parseCreateField}
+     * calls {@code optimizedTextOrNull()}, which for binary SMILE tokens returned {@code new Text(null)}
+     * instead of {@code null}.
+     */
+    public void testParseSmileBinaryValueInKeywordField() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (XContentGenerator generator = XContentType.SMILE.xContent().createGenerator(os)) {
+            generator.writeStartObject();
+            generator.writeBinaryField("field", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+            generator.writeEndObject();
+        }
+
+        SourceToParse source = new SourceToParse("1", new BytesArray(os.toByteArray()), XContentType.SMILE);
+
+        // Binary values have no text representation; the keyword field must be skipped without NPE.
+        ParsedDocument doc = mapper.parse(source);
+        assertThat(doc.rootDoc().getFields("field"), empty());
     }
 }


### PR DESCRIPTION
### Reason for this PR

This was spotted by reading Universal Profiling symbolizer logs.

```
[instance-0000000008][.profiling-returnpads-private-v001] Error while parsing document for index [.profiling-returnpads-private-v001]: [-1:60] failed to parse field [Symbfile.file.id] of type [keyword] in document with id 'qh4PLy8m7VHjlAhsqvyaEwA'. Preview of field's value: '[B@53785888' org.elasticsearch.index.mapper.DocumentParsingException: [-1:60] failed to parse field [Symbfile.file.id] of type [keyword] in document with id 'qh4PLy8m7VHjlAhsqvyaEwA'. Preview of field's value: '[B@53785888'
 at org.elasticsearch.index.mapper.FieldMapper.rethrowAsDocumentParsingException(FieldMapper.java:241) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:194) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:470) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseValue(DocumentParser.java:832) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:390) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:341) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:450) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.doParseObject(DocumentParser.java:538) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:526) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:380) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:341) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:450) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.doParseObject(DocumentParser.java:538) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:526) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:380) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:341) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.internalParseDocument(DocumentParser.java:152) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:98) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.DocumentMapper.parse(DocumentMapper.java:128) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.shard.IndexShard.prepareIndex(IndexShard.java:1087) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:1014) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.shard.IndexShard.applyIndexOperationOnPrimary(IndexShard.java:958) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.bulk.TransportShardBulkAction.executeBulkItemRequest(TransportShardBulkAction.java:420) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.bulk.TransportShardBulkAction$2.doRun(TransportShardBulkAction.java:277) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.bulk.TransportShardBulkAction.performOnPrimary(TransportShardBulkAction.java:345) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:182) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:83) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.action.support.replication.TransportWriteAction$1.doRun(TransportWriteAction.java:245) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1044) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) ~[elasticsearch-9.1.4.jar:?]
 at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) ~[?:?]
 at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) ~[?:?]
 at java.lang.Thread.run(Thread.java:1447) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.elasticsearch.xcontent.XContentString$UTF8Bytes.bytes()" because "this.bytes" is null
 at org.elasticsearch.xcontent.Text.string(Text.java:88) ~[elasticsearch-x-content-9.1.4.jar:?]
 at org.elasticsearch.xcontent.Text.stringLength(Text.java:98) ~[elasticsearch-x-content-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.Mapper$IgnoreAbove.isIgnored(Mapper.java:185) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.KeywordFieldMapper.indexValue(KeywordFieldMapper.java:1165) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.KeywordFieldMapper.parseCreateField(KeywordFieldMapper.java:1131) ~[elasticsearch-9.1.4.jar:?]
 at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:192) ~[elasticsearch-9.1.4.jar:?] ... 34 more
```

After some AI-assisted debugging, the proposed fix is to return `null` also for binary 

### Root cause

Introduced when `KeywordFieldMapper.parseCreateField()` was refactored from `textOrNull()` (returns a plain String, which is null for binary tokens) to `optimizedTextOrNull()` (returns an `XContentString` wrapper).
The regression seems to be introduced in `v9.1.4`.

The new method did not account for the binary token case, producing a hollow `Text(null)` object instead of a proper `null`.

### Additional context

Mapping for the file defined in https://github.com/inge4pres/elasticsearch/blob/42d5c7947c86da47c0902d4b0ee8caff02c0fed0/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-returnpads-private.json#L41-L51