### PR TITLE
Fix ILM getting stuck when CCR leader index is deleted

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UnfollowAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UnfollowAction.java
@@ -61,7 +61,7 @@ public final class UnfollowAction implements LifecycleAction {
             // if the index has no CCR metadata we'll skip the unfollow action completely
             return customIndexMetadata == null;
         });
-        WaitForIndexingCompleteStep step1 = new WaitForIndexingCompleteStep(indexingComplete, waitUntilTimeSeriesEndTimePassesStep);
+        WaitForIndexingCompleteStep step1 = new WaitForIndexingCompleteStep(indexingComplete, waitUntilTimeSeriesEndTimePassesStep, client);
 
         WaitUntilTimeSeriesEndTimePassesStep step2 = new WaitUntilTimeSeriesEndTimePassesStep(
             waitUntilTimeSeriesEndTimePassesStep,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
@@ -8,12 +8,16 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.index.Index;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
 import java.io.IOException;
 import java.util.Map;
@@ -21,13 +25,18 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.core.ilm.UnfollowAction.CCR_METADATA_KEY;
 
-final class WaitForIndexingCompleteStep extends ClusterStateWaitStep {
+/**
+ * Waits for the {@link LifecycleSettings#LIFECYCLE_INDEXING_COMPLETE} setting to be set to {@code true} on the leader index,
+ * which is then propagated to the follower via CCR. If all shard follow tasks have fatally failed (e.g. because the leader
+ * index was deleted), the condition is also considered met so that ILM can proceed with the unfollow process.
+ */
+final class WaitForIndexingCompleteStep extends AsyncWaitStep {
     private static final Logger logger = LogManager.getLogger(WaitForIndexingCompleteStep.class);
 
     static final String NAME = "wait-for-indexing-complete";
 
-    WaitForIndexingCompleteStep(StepKey key, StepKey nextStepKey) {
-        super(key, nextStepKey);
+    WaitForIndexingCompleteStep(StepKey key, StepKey nextStepKey, Client client) {
+        super(key, nextStepKey, client);
     }
 
     @Override
@@ -36,24 +45,58 @@ final class WaitForIndexingCompleteStep extends ClusterStateWaitStep {
     }
 
     @Override
-    public Result isConditionMet(Index index, ProjectState currentState) {
-        IndexMetadata followerIndex = currentState.metadata().index(index);
-        if (followerIndex == null) {
-            // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
-            return new Result(false, null);
-        }
-        Map<String, String> customIndexMetadata = followerIndex.getCustomData(CCR_METADATA_KEY);
+    public void evaluateCondition(ProjectState currentState, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        Map<String, String> customIndexMetadata = indexMetadata.getCustomData(CCR_METADATA_KEY);
         if (customIndexMetadata == null) {
-            return new Result(true, null);
+            listener.onResponse(true, null);
+            return;
         }
 
-        boolean indexingComplete = LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.get(followerIndex.getSettings());
+        boolean indexingComplete = LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.get(indexMetadata.getSettings());
         if (indexingComplete) {
-            return new Result(true, null);
-        } else {
-            return new Result(false, new IndexingNotCompleteInfo());
+            listener.onResponse(true, null);
+            return;
         }
+
+        FollowStatsAction.StatsRequest request = new FollowStatsAction.StatsRequest();
+        request.setIndices(new String[] { indexMetadata.getIndex().getName() });
+        getClient(currentState.projectId()).execute(FollowStatsAction.INSTANCE, request, ActionListener.wrap(response -> {
+            if (response.getTaskFailures().isEmpty() == false || response.getNodeFailures().isEmpty() == false) {
+                logger.debug(
+                    "[{}] follow stats request for index [{}] returned partial results due to task/node failures, will retry",
+                    getKey().action(),
+                    indexMetadata.getIndex().getName()
+                );
+                listener.onResponse(false, new IndexingNotCompleteInfo());
+            } else if (allShardFollowTasksFailed(response)) {
+                logger.info(
+                    "[{}] proceeding with unfollow for index [{}] because all shard follow tasks have fatally failed,"
+                        + " the leader index may have been deleted",
+                    getKey().action(),
+                    indexMetadata.getIndex().getName()
+                );
+                listener.onResponse(true, null);
+            } else {
+                listener.onResponse(false, new IndexingNotCompleteInfo());
+            }
+        }, e -> {
+            if (e instanceof ResourceNotFoundException) {
+                logger.info(
+                    "[{}] proceeding with unfollow for index [{}] because no shard follow tasks were found,"
+                        + " the leader index may have been deleted",
+                    getKey().action(),
+                    indexMetadata.getIndex().getName()
+                );
+                listener.onResponse(true, null);
+            } else {
+                listener.onResponse(false, new IndexingNotCompleteInfo());
+            }
+        }));
+    }
+
+    static boolean allShardFollowTasksFailed(FollowStatsAction.StatsResponses responses) {
+        return responses.getStatsResponses().isEmpty() == false
+            && responses.getStatsResponses().stream().allMatch(r -> r.status().getFatalException() != null);
     }
 
     static final class IndexingNotCompleteInfo implements ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
@@ -8,12 +8,14 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -27,8 +29,9 @@ import static org.elasticsearch.xpack.core.ilm.UnfollowAction.CCR_METADATA_KEY;
 
 /**
  * Waits for the {@link LifecycleSettings#LIFECYCLE_INDEXING_COMPLETE} setting to be set to {@code true} on the leader index,
- * which is then propagated to the follower via CCR. If all shard follow tasks have fatally failed (e.g. because the leader
- * index was deleted), the condition is also considered met so that ILM can proceed with the unfollow process.
+ * which is then propagated to the follower via CCR. If all shard follow tasks have fatally failed with an
+ * {@link IndexNotFoundException} (indicating the leader index was deleted), the condition is also considered met so that
+ * ILM can proceed with the unfollow process rather than waiting indefinitely.
  */
 final class WaitForIndexingCompleteStep extends AsyncWaitStep {
     private static final Logger logger = LogManager.getLogger(WaitForIndexingCompleteStep.class);
@@ -68,10 +71,10 @@ final class WaitForIndexingCompleteStep extends AsyncWaitStep {
                     indexMetadata.getIndex().getName()
                 );
                 listener.onResponse(false, new IndexingNotCompleteInfo());
-            } else if (allShardFollowTasksFailed(response)) {
+            } else if (allFollowTasksFailedWithIndexNotFound(response)) {
                 logger.info(
-                    "[{}] proceeding with unfollow for index [{}] because all shard follow tasks have fatally failed,"
-                        + " the leader index may have been deleted",
+                    "[{}] proceeding with unfollow for index [{}] because all shard follow tasks have fatally failed"
+                        + " with IndexNotFoundException, the leader index has been deleted",
                     getKey().action(),
                     indexMetadata.getIndex().getName()
                 );
@@ -94,9 +97,17 @@ final class WaitForIndexingCompleteStep extends AsyncWaitStep {
         }));
     }
 
-    static boolean allShardFollowTasksFailed(FollowStatsAction.StatsResponses responses) {
-        return responses.getStatsResponses().isEmpty() == false
-            && responses.getStatsResponses().stream().allMatch(r -> r.status().getFatalException() != null);
+    /**
+     * Returns {@code true} if every shard follow task has a fatal {@link IndexNotFoundException}, indicating the leader index
+     * was deleted. The fatal exception may be wrapped in a {@code RemoteTransportException}, so we unwrap before checking.
+     * Other fatal exception types are intentionally not treated as "leader deleted" to avoid automatically unfollowing
+     * when the issue might be resolvable by the user.
+     */
+    static boolean allFollowTasksFailedWithIndexNotFound(FollowStatsAction.StatsResponses responses) {
+        return responses.getStatsResponses().isEmpty() == false && responses.getStatsResponses().stream().allMatch(r -> {
+            var fatalException = r.status().getFatalException();
+            return fatalException != null && ExceptionsHelper.unwrapCause(fatalException) instanceof IndexNotFoundException;
+        });
     }
 
     static final class IndexingNotCompleteInfo implements ToXContentObject {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStepTests.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.xpack.core.ilm.ClusterStateWaitUntilThresholdStep.waitedMoreThanThresholdLevel;
-import static org.elasticsearch.xpack.core.ilm.UnfollowAction.CCR_METADATA_KEY;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -62,7 +61,7 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
     }
 
     public void testIndexIsMissingReturnsIncompleteResult() {
-        WaitForIndexingCompleteStep stepToExecute = new WaitForIndexingCompleteStep(randomStepKey(), randomStepKey());
+        ClusterStateWaitStep stepToExecute = createConditionStep(randomStepKey(), randomStepKey(), true);
         ClusterStateWaitUntilThresholdStep underTest = new ClusterStateWaitUntilThresholdStep(stepToExecute, randomStepKey());
         ClusterStateWaitStep.Result result = underTest.isConditionMet(
             new Index("testName", UUID.randomUUID().toString()),
@@ -75,19 +74,15 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
     public void testIsConditionMetForUnderlyingStep() {
         {
             // threshold is not breached and the underlying step condition is met
-            IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
-                .settings(
-                    settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "true")
-                        .put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "480h")
-                )
+            IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "480h"))
                 .putCustom(ILM_CUSTOM_METADATA_KEY, Map.of("step_time", String.valueOf(System.currentTimeMillis())))
-                .putCustom(CCR_METADATA_KEY, Map.of())
                 .numberOfShards(1)
                 .numberOfReplicas(0)
                 .build();
             ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, true));
 
-            WaitForIndexingCompleteStep stepToExecute = new WaitForIndexingCompleteStep(randomStepKey(), randomStepKey());
+            ClusterStateWaitStep stepToExecute = createConditionStep(randomStepKey(), randomStepKey(), true);
             ClusterStateWaitUntilThresholdStep underTest = new ClusterStateWaitUntilThresholdStep(stepToExecute, randomStepKey());
 
             ClusterStateWaitStep.Result result = underTest.isConditionMet(indexMetadata.getIndex(), state);
@@ -97,51 +92,34 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
 
         {
             // threshold is not breached and the underlying step condition is NOT met
-            IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
-                .settings(
-                    settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "false")
-                        .put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "48h")
-                )
+            IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "48h"))
                 .putCustom(ILM_CUSTOM_METADATA_KEY, Map.of("step_time", String.valueOf(System.currentTimeMillis())))
-                .putCustom(CCR_METADATA_KEY, Map.of())
                 .numberOfShards(1)
                 .numberOfReplicas(0)
                 .build();
 
             ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, true));
 
-            WaitForIndexingCompleteStep stepToExecute = new WaitForIndexingCompleteStep(randomStepKey(), randomStepKey());
+            ClusterStateWaitStep stepToExecute = createConditionStep(randomStepKey(), randomStepKey(), false);
             ClusterStateWaitUntilThresholdStep underTest = new ClusterStateWaitUntilThresholdStep(stepToExecute, randomStepKey());
             ClusterStateWaitStep.Result result = underTest.isConditionMet(indexMetadata.getIndex(), state);
 
             assertThat(result.complete(), is(false));
             assertThat(result.informationContext(), notNullValue());
-            WaitForIndexingCompleteStep.IndexingNotCompleteInfo info = (WaitForIndexingCompleteStep.IndexingNotCompleteInfo) result
-                .informationContext();
-            assertThat(
-                info.getMessage(),
-                equalTo(
-                    "waiting for the [index.lifecycle.indexing_complete] setting to be set to "
-                        + "true on the leader index, it is currently [false]"
-                )
-            );
         }
 
         {
             // underlying step is executed once even if the threshold is breached and the underlying complete result is returned
-            IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
-                .settings(
-                    settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "true")
-                        .put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "1s")
-                )
-                .putCustom(CCR_METADATA_KEY, Map.of())
+            IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "1s"))
                 .putCustom(ILM_CUSTOM_METADATA_KEY, Map.of("step_time", String.valueOf(1234L)))
                 .numberOfShards(1)
                 .numberOfReplicas(0)
                 .build();
             ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, true));
 
-            WaitForIndexingCompleteStep stepToExecute = new WaitForIndexingCompleteStep(randomStepKey(), randomStepKey());
+            ClusterStateWaitStep stepToExecute = createConditionStep(randomStepKey(), randomStepKey(), true);
             StepKey nextKeyOnThresholdBreach = randomStepKey();
             ClusterStateWaitUntilThresholdStep underTest = new ClusterStateWaitUntilThresholdStep(stepToExecute, nextKeyOnThresholdBreach);
 
@@ -154,13 +132,9 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
 
         {
             // underlying step is executed once even if the threshold is breached, but because the underlying step result is false the
-            // step under test will return `complete` (becuase the threshold is breached and we don't want to wait anymore)
-            IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
-                .settings(
-                    settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "false")
-                        .put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "1h")
-                )
-                .putCustom(CCR_METADATA_KEY, Map.of())
+            // step under test will return `complete` (because the threshold is breached and we don't want to wait anymore)
+            IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "1h"))
                 .putCustom(ILM_CUSTOM_METADATA_KEY, Map.of("step_time", String.valueOf(1234L)))
                 .numberOfShards(1)
                 .numberOfReplicas(0)
@@ -169,7 +143,7 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
             ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, true));
 
             StepKey currentStepKey = randomStepKey();
-            WaitForIndexingCompleteStep stepToExecute = new WaitForIndexingCompleteStep(currentStepKey, randomStepKey());
+            ClusterStateWaitStep stepToExecute = createConditionStep(currentStepKey, randomStepKey(), false);
             StepKey nextKeyOnThresholdBreach = randomStepKey();
             ClusterStateWaitUntilThresholdStep underTest = new ClusterStateWaitUntilThresholdStep(stepToExecute, nextKeyOnThresholdBreach);
             ClusterStateWaitStep.Result result = underTest.isConditionMet(indexMetadata.getIndex(), state);
@@ -185,7 +159,7 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
                         + "] lifecycle step, as part of ["
                         + currentStepKey.action()
                         + "] "
-                        + "action, for index [follower-index] executed for more than [1h]. Abandoning execution and moving to the next "
+                        + "action, for index [test-index] executed for more than [1h]. Abandoning execution and moving to the next "
                         + "fallback step ["
                         + nextKeyOnThresholdBreach
                         + "]"
@@ -195,6 +169,24 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
             // the next step must change to the provided one when the threshold is breached
             assertThat(underTest.getNextStepKey(), is(nextKeyOnThresholdBreach));
         }
+    }
+
+    private static ClusterStateWaitStep createConditionStep(StepKey key, StepKey nextKey, boolean conditionMet) {
+        return new ClusterStateWaitStep(key, nextKey) {
+            @Override
+            public Result isConditionMet(Index index, ProjectState currentState) {
+                if (conditionMet) {
+                    return new Result(true, null);
+                } else {
+                    return new Result(false, new SingleMessageFieldInfo("condition not met"));
+                }
+            }
+
+            @Override
+            public boolean isRetryable() {
+                return true;
+            }
+        };
     }
 
     public void testWaitedMoreThanThresholdLevelMath() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
@@ -6,14 +6,24 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
+import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.mockito.Mockito;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ilm.UnfollowAction.CCR_METADATA_KEY;
@@ -28,7 +38,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
     protected WaitForIndexingCompleteStep createRandomInstance() {
         StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
-        return new WaitForIndexingCompleteStep(stepKey, nextStepKey);
+        return new WaitForIndexingCompleteStep(stepKey, nextStepKey, client);
     }
 
     @Override
@@ -42,12 +52,12 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
-        return new WaitForIndexingCompleteStep(key, nextKey);
+        return new WaitForIndexingCompleteStep(key, nextKey, instance.getClient());
     }
 
     @Override
     protected WaitForIndexingCompleteStep copyInstance(WaitForIndexingCompleteStep instance) {
-        return new WaitForIndexingCompleteStep(instance.getKey(), instance.getNextStepKey());
+        return new WaitForIndexingCompleteStep(instance.getKey(), instance.getNextStepKey(), instance.getClient());
     }
 
     public void testConditionMet() {
@@ -61,9 +71,23 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
 
         WaitForIndexingCompleteStep step = createRandomInstance();
-        ClusterStateWaitStep.Result result = step.isConditionMet(indexMetadata.getIndex(), state);
-        assertThat(result.complete(), is(true));
-        assertThat(result.informationContext(), nullValue());
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(true));
+        assertThat(informationContextHolder[0], nullValue());
     }
 
     public void testConditionMetNotAFollowerIndex() {
@@ -76,9 +100,24 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
 
         WaitForIndexingCompleteStep step = createRandomInstance();
-        ClusterStateWaitStep.Result result = step.isConditionMet(indexMetadata.getIndex(), state);
-        assertThat(result.complete(), is(true));
-        assertThat(result.informationContext(), nullValue());
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(true));
+        assertThat(informationContextHolder[0], nullValue());
+        Mockito.verifyNoMoreInteractions(projectClient);
     }
 
     public void testConditionNotMet() {
@@ -93,14 +132,33 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             .numberOfReplicas(0)
             .build();
 
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, null))
+        );
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
+
         ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
 
         WaitForIndexingCompleteStep step = createRandomInstance();
-        ClusterStateWaitStep.Result result = step.isConditionMet(indexMetadata.getIndex(), state);
-        assertThat(result.complete(), is(false));
-        assertThat(result.informationContext(), notNullValue());
-        WaitForIndexingCompleteStep.IndexingNotCompleteInfo info = (WaitForIndexingCompleteStep.IndexingNotCompleteInfo) result
-            .informationContext();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+        WaitForIndexingCompleteStep.IndexingNotCompleteInfo info =
+            (WaitForIndexingCompleteStep.IndexingNotCompleteInfo) informationContextHolder[0];
         assertThat(
             info.getMessage(),
             equalTo(
@@ -110,12 +168,353 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         );
     }
 
-    public void testIndexDeleted() {
-        ProjectState state = projectStateWithEmptyProject();
+    public void testConditionMetWhenAllShardFollowTasksFailed() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(2)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, fatalException))
+        );
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
 
         WaitForIndexingCompleteStep step = createRandomInstance();
-        ClusterStateWaitStep.Result result = step.isConditionMet(new Index("this-index-doesnt-exist", "uuid"), state);
-        assertThat(result.complete(), is(false));
-        assertThat(result.informationContext(), nullValue());
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(true));
+        assertThat(informationContextHolder[0], nullValue());
+    }
+
+    public void testConditionNotMetWhenSomeShardFollowTasksFailed() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(2)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
+        );
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testConditionMetWhenNoShardFollowTasksFound() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        mockFollowStatsCallFailure(indexMetadata.getIndex().getName(), new ResourceNotFoundException("no tasks"));
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(true));
+        assertThat(informationContextHolder[0], nullValue());
+    }
+
+    public void testConditionNotMetOnFollowStatsError() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        mockFollowStatsCallFailure(indexMetadata.getIndex().getName(), new ElasticsearchException("something went wrong"));
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testConditionNotMetWhenEmptyStatsResponse() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), List.of(), List.of(), List.of());
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testConditionNotMetWhenPartialNodeFailures() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(2)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException))
+        );
+        List<FailedNodeException> nodeFailures = List.of(new FailedNodeException("node-1", "node unreachable", new Exception()));
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses, List.of(), nodeFailures);
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testConditionNotMetWhenPartialTaskFailures() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(2)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException))
+        );
+        List<TaskOperationFailure> taskFailures = List.of(new TaskOperationFailure("node-1", 1, new Exception("task failed")));
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses, taskFailures, List.of());
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testAllShardFollowTasksFailed() {
+        ElasticsearchException fatalException = new ElasticsearchException("index not found");
+        List<FollowStatsAction.StatsResponse> allFailed = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, fatalException))
+        );
+        assertThat(
+            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), allFailed)),
+            is(true)
+        );
+
+        List<FollowStatsAction.StatsResponse> someFailed = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
+        );
+        assertThat(
+            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), someFailed)),
+            is(false)
+        );
+
+        List<FollowStatsAction.StatsResponse> noneFailed = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, null)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
+        );
+        assertThat(
+            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), noneFailed)),
+            is(false)
+        );
+
+        assertThat(
+            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), List.of())),
+            is(false)
+        );
+    }
+
+    private static ShardFollowNodeTaskStatus createShardFollowTaskStatus(int shardId, ElasticsearchException fatalException) {
+        return new ShardFollowNodeTaskStatus(
+            "remote",
+            "leader-index",
+            "follower-index",
+            shardId,
+            0,
+            -1,
+            0,
+            -1,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Collections.emptyNavigableMap(),
+            0,
+            fatalException
+        );
+    }
+
+    private void mockFollowStatsCall(String expectedIndexName, List<FollowStatsAction.StatsResponse> statsResponses) {
+        mockFollowStatsCall(expectedIndexName, statsResponses, List.of(), List.of());
+    }
+
+    private void mockFollowStatsCall(
+        String expectedIndexName,
+        List<FollowStatsAction.StatsResponse> statsResponses,
+        List<TaskOperationFailure> taskFailures,
+        List<FailedNodeException> nodeFailures
+    ) {
+        Mockito.doAnswer(invocationOnMock -> {
+            FollowStatsAction.StatsRequest request = (FollowStatsAction.StatsRequest) invocationOnMock.getArguments()[1];
+            assertThat(request.indices().length, equalTo(1));
+            assertThat(request.indices()[0], equalTo(expectedIndexName));
+
+            @SuppressWarnings("unchecked")
+            ActionListener<FollowStatsAction.StatsResponses> listener = (ActionListener<FollowStatsAction.StatsResponses>) invocationOnMock
+                .getArguments()[2];
+            listener.onResponse(new FollowStatsAction.StatsResponses(taskFailures, nodeFailures, statsResponses));
+            return null;
+        }).when(projectClient).execute(Mockito.eq(FollowStatsAction.INSTANCE), Mockito.any(), Mockito.any());
+    }
+
+    private void mockFollowStatsCallFailure(String expectedIndexName, Exception exception) {
+        Mockito.doAnswer(invocationOnMock -> {
+            FollowStatsAction.StatsRequest request = (FollowStatsAction.StatsRequest) invocationOnMock.getArguments()[1];
+            assertThat(request.indices().length, equalTo(1));
+            assertThat(request.indices()[0], equalTo(expectedIndexName));
+
+            @SuppressWarnings("unchecked")
+            ActionListener<FollowStatsAction.StatsResponses> listener = (ActionListener<FollowStatsAction.StatsResponses>) invocationOnMock
+                .getArguments()[2];
+            listener.onFailure(exception);
+            return null;
+        }).when(projectClient).execute(Mockito.eq(FollowStatsAction.INSTANCE), Mockito.any(), Mockito.any());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
@@ -15,7 +15,9 @@ import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
@@ -168,7 +170,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         );
     }
 
-    public void testConditionMetWhenAllShardFollowTasksFailed() {
+    public void testConditionMetWhenAllShardFollowTasksFailedWithIndexNotFound() {
         IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
             .settings(settings(IndexVersion.current()))
             .putCustom(CCR_METADATA_KEY, Map.of())
@@ -176,7 +178,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             .numberOfReplicas(0)
             .build();
 
-        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        ElasticsearchException fatalException = new IndexNotFoundException("leader-index");
         List<FollowStatsAction.StatsResponse> statsResponses = List.of(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, fatalException))
@@ -213,7 +215,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             .numberOfReplicas(0)
             .build();
 
-        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        ElasticsearchException fatalException = new IndexNotFoundException("leader-index");
         List<FollowStatsAction.StatsResponse> statsResponses = List.of(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
@@ -346,7 +348,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             .numberOfReplicas(0)
             .build();
 
-        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        ElasticsearchException fatalException = new IndexNotFoundException("leader-index");
         List<FollowStatsAction.StatsResponse> statsResponses = List.of(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException))
         );
@@ -383,7 +385,7 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             .numberOfReplicas(0)
             .build();
 
-        ElasticsearchException fatalException = new ElasticsearchException("index [leader-index] not found");
+        ElasticsearchException fatalException = new IndexNotFoundException("leader-index");
         List<FollowStatsAction.StatsResponse> statsResponses = List.of(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException))
         );
@@ -412,23 +414,125 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         assertThat(informationContextHolder[0], notNullValue());
     }
 
-    public void testAllShardFollowTasksFailed() {
-        ElasticsearchException fatalException = new ElasticsearchException("index not found");
-        List<FollowStatsAction.StatsResponse> allFailed = List.of(
+    public void testConditionNotMetWhenAllTasksFailedWithNonIndexNotFoundException() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(2)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new ElasticsearchException("some unrelated fatal error");
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, fatalException))
         );
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(false));
+        assertThat(informationContextHolder[0], notNullValue());
+    }
+
+    public void testConditionMetWhenIndexNotFoundWrappedInRemoteTransportException() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("follower-index")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(CCR_METADATA_KEY, Map.of())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        ElasticsearchException fatalException = new RemoteTransportException("error on remote", new IndexNotFoundException("leader-index"));
+        List<FollowStatsAction.StatsResponse> statsResponses = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException))
+        );
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
+
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, false));
+
+        WaitForIndexingCompleteStep step = createRandomInstance();
+        boolean[] conditionMetHolder = new boolean[1];
+        ToXContentObject[] informationContextHolder = new ToXContentObject[1];
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
+                conditionMetHolder[0] = conditionMet;
+                informationContextHolder[0] = informationContext;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(conditionMetHolder[0], is(true));
+        assertThat(informationContextHolder[0], nullValue());
+    }
+
+    public void testAllFollowTasksFailedWithIndexNotFound() {
+        IndexNotFoundException indexNotFound = new IndexNotFoundException("leader-index");
+
+        List<FollowStatsAction.StatsResponse> allFailedWithIndexNotFound = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, indexNotFound)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, indexNotFound))
+        );
         assertThat(
-            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), allFailed)),
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), allFailedWithIndexNotFound)
+            ),
             is(true)
         );
 
-        List<FollowStatsAction.StatsResponse> someFailed = List.of(
-            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, fatalException)),
+        ElasticsearchException wrappedIndexNotFound = new RemoteTransportException("error", indexNotFound);
+        List<FollowStatsAction.StatsResponse> allFailedWrapped = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, wrappedIndexNotFound)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, wrappedIndexNotFound))
+        );
+        assertThat(
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), allFailedWrapped)
+            ),
+            is(true)
+        );
+
+        ElasticsearchException otherException = new ElasticsearchException("some other error");
+        List<FollowStatsAction.StatsResponse> allFailedOther = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, otherException)),
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, otherException))
+        );
+        assertThat(
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), allFailedOther)
+            ),
+            is(false)
+        );
+
+        List<FollowStatsAction.StatsResponse> someFailedIndexNotFound = List.of(
+            new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, indexNotFound)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
         );
         assertThat(
-            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), someFailed)),
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), someFailedIndexNotFound)
+            ),
             is(false)
         );
 
@@ -437,12 +541,16 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, null))
         );
         assertThat(
-            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), noneFailed)),
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), noneFailed)
+            ),
             is(false)
         );
 
         assertThat(
-            WaitForIndexingCompleteStep.allShardFollowTasksFailed(new FollowStatsAction.StatsResponses(List.of(), List.of(), List.of())),
+            WaitForIndexingCompleteStep.allFollowTasksFailedWithIndexNotFound(
+                new FollowStatsAction.StatsResponses(List.of(), List.of(), List.of())
+            ),
             is(false)
         );
     }


### PR DESCRIPTION
ℹ️ Agent generated PR ℹ️ 

## Summary

Fixes #137261

When a CCR leader index is deleted, the follower's ILM gets stuck at the `WaitForIndexingCompleteStep` because:

1. The `index.lifecycle.indexing_complete` setting is never set to `true` (the leader is gone and can't propagate it)
2. CCR metadata persists on the follower index (CCR deliberately doesn't propagate deletes)
3. The existing fallback — checking if CCR metadata is removed — never triggers

This PR converts `WaitForIndexingCompleteStep` from a `ClusterStateWaitStep` to an `AsyncWaitStep` so it can query `FollowStatsAction` to detect when all shard follow tasks have fatally failed. When the leader index is deleted, the shard follow tasks encounter a non-retryable `IndexNotFoundException` and enter a fatal failure state. The step now detects this condition and proceeds with the unfollow process instead of waiting indefinitely.

### Evaluation logic

1. **No CCR metadata** → proceed (not a follower, unchanged)
2. **`indexing_complete` is `true`** → proceed (normal happy path, unchanged)
3. **Query `FollowStatsAction`**:
   - Response has task/node failures (partial results) → wait and retry
   - All shard follow tasks have a `fatalException` → proceed
   - `ResourceNotFoundException` (no persistent tasks) → proceed
   - Some tasks healthy → wait (unchanged behavior)
   - Other errors → wait (unchanged behavior)

### Files changed

- `WaitForIndexingCompleteStep.java` — converted from `ClusterStateWaitStep` to `AsyncWaitStep`, added `FollowStatsAction` query logic
- `UnfollowAction.java` — pass `Client` to the updated constructor
- `WaitForIndexingCompleteStepTests.java` — updated for `AsyncWaitStep` API, added tests for fatal failure detection, partial failures, empty responses, and edge cases
- `ClusterStateWaitUntilThresholdStepTests.java` — replaced `WaitForIndexingCompleteStep` usage with inline `ClusterStateWaitStep` implementations (since the step is no longer a `ClusterStateWaitStep`)

## Test plan

- [x] `WaitForIndexingCompleteStepTests` — all branches covered
- [x] `ClusterStateWaitUntilThresholdStepTests` — adapted for step type change
- [x] `UnfollowActionTests` — step wiring verified
- [ ] Existing CCR ILM integration tests (`CCRIndexLifecycleIT`) should continue to pass