### PR TITLE
Check feature flag in IndexRoutingTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -405,9 +405,6 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.FlattenedRollingUpgradeIT
   method: testIndexing
   issue: https://github.com/elastic/elasticsearch/issues/143782
-- class: org.elasticsearch.cluster.routing.IndexRoutingTests
-  method: testRoutingPathBwcAfterTsidBasedRouting
-  issue: https://github.com/elastic/elasticsearch/issues/143787
 - class: org.elasticsearch.xpack.logsdb.KeywordRollingUpgradeIT
   method: testIndexing
   issue: https://github.com/elastic/elasticsearch/issues/143795
@@ -423,9 +420,6 @@ tests:
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testOperationBasedRecovery {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/143802
-- class: org.elasticsearch.cluster.routing.IndexRoutingTests
-  method: testRoutingPathBwc
-  issue: https://github.com/elastic/elasticsearch/issues/143814
 - class: org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapperTests
   method: testRetrievedFromIdInTimeSeriesMode
   issue: https://github.com/elastic/elasticsearch/issues/143815

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
@@ -664,7 +664,8 @@ public class IndexRoutingTests extends ESTestCase {
     }
 
     public void testRoutingPathBwc() throws IOException {
-        TimeSeriesRoutingFixture fixture = indexRoutingForRoutingPath(IndexVersion.current(), 8, "dim.*,other.*,top", randomBoolean());
+        boolean useSyntheticId = IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean();
+        TimeSeriesRoutingFixture fixture = indexRoutingForRoutingPath(IndexVersion.current(), 8, "dim.*,other.*,top", useSyntheticId);
         /*
          * These are the expected shards when we first added routing_path. If these values change
          * time series will be routed to unexpected shards. You may modify
@@ -683,11 +684,12 @@ public class IndexRoutingTests extends ESTestCase {
     }
 
     public void testRoutingPathBwcAfterTsidBasedRouting() throws IOException {
+        boolean useSyntheticId = IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean();
         TimeSeriesRoutingFixture fixture = indexRoutingForTimeSeriesDimensions(
             IndexVersion.current(),
             8,
             "dim.*,other.*,top",
-            randomBoolean()
+            useSyntheticId
         );
         /*
          * These are the expected shards after tsid based routing. If these values change


### PR DESCRIPTION
Test failed when testing with -Dbuild.snapshot=false because feature flag would be disabled.

Fixes: https://github.com/elastic/elasticsearch/issues/143814, https://github.com/elastic/elasticsearch/issues/143787