### PR TITLE
Disallow unmapped_fields="load" with full-text search/MATCH

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -86,6 +86,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SummationMode;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.expression.function.inference.CompletionFunction;
 import org.elasticsearch.xpack.esql.expression.function.inference.InferenceFunction;
@@ -274,7 +275,23 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
     public LogicalPlan analyze(LogicalPlan plan) {
         BitSet partialMetrics = new BitSet(FeatureMetric.values().length);
-        return verify(execute(plan), gatherPreAnalysisMetrics(plan, partialMetrics));
+        LogicalPlan analyzed = execute(plan);
+        if (context().unmappedResolution() == UnmappedResolution.LOAD) {
+            List<FullTextFunction> fullTextFunctions = new ArrayList<>();
+            analyzed.forEachExpressionDown(FullTextFunction.class, fullTextFunctions::add);
+            if (fullTextFunctions.isEmpty() == false) {
+                throw new VerificationException(
+                    List.of(
+                        Failure.fail(
+                            fullTextFunctions.get(0),
+                            "unmapped_fields=\"load\" is not allowed with full-text search (MATCH, match operator `:`, "
+                                + "MATCH_PHRASE, etc.); use FAIL or NULLIFY"
+                        )
+                    )
+                );
+            }
+        }
+        return verify(analyzed, gatherPreAnalysisMetrics(plan, partialMetrics));
     }
 
     public LogicalPlan verify(LogicalPlan plan, BitSet partialMetrics) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -86,7 +86,6 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SummationMode;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.expression.function.inference.CompletionFunction;
 import org.elasticsearch.xpack.esql.expression.function.inference.InferenceFunction;
@@ -276,21 +275,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     public LogicalPlan analyze(LogicalPlan plan) {
         BitSet partialMetrics = new BitSet(FeatureMetric.values().length);
         LogicalPlan analyzed = execute(plan);
-        if (context().unmappedResolution() == UnmappedResolution.LOAD) {
-            List<FullTextFunction> fullTextFunctions = new ArrayList<>();
-            analyzed.forEachExpressionDown(FullTextFunction.class, fullTextFunctions::add);
-            if (fullTextFunctions.isEmpty() == false) {
-                throw new VerificationException(
-                    List.of(
-                        Failure.fail(
-                            fullTextFunctions.get(0),
-                            "unmapped_fields=\"load\" is not allowed with full-text search (MATCH, match operator `:`, "
-                                + "MATCH_PHRASE, etc.); use FAIL or NULLIFY"
-                        )
-                    )
-                );
-            }
-        }
         return verify(analyzed, gatherPreAnalysisMetrics(plan, partialMetrics));
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
@@ -93,6 +94,10 @@ public class Verifier {
      * @param unmappedResolution the active unmapped-field resolution strategy; used to gate commands unsupported in certain modes
      * @return a collection of verification failures; empty if and only if the plan is valid
      */
+    Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics) {
+        return verify(plan, partialMetrics, null);
+    }
+
     Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics, UnmappedResolution unmappedResolution) {
         assert partialMetrics != null;
         Failures failures = new Failures();
@@ -136,6 +141,19 @@ public class Verifier {
             checkLimitBeforeInlineStats(p, failures);
             checkLimitBy(p, failures);
         });
+
+        // Disallow full-text search when unmapped_fields=load. We do not restrict to "only when the FTF
+        // is applied to an unmapped field" because FTFs like KQL can reference unmapped fields inside the
+        // query string (e.g. KQL("author: Faulkner")), and the desired behavior there is unclear.
+        if (unmappedResolution == UnmappedResolution.LOAD) {
+            List<FullTextFunction> fullTextFunctions = new ArrayList<>();
+            plan.forEachExpressionDown(FullTextFunction.class, fullTextFunctions::add);
+            if (fullTextFunctions.isEmpty() == false) {
+                String message = "unmapped_fields=\"load\" is not allowed with full-text search (MATCH, match operator `:`, "
+                    + "MATCH_PHRASE, etc.); use FAIL or NULLIFY";
+                fullTextFunctions.forEach(f -> failures.add(fail(f, message)));
+            }
+        }
 
         if (failures.hasFailures() == false) {
             licenseCheck(plan, failures);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -87,6 +87,13 @@ public class Verifier {
     }
 
     /**
+     * Verify that a {@link LogicalPlan} can be executed (no unmapped-field resolution context).
+     */
+    Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics) {
+        return verify(plan, partialMetrics, null);
+    }
+
+    /**
      * Verify that a {@link LogicalPlan} can be executed.
      *
      * @param plan The logical plan to be verified
@@ -94,10 +101,6 @@ public class Verifier {
      * @param unmappedResolution the active unmapped-field resolution strategy; used to gate commands unsupported in certain modes
      * @return a collection of verification failures; empty if and only if the plan is valid
      */
-    Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics) {
-        return verify(plan, partialMetrics, null);
-    }
-
     Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics, UnmappedResolution unmappedResolution) {
         assert partialMetrics != null;
         Failures failures = new Failures();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -117,6 +117,7 @@ public class Verifier {
 
         if (unmappedResolution == UnmappedResolution.LOAD) {
             checkLoadModeDisallowedCommands(plan, failures);
+            checkLoadModeDisallowedFunctions(plan, failures);
         }
 
         // collect plan checkers
@@ -144,19 +145,6 @@ public class Verifier {
             checkLimitBeforeInlineStats(p, failures);
             checkLimitBy(p, failures);
         });
-
-        // Disallow full-text search when unmapped_fields=load. We do not restrict to "only when the FTF
-        // is applied to an unmapped field" because FTFs like KQL can reference unmapped fields inside the
-        // query string (e.g. KQL("author: Faulkner")), and the desired behavior there is unclear.
-        if (unmappedResolution == UnmappedResolution.LOAD) {
-            List<FullTextFunction> fullTextFunctions = new ArrayList<>();
-            plan.forEachExpressionDown(FullTextFunction.class, fullTextFunctions::add);
-            if (fullTextFunctions.isEmpty() == false) {
-                String message = "unmapped_fields=\"load\" is not allowed with full-text search (MATCH, match operator `:`, "
-                    + "MATCH_PHRASE, etc.); use FAIL or NULLIFY";
-                fullTextFunctions.forEach(f -> failures.add(fail(f, message)));
-            }
-        }
 
         if (failures.hasFailures() == false) {
             licenseCheck(plan, failures);
@@ -391,6 +379,25 @@ public class Verifier {
                 failures.add(fail(p, "LOOKUP JOIN is not supported with unmapped_fields=\"load\""));
             }
         });
+    }
+
+    /**
+     * Disallow full-text search when unmapped_fields=load. We do not restrict to "only when the FTF
+     * is applied to an unmapped field" because FTFs like KQL can reference unmapped fields inside the
+     * query string (e.g. KQL("author: Faulkner")), and the desired behavior there is unclear.
+     */
+    private static void checkLoadModeDisallowedFunctions(LogicalPlan plan, Failures failures) {
+        List<FullTextFunction> fullTextFunctions = new ArrayList<>();
+        plan.forEachExpressionDown(FullTextFunction.class, fullTextFunctions::add);
+        fullTextFunctions.forEach(
+            f -> failures.add(
+                fail(
+                    f,
+                    "unmapped_fields=\"load\" does not support full-text search function [{}]; use \"fail\" or \"nullify\"",
+                    f.functionName()
+                )
+            )
+        );
     }
 
     private void licenseCheck(LogicalPlan plan, Failures failures) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -14,29 +14,27 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedTimestamp;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
-import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.plan.EsqlStatement;
-import org.elasticsearch.xpack.esql.plan.IndexPattern;
-import org.elasticsearch.xpack.esql.parser.EsqlParser;
-
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.configuration;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
-import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzeStatement;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultEnrichResolution;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.loadMapping;
-import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTests.withInlinestatsWarning;
+import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -574,11 +572,8 @@ public class AnalyzerUnmappedTests extends ESTestCase {
     }
 
     private void verificationFailureWithMapping(String mapping, String statement, String expectedFailure) {
-        var st = EsqlParser.INSTANCE.createStatement(statement);
-        var indexResolutions = Map.of(
-            new IndexPattern(Source.EMPTY, "test"),
-            loadMapping(mapping, "test")
-        );
+        var st = TEST_PARSER.createStatement(statement);
+        var indexResolutions = Map.of(new IndexPattern(Source.EMPTY, "test"), loadMapping(mapping, "test"));
         var analyzer = analyzer(
             indexResolutions,
             defaultLookupResolution(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -532,6 +532,17 @@ public class AnalyzerUnmappedTests extends ESTestCase {
         return "SET unmapped_fields=\"load\"; " + query;
     }
 
+    /**
+     * Reproducer for #141927: with unmapped_fields=load, full-text search (match operator) must fail at analysis
+     * instead of returning empty results.
+     */
+    public void testUnmappedFieldsLoadWithMatchOperatorFails() {
+        verificationFailure(
+            setUnmappedLoad("FROM test | WHERE first_name:\"foo\" | KEEP first_name"),
+            "unmapped_fields=\"load\" is not allowed with full-text search"
+        );
+    }
+
     @Override
     protected List<String> filteredWarnings() {
         return withInlinestatsWarning(withDefaultLimitWarning(super.filteredWarnings()));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -18,11 +18,24 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
-import java.util.List;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.EsqlStatement;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.parser.EsqlParser;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.configuration;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzeStatement;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultEnrichResolution;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTests.withInlinestatsWarning;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
@@ -533,14 +546,49 @@ public class AnalyzerUnmappedTests extends ESTestCase {
     }
 
     /**
-     * Reproducer for #141927: with unmapped_fields=load, full-text search (match operator) must fail at analysis
-     * instead of returning empty results.
+     * Reproducer for #141927: with unmapped_fields=load, full-text search (MATCH, match operator, MATCH_PHRASE, etc.)
+     * must fail at analysis instead of returning empty results.
+     * <p>
+     * One assertion per forbidden full-text function so that re-enabling any of them (e.g. QSTR, KNN, MATCH_PHRASE)
+     * would cause this test to fail. When full-text function support grows, this test will need updates; see #144121.
      */
-    public void testUnmappedFieldsLoadWithMatchOperatorFails() {
-        verificationFailure(
-            setUnmappedLoad("FROM test | WHERE first_name:\"foo\" | KEEP first_name"),
-            "unmapped_fields=\"load\" is not allowed with full-text search"
+    public void testUnmappedFieldsLoadWithFullTextSearchFails() {
+        String failure = "unmapped_fields=\"load\" is not allowed with full-text search";
+        verificationFailure(setUnmappedLoad("FROM test | WHERE first_name:\"foo\" | KEEP first_name"), failure);
+        verificationFailure(setUnmappedLoad("FROM test | WHERE match(first_name, \"foo\") | KEEP first_name"), failure);
+        verificationFailure(setUnmappedLoad("FROM test | WHERE match_phrase(first_name, \"foo bar\") | KEEP first_name"), failure);
+        if (EsqlCapabilities.Cap.MULTI_MATCH_FUNCTION.isEnabled()) {
+            verificationFailure(setUnmappedLoad("FROM test | WHERE multi_match(\"foo\", first_name) | KEEP first_name"), failure);
+        }
+        if (EsqlCapabilities.Cap.QSTR_FUNCTION.isEnabled()) {
+            verificationFailure(setUnmappedLoad("FROM test | WHERE qstr(\"first_name: foo\") | KEEP first_name"), failure);
+        }
+        if (EsqlCapabilities.Cap.KQL_FUNCTION.isEnabled()) {
+            verificationFailure(setUnmappedLoad("FROM test | WHERE kql(\"first_name: foo\") | KEEP first_name"), failure);
+        }
+        verificationFailureWithMapping(
+            "mapping-full_text_search.json",
+            setUnmappedLoad("FROM test | WHERE knn(vector, [1, 2, 3]) | KEEP vector"),
+            failure
         );
+    }
+
+    private void verificationFailureWithMapping(String mapping, String statement, String expectedFailure) {
+        var st = EsqlParser.INSTANCE.createStatement(statement);
+        var indexResolutions = Map.of(
+            new IndexPattern(Source.EMPTY, "test"),
+            loadMapping(mapping, "test")
+        );
+        var analyzer = analyzer(
+            indexResolutions,
+            defaultLookupResolution(),
+            defaultEnrichResolution(),
+            TEST_VERIFIER,
+            configuration(statement),
+            st.setting(UNMAPPED_FIELDS)
+        );
+        var e = expectThrows(VerificationException.class, () -> analyzer.analyze(st.plan()));
+        assertThat(e.getMessage(), containsString(expectedFailure));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -551,23 +551,42 @@ public class AnalyzerUnmappedTests extends ESTestCase {
      * would cause this test to fail. When full-text function support grows, this test will need updates; see #144121.
      */
     public void testUnmappedFieldsLoadWithFullTextSearchFails() {
-        String failure = "unmapped_fields=\"load\" is not allowed with full-text search";
-        verificationFailure(setUnmappedLoad("FROM test | WHERE first_name:\"foo\" | KEEP first_name"), failure);
-        verificationFailure(setUnmappedLoad("FROM test | WHERE match(first_name, \"foo\") | KEEP first_name"), failure);
-        verificationFailure(setUnmappedLoad("FROM test | WHERE match_phrase(first_name, \"foo bar\") | KEEP first_name"), failure);
+        // Assert the new message format and that the specific full-text function is named in brackets
+        // Function names in error messages use Function.functionName() (class simple name upper-cased) or override (e.g. QSTR, :)
+        verificationFailure(
+            setUnmappedLoad("FROM test | WHERE first_name:\"foo\" | KEEP first_name"),
+            "does not support full-text search function [:]"
+        );
+        verificationFailure(
+            setUnmappedLoad("FROM test | WHERE match(first_name, \"foo\") | KEEP first_name"),
+            "does not support full-text search function [MATCH]"
+        );
+        verificationFailure(
+            setUnmappedLoad("FROM test | WHERE match_phrase(first_name, \"foo bar\") | KEEP first_name"),
+            "does not support full-text search function [MatchPhrase]"
+        );
         if (EsqlCapabilities.Cap.MULTI_MATCH_FUNCTION.isEnabled()) {
-            verificationFailure(setUnmappedLoad("FROM test | WHERE multi_match(\"foo\", first_name) | KEEP first_name"), failure);
+            verificationFailure(
+                setUnmappedLoad("FROM test | WHERE multi_match(\"foo\", first_name) | KEEP first_name"),
+                "does not support full-text search function [MultiMatch]"
+            );
         }
         if (EsqlCapabilities.Cap.QSTR_FUNCTION.isEnabled()) {
-            verificationFailure(setUnmappedLoad("FROM test | WHERE qstr(\"first_name: foo\") | KEEP first_name"), failure);
+            verificationFailure(
+                setUnmappedLoad("FROM test | WHERE qstr(\"first_name: foo\") | KEEP first_name"),
+                "does not support full-text search function [QSTR]"
+            );
         }
         if (EsqlCapabilities.Cap.KQL_FUNCTION.isEnabled()) {
-            verificationFailure(setUnmappedLoad("FROM test | WHERE kql(\"first_name: foo\") | KEEP first_name"), failure);
+            verificationFailure(
+                setUnmappedLoad("FROM test | WHERE kql(\"first_name: foo\") | KEEP first_name"),
+                "does not support full-text search function [KQL]"
+            );
         }
         verificationFailureWithMapping(
             "mapping-full_text_search.json",
             setUnmappedLoad("FROM test | WHERE knn(vector, [1, 2, 3]) | KEEP vector"),
-            failure
+            "does not support full-text search function [KNN]"
         );
     }
 


### PR DESCRIPTION
- Fail at analysis instead of returning empty results. 

- Add unit test testUnmappedFieldsLoadWithMatchOperatorFails in AnalyzerUnmappedTests.

Closes https://github.com/elastic/elasticsearch/issues/141927