### PR TITLE
[TEST] Ensure-green inference system indices in AuthorizationTaskExecutorIT

### DIFF
--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
@@ -27,6 +27,8 @@ import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.inference.InferenceIndex;
+import org.elasticsearch.xpack.inference.InferenceSecretsIndex;
 import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
@@ -91,6 +93,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void createComponents() {
         modelRegistry = node().injector().getInstance(ModelRegistry.class);
         authorizationTaskExecutor = node().injector().getInstance(AuthorizationTaskExecutor.class);
+        ensureGreen(InferenceIndex.INDEX_PATTERN, InferenceSecretsIndex.INDEX_PATTERN);
     }
 
     @After


### PR DESCRIPTION
There are failures in the tests in AuthorizationTaskExecutorIT. We get the `all shards fail` error some times when we try to get models with `ModelRegistry.getAllModels`. After looking into this, I believe the cause is that the inference system indices may not manage to initialize properly by the time the test runs.

This calls the `ensureGreen()` method before any of those tests run. This should fix this potential issue.

Closes #140802
Closes #140849
Closes #143845
Relates #137911
Relates #138012
