### PR TITLE
Unmute APMYamlTestSuiteIT 20_metrics_ingest/Test... test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -217,8 +217,6 @@ tests:
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT
   method: testAvailabilityZoneAttribute
   issue: https://github.com/elastic/elasticsearch/issues/118564
-- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-  method: test {yaml=/20_metrics_ingest/Test metrics-apm.app-* setting event.ingested via ingest pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/118875
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability


### PR DESCRIPTION
The `global` template that was causing this index not to get the correct template applied on creation. It has since been removed in #115799, so this test can be unmuted.

Resolves #118875
