### PR TITLE
ESQL: Fix Parquet and ORC datasource allocation overhead

### DIFF
--- a/docs/changelog/143791.yaml
+++ b/docs/changelog/143791.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143791
+summary: Fix Parquet and ORC datasource allocation overhead
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -349,11 +349,6 @@ public class OrcFormatReader implements FormatReader {
             }
         }
 
-        /**
-         * Timestamps and dates need special handling since they require per-element
-         * transformation (getTime or days→millis), so they still use a builder.
-         * The repeating case is optimized via constant block.
-         */
         private Block createDatetimeBlock(ColumnVector vector, int rowCount) {
             if (vector instanceof TimestampColumnVector tsVector) {
                 if (tsVector.isRepeating) {
@@ -362,16 +357,20 @@ public class OrcFormatReader implements FormatReader {
                     }
                     return blockFactory.newConstantLongBlockWith(tsVector.getTime(0), rowCount);
                 }
-                try (var builder = blockFactory.newLongBlockBuilder(rowCount)) {
-                    for (int i = 0; i < rowCount; i++) {
-                        if (tsVector.noNulls == false && tsVector.isNull[i]) {
-                            builder.appendNull();
-                        } else {
-                            builder.appendLong(tsVector.getTime(i));
-                        }
-                    }
-                    return builder.build();
+                long[] millis = new long[rowCount];
+                for (int i = 0; i < rowCount; i++) {
+                    millis[i] = tsVector.getTime(i);
                 }
+                if (tsVector.noNulls) {
+                    return blockFactory.newLongArrayVector(millis, rowCount).asBlock();
+                }
+                return blockFactory.newLongArrayBlock(
+                    millis,
+                    rowCount,
+                    null,
+                    toBitSet(tsVector.isNull, rowCount),
+                    Block.MvOrdering.UNORDERED
+                );
             } else if (vector instanceof LongColumnVector longVector) {
                 if (longVector.isRepeating) {
                     if (longVector.noNulls == false && longVector.isNull[0]) {

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -495,6 +495,47 @@ public class OrcFormatReaderTests extends ESTestCase {
         }
     }
 
+    public void testReadTimestampColumnWithNulls() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("event_time", TypeDescription.createTimestampInstant());
+
+        long epochMillis = Instant.parse("2024-01-15T10:30:00Z").toEpochMilli();
+
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 3;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            TimestampColumnVector tsCol = (TimestampColumnVector) batch.cols[1];
+
+            idCol.vector[0] = 1L;
+            tsCol.time[0] = epochMillis;
+            tsCol.nanos[0] = 0;
+
+            idCol.vector[1] = 2L;
+            tsCol.noNulls = false;
+            tsCol.isNull[1] = true;
+
+            idCol.vector[2] = 3L;
+            tsCol.time[2] = epochMillis + 7200_000;
+            tsCol.nanos[2] = 0;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+
+            assertEquals(3, page.getPositionCount());
+
+            LongBlock tsBlock = (LongBlock) page.getBlock(1);
+            assertEquals(epochMillis, tsBlock.getLong(0));
+            assertTrue(tsBlock.isNull(1));
+            assertEquals(epochMillis + 7200_000, tsBlock.getLong(2));
+        }
+    }
+
     public void testReadDateColumn() throws Exception {
         TypeDescription schema = TypeDescription.createStruct()
             .addField("id", TypeDescription.createLong())

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -181,21 +181,42 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             if (buf.hasRemaining() == false) {
                 return 0;
             }
-            int bytesToRead = buf.remaining();
-            byte[] temp = new byte[bytesToRead];
-            int bytesRead = read(temp, 0, bytesToRead);
-            if (bytesRead > 0) {
-                buf.put(temp, 0, bytesRead);
+            if (buf.hasArray()) {
+                int off = buf.arrayOffset() + buf.position();
+                int bytesRead = read(buf.array(), off, buf.remaining());
+                if (bytesRead > 0) {
+                    buf.position(buf.position() + bytesRead);
+                }
+                return bytesRead;
             }
-            return bytesRead;
+            byte[] transfer = new byte[Math.min(buf.remaining(), StorageObject.TRANSFER_BUFFER_SIZE)];
+            int totalRead = 0;
+            while (buf.hasRemaining()) {
+                int toRead = Math.min(transfer.length, buf.remaining());
+                int n = read(transfer, 0, toRead);
+                if (n < 0) {
+                    break;
+                }
+                buf.put(transfer, 0, n);
+                totalRead += n;
+            }
+            return totalRead == 0 ? -1 : totalRead;
         }
 
         @Override
         public void readFully(java.nio.ByteBuffer buf) throws IOException {
-            int remaining = buf.remaining();
-            byte[] temp = new byte[remaining];
-            readFully(temp, 0, remaining);
-            buf.put(temp);
+            if (buf.hasArray()) {
+                int off = buf.arrayOffset() + buf.position();
+                readFully(buf.array(), off, buf.remaining());
+                buf.position(buf.limit());
+                return;
+            }
+            byte[] transfer = new byte[Math.min(buf.remaining(), StorageObject.TRANSFER_BUFFER_SIZE)];
+            while (buf.hasRemaining()) {
+                int toRead = Math.min(transfer.length, buf.remaining());
+                readFully(transfer, 0, toRead);
+                buf.put(transfer, 0, toRead);
+            }
         }
     }
 }


### PR DESCRIPTION
Eliminate unnecessary per-call allocations in the Parquet and ORC datasource read paths.

`ParquetStorageObjectAdapter`'s `read(ByteBuffer)` and `readFully(ByteBuffer)` allocated a full-size temporary `byte[]` on every call and copied into the target buffer. For heap-backed ByteBuffers, we now read directly into the backing array. For direct ByteBuffers, we use a small 8 KB chunked transfer matching the `StorageObject.readBytes()` pattern.

`OrcFormatReader`'s `TimestampColumnVector` path used a per-element `LongBlockBuilder`. This converts it to the same bulk array + `newLongArrayVector`/`newLongArrayBlock` pattern already used by all other ORC column types.

Developed using AI-assisted tooling.