### PR TITLE
[ML] Prevent cross-project search in datafeeds for serverless

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -311,6 +311,26 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         return TYPE + "-" + datafeedId;
     }
 
+    /**
+     * Returns a new DatafeedConfig with CPS mode explicitly disabled in IndicesOptions.
+     * This prevents automatic cross-project index rewriting when the datafeed executes searches.
+     *
+     * @param datafeed the original datafeed configuration
+     * @return new DatafeedConfig with CPS mode disabled, or original if already disabled
+     */
+    public static DatafeedConfig withCrossProjectModeDisabled(DatafeedConfig datafeed) {
+        Objects.requireNonNull(datafeed, "datafeed must not be null");
+
+        IndicesOptions baseOptions = datafeed.getIndicesOptions();
+        if (baseOptions.resolveCrossProjectIndexExpression()) {
+            IndicesOptions modifiedOptions = IndicesOptions.builder(baseOptions)
+                .crossProjectModeOptions(IndicesOptions.CrossProjectModeOptions.DEFAULT)
+                .build();
+            return new DatafeedConfig.Builder(datafeed).setIndicesOptions(modifiedOptions).build();
+        }
+        return datafeed;
+    }
+
     public String getId() {
         return id;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -1071,4 +1071,59 @@ public class DatafeedConfigTests extends AbstractXContentSerializingTestCase<Dat
             json.streamInput()
         );
     }
+
+    public void testWithCrossProjectModeDisabled_GivenNullDatafeed() {
+        expectThrows(NullPointerException.class, () -> DatafeedConfig.withCrossProjectModeDisabled(null));
+    }
+
+    public void testWithCrossProjectModeDisabled_GivenAlreadyDisabled() {
+        DatafeedConfig datafeed = createRandomizedDatafeedConfig("job-id");
+        assertFalse(datafeed.getIndicesOptions().resolveCrossProjectIndexExpression());
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
+        assertSame("Should return same instance when CPS already disabled", datafeed, result);
+    }
+
+    public void testWithCrossProjectModeDisabled_WithExplicitRemoteIndices() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed-with-remote", "job-id");
+        builder.setIndices(List.of("local:logs"));
+        DatafeedConfig datafeed = builder.build();
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
+        assertSame("Should return same instance when CPS already disabled", datafeed, result);
+        assertFalse(result.getIndicesOptions().resolveCrossProjectIndexExpression());
+        assertEquals(List.of("local:logs"), result.getIndices());
+    }
+
+    public void testWithCrossProjectModeDisabled_WithMixedIndices() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed-mixed", "job-id");
+        builder.setIndices(List.of("logs", "metrics"));
+        DatafeedConfig datafeed = builder.build();
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
+        assertSame("Should return same instance when CPS already disabled", datafeed, result);
+        assertFalse(result.getIndicesOptions().resolveCrossProjectIndexExpression());
+        assertEquals(List.of("logs", "metrics"), result.getIndices());
+    }
+
+    public void testWithCrossProjectModeDisabled_WithImplicitIndices() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed-implicit", "job-id");
+        builder.setIndices(List.of("logs"));
+        DatafeedConfig datafeed = builder.build();
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
+        assertSame("Should return same instance when CPS already disabled", datafeed, result);
+        assertFalse(result.getIndicesOptions().resolveCrossProjectIndexExpression());
+        assertEquals(List.of("logs"), result.getIndices());
+    }
+
+    public void testWithCrossProjectModeDisabled_WithWildcards() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed-wildcards", "job-id");
+        builder.setIndices(List.of("logs-*", "metrics-*"));
+        DatafeedConfig datafeed = builder.build();
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
+        assertSame("Should return same instance when CPS already disabled", datafeed, result);
+        assertFalse(result.getIndicesOptions().resolveCrossProjectIndexExpression());
+        assertEquals(List.of("logs-*", "metrics-*"), result.getIndices());
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -154,9 +154,10 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
             // This is important because it means the datafeed search will fail if the user
             // requesting the preview doesn't have permission to search the relevant indices.
             DatafeedConfig previewDatafeedConfig = previewDatafeedBuilder.build();
+            DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeDisabled(previewDatafeedConfig);
             DataExtractorFactory.create(
                 new ParentTaskAssigningClient(client, parentTaskId),
-                previewDatafeedConfig,
+                effectiveDatafeedConfig,
                 extraFilters,
                 job,
                 xContentRegistry,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -339,9 +339,10 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         StartDatafeedAction.DatafeedParams params,
         ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams>> listener
     ) {
+        DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeDisabled(datafeed);
         DataExtractorFactory.create(
             new ParentTaskAssigningClient(client, clusterService.localNode(), task),
-            datafeed,
+            effectiveDatafeed,
             job,
             xContentRegistry,
             // Fake DatafeedTimingStatsReporter that does not have access to results index

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -140,9 +140,10 @@ public class DatafeedJobBuilder {
             listener.onFailure(e);
         });
 
+        DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeDisabled(datafeedConfig);
         DataExtractorFactory.create(
             parentTaskAssigningClient,
-            datafeedConfig,
+            effectiveDatafeedConfig,
             job,
             xContentRegistry,
             timingStatsReporter,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -14,8 +14,9 @@ import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchScrollRequestBuilder;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.search.TransportClearScrollAction;
+import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -265,7 +266,21 @@ class ScrollDataExtractor implements DataExtractor {
 
     @SuppressWarnings("HiddenField")
     protected SearchResponse executeSearchScrollRequest(String scrollId) {
-        return executeSearchRequest(new SearchScrollRequestBuilder(client).setScroll(SCROLL_TIMEOUT).setScrollId(scrollId));
+        SearchScrollRequest request = new SearchScrollRequest(scrollId) {
+            @Override
+            public boolean allowsCrossProject() {
+                return false;
+            }
+        };
+        request.scroll(SCROLL_TIMEOUT);
+        return checkForSkippedClusters(
+            ClientHelper.executeWithHeaders(
+                context.queryContext.headers,
+                ClientHelper.ML_ORIGIN,
+                client,
+                () -> client.execute(TransportSearchScrollAction.TYPE, request).actionGet()
+            )
+        );
     }
 
     private void clearScroll() {
@@ -285,7 +300,12 @@ class ScrollDataExtractor implements DataExtractor {
 
     private void innerClearScroll(String scrollId) {
         if (scrollId != null) {
-            ClearScrollRequest request = new ClearScrollRequest();
+            ClearScrollRequest request = new ClearScrollRequest() {
+                @Override
+                public boolean allowsCrossProject() {
+                    return false;
+                }
+            };
             request.addScrollId(scrollId);
             ClientHelper.executeWithHeaders(
                 context.queryContext.headers,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -267,6 +267,9 @@ class ScrollDataExtractor implements DataExtractor {
     @SuppressWarnings("HiddenField")
     protected SearchResponse executeSearchScrollRequest(String scrollId) {
         SearchScrollRequest request = new SearchScrollRequest(scrollId) {
+
+            // This is a workaround to avoid the search scroll request from being routed to a different project.
+            // TODO: Remove this once we have a proper solution to handle cross-project search scroll requests.
             @Override
             public boolean allowsCrossProject() {
                 return false;
@@ -301,6 +304,9 @@ class ScrollDataExtractor implements DataExtractor {
     private void innerClearScroll(String scrollId) {
         if (scrollId != null) {
             ClearScrollRequest request = new ClearScrollRequest() {
+
+                // This is a workaround to avoid the clear scroll request from being routed to a different project.
+                // TODO: Remove this once we have a proper solution to handle cross-project clear scroll requests.
                 @Override
                 public boolean allowsCrossProject() {
                     return false;


### PR DESCRIPTION
This PR ensures ML datafeeds operate in local-only mode on the main branch by preventing automatic cross-project index rewriting. When cross-project search (CPS) is globally enabled in a serverless environment, unqualified index patterns like `logs` would normally be rewritten to `logs,remote:logs` during authorization. This change explicitly disables CPS mode for all datafeed operations by modifying `IndicesOptions` at runtime, ensuring datafeeds only search local indices regardless of global CPS settings. The implementation introduces a centralized `DatafeedConfig.withCrossProjectModeDisabled()` method that is applied at three critical points in the datafeed lifecycle: `TransportStartDatafeedAction`, `DatafeedJobBuilder`, and `TransportPreviewDatafeedAction`. 

Additionally, `ClearScrollRequest` and `SearchScrollRequest` instances created by `ScrollDataExtractor` override `allowsCrossProject()` to return `false`, preventing unnecessary UIAM project resolution during scroll operations. These scroll requests implement `CrossProjectCandidate` but not `IndicesRequest`, so they bypass `IndicesOptions` checks and would otherwise trigger cross-project authorization even for local-only scrolls.
