### PR TITLE
[TEST] Add rounding to time series agg results

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -372,30 +372,6 @@ tests:
 - class: org.elasticsearch.index.query.PrefixQueryBuilderTests
   method: testPrefixCircuitBreakerTripsWithLowLimit
   issue: https://github.com/elastic/elasticsearch/issues/143548
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-irate.Irate_of_ratio_promql}
-  issue: https://github.com/elastic/elasticsearch/issues/143616
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-irate.Irate_of_ratio}
-  issue: https://github.com/elastic/elasticsearch/issues/143617
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-irate.Irate_of_double_no_grouping_promql}
-  issue: https://github.com/elastic/elasticsearch/issues/143624
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-irate.Irate_of_double_no_grouping}
-  issue: https://github.com/elastic/elasticsearch/issues/143625
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_aggregate_metric_double}
-  issue: https://github.com/elastic/elasticsearch/issues/143631
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-delta.Delta_of_double_no_grouping}
-  issue: https://github.com/elastic/elasticsearch/issues/143632
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_aggregate_metric_double_grouping}
-  issue: https://github.com/elastic/elasticsearch/issues/143633
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-delta.Delta_of_double_no_grouping_promql}
-  issue: https://github.com/elastic/elasticsearch/issues/143634
 - class: org.elasticsearch.search.SearchLoggingIT
   method: testSearchLogShardInfoPartialFailure
   issue: https://github.com/elastic/elasticsearch/issues/143638
@@ -423,12 +399,6 @@ tests:
 - class: org.elasticsearch.compute.lucene.query.LuceneTopNSourceOperatorScoringTests
   method: testAccumulateSearchLoad
   issue: https://github.com/elastic/elasticsearch/issues/143750
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_double_no_grouping}
-  issue: https://github.com/elastic/elasticsearch/issues/143757
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-avg-over-time.Avg_over_time_of_double_no_grouping_promql}
-  issue: https://github.com/elastic/elasticsearch/issues/143758
 - class: org.elasticsearch.xpack.esql.action.EsqlQueryLoggingIT
   method: testLogging
   issue: https://github.com/elastic/elasticsearch/issues/143780

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
@@ -2,7 +2,10 @@ avg_over_time_of_double_no_grouping
 required_capability: ts_command_v0
 TS k8s
 | STATS cost=sum(avg_over_time(network.cost)) BY time_bucket = bucket(@timestamp,1minute)
-| SORT cost DESC, time_bucket DESC | LIMIT 10;
+| EVAL cost = round(cost, 4)
+| KEEP cost, time_bucket
+| SORT cost DESC, time_bucket DESC 
+| LIMIT 10;
 
 cost:double       | time_bucket:datetime
 69.6875           | 2024-05-10T00:09:00.000Z
@@ -11,7 +14,7 @@ cost:double       | time_bucket:datetime
 48.3125           | 2024-05-10T00:22:00.000Z
 45.8125           | 2024-05-10T00:15:00.000Z
 40.4375           | 2024-05-10T00:06:00.000Z
-39.54166666666667 | 2024-05-10T00:13:00.000Z
+39.5417           | 2024-05-10T00:13:00.000Z
 37.9375           | 2024-05-10T00:12:00.000Z
 36.6875           | 2024-05-10T00:19:00.000Z
 36.375            | 2024-05-10T00:11:00.000Z
@@ -20,7 +23,10 @@ cost:double       | time_bucket:datetime
 avg_over_time_of_double_no_grouping_promql
 required_capability: promql_command_v0
 PROMQL index=k8s step=1m cost=(sum(avg_over_time(network.cost[1m])))
-| SORT cost DESC, step DESC | LIMIT 10;
+| EVAL cost = round(cost, 4)
+| KEEP cost, step
+| SORT cost DESC, step DESC 
+| LIMIT 10;
 
 cost:double       | step:datetime
 69.6875           | 2024-05-10T00:09:00.000Z
@@ -29,7 +35,7 @@ cost:double       | step:datetime
 48.3125           | 2024-05-10T00:22:00.000Z
 45.8125           | 2024-05-10T00:15:00.000Z
 40.4375           | 2024-05-10T00:06:00.000Z
-39.54166666666667 | 2024-05-10T00:13:00.000Z
+39.5417           | 2024-05-10T00:13:00.000Z
 37.9375           | 2024-05-10T00:12:00.000Z
 36.6875           | 2024-05-10T00:19:00.000Z
 36.375            | 2024-05-10T00:11:00.000Z


### PR DESCRIPTION
`CsvIT` doesn't use force merging so there may be small differences in results due to float processing.

Unmuting also some tests that were fixed earlier but https://github.com/elastic/elasticsearch/pull/143657 muted again, likely due to a merge conflict.

Fixes #143758
Fixes #143757