### PR TITLE
update EQL index validation handling

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -366,7 +366,7 @@ public class IndexResolver {
             if (crossProjectEnabled) {
                 Map<String, ResolvedIndexExpressions> resolvedRemotely = response.getResolvedRemotely();
                 ElasticsearchException ex = CrossProjectIndexResolutionValidator.validate(
-                    iOpts,
+                    indicesOptions,
                     projectRouting,
                     resolvedIndexExpressions,
                     resolvedRemotely,


### PR DESCRIPTION
The basic issue, as I understand, is `iOpts` is always lenient when handling a cross project EQL request, so all the validation rules in `CrossProjectIndexResolutionValidator.validate` are bypassed.

This means requests which should fail actually succeed (see linked serverless PR for an example).

The change in this PR allows the linked test to pass, but I'm not sure this is the fix we want. In particular, we want to capture remote connection exceptions and pass them to `validate` (in a future PR), but the way EQL calls field caps with lenient options, then calls `validate` afterwards makes this awkward. Would we be able to call field caps with stricter options, so it calls `validate` with the appropriate parameters for us, or is there a reason we can't do this?