### PR TITLE
Fix observer leak in `TransportAddVotingConfigExclusionsActionTests`

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -378,7 +378,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         setState(clusterService, builder);
 
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        clusterStateObserver.waitForNextChange(new AdjustConfigurationForExclusions());
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),


### PR DESCRIPTION
This test doesn't need to adjust the cluster state, so the API under
test may return while the observer is still waiting, allowing the test
suite to finish, failing the observer's state update which trips an
assertion:

    java.lang.AssertionError: unexpected failure
        at __randomizedtesting.SeedInfo.seed([7F451E6BE71901FA]:0)
        at org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsActionTests$AdjustConfigurationForExclusions$1.onFailure(TransportAddVotingConfigExclusionsActionTests.java:606)
        at org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Entry.onRejection(MasterService.java:1941)
        at org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.onRejection(MasterService.java:1963)
        at org.elasticsearch.cluster.service.MasterService$5.lambda$doRun$0(MasterService.java:1517)
        at org.elasticsearch.action.ActionListener.run(ActionListener.java:468)
        at org.elasticsearch.cluster.service.MasterService$5.doRun(MasterService.java:1493)
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1114)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
    Caused by: org.elasticsearch.cluster.NotMasterException: node closed
    Caused by: org.elasticsearch.common.util.concurrent.EsRejectedExecutionException: master service is in state [STOPPED]

This commit removes the unnecessary observer.