### PR TITLE
[9.3] Fix observer leak in `TransportAddVotingConfigExclusionsActionTests` (#143806)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -378,7 +378,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         setState(clusterService, builder);
 
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        clusterStateObserver.waitForNextChange(new AdjustConfigurationForExclusions());
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix observer leak in `TransportAddVotingConfigExclusionsActionTests` (#143806)