### PR TITLE
[8.19] [CodeRabbit] inherit org wide coderabbit configurations (#143772)

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+inheritance: true
 reviews:
-  # Do not post "Review skipped" on PRs without the labels below
-  review_status: false
+  # those have been configured on the root level already
+  # review_status: false
+  # poem: false
   auto_review:
     labels:
       - "Team:Delivery"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CodeRabbit] inherit org wide coderabbit configurations (#143772)](https://github.com/elastic/elasticsearch/pull/143772)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)