### PR TITLE
Instrument FileChannelImpl#map for entitlements

### DIFF
--- a/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
+++ b/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -85,6 +86,18 @@ public final class EntitledActions {
             baseDir.resolve(actualFileMount.getFileName()),
             dataDir.getFileName().resolve(actualFileMount.getFileName())
         );
+    }
+
+    public static FileChannel openFileChannelForRead() throws IOException {
+        var file = createTempFileForRead();
+        Files.writeString(file, "test content for memory mapping");
+        return FileChannel.open(file);
+    }
+
+    public static FileChannel openFileChannelForReadWrite() throws IOException {
+        var file = createTempFileForWrite();
+        Files.writeString(file, "test content for memory mapping");
+        return FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE);
     }
 
     public static URLConnection createHttpURLConnection() throws IOException {

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
@@ -15,6 +15,7 @@ import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.net.StandardProtocolFamily;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.FileChannel;
@@ -81,6 +82,27 @@ class NioChannelsActions {
     static void asynchronousFileChannelOpenForReadWithOptions() throws IOException {
         var file = EntitledActions.createTempFileForRead();
         AsynchronousFileChannel.open(file, Set.of(StandardOpenOption.READ), EsExecutors.DIRECT_EXECUTOR_SERVICE).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void fileChannelMapReadOnly() throws IOException {
+        try (var channel = EntitledActions.openFileChannelForRead()) {
+            channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
+        }
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void fileChannelMapReadWrite() throws IOException {
+        try (var channel = EntitledActions.openFileChannelForReadWrite()) {
+            channel.map(FileChannel.MapMode.READ_WRITE, 0, channel.size());
+        }
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void fileChannelMapWithArena() throws IOException {
+        try (var channel = EntitledActions.openFileChannelForRead(); var arena = Arena.ofConfined()) {
+            channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size(), arena);
+        }
     }
 
     @SuppressForbidden(reason = "specifically testing jdk.nio.Channels")

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.lang.foreign.Arena;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscribers;
@@ -288,6 +289,15 @@ public class FileInstrumentation implements InstrumentationConfig {
                 new TypeToken<Set<? extends OpenOption>>() {},
                 TypeToken.of(FileAttribute[].class)
             ).enforce(Policies::fileReadOrWrite).elseThrowNotEntitled();
+        });
+
+        builder.on("sun.nio.ch.FileChannelImpl", FileChannel.class, rule -> {
+            rule.calling(FileChannel::map, FileChannel.MapMode.class, Long.class, Long.class)
+                .enforce((channel, mode) -> Policies.mapFileChannel(mode))
+                .elseThrowNotEntitled();
+            rule.calling(FileChannel::map, FileChannel.MapMode.class, Long.class, Long.class, Arena.class)
+                .enforce((channel, mode) -> Policies.mapFileChannel(mode))
+                .elseThrowNotEntitled();
         });
 
         builder.on(AsynchronousFileChannel.class, rule -> {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/Policies.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/Policies.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -223,6 +224,20 @@ public class Policies {
      */
     public static CheckMethod fileWrite(Path path) {
         return (callingClass, policyChecker) -> policyChecker.checkFileWrite(callingClass, path);
+    }
+
+    /**
+     * Returns a check method for memory-mapping a file channel.
+     * Uses {@link FileChannel.MapMode} to determine whether to check read or write entitlements.
+     *
+     * @param mode the map mode
+     * @return a check method that verifies the appropriate file descriptor entitlement
+     */
+    public static CheckMethod mapFileChannel(FileChannel.MapMode mode) {
+        if (mode == FileChannel.MapMode.READ_WRITE) {
+            return fileDescriptorWrite();
+        }
+        return fileDescriptorRead();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds entitlement instrumentation for `sun.nio.ch.FileChannelImpl#map`, covering both the `map(MapMode, long, long)` and `map(MapMode, long, long, Arena)` overloads
- Uses `fileDescriptorRead` for `READ_ONLY`/`PRIVATE` map modes and `fileDescriptorWrite` for `READ_WRITE`, consistent with how other file descriptor operations are checked
- Adds QA test actions verifying that plugins are denied access to `FileChannel#map`

## Rules by JDK version

Both rules live in the base `FileInstrumentation.java`, shared across all mrjar variants on main (9.x).

| Method | Policy | base (21) | main22 | main25 | main26 |
|--------|--------|:---------:|:------:|:------:|:------:|
| `FileChannelImpl#map(MapMode, long, long)` | `fileDescriptorRead` / `fileDescriptorWrite` | ✅ | ✅ | ✅ | ✅ |
| `FileChannelImpl#map(MapMode, long, long, Arena)` | `fileDescriptorRead` / `fileDescriptorWrite` | ✅ | ✅ | ✅ | ✅ |

### Backport notes (8.19)

The second `map` overload signature varies by JDK — a backport to 8.19 will need version-specific handling:

| JDK | `map(MapMode, long, long)` | Second overload |
|-----|:-:|---|
| 17–18 | ✅ | *none* — no memory-segment map overload exists |
| 19 | ✅ | `map(MapMode, long, long, MemorySession)` — needs `main19` |
| 20 | ✅ | `map(MapMode, long, long, SegmentScope)` — needs `main20` |
| 21+ | ✅ | `map(MapMode, long, long, Arena)` — needs `main21` |

For the 8.19 backport:
- `map(MapMode, long, long)` can go in the base `FileInstrumentation.java`
- The memory-segment overloads need to go in the existing `Java19Instrumentation`, `Java20Instrumentation`, and `Java21Instrumentation` files respectively, since the parameter types (`MemorySession`, `SegmentScope`, `Arena`) differ across JDK versions

## Test plan
- [x] `./gradlew :libs:entitlement:test` passes
- [x] `./gradlew :libs:entitlement:qa:javaRestTest` passes (includes new `fileChannelMapReadOnly`, `fileChannelMapReadWrite`, `fileChannelMapWithArena` tests)
- [x] Verified both `map` overloads exist on `FileChannelImpl` for JDK 21+ so this works across all supported JDKs on main