### PR TITLE
[9.3] fix(highlighting): support range queries on sorted indices in plain highlighter (#143680)

### DIFF
--- a/docs/changelog/143680.yaml
+++ b/docs/changelog/143680.yaml
@@ -1,0 +1,5 @@
+area: Highlighting
+issues: []
+pr: 143680
+summary: "Fix `UnsupportedOperationException` when using a `plain` highlighter with a query on a field used for index sorting (`index.sort.*`). "
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.search.fetch.subphase.highlight;
 
+import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.WeightedSpanTerm;
@@ -59,6 +60,8 @@ public final class CustomQueryScorer extends QueryScorer {
                 super.extract(((ESToParentBlockJoinQuery) query).getChildQuery(), boost, terms);
             } else if (query instanceof ScriptScoreQuery ssq) {
                 super.extract(ssq.getSubQuery(), boost, terms);
+            } else if (query instanceof IndexSortSortedNumericDocValuesRangeQuery isq) {
+                super.extract(isq.getFallbackQuery(), boost, terms);
             } else {
                 super.extract(query, boost, terms);
             }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
@@ -14,6 +14,8 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -122,6 +124,32 @@ public class PlainHighlighterTests extends HighlighterTestCase {
         ).highlighter(new HighlightBuilder().field("text").highlighterType("plain"));
 
         assertHighlights(highlight(mapperService, doc, search), "text", "<em>some</em> text");
+    }
+
+    public void testHighlightWithDateRangeAndIndexSort() throws Exception {
+        Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.sort.field", "timestamp").build();
+
+        MapperService mapperService = createMapperService(settings, """
+            { "_doc" : { "properties" : {
+                "text" : { "type" : "text" },
+                "timestamp" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            {
+              "text": "some important text to highlight",
+              "timestamp": "2025-01-15T10:30:00Z"
+            }
+            """));
+
+        SearchSourceBuilder search = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.matchQuery("text", "important"))
+                .filter(QueryBuilders.rangeQuery("timestamp").gte("2025-01-01").lte("2025-12-31"))
+        ).highlighter(new HighlightBuilder().field("text").highlighterType("plain"));
+
+        assertHighlights(highlight(mapperService, doc, search), "text", "some <em>important</em> text to highlight");
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix(highlighting): support range queries on sorted indices in plain highlighter (#143680)](https://github.com/elastic/elasticsearch/pull/143680)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)