### PR TITLE
Unmuting 100_sampling_with_reroute because it has been deleted

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -159,9 +159,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/117208
-- class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
-  method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
-  issue: https://github.com/elastic/elasticsearch/issues/137457
 - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
   method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/137565


### PR DESCRIPTION
100_sampling_with_reroute.yml was removed as part of https://github.com/elastic/elasticsearch/pull/143289 so there is no need to mute it.
Closes #137457