### PR TITLE
[9.3] Apply source filter to metadata field mappers when loading synthetic source (#143726)

### DIFF
--- a/docs/changelog/143726.yaml
+++ b/docs/changelog/143726.yaml
@@ -1,0 +1,6 @@
+area: Mapping
+issues:
+ - 143464
+pr: 143726
+summary: "Apply the source filter on metadata field mappers when loading from synthetic source"
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -979,9 +979,11 @@ public class ObjectMapper extends Mapper {
     }
 
     private SourceLoader.SyntheticFieldLoader innerSyntheticFieldLoader(SourceFilter filter, Mapper mapper) {
-        if (mapper instanceof MetadataFieldMapper metaMapper) {
-            return metaMapper.syntheticFieldLoader();
+        // We always need the ignored source to load other fields
+        if (mapper instanceof IgnoredSourceFieldMapper ignoredSourceMapper) {
+            return ignoredSourceMapper.syntheticFieldLoader();
         }
+
         if (filter != null && filter.isPathFiltered(mapper.fullPath(), mapper instanceof ObjectMapper)) {
             return SourceLoader.SyntheticFieldLoader.NOTHING;
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matchers;
@@ -144,5 +145,39 @@ public class DocCountFieldMapperTests extends MetadataMapperTestCase {
                 }
             }
         });
+    }
+
+    public void testSyntheticSourceFilterAppliesToDocCount() throws IOException {
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> b.startObject("count").field("type", "integer").endObject()));
+        int count = between(1, 1000);
+        SourceFilter filter = new SourceFilter(new String[] { "count" }, null);
+        SourceFilter filterWithDocCount = new SourceFilter(new String[] { "count", "_doc_count" }, null);
+        withLuceneIndex(
+            mapper,
+            iw -> iw.addDocument(mapper.documentMapper().parse(source(b -> b.field("count", 42).field(CONTENT_TYPE, count))).rootDoc()),
+            reader -> {
+                SourceLoader withoutFilter = mapper.mappingLookup().newSourceLoader(null, SourceFieldMetrics.NOOP);
+                SourceLoader withFilter = mapper.mappingLookup().newSourceLoader(filter, SourceFieldMetrics.NOOP);
+                SourceLoader withFilterAndDocCount = mapper.mappingLookup().newSourceLoader(filterWithDocCount, SourceFieldMetrics.NOOP);
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    int[] docIds = IntStream.range(0, leaf.reader().maxDoc()).toArray();
+
+                    LeafStoredFieldLoader sf1 = StoredFieldLoader.empty().getLoader(leaf, docIds);
+                    String unfilteredSource = withoutFilter.leaf(leaf.reader(), docIds).source(sf1, 0).internalSourceRef().utf8ToString();
+                    assertThat(unfilteredSource, equalTo("{\"_doc_count\":" + count + ",\"count\":42}"));
+
+                    LeafStoredFieldLoader sf2 = StoredFieldLoader.empty().getLoader(leaf, docIds);
+                    String filteredSource = withFilter.leaf(leaf.reader(), docIds).source(sf2, 0).internalSourceRef().utf8ToString();
+                    assertThat(filteredSource, equalTo("{\"count\":42}"));
+
+                    LeafStoredFieldLoader sf3 = StoredFieldLoader.empty().getLoader(leaf, docIds);
+                    String filteredSourceWithDocCount = withFilterAndDocCount.leaf(leaf.reader(), docIds)
+                        .source(sf3, 0)
+                        .internalSourceRef()
+                        .utf8ToString();
+                    assertThat(filteredSourceWithDocCount, equalTo("{\"_doc_count\":" + count + ",\"count\":42}"));
+                }
+            }
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ObjectMapper.Dynamic;
+import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -552,7 +553,21 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         assertThat(mapper.mapping().getRoot().syntheticFieldLoader(null).docValuesLoader(null, null), nullValue());
     }
 
-    public void testStoreArraySourceinSyntheticSourceMode() throws IOException {
+    public void testSyntheticFieldLoaderAlwaysIncludesIgnoredSource() throws IOException {
+        MapperService mapperService = createSytheticSourceMapperService(
+            mapping(b -> b.startObject("kwd").field("type", "keyword").endObject())
+        );
+        Mapping mapping = mapperService.documentMapper().mapping();
+        SourceFilter filterKwdOnly = new SourceFilter(new String[] { "kwd" }, null);
+
+        SourceLoader.SyntheticFieldLoader filteredSource = mapping.syntheticFieldLoader(filterKwdOnly);
+        SourceLoader.SyntheticFieldLoader unfilteredSource = mapping.syntheticFieldLoader(null);
+
+        assertTrue(filteredSource.storedFieldLoaders().anyMatch(e -> e.getKey().equals(IgnoredSourceFieldMapper.NAME)));
+        assertTrue(unfilteredSource.storedFieldLoaders().anyMatch(e -> e.getKey().equals(IgnoredSourceFieldMapper.NAME)));
+    }
+
+    public void testStoreArraySourceInSyntheticSourceMode() throws IOException {
         DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("o").field("type", "object").field("synthetic_source_keep", "arrays").endObject();
         })).documentMapper();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1890,6 +1890,12 @@ public class EsqlCapabilities {
          */
         INLINE_STATS_WITH_CONSTANTS(INLINE_STATS.enabled),
 
+        /**
+         * Fix for not including metadata _doc_count in the _timeseries column
+         * https://github.com/elastic/elasticsearch/issues/143464
+         */
+        FIX_DISPLAYING_TS_DIMENSIONS_IN_METRICS_GROUP_BY_ALL,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Apply source filter to metadata field mappers when loading synthetic source (#143726)](https://github.com/elastic/elasticsearch/pull/143726)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)