### PR TITLE
ESQL: Add error policy and configurable options for CSV format reader

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   api(project(':x-pack:plugin:core'))
   api(project(':x-pack:plugin:esql'))
   api(project(':x-pack:plugin:esql:compute'))
+  api(project(':x-pack:plugin:esql-datasource-csv'))
   api(project(':x-pack:plugin:analytics'))
   api(project(':x-pack:plugin:logsdb'))
   implementation project(path: ':libs:native')

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/CsvErrorPolicyBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/CsvErrorPolicyBenchmark.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.benchmark.esql;
 
+import org.elasticsearch.benchmark.Utils;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -60,6 +61,7 @@ public class CsvErrorPolicyBenchmark {
 
     @Setup(Level.Trial)
     public void setup() {
+        Utils.configureBenchmarkLogging();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("bench")).build();
         csvData = generateCsv(rowCount, errorFraction);
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/CsvErrorPolicyBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/CsvErrorPolicyBenchmark.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.benchmark.esql;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvFormatReader;
+import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the overhead of error policy checking in CSV parsing.
+ * Compares strict (no error tolerance) vs lenient (with error budget)
+ * on both clean data (happy path) and data with errors.
+ */
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class CsvErrorPolicyBenchmark {
+
+    @Param({ "1000", "10000" })
+    int rowCount;
+
+    @Param({ "0.0", "0.01", "0.05" })
+    double errorFraction;
+
+    private BlockFactory blockFactory;
+    private byte[] csvData;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("bench")).build();
+        csvData = generateCsv(rowCount, errorFraction);
+    }
+
+    @Benchmark
+    public int strictPolicy() throws IOException {
+        return readAll(ErrorPolicy.STRICT);
+    }
+
+    @Benchmark
+    public int lenientMaxErrors() throws IOException {
+        return readAll(new ErrorPolicy(Long.MAX_VALUE, false));
+    }
+
+    @Benchmark
+    public int lenientMaxErrorsWithRatio() throws IOException {
+        return readAll(new ErrorPolicy(Long.MAX_VALUE, 1.0, false));
+    }
+
+    @Benchmark
+    public int lenientWithLogging() throws IOException {
+        return readAll(new ErrorPolicy(Long.MAX_VALUE, true));
+    }
+
+    @Benchmark
+    public int nullFieldMode() throws IOException {
+        return readAll(new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, Long.MAX_VALUE, 1.0, false));
+    }
+
+    @Benchmark
+    public int nullFieldModeWithLogging() throws IOException {
+        return readAll(new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, Long.MAX_VALUE, 1.0, true));
+    }
+
+    private int readAll(ErrorPolicy policy) throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        StorageObject obj = createStorageObject(csvData);
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = reader.read(obj, null, 1000, policy)) {
+            while (iter.hasNext()) {
+                totalRows += iter.next().getPositionCount();
+            }
+        } catch (Exception e) {
+            if (policy.isStrict() && errorFraction > 0) {
+                return -1;
+            }
+            throw e;
+        }
+        return totalRows;
+    }
+
+    private static byte[] generateCsv(int rows, double errorFraction) {
+        StringBuilder sb = new StringBuilder(rows * 30);
+        sb.append("id:long,name:keyword,score:double\n");
+        int errorInterval = errorFraction > 0 ? (int) (1.0 / errorFraction) : Integer.MAX_VALUE;
+        for (int i = 1; i <= rows; i++) {
+            if (errorInterval < Integer.MAX_VALUE && i % errorInterval == 0) {
+                sb.append("bad_id,Name").append(i).append(",").append(i * 1.5).append("\n");
+            } else {
+                sb.append(i).append(",Name").append(i).append(",").append(i * 1.5).append("\n");
+            }
+        }
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://bench.csv");
+            }
+        };
+    }
+}

--- a/docs/changelog/143779.yaml
+++ b/docs/changelog/143779.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143779
+summary: Add error policy and configurable options for CSV format reader
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Configurable options for CSV/TSV parsing. Maps to common options found in
+ * DuckDB, ClickHouse, Spark, and Trino.
+ *
+ * @param delimiter          field separator character (default: comma)
+ * @param quoteChar          character used to quote fields (default: double-quote)
+ * @param escapeChar         character used to escape special characters (default: backslash)
+ * @param commentPrefix      prefix for comment lines to skip (default: "//")
+ * @param nullValue          string representation of null in the data (default: empty string)
+ * @param encoding           character encoding of the input (default: UTF-8)
+ * @param datetimeFormatter  custom datetime format pattern, or null for ISO-8601/epoch
+ * @param maxFieldSize       maximum size in bytes for a single field value; 0 means no limit
+ *                           (default: 10MB). Maps to DuckDB's max_line_size and provides
+ *                           OOM protection against malformed files.
+ */
+public record CsvFormatOptions(
+    char delimiter,
+    char quoteChar,
+    char escapeChar,
+    String commentPrefix,
+    String nullValue,
+    Charset encoding,
+    DateTimeFormatter datetimeFormatter,
+    int maxFieldSize
+) {
+    /** 10 MB default field size limit — generous for real-world data, prevents OOM on corrupt files. */
+    static final int DEFAULT_MAX_FIELD_SIZE = 10 * 1024 * 1024;
+
+    public static final CsvFormatOptions DEFAULT = new CsvFormatOptions(
+        ',',
+        '"',
+        '\\',
+        "//",
+        "",
+        StandardCharsets.UTF_8,
+        null,
+        DEFAULT_MAX_FIELD_SIZE
+    );
+
+    public static final CsvFormatOptions TSV = new CsvFormatOptions(
+        '\t',
+        '"',
+        '\\',
+        "//",
+        "",
+        StandardCharsets.UTF_8,
+        null,
+        DEFAULT_MAX_FIELD_SIZE
+    );
+
+    public CsvFormatOptions {
+        if (delimiter > 127) {
+            throw new IllegalArgumentException("delimiter must be an ASCII character, got: " + (int) delimiter);
+        }
+        if (quoteChar > 127) {
+            throw new IllegalArgumentException("quoteChar must be an ASCII character, got: " + (int) quoteChar);
+        }
+        if (escapeChar > 127) {
+            throw new IllegalArgumentException("escapeChar must be an ASCII character, got: " + (int) escapeChar);
+        }
+        if (maxFieldSize < 0) {
+            throw new IllegalArgumentException("maxFieldSize must be non-negative, got: " + maxFieldSize);
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.csv;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvParser;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
@@ -18,6 +19,8 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -25,6 +28,8 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -36,28 +41,85 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
 
 /**
- * Simple CSV format reader for external datasources.
+ * CSV/TSV format reader for external datasources.
  *
- * <p>CSV Format:
- * - First line: schema definition (column_name:type_name,...)
- * - Subsequent lines: data rows
- * - Empty values are treated as null
- * - Lines starting with "//" are comments and ignored
+ * <h2>File format</h2>
+ * <ul>
+ *   <li>First non-comment line: schema — {@code column:type} pairs separated by the delimiter
+ *   <li>Subsequent lines: data rows
+ *   <li>Empty/missing values → {@code null}
+ *   <li>Lines starting with the comment prefix (default {@code //}) are skipped
+ * </ul>
  *
- * <p>Supported types: integer, long, double, keyword, text, boolean, datetime
+ * <h2>Supported types</h2>
+ * {@code integer} ({@code int}, {@code i}), {@code long} ({@code l}),
+ * {@code double} ({@code d}), {@code keyword} ({@code k}, {@code string}, {@code s}),
+ * {@code text} ({@code txt}), {@code boolean} ({@code bool}),
+ * {@code datetime} ({@code date}, {@code dt}), {@code null} ({@code n}).
  *
- * <p>This reader works with any StorageProvider (HTTP, S3, local).
+ * <h2>Configurable options</h2>
+ * All options are set via the {@code WITH} clause and parsed by {@link #withConfig(java.util.Map)}.
+ *
+ * <table>
+ *   <caption>CSV options and their equivalents in other engines</caption>
+ *   <tr><th>ES/ESQL key</th><th>Default</th><th>Spark</th><th>DuckDB</th><th>ClickHouse</th></tr>
+ *   <tr><td>{@code delimiter}</td><td>{@code ,}</td><td>{@code sep}</td>
+ *       <td>{@code delim}</td><td>{@code format_csv_delimiter}</td></tr>
+ *   <tr><td>{@code quote}</td><td>{@code "}</td><td>{@code quote}</td>
+ *       <td>{@code quote}</td><td>{@code format_csv_allow_single_quotes}</td></tr>
+ *   <tr><td>{@code escape}</td><td>{@code \}</td><td>{@code escape}</td>
+ *       <td>{@code escape}</td><td>—</td></tr>
+ *   <tr><td>{@code comment}</td><td>{@code //}</td><td>{@code comment}</td>
+ *       <td>{@code comment}</td><td>—</td></tr>
+ *   <tr><td>{@code null_value}</td><td>(empty)</td><td>{@code nullValue}</td>
+ *       <td>{@code nullstr}</td><td>{@code format_csv_null_representation}</td></tr>
+ *   <tr><td>{@code encoding}</td><td>{@code UTF-8}</td><td>{@code encoding}</td>
+ *       <td>—</td><td>—</td></tr>
+ *   <tr><td>{@code datetime_format}</td><td>ISO-8601 / epoch</td><td>{@code timestampFormat}</td>
+ *       <td>{@code timestampformat}</td><td>{@code date_time_input_format}</td></tr>
+ *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>{@code maxCharsPerColumn}</td>
+ *       <td>{@code max_line_size}</td><td>—</td></tr>
+ * </table>
+ *
+ * <h2>Error handling</h2>
+ * Controlled by {@link ErrorPolicy} and its {@link ErrorPolicy.Mode}:
+ * <table>
+ *   <caption>Error mode comparison</caption>
+ *   <tr><th>ES/ESQL key</th><th>Spark</th><th>DuckDB</th><th>Behaviour</th></tr>
+ *   <tr><td>{@code fail_fast}</td><td>FAILFAST</td><td>(default)</td><td>Abort on first error</td></tr>
+ *   <tr><td>{@code skip_row}</td><td>DROPMALFORMED</td><td>ignore_errors</td>
+ *       <td>Drop the entire bad row</td></tr>
+ *   <tr><td>{@code null_field}</td><td>PERMISSIVE</td><td>—</td>
+ *       <td>Null-fill unparseable fields, keep the row</td></tr>
+ * </table>
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ *   FROM s3://bucket/data.tsv WITH {"delimiter": "\t", "error_mode": "skip_row", "max_errors": 100}
+ * }</pre>
+ *
+ * <p>Works with any {@link org.elasticsearch.xpack.esql.datasources.spi.StorageProvider}
+ * (HTTP, S3, local filesystem).
  */
 public class CsvFormatReader implements SegmentableFormatReader {
+
+    private static final Logger logger = LogManager.getLogger(CsvFormatReader.class);
 
     private static final int READER_BUFFER_SIZE = 64 * 1024;
 
@@ -70,12 +132,132 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     private final CsvMapper sharedCsvMapper;
 
+    private final CsvFormatOptions options;
+
     public CsvFormatReader(BlockFactory blockFactory) {
+        this(blockFactory, CsvFormatOptions.DEFAULT);
+    }
+
+    private CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options) {
         this.blockFactory = blockFactory;
-        this.sharedCsvMapper = new CsvMapper();
-        this.sharedCsvMapper.enable(CsvParser.Feature.TRIM_SPACES);
-        this.sharedCsvMapper.enable(CsvParser.Feature.SKIP_EMPTY_LINES);
-        this.sharedCsvMapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+        this.options = options;
+        this.sharedCsvMapper = createMapper(options);
+    }
+
+    private static CsvMapper createMapper(CsvFormatOptions opts) {
+        CsvMapper mapper = new CsvMapper();
+        mapper.enable(CsvParser.Feature.TRIM_SPACES);
+        mapper.enable(CsvParser.Feature.SKIP_EMPTY_LINES);
+        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+        if (opts.maxFieldSize() > 0) {
+            mapper.getFactory().setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(opts.maxFieldSize()).build());
+        }
+        return mapper;
+    }
+
+    private static CsvFormatOptions parseOptionsFromConfig(Map<String, Object> config) {
+        char delimiter = parseChar(config.get("delimiter"), ',');
+        char quoteChar = parseChar(config.get("quote"), '"');
+        char escapeChar = parseChar(config.get("escape"), '\\');
+        String commentPrefix = parseString(config.get("comment"), "//");
+        String nullValue = parseString(config.get("null_value"), "");
+        Charset encoding = parseEncoding(config.get("encoding"));
+        DateTimeFormatter datetimeFormatter = parseDatetimeFormat(config.get("datetime_format"));
+        int maxFieldSize = parseInt(config.get("max_field_size"), CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE);
+
+        if (delimiter == ','
+            && quoteChar == '"'
+            && escapeChar == '\\'
+            && "//".equals(commentPrefix)
+            && "".equals(nullValue)
+            && StandardCharsets.UTF_8.equals(encoding)
+            && datetimeFormatter == null
+            && maxFieldSize == CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE) {
+            return null;
+        }
+        return new CsvFormatOptions(delimiter, quoteChar, escapeChar, commentPrefix, nullValue, encoding, datetimeFormatter, maxFieldSize);
+    }
+
+    private static char parseChar(Object value, char defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String s = value.toString();
+        if (s.isEmpty()) {
+            return defaultValue;
+        }
+        if (s.length() == 1) {
+            return s.charAt(0);
+        }
+        if ("\\t".equals(s)) {
+            return '\t';
+        }
+        if ("\\n".equals(s)) {
+            return '\n';
+        }
+        if ("\\r".equals(s)) {
+            return '\r';
+        }
+        if ("\\\\".equals(s)) {
+            return '\\';
+        }
+        return s.charAt(0);
+    }
+
+    private static String parseString(Object value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        return value.toString();
+    }
+
+    private static int parseInt(Object value, int defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid integer value [" + value + "]", e);
+        }
+    }
+
+    private static Charset parseEncoding(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return StandardCharsets.UTF_8;
+        }
+        try {
+            return Charset.forName(value.toString());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid encoding [" + value + "]", e);
+        }
+    }
+
+    private static DateTimeFormatter parseDatetimeFormat(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return null;
+        }
+        try {
+            return DateTimeFormatter.ofPattern(value.toString(), Locale.ROOT);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid datetime format [" + value + "]", e);
+        }
+    }
+
+    /**
+     * Returns a new CsvFormatReader configured with the given options.
+     */
+    public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
+        return new CsvFormatReader(blockFactory, newOptions);
+    }
+
+    @Override
+    public FormatReader withConfig(Map<String, Object> config) {
+        if (config == null || config.isEmpty()) {
+            return this;
+        }
+        CsvFormatOptions parsed = parseOptionsFromConfig(config);
+        return parsed == null ? this : withOptions(parsed);
     }
 
     @Override
@@ -88,13 +270,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private List<Attribute> readSchema(StorageObject object) throws IOException {
         try (
             InputStream stream = object.newStream();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8), READER_BUFFER_SIZE)
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE)
         ) {
-
             String line;
             while ((line = reader.readLine()) != null) {
                 line = line.trim();
-                if (line.isEmpty() || line.startsWith("//")) {
+                if (line.isEmpty() || (options.commentPrefix().isEmpty() == false && line.startsWith(options.commentPrefix()))) {
                     continue;
                 }
                 return parseSchema(line);
@@ -105,10 +286,16 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     @Override
     public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize) throws IOException {
-        InputStream stream = object.newStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8), READER_BUFFER_SIZE);
+        return read(object, projectedColumns, batchSize, defaultErrorPolicy());
+    }
 
-        return new CsvBatchIterator(reader, stream, projectedColumns, batchSize, null);
+    @Override
+    public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize, ErrorPolicy errorPolicy)
+        throws IOException {
+        InputStream stream = object.newStream();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE);
+        ErrorPolicy effective = errorPolicy != null ? errorPolicy : defaultErrorPolicy();
+        return new CsvBatchIterator(reader, stream, projectedColumns, batchSize, null, effective);
     }
 
     @Override
@@ -120,12 +307,26 @@ public class CsvFormatReader implements SegmentableFormatReader {
         boolean lastSplit,
         List<Attribute> resolvedAttributes
     ) throws IOException {
+        return readSplit(object, projectedColumns, batchSize, skipFirstLine, lastSplit, resolvedAttributes, defaultErrorPolicy());
+    }
+
+    @Override
+    public CloseableIterator<Page> readSplit(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        boolean skipFirstLine,
+        boolean lastSplit,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
         InputStream stream = object.newStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8), READER_BUFFER_SIZE);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE);
         if (skipFirstLine) {
             reader.readLine();
         }
-        return new CsvBatchIterator(reader, stream, projectedColumns, batchSize, resolvedAttributes);
+        ErrorPolicy effective = errorPolicy != null ? errorPolicy : defaultErrorPolicy();
+        return new CsvBatchIterator(reader, stream, projectedColumns, batchSize, resolvedAttributes, effective);
     }
 
     /**
@@ -135,21 +336,29 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * correctly — a pair of double-quotes inside a quoted field does not toggle
      * the quoting state. Safe for TSV (which has no quoting, so the
      * {@code inQuotes} flag never toggles).
+     * <p>
+     * <b>Limitation:</b> this method only handles RFC 4180 doubled-quote escaping
+     * ({@code ""}). Backslash-based escaping ({@code \"}) is not recognized here;
+     * when {@code escapeChar} differs from {@code quoteChar}, boundaries may be
+     * mis-detected inside fields that use backslash escaping. This is acceptable
+     * because split-based parallel reads are an optimisation — the Jackson parser
+     * in each split handles escape characters correctly.
      */
     @Override
     public long findNextRecordBoundary(InputStream stream) throws IOException {
         long consumed = 0;
         boolean inQuotes = false;
+        byte quoteAsByte = (byte) options.quoteChar();
         byte[] buf = new byte[8192];
         int bytesRead;
         while ((bytesRead = stream.read(buf, 0, buf.length)) > 0) {
             for (int i = 0; i < bytesRead; i++) {
                 consumed++;
                 byte b = buf[i];
-                if (b == '"') {
+                if (b == quoteAsByte) {
                     if (inQuotes) {
                         if (i + 1 < bytesRead) {
-                            if (buf[i + 1] == '"') {
+                            if (buf[i + 1] == quoteAsByte) {
                                 i++;
                                 consumed++;
                                 continue;
@@ -166,7 +375,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             return -1;
                         }
                         consumed++;
-                        if (next == '"') {
+                        if (next == quoteAsByte) {
                             continue;
                         }
                         inQuotes = false;
@@ -201,7 +410,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     private List<Attribute> parseSchema(String schemaLine) {
-        String[] columns = schemaLine.split(",");
+        String[] columns = schemaLine.split(Pattern.quote(Character.toString(options.delimiter())));
         List<Attribute> attributes = new ArrayList<>(columns.length);
 
         for (String column : columns) {
@@ -247,25 +456,30 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final List<String> projectedColumns;
         private final int batchSize;
         private final List<Attribute> preResolvedSchema;
+        private final ErrorPolicy errorPolicy;
 
         private List<Attribute> schema;
         private List<Integer> projectedIndices;
         private Iterator<List<?>> csvIterator;
         private Page nextPage;
         private boolean closed = false;
+        private long errorCount = 0;
+        private long totalRowCount = 0;
 
         CsvBatchIterator(
             BufferedReader reader,
             InputStream stream,
             List<String> projectedColumns,
             int batchSize,
-            List<Attribute> preResolvedSchema
+            List<Attribute> preResolvedSchema,
+            ErrorPolicy errorPolicy
         ) {
             this.reader = reader;
             this.stream = stream;
             this.projectedColumns = projectedColumns;
             this.batchSize = batchSize;
             this.preResolvedSchema = preResolvedSchema;
+            this.errorPolicy = errorPolicy;
         }
 
         @Override
@@ -312,7 +526,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         line = line.trim();
-                        if (line.isEmpty() || line.startsWith("//")) {
+                        if (line.isEmpty() || (options.commentPrefix().isEmpty() == false && line.startsWith(options.commentPrefix()))) {
                             continue;
                         }
                         schema = parseSchema(line);
@@ -324,42 +538,44 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                 }
                 CsvSchema csvSchema = CsvSchema.emptySchema()
-                    .withColumnSeparator(',')
-                    .withQuoteChar('"')
-                    .withEscapeChar('\\')
-                    .withNullValue("");
+                    .withColumnSeparator(options.delimiter())
+                    .withQuoteChar(options.quoteChar())
+                    .withEscapeChar(options.escapeChar())
+                    .withNullValue(options.nullValue());
 
                 csvIterator = sharedCsvMapper.readerFor(List.class).with(csvSchema).readValues(reader);
             }
 
-            // Read batch of rows using Jackson CSV parser
-            List<String[]> rows = new ArrayList<>();
-            while (rows.size() < batchSize && csvIterator.hasNext()) {
-                List<?> rowList = csvIterator.next();
-                // Convert List to String array
-                String[] row = new String[rowList.size()];
-                for (int i = 0; i < rowList.size(); i++) {
-                    Object val = rowList.get(i);
-                    row[i] = val != null ? val.toString() : null;
-                }
-                // Skip comment lines (Jackson doesn't have native comment support)
-                if (row.length > 0) {
-                    String firstCell = row[0];
-                    if (firstCell != null) {
-                        String trimmedFirstCell = firstCell.trim();
-                        if (trimmedFirstCell.startsWith("//")) {
-                            continue;
+            while (true) {
+                List<String[]> rows = new ArrayList<>();
+                while (rows.size() < batchSize && csvIterator.hasNext()) {
+                    List<?> rowList = csvIterator.next();
+                    String[] row = new String[rowList.size()];
+                    for (int i = 0; i < rowList.size(); i++) {
+                        Object val = rowList.get(i);
+                        row[i] = val != null ? val.toString() : null;
+                    }
+                    if (row.length > 0) {
+                        String firstCell = row[0];
+                        if (firstCell != null && options.commentPrefix().isEmpty() == false) {
+                            String trimmedFirstCell = firstCell.trim();
+                            if (trimmedFirstCell.startsWith(options.commentPrefix())) {
+                                continue;
+                            }
                         }
                     }
+                    rows.add(row);
                 }
-                rows.add(row);
-            }
 
-            if (rows.isEmpty()) {
-                return null; // No more data
-            }
+                if (rows.isEmpty()) {
+                    return null;
+                }
 
-            return convertRowsToPage(rows);
+                Page page = convertRowsToPage(rows);
+                if (page != null || errorPolicy.isStrict()) {
+                    return page;
+                }
+            }
         }
 
         private List<Integer> computeProjectedIndices() {
@@ -392,10 +608,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Page convertRowsToPage(List<String[]> rows) {
-            int rowCount = rows.size();
             int columnCount = projectedIndices.size();
 
-            // Create block builders for projected columns
             BlockUtils.BuilderWrapper[] builders = new BlockUtils.BuilderWrapper[columnCount];
             try {
                 for (int i = 0; i < columnCount; i++) {
@@ -404,45 +618,122 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
                         org.elasticsearch.compute.data.ElementType.fromJava(javaClassForDataType(attr.dataType())),
-                        rowCount
+                        rows.size()
                     );
                 }
 
-                // Fill blocks with data
+                int acceptedRows = 0;
                 for (String[] row : rows) {
-                    // Jackson CSV may return shorter arrays if trailing values are empty
-                    // We need to handle this gracefully
-                    if (row.length > schema.size()) {
-                        throw new ParsingException("CSV row has [{}] columns but schema defines [{}] columns", row.length, schema.size());
-                    }
-
-                    for (int i = 0; i < columnCount; i++) {
-                        int schemaIndex = projectedIndices.get(i);
-                        Attribute attr = schema.get(schemaIndex);
-
-                        // Handle case where row is shorter than expected (trailing empty values)
-                        String value = schemaIndex < row.length ? row[schemaIndex] : "";
-                        if (value != null) {
-                            value = value.trim();
+                    totalRowCount++;
+                    try {
+                        if (row.length > schema.size()) {
+                            throw new ParsingException(
+                                "CSV row has [{}] columns but schema defines [{}] columns",
+                                row.length,
+                                schema.size()
+                            );
                         }
-
-                        Object converted = convertValue(value, attr.dataType());
-                        BlockUtils.BuilderWrapper wrapper = builders[i];
-                        wrapper.append().accept(converted);
+                        Object[] converted = convertRow(row, columnCount);
+                        for (int i = 0; i < columnCount; i++) {
+                            builders[i].append().accept(converted[i]);
+                        }
+                        acceptedRows++;
+                    } catch (BudgetExceededException budgetExceeded) {
+                        throw budgetExceeded.wrapped;
+                    } catch (Exception e) {
+                        handleRowError(e, row);
                     }
                 }
 
-                // Build blocks
+                if (acceptedRows == 0) {
+                    return null;
+                }
+
                 Block[] blocks = new Block[columnCount];
                 for (int i = 0; i < columnCount; i++) {
-                    BlockUtils.BuilderWrapper wrapper = builders[i];
-                    Block.Builder builder = wrapper.builder();
-                    blocks[i] = builder.build();
+                    blocks[i] = builders[i].builder().build();
                 }
 
-                return new Page(rowCount, blocks);
+                return new Page(acceptedRows, blocks);
             } finally {
                 Releasables.closeExpectNoException(builders);
+            }
+        }
+
+        /**
+         * Converts a raw CSV row to typed values. In {@link ErrorPolicy.Mode#NULL_FIELD NULL_FIELD} mode,
+         * individual field parse errors produce null instead of failing the entire row.
+         */
+        private Object[] convertRow(String[] row, int columnCount) {
+            Object[] converted = new Object[columnCount];
+            boolean permissive = errorPolicy.isPermissive();
+            for (int i = 0; i < columnCount; i++) {
+                int schemaIndex = projectedIndices.get(i);
+                Attribute attr = schema.get(schemaIndex);
+                String value = schemaIndex < row.length ? row[schemaIndex] : "";
+                if (value != null) {
+                    value = value.trim();
+                }
+                if (permissive) {
+                    try {
+                        converted[i] = convertValue(value, attr.dataType());
+                    } catch (Exception fieldError) {
+                        converted[i] = null;
+                        handleFieldError(fieldError, value, attr);
+                    }
+                } else {
+                    converted[i] = convertValue(value, attr.dataType());
+                }
+            }
+            return converted;
+        }
+
+        private void handleRowError(Exception e, String[] row) {
+            if (errorPolicy.isStrict()) {
+                if (e instanceof RuntimeException rte) {
+                    throw rte;
+                }
+                throw new EsqlIllegalArgumentException(e, "Failed to parse CSV row");
+            }
+            errorCount++;
+            if (errorPolicy.logErrors()) {
+                logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), e.getMessage());
+            }
+            if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
+                throw new EsqlIllegalArgumentException(
+                    e,
+                    "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
+                    errorCount,
+                    totalRowCount,
+                    errorPolicy.maxErrors(),
+                    errorPolicy.maxErrorRatio()
+                );
+            }
+        }
+
+        private void handleFieldError(Exception e, String value, Attribute attr) {
+            errorCount++;
+            if (errorPolicy.logErrors()) {
+                logger.warn(
+                    "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
+                    attr.name(),
+                    value,
+                    errorCount,
+                    errorPolicy.maxErrors(),
+                    e.getMessage()
+                );
+            }
+            if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
+                throw new BudgetExceededException(
+                    new EsqlIllegalArgumentException(
+                        e,
+                        "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
+                        errorCount,
+                        totalRowCount,
+                        errorPolicy.maxErrors(),
+                        errorPolicy.maxErrorRatio()
+                    )
+                );
             }
         }
 
@@ -459,9 +750,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Object convertValue(String value, DataType dataType) {
-            // Jackson CSV uses null for empty values when configured with withNullValue("")
-            // Also handle explicit "null" string
+            // Jackson CSV uses null for empty values when configured with withNullValue
+            // Also handle explicit "null" string and configurable null_value
             if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
+                return null;
+            }
+            if (options.nullValue().isEmpty() == false && value.equals(options.nullValue())) {
                 return null;
             }
 
@@ -490,6 +784,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     // overflow or not actually numeric, fall through to ISO-8601
                 }
             }
+            DateTimeFormatter formatter = options.datetimeFormatter();
+            if (formatter != null) {
+                try {
+                    return LocalDateTime.parse(value, formatter).toInstant(ZoneOffset.UTC).toEpochMilli();
+                } catch (DateTimeParseException e) {
+                    throw new EsqlIllegalArgumentException(e, "Failed to parse CSV datetime value [{}]", value);
+                }
+            }
             try {
                 return Instant.parse(value).toEpochMilli();
             } catch (DateTimeParseException e) {
@@ -508,6 +810,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             return true;
+        }
+    }
+
+    /**
+     * Sentinel exception used by {@code handleFieldError} so that budget-exceeded
+     * errors from NULL_FIELD mode can be distinguished from ordinary parse errors
+     * in the row-level catch block without double-counting.
+     */
+    private static final class BudgetExceededException extends RuntimeException {
+        final EsqlIllegalArgumentException wrapped;
+
+        BudgetExceededException(EsqlIllegalArgumentException wrapped) {
+            super(wrapped);
+            this.wrapped = wrapped;
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -448,7 +448,17 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     /**
      * Iterator that reads CSV data in batches and converts to ESQL Pages.
-     * Uses Jackson CSV parser for robust CSV parsing with proper quote and escape handling.
+     * <p>
+     * Performance-critical design choices:
+     * <ul>
+     *   <li>Pre-computed {@code int[]} for projected column indices — avoids autoboxing
+     *   <li>Pre-computed {@code DataType[]} and {@code Attribute[]} arrays — avoids list lookups per field
+     *   <li>Hoisted invariant flags ({@code hasCommentFilter}, {@code hasCustomNullValue}) — avoids per-row checks
+     *   <li>Exception-free error path: {@code tryConvertValue} returns {@code null} on failure and sets
+     *       {@code lastFieldError} — avoids exception allocation/stack-fill on the hot path
+     *   <li>Reusable {@code Object[]} buffer across rows — avoids per-row allocation
+     *   <li>Mode ordinal resolved once at construction — single int comparison per row instead of method calls
+     * </ul>
      */
     private class CsvBatchIterator implements CloseableIterator<Page> {
         private final BufferedReader reader;
@@ -458,13 +468,26 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final List<Attribute> preResolvedSchema;
         private final ErrorPolicy errorPolicy;
 
+        private final int modeOrdinal;
+        private final boolean logErrors;
+        private final boolean hasCommentFilter;
+        private final boolean hasCustomNullValue;
+        private final String nullValueStr;
+        private final DateTimeFormatter datetimeFormatter;
+
         private List<Attribute> schema;
-        private List<Integer> projectedIndices;
+        private int[] projectedIdx;
+        private DataType[] projectedTypes;
+        private Attribute[] projectedAttrs;
+        private int columnCount;
+        private Object[] rowBuffer;
         private Iterator<List<?>> csvIterator;
         private Page nextPage;
         private boolean closed = false;
         private long errorCount = 0;
         private long totalRowCount = 0;
+
+        private String lastFieldError;
 
         CsvBatchIterator(
             BufferedReader reader,
@@ -480,6 +503,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
             this.batchSize = batchSize;
             this.preResolvedSchema = preResolvedSchema;
             this.errorPolicy = errorPolicy;
+            this.modeOrdinal = errorPolicy.mode().ordinal();
+            this.logErrors = errorPolicy.logErrors();
+            this.hasCommentFilter = options.commentPrefix().isEmpty() == false;
+            this.hasCustomNullValue = options.nullValue().isEmpty() == false;
+            this.nullValueStr = options.nullValue();
+            this.datetimeFormatter = options.datetimeFormatter();
         }
 
         @Override
@@ -521,22 +550,21 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (schema == null) {
                 if (preResolvedSchema != null) {
                     schema = preResolvedSchema;
-                    projectedIndices = computeProjectedIndices();
                 } else {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         line = line.trim();
-                        if (line.isEmpty() || (options.commentPrefix().isEmpty() == false && line.startsWith(options.commentPrefix()))) {
+                        if (line.isEmpty() || (hasCommentFilter && line.startsWith(options.commentPrefix()))) {
                             continue;
                         }
                         schema = parseSchema(line);
-                        projectedIndices = computeProjectedIndices();
                         break;
                     }
                     if (schema == null) {
                         return null;
                     }
                 }
+                initProjection();
                 CsvSchema csvSchema = CsvSchema.emptySchema()
                     .withColumnSeparator(options.delimiter())
                     .withQuoteChar(options.quoteChar())
@@ -555,13 +583,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         Object val = rowList.get(i);
                         row[i] = val != null ? val.toString() : null;
                     }
-                    if (row.length > 0) {
-                        String firstCell = row[0];
-                        if (firstCell != null && options.commentPrefix().isEmpty() == false) {
-                            String trimmedFirstCell = firstCell.trim();
-                            if (trimmedFirstCell.startsWith(options.commentPrefix())) {
-                                continue;
-                            }
+                    if (hasCommentFilter && row.length > 0 && row[0] != null) {
+                        String trimmedFirstCell = row[0].trim();
+                        if (trimmedFirstCell.startsWith(options.commentPrefix())) {
+                            continue;
                         }
                     }
                     rows.add(row);
@@ -572,76 +597,72 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
 
                 Page page = convertRowsToPage(rows);
-                if (page != null || errorPolicy.isStrict()) {
+                if (page != null || modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
                     return page;
                 }
             }
         }
 
-        private List<Integer> computeProjectedIndices() {
+        private void initProjection() {
+            int schemaSize = schema.size();
             if (projectedColumns == null || projectedColumns.isEmpty()) {
-                // Return all columns
-                List<Integer> indices = new ArrayList<>(schema.size());
-                for (int i = 0; i < schema.size(); i++) {
-                    indices.add(i);
+                columnCount = schemaSize;
+                projectedIdx = new int[schemaSize];
+                for (int i = 0; i < schemaSize; i++) {
+                    projectedIdx[i] = i;
                 }
-                return indices;
-            }
-
-            // Map projected column names to indices
-            List<Integer> indices = new ArrayList<>(projectedColumns.size());
-            for (String colName : projectedColumns) {
-                int index = -1;
-                for (int i = 0; i < schema.size(); i++) {
-                    Attribute attr = schema.get(i);
-                    if (attr.name().equals(colName)) {
-                        index = i;
-                        break;
+            } else {
+                columnCount = projectedColumns.size();
+                projectedIdx = new int[columnCount];
+                for (int c = 0; c < columnCount; c++) {
+                    String colName = projectedColumns.get(c);
+                    int index = -1;
+                    for (int i = 0; i < schemaSize; i++) {
+                        if (schema.get(i).name().equals(colName)) {
+                            index = i;
+                            break;
+                        }
                     }
+                    if (index == -1) {
+                        throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
+                    }
+                    projectedIdx[c] = index;
                 }
-                if (index == -1) {
-                    throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
-                }
-                indices.add(index);
             }
-            return indices;
+            projectedTypes = new DataType[columnCount];
+            projectedAttrs = new Attribute[columnCount];
+            for (int i = 0; i < columnCount; i++) {
+                Attribute attr = schema.get(projectedIdx[i]);
+                projectedAttrs[i] = attr;
+                projectedTypes[i] = attr.dataType();
+            }
+            rowBuffer = new Object[columnCount];
         }
 
         private Page convertRowsToPage(List<String[]> rows) {
-            int columnCount = projectedIndices.size();
-
             BlockUtils.BuilderWrapper[] builders = new BlockUtils.BuilderWrapper[columnCount];
             try {
                 for (int i = 0; i < columnCount; i++) {
-                    int schemaIndex = projectedIndices.get(i);
-                    Attribute attr = schema.get(schemaIndex);
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
-                        org.elasticsearch.compute.data.ElementType.fromJava(javaClassForDataType(attr.dataType())),
+                        org.elasticsearch.compute.data.ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
                         rows.size()
                     );
                 }
 
+                int schemaSize = schema.size();
                 int acceptedRows = 0;
                 for (String[] row : rows) {
                     totalRowCount++;
-                    try {
-                        if (row.length > schema.size()) {
-                            throw new ParsingException(
-                                "CSV row has [{}] columns but schema defines [{}] columns",
-                                row.length,
-                                schema.size()
-                            );
-                        }
-                        Object[] converted = convertRow(row, columnCount);
+                    if (row.length > schemaSize) {
+                        onRowError("CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns", null, row);
+                        continue;
+                    }
+                    if (convertRowInPlace(row)) {
                         for (int i = 0; i < columnCount; i++) {
-                            builders[i].append().accept(converted[i]);
+                            builders[i].append().accept(rowBuffer[i]);
                         }
                         acceptedRows++;
-                    } catch (BudgetExceededException budgetExceeded) {
-                        throw budgetExceeded.wrapped;
-                    } catch (Exception e) {
-                        handleRowError(e, row);
                     }
                 }
 
@@ -661,78 +682,160 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         /**
-         * Converts a raw CSV row to typed values. In {@link ErrorPolicy.Mode#NULL_FIELD NULL_FIELD} mode,
-         * individual field parse errors produce null instead of failing the entire row.
+         * Converts a raw CSV row into {@link #rowBuffer} in place.
+         * Returns {@code true} if the row was accepted, {@code false} if it was skipped.
+         * Throws on budget exceeded or strict-mode failure.
          */
-        private Object[] convertRow(String[] row, int columnCount) {
-            Object[] converted = new Object[columnCount];
-            boolean permissive = errorPolicy.isPermissive();
+        private boolean convertRowInPlace(String[] row) {
+            int mode = this.modeOrdinal;
             for (int i = 0; i < columnCount; i++) {
-                int schemaIndex = projectedIndices.get(i);
-                Attribute attr = schema.get(schemaIndex);
-                String value = schemaIndex < row.length ? row[schemaIndex] : "";
+                int si = projectedIdx[i];
+                String value = si < row.length ? row[si] : null;
                 if (value != null) {
                     value = value.trim();
                 }
-                if (permissive) {
-                    try {
-                        converted[i] = convertValue(value, attr.dataType());
-                    } catch (Exception fieldError) {
-                        converted[i] = null;
-                        handleFieldError(fieldError, value, attr);
+                Object result = tryConvertValue(value, projectedTypes[i]);
+                if (lastFieldError != null) {
+                    if (mode == ErrorPolicy.Mode.NULL_FIELD.ordinal()) {
+                        rowBuffer[i] = null;
+                        onFieldError(lastFieldError, value, projectedAttrs[i]);
+                        lastFieldError = null;
+                    } else {
+                        String err = lastFieldError;
+                        lastFieldError = null;
+                        onRowError(err, null, row);
+                        return false;
                     }
                 } else {
-                    converted[i] = convertValue(value, attr.dataType());
+                    rowBuffer[i] = result;
                 }
             }
-            return converted;
+            return true;
         }
 
-        private void handleRowError(Exception e, String[] row) {
-            if (errorPolicy.isStrict()) {
-                if (e instanceof RuntimeException rte) {
-                    throw rte;
+        /**
+         * Attempts to convert a string value to the target type.
+         * On success, returns the converted value and {@code lastFieldError} is null.
+         * On failure, returns null and sets {@code lastFieldError} to a description.
+         * This avoids exception allocation on the hot path.
+         */
+        private Object tryConvertValue(String value, DataType dataType) {
+            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
+                return null;
+            }
+            if (hasCustomNullValue && value.equals(nullValueStr)) {
+                return null;
+            }
+            return switch (dataType) {
+                case INTEGER -> tryParseInt(value);
+                case LONG -> tryParseLong(value);
+                case DOUBLE -> tryParseDouble(value);
+                case KEYWORD, TEXT -> new BytesRef(value);
+                case BOOLEAN -> tryParseBoolean(value);
+                case DATETIME -> tryParseDatetime(value);
+                case NULL -> null;
+                default -> {
+                    lastFieldError = "Unsupported data type: " + dataType;
+                    yield null;
                 }
-                throw new EsqlIllegalArgumentException(e, "Failed to parse CSV row");
-            }
-            errorCount++;
-            if (errorPolicy.logErrors()) {
-                logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), e.getMessage());
-            }
-            if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
-                throw new EsqlIllegalArgumentException(
-                    e,
-                    "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
-                    errorCount,
-                    totalRowCount,
-                    errorPolicy.maxErrors(),
-                    errorPolicy.maxErrorRatio()
-                );
+            };
+        }
+
+        private Object tryParseInt(String value) {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                lastFieldError = "Failed to parse CSV value [" + value + "] as [INTEGER]";
+                return null;
             }
         }
 
-        private void handleFieldError(Exception e, String value, Attribute attr) {
+        private Object tryParseLong(String value) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                lastFieldError = "Failed to parse CSV value [" + value + "] as [LONG]";
+                return null;
+            }
+        }
+
+        private Object tryParseDouble(String value) {
+            try {
+                return Double.parseDouble(value);
+            } catch (NumberFormatException e) {
+                lastFieldError = "Failed to parse CSV value [" + value + "] as [DOUBLE]";
+                return null;
+            }
+        }
+
+        private Object tryParseBoolean(String value) {
+            try {
+                return Booleans.parseBoolean(value);
+            } catch (IllegalArgumentException e) {
+                lastFieldError = "Failed to parse CSV value [" + value + "] as [BOOLEAN]";
+                return null;
+            }
+        }
+
+        private Object tryParseDatetime(String value) {
+            if (looksNumeric(value)) {
+                try {
+                    return Long.parseLong(value);
+                } catch (NumberFormatException e) {
+                    // overflow — fall through
+                }
+            }
+            if (datetimeFormatter != null) {
+                try {
+                    return LocalDateTime.parse(value, datetimeFormatter).toInstant(ZoneOffset.UTC).toEpochMilli();
+                } catch (DateTimeParseException e) {
+                    lastFieldError = "Failed to parse CSV datetime value [" + value + "]";
+                    return null;
+                }
+            }
+            try {
+                return Instant.parse(value).toEpochMilli();
+            } catch (DateTimeParseException e) {
+                lastFieldError = "Failed to parse CSV datetime value [" + value + "]";
+                return null;
+            }
+        }
+
+        private void onRowError(String message, Exception cause, String[] row) {
+            if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
+                throw new EsqlIllegalArgumentException(cause, message);
+            }
             errorCount++;
-            if (errorPolicy.logErrors()) {
+            if (logErrors) {
+                logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), message);
+            }
+            checkBudget(message, cause);
+        }
+
+        private void onFieldError(String message, String value, Attribute attr) {
+            errorCount++;
+            if (logErrors) {
                 logger.warn(
                     "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
                     attr.name(),
                     value,
                     errorCount,
                     errorPolicy.maxErrors(),
-                    e.getMessage()
+                    message
                 );
             }
+            checkBudget(message, null);
+        }
+
+        private void checkBudget(String message, Exception cause) {
             if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
-                throw new BudgetExceededException(
-                    new EsqlIllegalArgumentException(
-                        e,
-                        "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
-                        errorCount,
-                        totalRowCount,
-                        errorPolicy.maxErrors(),
-                        errorPolicy.maxErrorRatio()
-                    )
+                throw new EsqlIllegalArgumentException(
+                    cause,
+                    "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
+                    errorCount,
+                    totalRowCount,
+                    errorPolicy.maxErrors(),
+                    errorPolicy.maxErrorRatio()
                 );
             }
         }
@@ -749,56 +852,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
             };
         }
 
-        private Object convertValue(String value, DataType dataType) {
-            // Jackson CSV uses null for empty values when configured with withNullValue
-            // Also handle explicit "null" string and configurable null_value
-            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
-                return null;
-            }
-            if (options.nullValue().isEmpty() == false && value.equals(options.nullValue())) {
-                return null;
-            }
-
-            try {
-                return switch (dataType) {
-                    case INTEGER -> Integer.parseInt(value);
-                    case LONG -> Long.parseLong(value);
-                    case DOUBLE -> Double.parseDouble(value);
-                    case KEYWORD, TEXT -> new BytesRef(value);
-                    case BOOLEAN -> Booleans.parseBoolean(value);
-                    case DATETIME -> parseDatetime(value);
-                    case NULL -> null;
-                    default -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
-                };
-            } catch (NumberFormatException e) {
-                throw new EsqlIllegalArgumentException(e, "Failed to parse CSV value [{}] as [{}]", value, dataType);
-            }
-        }
-
-        private long parseDatetime(String value) {
-            // Numeric strings (epoch millis) contain only digits and optionally a leading minus
-            if (looksNumeric(value)) {
-                try {
-                    return Long.parseLong(value);
-                } catch (NumberFormatException e) {
-                    // overflow or not actually numeric, fall through to ISO-8601
-                }
-            }
-            DateTimeFormatter formatter = options.datetimeFormatter();
-            if (formatter != null) {
-                try {
-                    return LocalDateTime.parse(value, formatter).toInstant(ZoneOffset.UTC).toEpochMilli();
-                } catch (DateTimeParseException e) {
-                    throw new EsqlIllegalArgumentException(e, "Failed to parse CSV datetime value [{}]", value);
-                }
-            }
-            try {
-                return Instant.parse(value).toEpochMilli();
-            } catch (DateTimeParseException e) {
-                throw new EsqlIllegalArgumentException(e, "Failed to parse CSV datetime value [{}]", value);
-            }
-        }
-
         private static boolean looksNumeric(String value) {
             int start = (value.charAt(0) == '-') ? 1 : 0;
             if (start >= value.length()) {
@@ -810,20 +863,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             return true;
-        }
-    }
-
-    /**
-     * Sentinel exception used by {@code handleFieldError} so that budget-exceeded
-     * errors from NULL_FIELD mode can be distinguished from ordinary parse errors
-     * in the row-level catch block without double-counting.
-     */
-    private static final class BudgetExceededException extends RuntimeException {
-        final EsqlIllegalArgumentException wrapped;
-
-        BudgetExceededException(EsqlIllegalArgumentException wrapped) {
-            super(wrapped);
-            this.wrapped = wrapped;
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -11,8 +11,10 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
@@ -20,6 +22,8 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
@@ -29,7 +33,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class CsvFormatReaderTests extends ESTestCase {
 
@@ -306,6 +313,1026 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> reader.schema(object));
         assertTrue(e.getMessage().contains("illegal data type"));
+    }
+
+    public void testDefaultErrorPolicyIsStrict() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(ErrorPolicy.STRICT, reader.defaultErrorPolicy());
+        assertTrue(reader.defaultErrorPolicy().isStrict());
+    }
+
+    public void testStrictPolicyFailsOnMalformedRow() {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            not_a_number,Bob
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10, ErrorPolicy.STRICT)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("Failed to parse CSV value"));
+    }
+
+    public void testLenientPolicySkipsMalformedRows() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            not_a_number,Bob
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, lenient)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testErrorBudgetExceeded() {
+        String csv = """
+            id:long,name:keyword
+            bad1,Alice
+            bad2,Bob
+            bad3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy limited = new ErrorPolicy(2, false);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10, limited)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("error budget exceeded"));
+    }
+
+    public void testLenientPolicyWithExtraColumns() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,Bob,extra_column
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, lenient)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(1));
+
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testLenientPolicyAllRowsBad() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            bad1,Alice
+            bad2,Bob
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, true);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, lenient)) {
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testLenientPolicyAcrossBatches() throws IOException {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 1; i <= 15; i++) {
+            if (i % 3 == 0) {
+                csv.append("bad,Name").append(i).append("\n");
+            } else {
+                csv.append(i).append(",Name").append(i).append("\n");
+            }
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, false);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 5, lenient)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+            }
+        }
+        assertEquals(10, totalRows);
+    }
+
+    public void testErrorRatioExceeded() {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 1; i <= 10; i++) {
+            if (i <= 4) {
+                csv.append("bad").append(i).append(",Name").append(i).append("\n");
+            } else {
+                csv.append(i).append(",Name").append(i).append("\n");
+            }
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy ratioPolicy = new ErrorPolicy(Long.MAX_VALUE, 0.3, true);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10, ratioPolicy)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("error budget exceeded"));
+    }
+
+    public void testErrorRatioWithinBudget() throws IOException {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 1; i <= 100; i++) {
+            if (i == 50) {
+                csv.append("bad,Name").append(i).append("\n");
+            } else {
+                csv.append(i).append(",Name").append(i).append("\n");
+            }
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy ratioPolicy = new ErrorPolicy(Long.MAX_VALUE, 0.1, false);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 200, ratioPolicy)) {
+            while (iterator.hasNext()) {
+                totalRows += iterator.next().getPositionCount();
+            }
+        }
+        assertEquals(99, totalRows);
+    }
+
+    // --- Delimiter and format variation tests ---
+
+    public void testSemicolonInQuotedField() throws IOException {
+        String csv = "id:long,data:keyword\n1,\"value;with;semicolons\"\n2,normal\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("value;with;semicolons"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    public void testPipeInQuotedField() throws IOException {
+        String csv = "id:long,data:keyword\n1,\"col1|col2|col3\"\n2,simple\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("col1|col2|col3"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    // --- Quoted field handling tests (RFC 4180) ---
+
+    public void testQuotedFieldsWithCommas() throws IOException {
+        String csv = "id:long,name:keyword\n1,\"Smith, John\"\n2,\"Doe, Jane\"\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("Smith, John"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("Doe, Jane"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    public void testQuotedFieldsWithNewlines() throws IOException {
+        String csv = "id:long,description:keyword\n1,\"line1\nline2\"\n2,\"simple\"\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("line1\nline2"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    public void testEscapedQuotesInFields() throws IOException {
+        String csv = "id:long,name:keyword\n1,\"She said \\\"hello\\\"\"\n2,normal\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+        }
+    }
+
+    // --- Empty and null value handling ---
+
+    public void testEmptyFieldsTreatedAsNull() throws IOException {
+        String csv = "id:long,name:keyword,score:double\n1,,95.5\n2,Bob,\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(1).isNull(0));
+            assertTrue(page.getBlock(2).isNull(1));
+        }
+    }
+
+    public void testExplicitNullString() throws IOException {
+        String csv = "id:long,name:keyword\n1,null\n2,Bob\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(1).isNull(0));
+            assertFalse(page.getBlock(1).isNull(1));
+        }
+    }
+
+    // --- Trailing/missing column handling ---
+
+    public void testFewerColumnsThanSchema() throws IOException {
+        String csv = "id:long,name:keyword,score:double\n1,Alice\n2,Bob,87.3\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(2).isNull(0));
+            assertFalse(page.getBlock(2).isNull(1));
+        }
+    }
+
+    // --- Whitespace trimming ---
+
+    public void testWhitespaceTrimming() throws IOException {
+        String csv = "id:long,name:keyword\n 1 , Alice \n 2 , Bob \n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    // --- All supported data types ---
+
+    public void testAllSupportedDataTypes() throws IOException {
+        String csv = "i:integer,l:long,d:double,k:keyword,t:text,b:boolean,dt:datetime,n:null\n"
+            + "42,9999999999,3.14,hello,world,true,2021-01-01T00:00:00Z,\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(8, page.getBlockCount());
+        }
+    }
+
+    // --- Type alias coverage ---
+
+    public void testTypeAliases() throws IOException {
+        String csv = "a:int,b:l,c:d,d:k,e:s,f:txt,g:bool,h:date,i:dt,j:n\n"
+            + "1,2,3.0,kw,str,text,false,2021-01-01T00:00:00Z,2021-01-01T00:00:00Z,\n";
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(10, page.getBlockCount());
+        }
+    }
+
+    // --- Empty file handling ---
+
+    public void testEmptyFile() throws IOException {
+        StorageObject object = createStorageObject("");
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testSchemaOnlyNoData() throws IOException {
+        String csv = "id:long,name:keyword\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    // --- Mixed error types with lenient policy ---
+
+    public void testMixedErrorTypesWithLenientPolicy() throws IOException {
+        String csv = """
+            id:long,score:double,active:boolean,ts:datetime
+            1,95.5,true,2021-01-01T00:00:00Z
+            bad_id,95.5,true,2021-01-01T00:00:00Z
+            3,not_a_double,true,2021-01-01T00:00:00Z
+            4,80.0,not_bool,2021-01-01T00:00:00Z
+            5,90.0,false,not_a_date
+            6,85.0,true,2021-06-15T12:00:00Z
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, true);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, lenient)) {
+            while (iterator.hasNext()) {
+                totalRows += iterator.next().getPositionCount();
+            }
+        }
+        assertEquals(2, totalRows);
+    }
+
+    // --- Large batch with sparse errors ---
+
+    public void testLargeBatchWithSparseErrors() throws IOException {
+        StringBuilder csv = new StringBuilder("id:long,value:integer\n");
+        int expectedGood = 0;
+        for (int i = 1; i <= 1000; i++) {
+            if (i % 100 == 0) {
+                csv.append("bad,").append(i).append("\n");
+            } else {
+                csv.append(i).append(",").append(i * 10).append("\n");
+                expectedGood++;
+            }
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, false);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 200, lenient)) {
+            while (iterator.hasNext()) {
+                totalRows += iterator.next().getPositionCount();
+            }
+        }
+        assertEquals(expectedGood, totalRows);
+    }
+
+    // --- Configurable Delimiter Tests (Gap 3) ---
+
+    public void testTsvPreset() throws IOException {
+        String tsv = "id:long\tname:keyword\tvalue:integer\n1\tAlice\t100\n2\tBob\t200\n";
+        StorageObject object = createStorageObject(tsv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(CsvFormatOptions.TSV);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(100, ((IntBlock) page.getBlock(2)).getInt(0));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            assertEquals(200, ((IntBlock) page.getBlock(2)).getInt(1));
+        }
+    }
+
+    public void testPipeDelimited() throws IOException {
+        String csv = "id:long|name:keyword|score:double\n1|Alice|95.5\n2|Bob|87.3\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            '|',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(95.5, ((DoubleBlock) page.getBlock(2)).getDouble(0), 0.001);
+        }
+    }
+
+    public void testSemicolonDelimited() throws IOException {
+        String csv = "id:long;name:keyword;value:integer\n1;Alice;42\n2;Bob;99\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ';',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(42, ((IntBlock) page.getBlock(2)).getInt(0));
+        }
+    }
+
+    public void testRandomizedDelimiter() throws IOException {
+        char delimiter = randomFrom(',', '\t', '|', ';');
+        int numCols = between(2, 5);
+        int numRows = between(5, 20);
+        StringBuilder schema = new StringBuilder();
+        StringBuilder data = new StringBuilder();
+        for (int c = 0; c < numCols; c++) {
+            if (c > 0) schema.append(delimiter);
+            schema.append("col").append(c).append(":long");
+        }
+        schema.append("\n");
+        for (int r = 0; r < numRows; r++) {
+            for (int c = 0; c < numCols; c++) {
+                if (c > 0) data.append(delimiter);
+                data.append(r * 10 + c);
+            }
+            data.append("\n");
+        }
+        CsvFormatOptions options = new CsvFormatOptions(
+            delimiter,
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(schema.append(data).toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, between(2, 10))) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    long expected = (totalRows - page.getPositionCount() + i) * 10L;
+                    assertEquals(expected, ((LongBlock) page.getBlock(0)).getLong(i));
+                }
+            }
+        }
+        assertEquals(numRows, totalRows);
+    }
+
+    // --- Configurable Quote/Escape Characters (Gap 4) ---
+
+    public void testSingleQuoteAsQuoteChar() throws IOException {
+        String csv = "id:long,name:keyword\n1,'Alice'\n2,'Bob,Smith'\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            '\'',
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("Bob,Smith"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    public void testCustomEscapeChar() throws IOException {
+        String csv = "id:long,data:keyword\n1,\"value\\\"quoted\"\n2,normal\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            '"',
+            '\\',
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("value\"quoted"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    public void testRandomizedQuoteChar() throws IOException {
+        char quoteChar = randomFrom('"', '\'');
+        String csv = "id:long,name:keyword\n1," + quoteChar + "Alice" + quoteChar + "\n2," + quoteChar + "Bob" + quoteChar + "\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            quoteChar,
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    // --- Custom Comment Prefix (Gap 4) ---
+
+    public void testHashCommentPrefix() throws IOException {
+        String csv = """
+            # This is a comment
+            id:long,name:keyword
+            # Another comment
+            1,Alice
+            2,Bob
+            """;
+
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            "#",
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+        }
+    }
+
+    public void testCustomCommentPrefix() throws IOException {
+        String csv = """
+            -- SQL style comment
+            id:long,name:keyword
+            -- Another comment
+            1,Alice
+            2,Bob
+            """;
+
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            "--",
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+        }
+    }
+
+    // --- Custom Null Value (Gap 4) ---
+
+    public void testNaAsNullValue() throws IOException {
+        String csv = "id:long,name:keyword,score:double\n1,N/A,95.5\n2,Bob,N/A\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            "N/A",
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(1).isNull(0));
+            assertTrue(page.getBlock(2).isNull(1));
+        }
+    }
+
+    public void testBackslashNAsNullValue() throws IOException {
+        String csv = "id:long,name:keyword\n1,\\N\n2,Bob\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            '\0',
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            "\\N",
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(1).isNull(0));
+            assertFalse(page.getBlock(1).isNull(1));
+        }
+    }
+
+    // --- PERMISSIVE Mode (Gap 1) ---
+
+    public void testPermissiveModeNullFillsBadFields() throws IOException {
+        String csv = """
+            id:long,name:keyword,score:double
+            1,Alice,95.5
+            not_a_number,Bob,87.3
+            3,Charlie,bad_double
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(95.5, ((DoubleBlock) page.getBlock(2)).getDouble(0), 0.001);
+            assertTrue(page.getBlock(0).isNull(1));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            assertEquals(87.3, ((DoubleBlock) page.getBlock(2)).getDouble(1), 0.001);
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
+            assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(2, new BytesRef()));
+            assertTrue(page.getBlock(2).isNull(2));
+        }
+    }
+
+    public void testPermissiveModeKeepsAllRows() throws IOException {
+        String csv = """
+            id:long,name:keyword,age:integer
+            1,Alice,30
+            bad_id,Bob,25
+            3,Charlie,not_int
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertTrue(page.getBlock(0).isNull(1));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
+            assertTrue(page.getBlock(2).isNull(2));
+        }
+    }
+
+    public void testPermissiveModeErrorBudgetExceeded() {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            bad2,Bob
+            bad3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 1, 0.0, false);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("error budget exceeded"));
+    }
+
+    public void testPermissiveModeMultipleBadFieldsInSameRow() throws IOException {
+        String csv = """
+            id:long,name:keyword,age:integer,active:boolean
+            1,Alice,30,true
+            bad_id,valid_name,bad_age,bad_bool
+            3,Charlie,25,false
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(30, ((IntBlock) page.getBlock(2)).getInt(0));
+            assertFalse(page.getBlock(3).isNull(0));
+            assertTrue(((BooleanBlock) page.getBlock(3)).getBoolean(0));
+            assertTrue(page.getBlock(0).isNull(1));
+            assertEquals(new BytesRef("valid_name"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            assertTrue(page.getBlock(2).isNull(1));
+            assertTrue(page.getBlock(3).isNull(1));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
+            assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(2, new BytesRef()));
+        }
+    }
+
+    // --- Custom Datetime Format (Gap 6) ---
+
+    public void testCustomDatetimeFormat() throws IOException {
+        String csv = "id:long,ts:datetime\n1,2021-01-15 14:30:00\n2,2022-06-20 09:00:00\n";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            formatter,
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(Instant.parse("2021-01-15T14:30:00Z").toEpochMilli(), ((LongBlock) page.getBlock(1)).getLong(0));
+            assertEquals(Instant.parse("2022-06-20T09:00:00Z").toEpochMilli(), ((LongBlock) page.getBlock(1)).getLong(1));
+        }
+    }
+
+    // --- withConfig() Integration Tests ---
+
+    public void testWithConfigDelimiter() throws IOException {
+        String csv = "id:long|name:keyword\n1|Alice\n2|Bob\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader configured = baseReader.withConfig(Map.of("delimiter", "|"));
+
+        try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    public void testWithConfigMultipleOptions() throws IOException {
+        String csv = "id:long;name:keyword\n1;N/A\n2;Bob\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader configured = baseReader.withConfig(Map.of("delimiter", ";", "null_value", "N/A", "comment", "#"));
+
+        try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertTrue(page.getBlock(1).isNull(0));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    public void testWithConfigEmptyReturnsSameReader() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        FormatReader result = reader.withConfig(Map.of());
+        assertSame(reader, result);
+    }
+
+    public void testWithConfigNullReturnsSameReader() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        FormatReader result = reader.withConfig(null);
+        assertSame(reader, result);
+    }
+
+    // --- Randomized Tests ---
+
+    public void testRandomizedDelimiterColumnRowBatchCount() throws IOException {
+        char delimiter = randomFrom(',', '\t', '|', ';');
+        int numCols = between(2, 10);
+        int numRows = between(1, 100);
+        int batchSize = between(1, 20);
+        StringBuilder schema = new StringBuilder();
+        StringBuilder data = new StringBuilder();
+        for (int c = 0; c < numCols; c++) {
+            if (c > 0) schema.append(delimiter);
+            schema.append("c").append(c).append(":long");
+        }
+        schema.append("\n");
+        for (int r = 0; r < numRows; r++) {
+            for (int c = 0; c < numCols; c++) {
+                if (c > 0) data.append(delimiter);
+                data.append(r * 1000L + c);
+            }
+            data.append("\n");
+        }
+        CsvFormatOptions options = new CsvFormatOptions(
+            delimiter,
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize()
+        );
+        StorageObject object = createStorageObject(schema.append(data).toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, batchSize)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    int rowIdx = totalRows - page.getPositionCount() + i;
+                    long expected = rowIdx * 1000L;
+                    assertEquals(expected, ((LongBlock) page.getBlock(0)).getLong(i));
+                }
+            }
+        }
+        assertEquals(numRows, totalRows);
+    }
+
+    public void testRandomizedErrorInjectionDropMalformed() throws IOException {
+        int numRows = between(10, 50);
+        int numBad = between(1, 5);
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 1; i <= numRows; i++) {
+            if (i <= numBad) {
+                csv.append("bad").append(i).append(",Name").append(i).append("\n");
+            } else {
+                csv.append(i).append(",Name").append(i).append("\n");
+            }
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy dropMalformed = new ErrorPolicy(numBad + 10, false);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, between(2, 15), dropMalformed)) {
+            while (iterator.hasNext()) {
+                totalRows += iterator.next().getPositionCount();
+            }
+        }
+        assertEquals(numRows - numBad, totalRows);
+    }
+
+    public void testRandomizedErrorInjectionPermissive() throws IOException {
+        int numRows = between(10, 50);
+        int numBadId = between(1, 3);
+        StringBuilder csv = new StringBuilder("id:long,name:keyword,score:double\n");
+        for (int i = 1; i <= numRows; i++) {
+            if (i <= numBadId) {
+                csv.append("bad").append(i).append(",Name").append(i).append(",").append(90.0 + i).append("\n");
+            } else {
+                csv.append(i).append(",Name").append(i).append(",").append(90.0 + i).append("\n");
+            }
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(object, null, between(2, 15), permissive)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    int rowIdx = totalRows - page.getPositionCount() + i;
+                    if (rowIdx < numBadId) {
+                        assertTrue("Row " + rowIdx + " with bad id should have null id", page.getBlock(0).isNull(i));
+                    } else {
+                        assertEquals((long) (rowIdx + 1), ((LongBlock) page.getBlock(0)).getLong(i));
+                    }
+                }
+            }
+        }
+        assertEquals(numRows, totalRows);
     }
 
     private StorageObject createStorageObject(String csvContent) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -65,6 +66,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final Set<String> partitionColumnNames;
     private final Map<String, Object> partitionValues;
     private final ExternalSliceQueue sliceQueue;
+    private final ErrorPolicy errorPolicy;
 
     public AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
@@ -78,7 +80,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         FileSet fileSet,
         Set<String> partitionColumnNames,
         Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue
+        ExternalSliceQueue sliceQueue,
+        ErrorPolicy errorPolicy
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -114,6 +117,38 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.partitionColumnNames = partitionColumnNames != null ? partitionColumnNames : Set.of();
         this.partitionValues = partitionValues != null ? partitionValues : Map.of();
         this.sliceQueue = sliceQueue;
+        this.errorPolicy = errorPolicy != null ? errorPolicy : formatReader.defaultErrorPolicy();
+    }
+
+    public AsyncExternalSourceOperatorFactory(
+        StorageProvider storageProvider,
+        FormatReader formatReader,
+        StoragePath path,
+        List<Attribute> attributes,
+        int batchSize,
+        int maxBufferSize,
+        int rowLimit,
+        Executor executor,
+        FileSet fileSet,
+        Set<String> partitionColumnNames,
+        Map<String, Object> partitionValues,
+        ExternalSliceQueue sliceQueue
+    ) {
+        this(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            batchSize,
+            maxBufferSize,
+            rowLimit,
+            executor,
+            fileSet,
+            partitionColumnNames,
+            partitionValues,
+            sliceQueue,
+            null
+        );
     }
 
     public AsyncExternalSourceOperatorFactory(
@@ -141,7 +176,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             fileSet,
             partitionColumnNames,
             partitionValues,
-            sliceQueue
+            sliceQueue,
+            null
         );
     }
 
@@ -169,6 +205,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             fileSet,
             partitionColumnNames,
             partitionValues,
+            null,
             null
         );
     }
@@ -195,6 +232,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             fileSet,
             null,
             null,
+            null,
             null
         );
     }
@@ -217,6 +255,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             maxBufferSize,
             FormatReader.NO_LIMIT,
             executor,
+            null,
             null,
             null,
             null,
@@ -306,7 +345,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                                     batchSize,
                                     skipFirstLine,
                                     lastSplit,
-                                    attributes
+                                    attributes,
+                                    errorPolicy
                                 )
                             ) {
                                 int consumed = drainPagesWithBudget(pages, buffer, injector);
@@ -343,7 +383,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     }
                     StorageObject obj = storageProvider.newObject(entry.path(), entry.length(), entry.lastModified());
                     int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : rowsRemaining;
-                    try (CloseableIterator<Page> pages = formatReader.read(obj, projectedColumns, batchSize, fileBudget)) {
+                    try (CloseableIterator<Page> pages = formatReader.read(obj, projectedColumns, batchSize, fileBudget, errorPolicy)) {
                         int consumed = drainPagesWithBudget(pages, buffer, injector);
                         if (rowLimit != FormatReader.NO_LIMIT) {
                             rowsRemaining -= consumed;
@@ -366,12 +406,20 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector
     ) {
-        formatReader.readAsync(storageObject, projectedColumns, batchSize, rowLimit, executor, ActionListener.wrap(iterator -> {
-            consumePagesInBackground(iterator, buffer, driverContext, injector);
-        }, e -> {
-            buffer.onFailure(e);
-            driverContext.removeAsyncAction();
-        }));
+        formatReader.readAsync(
+            storageObject,
+            projectedColumns,
+            batchSize,
+            rowLimit,
+            errorPolicy,
+            executor,
+            ActionListener.wrap(iterator -> {
+                consumePagesInBackground(iterator, buffer, driverContext, injector);
+            }, e -> {
+                buffer.onFailure(e);
+                driverContext.removeAsyncAction();
+            })
+        );
     }
 
     private void startSyncWrapperRead(
@@ -384,7 +432,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         executor.execute(() -> {
             CloseableIterator<Page> pages = null;
             try {
-                pages = formatReader.read(storageObject, projectedColumns, batchSize, rowLimit);
+                pages = formatReader.read(storageObject, projectedColumns, batchSize, rowLimit, errorPolicy);
                 consumePages(pages, buffer, injector);
             } catch (Exception e) {
                 buffer.onFailure(e);
@@ -555,5 +603,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
 
     public ExternalSliceQueue sliceQueue() {
         return sliceQueue;
+    }
+
+    public ErrorPolicy errorPolicy() {
+        return errorPolicy;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
@@ -11,12 +11,14 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Delegating {@link FormatReader} that wraps the raw {@link StorageObject} in a
@@ -46,9 +48,26 @@ final class CompressionDelegatingFormatReader implements FormatReader {
     }
 
     @Override
+    public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize, ErrorPolicy errorPolicy)
+        throws IOException {
+        return inner.read(new DecompressingStorageObject(object, codec), projectedColumns, batchSize, errorPolicy);
+    }
+
+    @Override
     public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize, int rowLimit)
         throws IOException {
         return inner.read(new DecompressingStorageObject(object, codec), projectedColumns, batchSize, rowLimit);
+    }
+
+    @Override
+    public CloseableIterator<Page> read(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        int rowLimit,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        return inner.read(new DecompressingStorageObject(object, codec), projectedColumns, batchSize, rowLimit, errorPolicy);
     }
 
     @Override
@@ -88,6 +107,32 @@ final class CompressionDelegatingFormatReader implements FormatReader {
     }
 
     @Override
+    public CloseableIterator<Page> readSplit(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        boolean skipFirstLine,
+        boolean lastSplit,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        return inner.readSplit(
+            new DecompressingStorageObject(object, codec),
+            projectedColumns,
+            batchSize,
+            skipFirstLine,
+            lastSplit,
+            resolvedAttributes,
+            errorPolicy
+        );
+    }
+
+    @Override
+    public ErrorPolicy defaultErrorPolicy() {
+        return inner.defaultErrorPolicy();
+    }
+
+    @Override
     public String formatName() {
         return inner.formatName();
     }
@@ -95,6 +140,12 @@ final class CompressionDelegatingFormatReader implements FormatReader {
     @Override
     public List<String> fileExtensions() {
         return inner.fileExtensions();
+    }
+
+    @Override
+    public FormatReader withConfig(Map<String, Object> config) {
+        FormatReader configured = inner.withConfig(config);
+        return configured == inner ? this : new CompressionDelegatingFormatReader(configured, codec);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -102,7 +103,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
             }
 
             StorageObject storageObject = provider.newObject(storagePath);
-            FormatReader reader = resolveFormatReader(storagePath.objectName(), config);
+            FormatReader reader = resolveFormatReader(storagePath.objectName(), config).withConfig(config);
             return reader.metadata(storageObject);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to resolve metadata for [" + location + "]", e);
@@ -127,7 +128,8 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 storage = storageRegistry.provider(path);
             }
 
-            FormatReader format = resolveFormatReader(path.objectName(), config);
+            FormatReader format = resolveFormatReader(path.objectName(), config).withConfig(config);
+            ErrorPolicy errorPolicy = resolveErrorPolicy(config, format);
 
             Map<String, Object> partitionValues = Map.of();
             if (context.split() instanceof FileSplit fileSplit) {
@@ -146,12 +148,84 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 context.fileSet(),
                 context.partitionColumnNames(),
                 partitionValues,
-                context.sliceQueue()
+                context.sliceQueue(),
+                errorPolicy
             );
         };
     }
 
     static final String CONFIG_FORMAT = "format";
+    static final String CONFIG_MAX_ERRORS = "max_errors";
+    static final String CONFIG_MAX_ERROR_RATIO = "max_error_ratio";
+    static final String CONFIG_ERROR_MODE = "error_mode";
+
+    static ErrorPolicy resolveErrorPolicy(Map<String, Object> config, FormatReader format) {
+        if (config == null) {
+            return format.defaultErrorPolicy();
+        }
+        Object maxErrorsValue = config.get(CONFIG_MAX_ERRORS);
+        Object maxErrorRatioValue = config.get(CONFIG_MAX_ERROR_RATIO);
+        Object errorModeValue = config.get(CONFIG_ERROR_MODE);
+        if (maxErrorsValue == null && maxErrorRatioValue == null && errorModeValue == null) {
+            return format.defaultErrorPolicy();
+        }
+
+        // When only budget keys are set (no explicit mode), default to SKIP_ROW.
+        // When only mode is set, budget defaults depend on the mode.
+        ErrorPolicy.Mode mode = ErrorPolicy.Mode.SKIP_ROW;
+        if (errorModeValue != null) {
+            String modeStr = errorModeValue.toString();
+            try {
+                mode = ErrorPolicy.Mode.parse(modeStr);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]", e);
+            }
+            if (mode == null) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]");
+            }
+        }
+
+        // FAIL_FAST is incompatible with budget settings — it always aborts on the first error.
+        if (mode == ErrorPolicy.Mode.FAIL_FAST) {
+            if (maxErrorsValue != null || maxErrorRatioValue != null) {
+                throw new IllegalArgumentException(
+                    "["
+                        + CONFIG_MAX_ERRORS
+                        + "] and ["
+                        + CONFIG_MAX_ERROR_RATIO
+                        + "] cannot be used with ["
+                        + CONFIG_ERROR_MODE
+                        + "="
+                        + mode
+                        + "]; fail_fast always aborts on the first error"
+                );
+            }
+            return ErrorPolicy.STRICT;
+        }
+
+        long maxErrors;
+        if (maxErrorsValue != null) {
+            try {
+                maxErrors = Long.parseLong(maxErrorsValue.toString());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERRORS + "]: [" + maxErrorsValue + "]", e);
+            }
+        } else {
+            maxErrors = Long.MAX_VALUE;
+        }
+
+        double maxErrorRatio = 0.0;
+        if (maxErrorRatioValue != null) {
+            try {
+                maxErrorRatio = Double.parseDouble(maxErrorRatioValue.toString());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERROR_RATIO + "]: [" + maxErrorRatioValue + "]", e);
+            }
+        }
+
+        boolean logErrors = maxErrors < Long.MAX_VALUE || maxErrorRatio > 0.0;
+        return new ErrorPolicy(mode, maxErrors, maxErrorRatio, logErrors);
+    }
 
     private FormatReader resolveFormatReader(String objectName, Map<String, Object> config) {
         if (config != null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.util.Locale;
+
+/**
+ * Configures how format readers handle malformed or unparseable rows.
+ *
+ * <h2>Error modes</h2>
+ * <table>
+ *   <caption>Error mode comparison across engines</caption>
+ *   <tr><th>ES/ESQL</th><th>Spark</th><th>DuckDB</th><th>ClickHouse</th><th>Behaviour</th></tr>
+ *   <tr><td>{@link Mode#FAIL_FAST FAIL_FAST}</td><td>FAILFAST</td><td>(default)</td>
+ *       <td>errors_num=0</td><td>Abort on first error</td></tr>
+ *   <tr><td>{@link Mode#SKIP_ROW SKIP_ROW}</td><td>DROPMALFORMED</td><td>ignore_errors</td>
+ *       <td>errors_num&gt;0</td><td>Drop the entire bad row</td></tr>
+ *   <tr><td>{@link Mode#NULL_FIELD NULL_FIELD}</td><td>PERMISSIVE</td><td>—</td>
+ *       <td>—</td><td>Null-fill unparseable fields, keep the row</td></tr>
+ * </table>
+ *
+ * <h2>Error budget</h2>
+ * {@code maxErrors} and {@code maxErrorRatio} only apply to {@link Mode#SKIP_ROW} and
+ * {@link Mode#NULL_FIELD}. They are ignored in {@link Mode#FAIL_FAST} (which always aborts
+ * on the first error).  When both are set, whichever limit is hit first triggers failure.
+ * <table>
+ *   <caption>Error budget comparison across engines</caption>
+ *   <tr><th>ES/ESQL</th><th>DuckDB</th><th>ClickHouse</th></tr>
+ *   <tr><td>{@code max_errors}</td><td>rejects_limit</td>
+ *       <td>input_format_allow_errors_num</td></tr>
+ *   <tr><td>{@code max_error_ratio}</td><td>—</td>
+ *       <td>input_format_allow_errors_ratio</td></tr>
+ * </table>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ *   FROM s3://bucket/data.csv WITH {"max_errors": 100}
+ *   FROM s3://bucket/data.csv WITH {"error_mode": "skip_row", "max_error_ratio": 0.1}
+ *   FROM s3://bucket/data.csv WITH {"error_mode": "null_field"}
+ * }</pre>
+ *
+ * @param mode           how to handle rows with parse errors
+ * @param maxErrors      maximum number of errors to tolerate before failing
+ *                       (only meaningful for {@code SKIP_ROW} and {@code NULL_FIELD})
+ * @param maxErrorRatio  maximum fraction of rows (0.0–1.0) that may be errors before
+ *                       failing; 0.0 disables ratio-based tolerance
+ *                       (only meaningful for {@code SKIP_ROW} and {@code NULL_FIELD})
+ * @param logErrors      whether to log each skipped/null-filled row at WARN level
+ */
+public record ErrorPolicy(Mode mode, long maxErrors, double maxErrorRatio, boolean logErrors) {
+
+    /**
+     * Determines what happens to a row (or field) that fails to parse.
+     */
+    public enum Mode {
+        /** Abort immediately — equivalent to Spark {@code FAILFAST}. */
+        FAIL_FAST,
+        /** Drop the entire row — equivalent to Spark {@code DROPMALFORMED}, DuckDB {@code ignore_errors}. */
+        SKIP_ROW,
+        /** Null-fill unparseable fields, keep the row — equivalent to Spark {@code PERMISSIVE}. */
+        NULL_FIELD;
+
+        /**
+         * Case-insensitive parse; accepts underscore form ({@code skip_row}).
+         * Returns {@code null} for null/empty input.
+         */
+        public static Mode parse(String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            String normalized = value.toUpperCase(Locale.ROOT).replace(" ", "_");
+            return Mode.valueOf(normalized);
+        }
+    }
+
+    /** Fail immediately on any malformed row. */
+    public static final ErrorPolicy STRICT = new ErrorPolicy(Mode.FAIL_FAST, 0, 0.0, false);
+
+    /** Skip all malformed rows without limit, logging each one. */
+    public static final ErrorPolicy LENIENT = new ErrorPolicy(Mode.SKIP_ROW, Long.MAX_VALUE, 1.0, true);
+
+    public ErrorPolicy {
+        if (mode == null) {
+            throw new IllegalArgumentException("mode must not be null");
+        }
+        if (maxErrors < 0) {
+            throw new IllegalArgumentException("maxErrors must be non-negative, got: " + maxErrors);
+        }
+        if (maxErrorRatio < 0.0 || maxErrorRatio > 1.0) {
+            throw new IllegalArgumentException("maxErrorRatio must be between 0.0 and 1.0, got: " + maxErrorRatio);
+        }
+    }
+
+    /**
+     * Convenience constructor for {@link Mode#SKIP_ROW} without ratio-based tolerance.
+     */
+    public ErrorPolicy(long maxErrors, boolean logErrors) {
+        this(Mode.SKIP_ROW, maxErrors, 0.0, logErrors);
+    }
+
+    /**
+     * Convenience constructor for {@link Mode#SKIP_ROW} with ratio-based tolerance.
+     */
+    public ErrorPolicy(long maxErrors, double maxErrorRatio, boolean logErrors) {
+        this(Mode.SKIP_ROW, maxErrors, maxErrorRatio, logErrors);
+    }
+
+    public boolean isStrict() {
+        return mode == Mode.FAIL_FAST;
+    }
+
+    public boolean isPermissive() {
+        return mode == Mode.NULL_FIELD;
+    }
+
+    /**
+     * Checks whether the error budget has been exceeded given the current counts.
+     * Always returns {@code false} for {@link Mode#FAIL_FAST} (which never reaches
+     * this check — it throws immediately in the caller).
+     *
+     * @param errorsSoFar  total errors encountered so far
+     * @param rowsSoFar    total rows processed so far (including errors)
+     * @return true if the budget is exceeded and processing should stop
+     */
+    public boolean isBudgetExceeded(long errorsSoFar, long rowsSoFar) {
+        if (errorsSoFar > maxErrors) {
+            return true;
+        }
+        if (maxErrorRatio > 0.0 && rowsSoFar > 0) {
+            double currentRatio = (double) errorsSoFar / rowsSoFar;
+            return currentRatio > maxErrorRatio;
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -132,8 +132,7 @@ public record ErrorPolicy(Mode mode, long maxErrors, double maxErrorRatio, boole
             return true;
         }
         if (maxErrorRatio > 0.0 && rowsSoFar > 0) {
-            double currentRatio = (double) errorsSoFar / rowsSoFar;
-            return currentRatio > maxErrorRatio;
+            return (double) errorsSoFar > maxErrorRatio * rowsSoFar;
         }
         return false;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Executor;
 
@@ -50,6 +51,15 @@ public interface FormatReader extends Closeable {
         return SchemaResolution.FIRST_FILE_WINS;
     }
 
+    /**
+     * Returns the default error policy for this format.
+     * Override to change the default behavior for a specific format (e.g. NDJSON
+     * defaults to lenient because skipping malformed lines is its natural behavior).
+     */
+    default ErrorPolicy defaultErrorPolicy() {
+        return ErrorPolicy.STRICT;
+    }
+
     // === SYNC API (required - implement this for simple formats) ===
 
     SourceMetadata metadata(StorageObject object) throws IOException;
@@ -60,9 +70,30 @@ public interface FormatReader extends Closeable {
 
     CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize) throws IOException;
 
+    /**
+     * Read with an explicit error policy. Implementations that support error tolerance
+     * should override this to honor the policy. The default delegates to
+     * {@link #read(StorageObject, List, int)} which uses the format's default error policy.
+     */
+    default CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize, ErrorPolicy errorPolicy)
+        throws IOException {
+        return read(object, projectedColumns, batchSize);
+    }
+
     default CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize, int rowLimit)
         throws IOException {
         CloseableIterator<Page> iter = read(object, projectedColumns, batchSize);
+        return rowLimit == NO_LIMIT ? iter : new LimitingIterator(iter, rowLimit);
+    }
+
+    default CloseableIterator<Page> read(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        int rowLimit,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        CloseableIterator<Page> iter = read(object, projectedColumns, batchSize, errorPolicy);
         return rowLimit == NO_LIMIT ? iter : new LimitingIterator(iter, rowLimit);
     }
 
@@ -87,9 +118,31 @@ public interface FormatReader extends Closeable {
         return readSplit(object, projectedColumns, batchSize, skipFirstLine, resolvedAttributes);
     }
 
+    default CloseableIterator<Page> readSplit(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        boolean skipFirstLine,
+        boolean lastSplit,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        return readSplit(object, projectedColumns, batchSize, skipFirstLine, lastSplit, resolvedAttributes);
+    }
+
     String formatName();
 
     List<String> fileExtensions();
+
+    /**
+     * Returns a format reader configured with the given config map.
+     * Implementations should parse format-specific options from the config
+     * and return a new reader instance if any options are present.
+     * The default returns {@code this} (no configuration).
+     */
+    default FormatReader withConfig(Map<String, Object> config) {
+        return this;
+    }
 
     // === ASYNC API (optional - default wraps sync in executor) ===
 
@@ -111,9 +164,22 @@ public interface FormatReader extends Closeable {
         Executor executor,
         ActionListener<CloseableIterator<Page>> listener
     ) {
+        readAsync(object, projectedColumns, batchSize, rowLimit, null, executor, listener);
+    }
+
+    default void readAsync(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        int rowLimit,
+        ErrorPolicy errorPolicy,
+        Executor executor,
+        ActionListener<CloseableIterator<Page>> listener
+    ) {
         executor.execute(() -> {
             try {
-                listener.onResponse(read(object, projectedColumns, batchSize, rowLimit));
+                ErrorPolicy effective = errorPolicy != null ? errorPolicy : defaultErrorPolicy();
+                listener.onResponse(read(object, projectedColumns, batchSize, rowLimit, effective));
             } catch (Exception e) {
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactoryErrorPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactoryErrorPolicyTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FileSourceFactoryErrorPolicyTests extends ESTestCase {
+
+    public void testResolveMaxErrorsFromConfig() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("max_errors", "100"), reader);
+        assertEquals(100, policy.maxErrors());
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, policy.mode());
+        assertTrue(policy.logErrors());
+    }
+
+    public void testResolveMaxErrorRatioFromConfig() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("max_error_ratio", "0.1"), reader);
+        assertEquals(Long.MAX_VALUE, policy.maxErrors());
+        assertEquals(0.1, policy.maxErrorRatio(), 0.001);
+        assertTrue(policy.logErrors());
+    }
+
+    public void testResolveBothMaxErrorsAndRatio() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("max_errors", "50", "max_error_ratio", "0.2"), reader);
+        assertEquals(50, policy.maxErrors());
+        assertEquals(0.2, policy.maxErrorRatio(), 0.001);
+    }
+
+    public void testResolveZeroMaxErrors() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("max_errors", "0"), reader);
+        assertEquals(0, policy.maxErrors());
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, policy.mode());
+    }
+
+    public void testResolveFallsBackToFormatDefault() {
+        FormatReader reader = mock(FormatReader.class);
+        ErrorPolicy customDefault = new ErrorPolicy(50, false);
+        when(reader.defaultErrorPolicy()).thenReturn(customDefault);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of(), reader);
+        assertSame(customDefault, policy);
+    }
+
+    public void testResolveNullConfig() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(null, reader);
+        assertSame(ErrorPolicy.STRICT, policy);
+    }
+
+    public void testResolveInvalidMaxErrors() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> FileSourceFactory.resolveErrorPolicy(Map.of("max_errors", "not_a_number"), reader)
+        );
+    }
+
+    public void testResolveInvalidMaxErrorRatio() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> FileSourceFactory.resolveErrorPolicy(Map.of("max_error_ratio", "not_a_number"), reader)
+        );
+    }
+
+    public void testResolveNullFieldMode() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "null_field", "max_errors", "50"), reader);
+        assertEquals(ErrorPolicy.Mode.NULL_FIELD, policy.mode());
+        assertEquals(50, policy.maxErrors());
+        assertTrue(policy.isPermissive());
+    }
+
+    public void testResolveSkipRowMode() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "skip_row", "max_errors", "10"), reader);
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, policy.mode());
+        assertEquals(10, policy.maxErrors());
+    }
+
+    public void testResolveFailFastMode() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "fail_fast"), reader);
+        assertSame(ErrorPolicy.STRICT, policy);
+    }
+
+    public void testResolveFailFastWithBudgetThrows() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "fail_fast", "max_errors", "10"), reader)
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "fail_fast", "max_error_ratio", "0.1"), reader)
+        );
+    }
+
+    public void testResolveInvalidErrorMode() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "invalid_mode"), reader)
+        );
+    }
+
+    public void testResolveEmptyErrorModeThrows() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        expectThrows(IllegalArgumentException.class, () -> FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", ""), reader));
+    }
+
+    public void testResolveNullFieldModeWithoutBudgetDefaultsToUnlimited() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "null_field"), reader);
+        assertEquals(ErrorPolicy.Mode.NULL_FIELD, policy.mode());
+        assertEquals(Long.MAX_VALUE, policy.maxErrors());
+        assertFalse(policy.logErrors());
+    }
+
+    public void testResolveSkipRowModeWithoutBudgetDefaultsToUnlimited() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "skip_row"), reader);
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, policy.mode());
+        assertEquals(Long.MAX_VALUE, policy.maxErrors());
+        assertFalse(policy.logErrors());
+    }
+
+    public void testLogErrorsEnabledWhenBudgetIsFinite() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy withCount = FileSourceFactory.resolveErrorPolicy(Map.of("max_errors", "10"), reader);
+        assertTrue(withCount.logErrors());
+
+        ErrorPolicy withRatio = FileSourceFactory.resolveErrorPolicy(Map.of("max_error_ratio", "0.05"), reader);
+        assertTrue(withRatio.logErrors());
+    }
+
+    public void testLogErrorsDisabledWhenBudgetIsUnlimited() {
+        FormatReader reader = mock(FormatReader.class);
+        when(reader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+
+        ErrorPolicy policy = FileSourceFactory.resolveErrorPolicy(Map.of("error_mode", "skip_row"), reader);
+        assertFalse(policy.logErrors());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicyTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class ErrorPolicyTests extends ESTestCase {
+
+    public void testStrictPolicy() {
+        ErrorPolicy strict = ErrorPolicy.STRICT;
+        assertEquals(0, strict.maxErrors());
+        assertEquals(0.0, strict.maxErrorRatio(), 0.0);
+        assertFalse(strict.logErrors());
+        assertTrue(strict.isStrict());
+    }
+
+    public void testLenientPolicy() {
+        ErrorPolicy lenient = ErrorPolicy.LENIENT;
+        assertEquals(Long.MAX_VALUE, lenient.maxErrors());
+        assertEquals(1.0, lenient.maxErrorRatio(), 0.0);
+        assertTrue(lenient.logErrors());
+        assertFalse(lenient.isStrict());
+    }
+
+    public void testCustomPolicy() {
+        ErrorPolicy custom = new ErrorPolicy(100, 0.1, true);
+        assertEquals(100, custom.maxErrors());
+        assertEquals(0.1, custom.maxErrorRatio(), 0.001);
+        assertTrue(custom.logErrors());
+        assertFalse(custom.isStrict());
+    }
+
+    public void testConvenienceConstructor() {
+        ErrorPolicy simple = new ErrorPolicy(50, true);
+        assertEquals(50, simple.maxErrors());
+        assertEquals(0.0, simple.maxErrorRatio(), 0.0);
+        assertTrue(simple.logErrors());
+    }
+
+    public void testZeroMaxErrorsIsNotStrictInSkipRowMode() {
+        ErrorPolicy zeroErrors = new ErrorPolicy(0, true);
+        assertFalse(zeroErrors.isStrict());
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, zeroErrors.mode());
+    }
+
+    public void testFailFastModeIsStrict() {
+        ErrorPolicy failFast = new ErrorPolicy(ErrorPolicy.Mode.FAIL_FAST, 0, 0.0, false);
+        assertTrue(failFast.isStrict());
+    }
+
+    public void testIsStrictOnlyChecksMode() {
+        ErrorPolicy failFastWithBudget = new ErrorPolicy(ErrorPolicy.Mode.FAIL_FAST, 100, 0.5, true);
+        assertTrue(failFastWithBudget.isStrict());
+    }
+
+    public void testNegativeMaxErrorsThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new ErrorPolicy(-1, false));
+    }
+
+    public void testInvalidRatioThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new ErrorPolicy(0, -0.1, false));
+        expectThrows(IllegalArgumentException.class, () -> new ErrorPolicy(0, 1.1, false));
+    }
+
+    public void testBudgetExceededByCount() {
+        ErrorPolicy policy = new ErrorPolicy(5, false);
+        assertFalse(policy.isBudgetExceeded(5, 100));
+        assertTrue(policy.isBudgetExceeded(6, 100));
+    }
+
+    public void testBudgetExceededByRatio() {
+        ErrorPolicy policy = new ErrorPolicy(Long.MAX_VALUE, 0.1, false);
+        assertFalse(policy.isBudgetExceeded(1, 100));
+        assertTrue(policy.isBudgetExceeded(11, 100));
+        assertTrue(policy.isBudgetExceeded(2, 10));
+    }
+
+    public void testBudgetExceededByEitherCountOrRatio() {
+        ErrorPolicy policy = new ErrorPolicy(5, 0.5, false);
+        assertTrue(policy.isBudgetExceeded(6, 100));
+        assertTrue(policy.isBudgetExceeded(3, 5));
+        assertFalse(policy.isBudgetExceeded(2, 100));
+    }
+
+    public void testBudgetNotExceededWithZeroRows() {
+        ErrorPolicy policy = new ErrorPolicy(Long.MAX_VALUE, 0.1, false);
+        assertFalse(policy.isBudgetExceeded(0, 0));
+    }
+
+    public void testNullFieldMode() {
+        ErrorPolicy nullField = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, true);
+        assertTrue(nullField.isPermissive());
+        assertFalse(nullField.isStrict());
+        assertEquals(ErrorPolicy.Mode.NULL_FIELD, nullField.mode());
+    }
+
+    public void testModeCannotBeNull() {
+        expectThrows(IllegalArgumentException.class, () -> new ErrorPolicy(null, 0, 0.0, false));
+    }
+
+    public void testModeParsing() {
+        assertEquals(ErrorPolicy.Mode.FAIL_FAST, ErrorPolicy.Mode.parse("FAIL_FAST"));
+        assertEquals(ErrorPolicy.Mode.FAIL_FAST, ErrorPolicy.Mode.parse("fail_fast"));
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, ErrorPolicy.Mode.parse("SKIP_ROW"));
+        assertEquals(ErrorPolicy.Mode.SKIP_ROW, ErrorPolicy.Mode.parse("skip_row"));
+        assertEquals(ErrorPolicy.Mode.NULL_FIELD, ErrorPolicy.Mode.parse("null_field"));
+        assertEquals(ErrorPolicy.Mode.NULL_FIELD, ErrorPolicy.Mode.parse("NULL_FIELD"));
+        assertNull(ErrorPolicy.Mode.parse(null));
+        assertNull(ErrorPolicy.Mode.parse(""));
+    }
+
+    public void testModeParsingInvalid() {
+        expectThrows(IllegalArgumentException.class, () -> ErrorPolicy.Mode.parse("invalid"));
+    }
+}


### PR DESCRIPTION
Adds resilient error handling and configurable parsing options to the ESQL CSV datasource format reader.

**Error policy** — three modes control how malformed rows are handled during CSV ingestion:
- `FAIL_FAST` — abort on the first error (default, equivalent to Spark `FAILFAST`)
- `SKIP_ROW` — drop the malformed row and continue (equivalent to Spark `DROPMALFORMED`, DuckDB `ignore_errors`)
- `NULL_FIELD` — null-fill unparseable fields while keeping the row (equivalent to Spark `PERMISSIVE`)

An error budget (`max_errors`, `max_error_ratio`) caps how many errors are tolerated before aborting, giving operators fine-grained control over data quality vs. throughput.

**Configurable format options**: delimiter, quote/escape characters, comment prefix, null representation, encoding, datetime format, and max field size can all be set per-query via `WITH` parameters

Both features are wired through the existing `FormatReader` SPI via a new `withConfig(Map)` method, keeping the interface backward-compatible.

Developed using AI-assisted tooling