### PR TITLE
ESQL: Move caps for function bugs into definition

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -248,28 +248,6 @@ public class EsqlCapabilities {
         COUNTER_TYPES,
 
         /**
-         * Support for reversing whole grapheme clusters. This is not supported
-         * on JDK versions less than 20 which are not supported in ES 9.0.0+ but this
-         * exists to keep the {@code 8.x} branch similar to the {@code main} branch.
-         */
-        FN_REVERSE_GRAPHEME_CLUSTERS,
-
-        /**
-         * Fix a bug leading to the scratch leaking data to other rows.
-         */
-        FN_IP_PREFIX_FIX_DIRTY_SCRATCH_LEAK,
-
-        /**
-         * Fix on function {@code SUBSTRING} that makes it not return null on empty strings.
-         */
-        FN_SUBSTRING_EMPTY_NULL,
-
-        /**
-         * Fixes on function {@code ROUND} that avoid it throwing exceptions on runtime for unsigned long cases.
-         */
-        FN_ROUND_UL_FIXES,
-
-        /**
          * support for MV_CONTAINS function
          * <a href="https://github.com/elastic/elasticsearch/pull/133099/">Add MV_CONTAINS function #133099</a>
          */
@@ -2167,12 +2145,6 @@ public class EsqlCapabilities {
          * Support for the METRICS_INFO command.
          */
         METRICS_INFO_COMMAND,
-
-        /**
-         * Produce a {@code warning} and {@code null} when you run
-         * {@code ABS} on {@code Long.MIN_VALUE}.
-         */
-        FN_ABS_MIN_WARNING,
 
         /**
          * Supports the REGISTERED_DOMAIN command.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -395,7 +395,7 @@ public class EsqlFunctionRegistry {
                 def(Last.class, bi(Last::new), "last"), },
             // math
             new FunctionDefinition[] {
-                def(Abs.class, Abs::new, "abs"),
+                Abs.DEFINITION,
                 def(Acos.class, Acos::new, "acos"),
                 def(Asin.class, Asin::new, "asin"),
                 def(Atan.class, Atan::new, "atan"),
@@ -420,7 +420,7 @@ public class EsqlFunctionRegistry {
                 def(ClampMin.class, ClampMin::new, "clamp_min"),
                 def(Pi.class, Pi::new, "pi"),
                 def(Pow.class, Pow::new, "pow"),
-                def(Round.class, Round::new, "round"),
+                Round.DEFINITION,
                 def(RoundTo.class, RoundTo::new, "round_to"),
                 def(Scalb.class, Scalb::new, "scalb"),
                 def(Signum.class, Signum::new, "signum"),
@@ -448,13 +448,13 @@ public class EsqlFunctionRegistry {
                 def(RTrim.class, RTrim::new, "rtrim"),
                 def(Repeat.class, Repeat::new, "repeat"),
                 def(Replace.class, Replace::new, "replace"),
-                def(Reverse.class, Reverse::new, "reverse"),
+                Reverse.DEFINITION,
                 def(Right.class, Right::new, "right"),
                 def(Sha1.class, Sha1::new, "sha1"),
                 def(Sha256.class, Sha256::new, "sha256"),
                 def(Space.class, Space::new, "space"),
                 def(StartsWith.class, StartsWith::new, "starts_with"),
-                def(Substring.class, Substring::new, "substring"),
+                Substring.DEFINITION,
                 def(ToLower.class, ToLower::new, "to_lower"),
                 def(ToUpper.class, ToUpper::new, "to_upper"),
                 def(Trim.class, Trim::new, "trim"),
@@ -499,9 +499,10 @@ public class EsqlFunctionRegistry {
             // null
             new FunctionDefinition[] { def(Coalesce.class, Coalesce::new, "coalesce"), },
             // IP
-            new FunctionDefinition[] { def(CIDRMatch.class, CIDRMatch::new, "cidr_match") },
-            new FunctionDefinition[] { def(IpPrefix.class, IpPrefix::new, "ip_prefix") },
-            new FunctionDefinition[] { def(NetworkDirection.class, NetworkDirection::new, "network_direction", "netdir") },
+            new FunctionDefinition[] {
+                def(CIDRMatch.class, CIDRMatch::new, "cidr_match"),
+                IpPrefix.DEFINITION,
+                def(NetworkDirection.class, NetworkDirection::new, "network_direction", "netdir") },
             // conversion functions
             new FunctionDefinition[] {
                 def(FromBase64.class, FromBase64::new, "from_base64"),
@@ -1044,6 +1045,9 @@ public class EsqlFunctionRegistry {
             }
             String name = "fn_" + def.name();
             capabilities.add(name, enabled);
+            for (String sub : def.capabilities()) {
+                capabilities.add(name + "_" + sub, enabled);
+            }
         }
     }
 
@@ -1101,6 +1105,14 @@ public class EsqlFunctionRegistry {
         BiFunction<Source, Expression, T> ctorRef,
         String... names
     ) {
+        return unary(function, ctorRef, names);
+    }
+
+    public static <T extends Function> FunctionDefinition unary(
+        Class<T> function,
+        BiFunction<Source, Expression, T> ctorRef,
+        String... names
+    ) {
         FunctionBuilder builder = (source, children, cfg) -> {
             checkIsUniFunction(children.size());
             return ctorRef.apply(source, children.get(0));
@@ -1126,6 +1138,10 @@ public class EsqlFunctionRegistry {
      */
     @SuppressWarnings("overloads")  // These are ambiguous if you aren't using ctor references but we always do
     public static <T extends Function> FunctionDefinition def(Class<T> function, BinaryBuilder<T> ctorRef, String... names) {
+        return binary(function, ctorRef, names);
+    }
+
+    public static <T extends Function> FunctionDefinition binary(Class<T> function, BinaryBuilder<T> ctorRef, String... names) {
         FunctionBuilder builder = (source, children, cfg) -> {
             boolean isBinaryOptionalParamFunction = OptionalArgument.class.isAssignableFrom(function);
             if (isBinaryOptionalParamFunction && (children.size() > 2 || children.size() < 1)) {
@@ -1150,7 +1166,11 @@ public class EsqlFunctionRegistry {
      * Build a {@linkplain FunctionDefinition} for a ternary function.
      */
     @SuppressWarnings("overloads")  // These are ambiguous if you aren't using ctor references but we always do
-    protected static <T extends Function> FunctionDefinition def(Class<T> function, TernaryBuilder<T> ctorRef, String... names) {
+    public static <T extends Function> FunctionDefinition def(Class<T> function, TernaryBuilder<T> ctorRef, String... names) {
+        return ternary(function, ctorRef, names);
+    }
+
+    public static <T extends Function> FunctionDefinition ternary(Class<T> function, TernaryBuilder<T> ctorRef, String... names) {
         FunctionBuilder builder = (source, children, cfg) -> {
             checkIsOptionalTriFunction(function, children.size());
             return ctorRef.build(
@@ -1163,7 +1183,7 @@ public class EsqlFunctionRegistry {
         return def(function, builder, names);
     }
 
-    protected interface TernaryBuilder<T> {
+    public interface TernaryBuilder<T> {
         T build(Source source, Expression one, Expression two, Expression three);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionDefinition.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionDefinition.java
@@ -30,12 +30,24 @@ public class FunctionDefinition {
     private final List<String> aliases;
     private final Class<? extends Function> clazz;
     private final Builder builder;
+    private final List<String> subCapabilities;
 
     public FunctionDefinition(String name, List<String> aliases, Class<? extends Function> clazz, Builder builder) {
+        this(name, aliases, clazz, builder, List.of());
+    }
+
+    private FunctionDefinition(
+        String name,
+        List<String> aliases,
+        Class<? extends Function> clazz,
+        Builder builder,
+        List<String> subCapabilities
+    ) {
         this.name = name;
         this.aliases = aliases;
         this.clazz = clazz;
         this.builder = builder;
+        this.subCapabilities = subCapabilities;
     }
 
     public String name() {
@@ -52,6 +64,26 @@ public class FunctionDefinition {
 
     public Builder builder() {
         return builder;
+    }
+
+    public List<String> capabilities() {
+        return subCapabilities;
+    }
+
+    /**
+     * Adds capabilities to mark changes or fixes to the function. Use it like:
+     * {@snippet :
+     * public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.ternary(IpPrefix.class, IpPrefix::new, "ip_prefix")
+     *     .withSubCapabilities(
+     *         List.of(
+     *             // Fix a bug leading to the scratch leaking data to other rows.
+     *             "fix_dirty_scratch_leak"
+     *         )
+     *     );
+     * }
+     */
+    public FunctionDefinition withSubCapabilities(List<String> subCapabilities) {
+        return new FunctionDefinition(name, aliases, clazz, builder, subCapabilities);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
@@ -19,7 +19,9 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -43,6 +45,13 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
  */
 public class IpPrefix extends EsqlScalarFunction implements OptionalArgument {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "IpPrefix", IpPrefix::new);
+    public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.ternary(IpPrefix.class, IpPrefix::new, "ip_prefix")
+        .withSubCapabilities(
+            List.of(
+                // Fix a bug leading to the scratch leaking data to other rows.
+                "fix_dirty_scratch_leak"
+            )
+        );
 
     // Borrowed from Lucene, rfc4291 prefix
     private static final byte[] IPV4_PREFIX = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1 };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Abs.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Abs.java
@@ -16,7 +16,9 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
@@ -26,6 +28,16 @@ import java.util.List;
 
 public class Abs extends UnaryScalarFunction {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Abs", Abs::new);
+    public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.unary(Abs.class, Abs::new, "abs")
+        .withSubCapabilities(
+            List.of(
+                /*
+                 * Produce a {@code warning} and {@code null} when you run
+                 * {@code ABS} on {@code Long.MIN_VALUE}.
+                 */
+                "min_warning"
+            )
+        );
 
     @FunctionInfo(
         returnType = { "double", "integer", "long", "unsigned_long" },

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
@@ -19,7 +19,9 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.operator.math.Math
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -42,6 +44,13 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.longToUnsi
 
 public class Round extends EsqlScalarFunction implements OptionalArgument {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Round", Round::new);
+    public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.binary(Round.class, Round::new, "round")
+        .withSubCapabilities(
+            List.of(
+                // Fixes on function {@code ROUND} that avoid it throwing exceptions on runtime for unsigned long cases.
+                "ul_fixes"
+            )
+        );
 
     private static final BiFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> EVALUATOR_IDENTITY = (s, e) -> e;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
@@ -201,9 +201,13 @@
  *         versions of Elasticsearch. We do that with a {@link org.elasticsearch.rest.RestHandler#supportedCapabilities capability}
  *         on the REST handler. Your new function automatically created a capability when it was
  *         registered in the {@link org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry}.
- *         So you can add {@code required_capability: fn_my_function} to all of your csv-spec
- *         tests. Run those csv-spec tests as integration tests to double-check that they run on
- *         the main branch.
+ *         It has the format {@code fn_my_function}. So you can add {@code required_capability: fn_my_function}
+ *         to all of your csv-spec tests. Run those csv-spec tests as integration tests to
+ *         double-check that they run on the main branch.
+ *         <br><br>
+ *         NOTE: When you fix bug in your function, use
+ *         {@link org.elasticsearch.xpack.esql.expression.function.FunctionDefinition#withSubCapabilities}
+ *         to make capabilities to mark the fix.
  *         <br><br>
  *         NOTE: You may notice tests gated based on Elasticsearch version. This was the old way
  *         of doing things. Now, we use specific capabilities for each function.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
@@ -15,7 +15,9 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
@@ -35,6 +37,17 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStr
  */
 public class Reverse extends UnaryScalarFunction {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Reverse", Reverse::new);
+    public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.unary(Reverse.class, Reverse::new, "reverse")
+        .withSubCapabilities(
+            List.of(
+                /*
+                 * Support for reversing whole grapheme clusters. This is not supported
+                 * on JDK versions less than 20 which are not supported in ES 9.0.0+ but this
+                 * exists to keep the {@code 8.x} branch similar to the {@code main} branch.
+                 */
+                "grapheme_clusters"
+            )
+        );
 
     @FunctionInfo(
         returnType = { "keyword" },

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Substring.java
@@ -19,7 +19,9 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -42,6 +44,13 @@ public class Substring extends EsqlScalarFunction implements OptionalArgument {
         "Substring",
         Substring::new
     );
+    public static final FunctionDefinition DEFINITION = EsqlFunctionRegistry.ternary(Substring.class, Substring::new, "substring")
+        .withSubCapabilities(
+            List.of(
+                // Fix on function {@code SUBSTRING} that makes it not return null on empty strings.
+                "empty_null"
+            )
+        );
 
     private final Expression str, start, length;
 


### PR DESCRIPTION
Moves the capabilities marking bug fixes in functions into the functions themselves, out of our giant capabilities list.
