### PR TITLE
ESQL: Allow more leeway in test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -426,9 +426,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.security.CliApiKeyIT
   method: testCliConnectionWithInvalidApiKey
   issue: https://github.com/elastic/elasticsearch/issues/143646
-- class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
-  method: testSplitOnSize
-  issue: https://github.com/elastic/elasticsearch/issues/143720
 - class: org.elasticsearch.compute.lucene.query.LuceneTopNSourceOperatorScoringTests
   method: testAccumulateSearchLoad
   issue: https://github.com/elastic/elasticsearch/issues/143750

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -107,7 +107,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-//@Repeat(iterations = 100)
 public class TopNOperatorTests extends OperatorTestCase {
     // versions taken from org.elasticsearch.xpack.versionfield.VersionTests
     private static final List<String> VERSIONS = List.of(
@@ -2132,7 +2131,7 @@ public class TopNOperatorTests extends OperatorTestCase {
              * With very small bytes we might break too early. That's ok. Small
              * ones are rare and if we have them then a few early-breaks is fine.
              */
-            minPageSize -= 10;
+            minPageSize -= 20;
         }
         if (byteLength < PageCacheRecycler.PAGE_SIZE_IN_BYTES) {
             /*


### PR DESCRIPTION
Test asserts the size of returned blocks and sometimes they are smaller than expected. We overestimate block sizes when building and sometimes we'll overestimate more than we expected.

Closes #143720
