### PR TITLE
ESQL: Add configurable bracket-based multi-value support for CSV reader

### DIFF
--- a/docs/changelog/143890.yaml
+++ b/docs/changelog/143890.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143890
+summary: Add configurable bracket-based multi-value support for CSV reader
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -25,7 +25,7 @@ import java.time.format.DateTimeFormatter;
  * @param maxFieldSize       maximum size in bytes for a single field value; 0 means no limit
  *                           (default: 10MB). Maps to DuckDB's max_line_size and provides
  *                           OOM protection against malformed files.
- * @param multiValueSyntax   syntax for multi-value fields: NONE (default) or BRACKETS ([a,b,c])
+ * @param multiValueSyntax   syntax for multi-value fields: BRACKETS (default, [a,b,c]) or NONE
  */
 public record CsvFormatOptions(
     char delimiter,
@@ -56,7 +56,7 @@ public record CsvFormatOptions(
         StandardCharsets.UTF_8,
         null,
         DEFAULT_MAX_FIELD_SIZE,
-        MultiValueSyntax.NONE
+        MultiValueSyntax.BRACKETS
     );
 
     public static final CsvFormatOptions TSV = new CsvFormatOptions(
@@ -68,7 +68,7 @@ public record CsvFormatOptions(
         StandardCharsets.UTF_8,
         null,
         DEFAULT_MAX_FIELD_SIZE,
-        MultiValueSyntax.NONE
+        MultiValueSyntax.BRACKETS
     );
 
     public CsvFormatOptions {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
  * @param maxFieldSize       maximum size in bytes for a single field value; 0 means no limit
  *                           (default: 10MB). Maps to DuckDB's max_line_size and provides
  *                           OOM protection against malformed files.
+ * @param multiValueSyntax   syntax for multi-value fields: NONE (default) or BRACKETS ([a,b,c])
  */
 public record CsvFormatOptions(
     char delimiter,
@@ -34,8 +35,15 @@ public record CsvFormatOptions(
     String nullValue,
     Charset encoding,
     DateTimeFormatter datetimeFormatter,
-    int maxFieldSize
+    int maxFieldSize,
+    MultiValueSyntax multiValueSyntax
 ) {
+
+    public enum MultiValueSyntax {
+        NONE,
+        BRACKETS
+    }
+
     /** 10 MB default field size limit — generous for real-world data, prevents OOM on corrupt files. */
     static final int DEFAULT_MAX_FIELD_SIZE = 10 * 1024 * 1024;
 
@@ -47,7 +55,8 @@ public record CsvFormatOptions(
         "",
         StandardCharsets.UTF_8,
         null,
-        DEFAULT_MAX_FIELD_SIZE
+        DEFAULT_MAX_FIELD_SIZE,
+        MultiValueSyntax.NONE
     );
 
     public static final CsvFormatOptions TSV = new CsvFormatOptions(
@@ -58,7 +67,8 @@ public record CsvFormatOptions(
         "",
         StandardCharsets.UTF_8,
         null,
-        DEFAULT_MAX_FIELD_SIZE
+        DEFAULT_MAX_FIELD_SIZE,
+        MultiValueSyntax.NONE
     );
 
     public CsvFormatOptions {
@@ -73,6 +83,9 @@ public record CsvFormatOptions(
         }
         if (maxFieldSize < 0) {
             throw new IllegalArgumentException("maxFieldSize must be non-negative, got: " + maxFieldSize);
+        }
+        if (multiValueSyntax == null) {
+            throw new IllegalArgumentException("multiValueSyntax must not be null");
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -75,47 +75,6 @@ import java.util.regex.Pattern;
  *
  * <h2>Configurable options</h2>
  * All options are set via the {@code WITH} clause and parsed by {@link #withConfig(java.util.Map)}.
- *
- * <table>
- *   <caption>CSV options and their equivalents in other engines</caption>
- *   <tr><th>ES/ESQL key</th><th>Default</th><th>Spark</th><th>DuckDB</th><th>ClickHouse</th></tr>
- *   <tr><td>{@code delimiter}</td><td>{@code ,}</td><td>{@code sep}</td>
- *       <td>{@code delim}</td><td>{@code format_csv_delimiter}</td></tr>
- *   <tr><td>{@code quote}</td><td>{@code "}</td><td>{@code quote}</td>
- *       <td>{@code quote}</td><td>{@code format_csv_allow_single_quotes}</td></tr>
- *   <tr><td>{@code escape}</td><td>{@code \}</td><td>{@code escape}</td>
- *       <td>{@code escape}</td><td>—</td></tr>
- *   <tr><td>{@code comment}</td><td>{@code //}</td><td>{@code comment}</td>
- *       <td>{@code comment}</td><td>—</td></tr>
- *   <tr><td>{@code null_value}</td><td>(empty)</td><td>{@code nullValue}</td>
- *       <td>{@code nullstr}</td><td>{@code format_csv_null_representation}</td></tr>
- *   <tr><td>{@code encoding}</td><td>{@code UTF-8}</td><td>{@code encoding}</td>
- *       <td>—</td><td>—</td></tr>
- *   <tr><td>{@code datetime_format}</td><td>ISO-8601 / epoch</td><td>{@code timestampFormat}</td>
- *       <td>{@code timestampformat}</td><td>{@code date_time_input_format}</td></tr>
- *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>{@code maxCharsPerColumn}</td>
- *       <td>{@code max_line_size}</td><td>—</td></tr>
- * </table>
- *
- * <h2>Error handling</h2>
- * Controlled by {@link ErrorPolicy} and its {@link ErrorPolicy.Mode}:
- * <table>
- *   <caption>Error mode comparison</caption>
- *   <tr><th>ES/ESQL key</th><th>Spark</th><th>DuckDB</th><th>Behaviour</th></tr>
- *   <tr><td>{@code fail_fast}</td><td>FAILFAST</td><td>(default)</td><td>Abort on first error</td></tr>
- *   <tr><td>{@code skip_row}</td><td>DROPMALFORMED</td><td>ignore_errors</td>
- *       <td>Drop the entire bad row</td></tr>
- *   <tr><td>{@code null_field}</td><td>PERMISSIVE</td><td>—</td>
- *       <td>Null-fill unparseable fields, keep the row</td></tr>
- * </table>
- *
- * <h2>Example</h2>
- * <pre>{@code
- *   FROM s3://bucket/data.tsv WITH {"delimiter": "\t", "error_mode": "skip_row", "max_errors": 100}
- * }</pre>
- *
- * <p>Works with any {@link org.elasticsearch.xpack.esql.datasources.spi.StorageProvider}
- * (HTTP, S3, local filesystem).
  */
 public class CsvFormatReader implements SegmentableFormatReader {
 
@@ -124,14 +83,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private static final int READER_BUFFER_SIZE = 64 * 1024;
 
     private final BlockFactory blockFactory;
-
-    /**
-     * Jackson CsvMapper is thread-safe after configuration (all enable/disable
-     * calls happen in the constructor). Shared across all CsvBatchIterator
-     * instances to avoid repeated configuration overhead.
-     */
     private final CsvMapper sharedCsvMapper;
-
     private final CsvFormatOptions options;
     private final String format;
     private final List<String> extensions;
@@ -172,6 +124,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         Charset encoding = parseEncoding(config.get("encoding"));
         DateTimeFormatter datetimeFormatter = parseDatetimeFormat(config.get("datetime_format"));
         int maxFieldSize = parseInt(config.get("max_field_size"), CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE);
+        CsvFormatOptions.MultiValueSyntax multiValueSyntax = parseMultiValueSyntax(config.get("multi_value_syntax"));
 
         if (delimiter == ','
             && quoteChar == '"'
@@ -180,10 +133,35 @@ public class CsvFormatReader implements SegmentableFormatReader {
             && "".equals(nullValue)
             && StandardCharsets.UTF_8.equals(encoding)
             && datetimeFormatter == null
-            && maxFieldSize == CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE) {
+            && maxFieldSize == CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE
+            && multiValueSyntax == CsvFormatOptions.MultiValueSyntax.NONE) {
             return null;
         }
-        return new CsvFormatOptions(delimiter, quoteChar, escapeChar, commentPrefix, nullValue, encoding, datetimeFormatter, maxFieldSize);
+        return new CsvFormatOptions(
+            delimiter,
+            quoteChar,
+            escapeChar,
+            commentPrefix,
+            nullValue,
+            encoding,
+            datetimeFormatter,
+            maxFieldSize,
+            multiValueSyntax
+        );
+    }
+
+    private static CsvFormatOptions.MultiValueSyntax parseMultiValueSyntax(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return CsvFormatOptions.MultiValueSyntax.NONE;
+        }
+        String s = value.toString().trim().toLowerCase(Locale.ROOT);
+        if ("none".equals(s)) {
+            return CsvFormatOptions.MultiValueSyntax.NONE;
+        }
+        if ("brackets".equals(s)) {
+            return CsvFormatOptions.MultiValueSyntax.BRACKETS;
+        }
+        throw new IllegalArgumentException("Invalid multi_value_syntax [" + value + "]. Accepted values: \"none\", \"brackets\"");
     }
 
     private static char parseChar(Object value, char defaultValue) {
@@ -252,9 +230,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
     }
 
-    /**
-     * Returns a new CsvFormatReader configured with the given options.
-     */
     public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
         return new CsvFormatReader(blockFactory, newOptions, format, extensions);
     }
@@ -337,21 +312,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         return new CsvBatchIterator(reader, stream, projectedColumns, batchSize, resolvedAttributes, effective);
     }
 
-    /**
-     * Quote-aware record boundary detection for parallel parsing.
-     * Tracks CSV quoting state so that newlines inside quoted fields are not
-     * treated as record boundaries. Handles RFC 4180 escaped quotes ({@code ""})
-     * correctly — a pair of double-quotes inside a quoted field does not toggle
-     * the quoting state. Safe for TSV (which has no quoting, so the
-     * {@code inQuotes} flag never toggles).
-     * <p>
-     * <b>Limitation:</b> this method only handles RFC 4180 doubled-quote escaping
-     * ({@code ""}). Backslash-based escaping ({@code \"}) is not recognized here;
-     * when {@code escapeChar} differs from {@code quoteChar}, boundaries may be
-     * mis-detected inside fields that use backslash escaping. This is acceptable
-     * because split-based parallel reads are an optimisation — the Jackson parser
-     * in each split handles escape characters correctly.
-     */
     @Override
     public long findNextRecordBoundary(InputStream stream) throws IOException {
         long consumed = 0;
@@ -413,30 +373,24 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     @Override
-    public void close() throws IOException {
-        // No resources to close at reader level
-    }
+    public void close() throws IOException {}
 
     private List<Attribute> parseSchema(String schemaLine) {
         String[] columns = schemaLine.split(Pattern.quote(Character.toString(options.delimiter())));
         List<Attribute> attributes = new ArrayList<>(columns.length);
-
         for (String column : columns) {
             String trimmedColumn = column.trim();
             String[] parts = trimmedColumn.split(":");
             if (parts.length != 2) {
                 throw new ParsingException("Invalid CSV schema format: [{}]. Expected 'name:type'", column);
             }
-
             String name = parts[0].trim();
             String trimmedType = parts[1].trim();
             String typeName = trimmedType.toUpperCase(java.util.Locale.ROOT);
             DataType dataType = parseDataType(typeName);
-
             EsField field = new EsField(name, dataType, java.util.Map.of(), true, EsField.TimeSeriesFieldType.NONE);
             attributes.add(new FieldAttribute(Source.EMPTY, name, field));
         }
-
         return attributes;
     }
 
@@ -454,20 +408,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         };
     }
 
-    /**
-     * Iterator that reads CSV data in batches and converts to ESQL Pages.
-     * <p>
-     * Performance-critical design choices:
-     * <ul>
-     *   <li>Pre-computed {@code int[]} for projected column indices — avoids autoboxing
-     *   <li>Pre-computed {@code DataType[]} and {@code Attribute[]} arrays — avoids list lookups per field
-     *   <li>Hoisted invariant flags ({@code hasCommentFilter}, {@code hasCustomNullValue}) — avoids per-row checks
-     *   <li>Exception-free error path: {@code tryConvertValue} returns {@code null} on failure and sets
-     *       {@code lastFieldError} — avoids exception allocation/stack-fill on the hot path
-     *   <li>Reusable {@code Object[]} buffer across rows — avoids per-row allocation
-     *   <li>Mode ordinal resolved once at construction — single int comparison per row instead of method calls
-     * </ul>
-     */
     private class CsvBatchIterator implements CloseableIterator<Page> {
         private final BufferedReader reader;
         private final InputStream stream;
@@ -475,14 +415,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final int batchSize;
         private final List<Attribute> preResolvedSchema;
         private final ErrorPolicy errorPolicy;
-
         private final int modeOrdinal;
         private final boolean logErrors;
         private final boolean hasCommentFilter;
         private final boolean hasCustomNullValue;
         private final String nullValueStr;
         private final DateTimeFormatter datetimeFormatter;
-
+        private final boolean bracketMultiValues;
+        private static final int MAX_WARNINGS = 20;
+        private final List<String> warnings = new ArrayList<>();
         private List<Attribute> schema;
         private int[] projectedIdx;
         private DataType[] projectedTypes;
@@ -494,7 +435,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private boolean closed = false;
         private long errorCount = 0;
         private long totalRowCount = 0;
-
         private String lastFieldError;
 
         CsvBatchIterator(
@@ -517,16 +457,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
             this.hasCustomNullValue = options.nullValue().isEmpty() == false;
             this.nullValueStr = options.nullValue();
             this.datetimeFormatter = options.datetimeFormatter();
+            this.bracketMultiValues = options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS;
         }
 
         @Override
         public boolean hasNext() {
-            if (closed) {
-                return false;
-            }
-            if (nextPage != null) {
-                return true;
-            }
+            if (closed) return false;
+            if (nextPage != null) return true;
             try {
                 nextPage = readNextBatch();
                 return nextPage != null;
@@ -537,9 +474,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         @Override
         public Page next() {
-            if (hasNext() == false) {
-                throw new NoSuchElementException();
-            }
+            if (hasNext() == false) throw new NoSuchElementException();
             Page result = nextPage;
             nextPage = null;
             return result;
@@ -549,6 +484,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
         public void close() throws IOException {
             if (closed == false) {
                 closed = true;
+                if (modeOrdinal != ErrorPolicy.Mode.FAIL_FAST.ordinal() && errorCount > 0) {
+                    logger.info(
+                        "CSV parsing completed with [{}] errors out of [{}] rows (policy: {})",
+                        errorCount,
+                        totalRowCount,
+                        errorPolicy.mode()
+                    );
+                }
                 reader.close();
                 stream.close();
             }
@@ -562,15 +505,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         line = line.trim();
-                        if (line.isEmpty() || (hasCommentFilter && line.startsWith(options.commentPrefix()))) {
-                            continue;
-                        }
+                        if (line.isEmpty() || (hasCommentFilter && line.startsWith(options.commentPrefix()))) continue;
                         schema = parseSchema(line);
                         break;
                     }
-                    if (schema == null) {
-                        return null;
-                    }
+                    if (schema == null) return null;
                 }
                 initProjection();
                 CsvSchema csvSchema = CsvSchema.emptySchema()
@@ -578,10 +517,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     .withQuoteChar(options.quoteChar())
                     .withEscapeChar(options.escapeChar())
                     .withNullValue(options.nullValue());
-
                 csvIterator = sharedCsvMapper.readerFor(List.class).with(csvSchema).readValues(reader);
             }
-
             while (true) {
                 List<String[]> rows = new ArrayList<>();
                 while (rows.size() < batchSize && csvIterator.hasNext()) {
@@ -593,21 +530,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     if (hasCommentFilter && row.length > 0 && row[0] != null) {
                         String trimmedFirstCell = row[0].trim();
-                        if (trimmedFirstCell.startsWith(options.commentPrefix())) {
-                            continue;
-                        }
+                        if (trimmedFirstCell.startsWith(options.commentPrefix())) continue;
                     }
                     rows.add(row);
                 }
-
-                if (rows.isEmpty()) {
-                    return null;
-                }
-
+                if (rows.isEmpty()) return null;
                 Page page = convertRowsToPage(rows);
-                if (page != null || modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
-                    return page;
-                }
+                if (page != null || modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) return page;
             }
         }
 
@@ -616,9 +545,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (projectedColumns == null || projectedColumns.isEmpty()) {
                 columnCount = schemaSize;
                 projectedIdx = new int[schemaSize];
-                for (int i = 0; i < schemaSize; i++) {
+                for (int i = 0; i < schemaSize; i++)
                     projectedIdx[i] = i;
-                }
             } else {
                 columnCount = projectedColumns.size();
                 projectedIdx = new int[columnCount];
@@ -631,9 +559,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             break;
                         }
                     }
-                    if (index == -1) {
-                        throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
-                    }
+                    if (index == -1) throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
                     projectedIdx[c] = index;
                 }
             }
@@ -657,7 +583,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         rows.size()
                     );
                 }
-
                 int schemaSize = schema.size();
                 int acceptedRows = 0;
                 for (String[] row : rows) {
@@ -667,41 +592,27 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         continue;
                     }
                     if (convertRowInPlace(row)) {
-                        for (int i = 0; i < columnCount; i++) {
+                        for (int i = 0; i < columnCount; i++)
                             builders[i].append().accept(rowBuffer[i]);
-                        }
                         acceptedRows++;
                     }
                 }
-
-                if (acceptedRows == 0) {
-                    return null;
-                }
-
+                if (acceptedRows == 0) return null;
                 Block[] blocks = new Block[columnCount];
-                for (int i = 0; i < columnCount; i++) {
+                for (int i = 0; i < columnCount; i++)
                     blocks[i] = builders[i].builder().build();
-                }
-
                 return new Page(acceptedRows, blocks);
             } finally {
                 Releasables.closeExpectNoException(builders);
             }
         }
 
-        /**
-         * Converts a raw CSV row into {@link #rowBuffer} in place.
-         * Returns {@code true} if the row was accepted, {@code false} if it was skipped.
-         * Throws on budget exceeded or strict-mode failure.
-         */
         private boolean convertRowInPlace(String[] row) {
             int mode = this.modeOrdinal;
             for (int i = 0; i < columnCount; i++) {
                 int si = projectedIdx[i];
                 String value = si < row.length ? row[si] : null;
-                if (value != null) {
-                    value = value.trim();
-                }
+                if (value != null) value = value.trim();
                 Object result = tryConvertValue(value, projectedTypes[i]);
                 if (lastFieldError != null) {
                     if (mode == ErrorPolicy.Mode.NULL_FIELD.ordinal()) {
@@ -721,19 +632,63 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return true;
         }
 
-        /**
-         * Attempts to convert a string value to the target type.
-         * On success, returns the converted value and {@code lastFieldError} is null.
-         * On failure, returns null and sets {@code lastFieldError} to a description.
-         * This avoids exception allocation on the hot path.
-         */
         private Object tryConvertValue(String value, DataType dataType) {
-            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
-                return null;
+            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) return null;
+            if (hasCustomNullValue && value.equals(nullValueStr)) return null;
+            if (bracketMultiValues && value.startsWith("[") && value.endsWith("]")) return tryConvertMultiValue(value, dataType);
+            return switch (dataType) {
+                case INTEGER -> tryParseInt(value);
+                case LONG -> tryParseLong(value);
+                case DOUBLE -> tryParseDouble(value);
+                case KEYWORD, TEXT -> new BytesRef(value);
+                case BOOLEAN -> tryParseBoolean(value);
+                case DATETIME -> tryParseDatetime(value);
+                case NULL -> null;
+                default -> {
+                    lastFieldError = "Unsupported data type: " + dataType;
+                    yield null;
+                }
+            };
+        }
+
+        private Object tryConvertMultiValue(String value, DataType dataType) {
+            String content = value.substring(1, value.length() - 1).trim();
+            if (content.isEmpty()) return null;
+            List<String> parts = splitBracketContent(content);
+            List<Object> result = new ArrayList<>(parts.size());
+            for (String part : parts) {
+                Object elem = parseElement(part, dataType);
+                if (lastFieldError != null) return null;
+                if (elem != null) result.add(elem);
             }
-            if (hasCustomNullValue && value.equals(nullValueStr)) {
-                return null;
+            return result.isEmpty() ? null : result;
+        }
+
+        private List<String> splitBracketContent(String content) {
+            List<String> result = new ArrayList<>();
+            StringBuilder current = new StringBuilder();
+            int i = 0;
+            while (i < content.length()) {
+                char c = content.charAt(i);
+                if (c == '\\' && i + 1 < content.length() && content.charAt(i + 1) == ',') {
+                    current.append(',');
+                    i += 2;
+                } else if (c == ',') {
+                    result.add(current.toString().trim());
+                    current = new StringBuilder();
+                    i++;
+                } else {
+                    current.append(c);
+                    i++;
+                }
             }
+            result.add(current.toString().trim());
+            return result;
+        }
+
+        private Object parseElement(String value, DataType dataType) {
+            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) return null;
+            if (hasCustomNullValue && value.equals(nullValueStr)) return null;
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
                 case LONG -> tryParseLong(value);
@@ -789,9 +744,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (looksNumeric(value)) {
                 try {
                     return Long.parseLong(value);
-                } catch (NumberFormatException e) {
-                    // overflow — fall through
-                }
+                } catch (NumberFormatException e) {}
             }
             if (datetimeFormatter != null) {
                 try {
@@ -810,28 +763,24 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private void onRowError(String message, Exception cause, String[] row) {
-            if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
-                throw new EsqlIllegalArgumentException(cause, message);
-            }
+            if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) throw new EsqlIllegalArgumentException(cause, message);
             errorCount++;
-            if (logErrors) {
-                logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), message);
-            }
+            if (warnings.size() < MAX_WARNINGS) warnings.add("Row error: " + message);
+            if (logErrors) logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), message);
             checkBudget(message, cause);
         }
 
         private void onFieldError(String message, String value, Attribute attr) {
             errorCount++;
-            if (logErrors) {
-                logger.warn(
-                    "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
-                    attr.name(),
-                    value,
-                    errorCount,
-                    errorPolicy.maxErrors(),
-                    message
-                );
-            }
+            if (warnings.size() < MAX_WARNINGS) warnings.add("Field [" + attr.name() + "] value [" + value + "]: " + message);
+            if (logErrors) logger.warn(
+                "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
+                attr.name(),
+                value,
+                errorCount,
+                errorPolicy.maxErrors(),
+                message
+            );
             checkBudget(message, null);
         }
 
@@ -862,13 +811,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private static boolean looksNumeric(String value) {
             int start = (value.charAt(0) == '-') ? 1 : 0;
-            if (start >= value.length()) {
-                return false;
-            }
+            if (start >= value.length()) return false;
             for (int i = start; i < value.length(); i++) {
-                if (value.charAt(i) < '0' || value.charAt(i) > '9') {
-                    return false;
-                }
+                if (value.charAt(i) < '0' || value.charAt(i) > '9') return false;
             }
             return true;
         }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -96,7 +96,7 @@ import java.util.regex.Pattern;
  *       <td>{@code timestampformat}</td><td>{@code date_time_input_format}</td></tr>
  *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>{@code maxCharsPerColumn}</td>
  *       <td>{@code max_line_size}</td><td>—</td></tr>
- *   <tr><td>{@code multi_value_syntax}</td><td>{@code none}</td><td>—</td>
+ *   <tr><td>{@code multi_value_syntax}</td><td>{@code brackets}</td><td>—</td>
  *       <td>—</td><td>{@code Array()} type notation</td></tr>
  * </table>
  *
@@ -184,7 +184,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             && StandardCharsets.UTF_8.equals(encoding)
             && datetimeFormatter == null
             && maxFieldSize == CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE
-            && multiValueSyntax == CsvFormatOptions.MultiValueSyntax.NONE) {
+            && multiValueSyntax == CsvFormatOptions.MultiValueSyntax.BRACKETS) {
             return null;
         }
         return new CsvFormatOptions(
@@ -202,7 +202,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     private static CsvFormatOptions.MultiValueSyntax parseMultiValueSyntax(Object value) {
         if (value == null || value.toString().isEmpty()) {
-            return CsvFormatOptions.MultiValueSyntax.NONE;
+            return CsvFormatOptions.MultiValueSyntax.BRACKETS;
         }
         String s = value.toString().trim().toLowerCase(Locale.ROOT);
         if ("none".equals(s)) {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -76,6 +76,55 @@ import java.util.regex.Pattern;
  *
  * <h2>Configurable options</h2>
  * All options are set via the {@code WITH} clause and parsed by {@link #withConfig(java.util.Map)}.
+ *
+ * <table>
+ *   <caption>CSV options and their equivalents in other engines</caption>
+ *   <tr><th>ES/ESQL key</th><th>Default</th><th>Spark</th><th>DuckDB</th><th>ClickHouse</th></tr>
+ *   <tr><td>{@code delimiter}</td><td>{@code ,}</td><td>{@code sep}</td>
+ *       <td>{@code delim}</td><td>{@code format_csv_delimiter}</td></tr>
+ *   <tr><td>{@code quote}</td><td>{@code "}</td><td>{@code quote}</td>
+ *       <td>{@code quote}</td><td>{@code format_csv_allow_single_quotes}</td></tr>
+ *   <tr><td>{@code escape}</td><td>{@code \}</td><td>{@code escape}</td>
+ *       <td>{@code escape}</td><td>—</td></tr>
+ *   <tr><td>{@code comment}</td><td>{@code //}</td><td>{@code comment}</td>
+ *       <td>{@code comment}</td><td>—</td></tr>
+ *   <tr><td>{@code null_value}</td><td>(empty)</td><td>{@code nullValue}</td>
+ *       <td>{@code nullstr}</td><td>{@code format_csv_null_representation}</td></tr>
+ *   <tr><td>{@code encoding}</td><td>{@code UTF-8}</td><td>{@code encoding}</td>
+ *       <td>—</td><td>—</td></tr>
+ *   <tr><td>{@code datetime_format}</td><td>ISO-8601 / epoch</td><td>{@code timestampFormat}</td>
+ *       <td>{@code timestampformat}</td><td>{@code date_time_input_format}</td></tr>
+ *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>{@code maxCharsPerColumn}</td>
+ *       <td>{@code max_line_size}</td><td>—</td></tr>
+ *   <tr><td>{@code multi_value_syntax}</td><td>{@code none}</td><td>—</td>
+ *       <td>—</td><td>{@code Array()} type notation</td></tr>
+ * </table>
+ *
+ * <h2>Error handling</h2>
+ * Controlled by {@link ErrorPolicy} and its {@link ErrorPolicy.Mode}:
+ * <table>
+ *   <caption>Error mode comparison</caption>
+ *   <tr><th>ES/ESQL key</th><th>Spark</th><th>DuckDB</th><th>Behaviour</th></tr>
+ *   <tr><td>{@code fail_fast}</td><td>FAILFAST</td><td>(default)</td><td>Abort on first error</td></tr>
+ *   <tr><td>{@code skip_row}</td><td>DROPMALFORMED</td><td>ignore_errors</td>
+ *       <td>Drop the entire bad row</td></tr>
+ *   <tr><td>{@code null_field}</td><td>PERMISSIVE</td><td>—</td>
+ *       <td>Null-fill unparseable fields, keep the row</td></tr>
+ * </table>
+ *
+ * <h2>Examples</h2>
+ * <pre>{@code
+ *   FROM s3://bucket/data.tsv WITH {"delimiter": "\t", "error_mode": "skip_row", "max_errors": 100}
+ * }</pre>
+ * <pre>{@code
+ *   FROM s3://bucket/employees.csv WITH {"multi_value_syntax": "brackets"}
+ * }</pre>
+ * <pre>{@code
+ *   FROM s3://bucket/data.csv WITH {"multi_value_syntax": "brackets", "error_mode": "skip_row"}
+ * }</pre>
+ *
+ * <p>Works with any {@link org.elasticsearch.xpack.esql.datasources.spi.StorageProvider}
+ * (HTTP, S3, local filesystem).
  */
 public class CsvFormatReader implements SegmentableFormatReader {
 
@@ -424,9 +473,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final DateTimeFormatter datetimeFormatter;
         private final boolean bracketMultiValues;
         private static final int MAX_WARNINGS = 20;
-        // TODO: propagate warnings to the query response (similar to deprecation warnings in search)
-        // when the compute framework supports it. For now, warnings are collected here and a summary
-        // is logged at INFO level in close().
         private final List<String> warnings = new ArrayList<>();
         private List<Attribute> schema;
         private int[] projectedIdx;
@@ -466,8 +512,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         @Override
         public boolean hasNext() {
-            if (closed) return false;
-            if (nextPage != null) return true;
+            if (closed) {
+                return false;
+            }
+            if (nextPage != null) {
+                return true;
+            }
             try {
                 nextPage = readNextBatch();
                 return nextPage != null;
@@ -478,7 +528,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         @Override
         public Page next() {
-            if (hasNext() == false) throw new NoSuchElementException();
+            if (hasNext() == false) {
+                throw new NoSuchElementException();
+            }
             Page result = nextPage;
             nextPage = null;
             return result;
@@ -509,13 +561,18 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         line = line.trim();
-                        if (line.isEmpty() || (hasCommentFilter && line.startsWith(options.commentPrefix()))) continue;
+                        if (line.isEmpty() || (hasCommentFilter && line.startsWith(options.commentPrefix()))) {
+                            continue;
+                        }
                         schema = parseSchema(line);
                         break;
                     }
-                    if (schema == null) return null;
+                    if (schema == null) {
+                        return null;
+                    }
                 }
                 initProjection();
+
                 CsvSchema csvSchema = CsvSchema.emptySchema()
                     .withColumnSeparator(options.delimiter())
                     .withQuoteChar(options.quoteChar())
@@ -534,13 +591,21 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     if (hasCommentFilter && row.length > 0 && row[0] != null) {
                         String trimmedFirstCell = row[0].trim();
-                        if (trimmedFirstCell.startsWith(options.commentPrefix())) continue;
+                        if (trimmedFirstCell.startsWith(options.commentPrefix())) {
+                            continue;
+                        }
                     }
                     rows.add(row);
                 }
-                if (rows.isEmpty()) return null;
+
+                if (rows.isEmpty()) {
+                    return null;
+                }
+
                 Page page = convertRowsToPage(rows);
-                if (page != null || modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) return page;
+                if (page != null || modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
+                    return page;
+                }
             }
         }
 
@@ -549,8 +614,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (projectedColumns == null || projectedColumns.isEmpty()) {
                 columnCount = schemaSize;
                 projectedIdx = new int[schemaSize];
-                for (int i = 0; i < schemaSize; i++)
+                for (int i = 0; i < schemaSize; i++) {
                     projectedIdx[i] = i;
+                }
             } else {
                 columnCount = projectedColumns.size();
                 projectedIdx = new int[columnCount];
@@ -563,7 +629,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             break;
                         }
                     }
-                    if (index == -1) throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
+                    if (index == -1) {
+                        throw new EsqlIllegalArgumentException("Column not found in CSV schema: [{}]", colName);
+                    }
                     projectedIdx[c] = index;
                 }
             }
@@ -596,15 +664,19 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         continue;
                     }
                     if (convertRowInPlace(row)) {
-                        for (int i = 0; i < columnCount; i++)
+                        for (int i = 0; i < columnCount; i++) {
                             builders[i].append().accept(rowBuffer[i]);
+                        }
                         acceptedRows++;
                     }
                 }
-                if (acceptedRows == 0) return null;
+                if (acceptedRows == 0) {
+                    return null;
+                }
                 Block[] blocks = new Block[columnCount];
-                for (int i = 0; i < columnCount; i++)
+                for (int i = 0; i < columnCount; i++) {
                     blocks[i] = builders[i].builder().build();
+                }
                 return new Page(acceptedRows, blocks);
             } finally {
                 Releasables.closeExpectNoException(builders);
@@ -616,7 +688,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             for (int i = 0; i < columnCount; i++) {
                 int si = projectedIdx[i];
                 String value = si < row.length ? row[si] : null;
-                if (value != null) value = value.trim();
+                if (value != null) {
+                    value = value.trim();
+                }
                 Object result = tryConvertValue(value, projectedTypes[i]);
                 if (lastFieldError != null) {
                     if (mode == ErrorPolicy.Mode.NULL_FIELD.ordinal()) {
@@ -637,9 +711,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Object tryConvertValue(String value, DataType dataType) {
-            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) return null;
-            if (hasCustomNullValue && value.equals(nullValueStr)) return null;
-            if (bracketMultiValues && value.startsWith("[") && value.endsWith("]")) return tryConvertMultiValue(value, dataType);
+            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
+                return null;
+            }
+            if (hasCustomNullValue && value.equals(nullValueStr)) {
+                return null;
+            }
+            if (bracketMultiValues && value.startsWith("[") && value.endsWith("]")) {
+                return tryConvertMultiValue(value, dataType);
+            }
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
                 case LONG -> tryParseLong(value);
@@ -657,13 +737,19 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private Object tryConvertMultiValue(String value, DataType dataType) {
             String content = value.substring(1, value.length() - 1).trim();
-            if (content.isEmpty()) return null;
+            if (content.isEmpty()) {
+                return null;
+            }
             List<String> parts = splitBracketContent(content);
             List<Object> result = new ArrayList<>(parts.size());
             for (String part : parts) {
                 Object elem = parseElement(part, dataType);
-                if (lastFieldError != null) return null;
-                if (elem != null) result.add(elem);
+                if (lastFieldError != null) {
+                    return null;
+                }
+                if (elem != null) {
+                    result.add(elem);
+                }
             }
             return result.isEmpty() ? null : result;
         }
@@ -692,8 +778,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Object parseElement(String value, DataType dataType) {
-            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) return null;
-            if (hasCustomNullValue && value.equals(nullValueStr)) return null;
+            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
+                return null;
+            }
+            if (hasCustomNullValue && value.equals(nullValueStr)) {
+                return null;
+            }
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
                 case LONG -> tryParseLong(value);
@@ -768,16 +858,22 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private void onRowError(String message, Exception cause, String[] row) {
-            if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) throw new EsqlIllegalArgumentException(cause, message);
+            if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
+                throw new EsqlIllegalArgumentException(cause, message);
+            }
             errorCount++;
-            if (warnings.size() < MAX_WARNINGS) warnings.add("Row error: " + message);
+            if (warnings.size() < MAX_WARNINGS) {
+                warnings.add("Row error: " + message);
+            }
             if (logErrors) logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), message);
             checkBudget(message, cause);
         }
 
         private void onFieldError(String message, String value, Attribute attr) {
             errorCount++;
-            if (warnings.size() < MAX_WARNINGS) warnings.add("Field [" + attr.name() + "] value [" + value + "]: " + message);
+            if (warnings.size() < MAX_WARNINGS) {
+                warnings.add("Field [" + attr.name() + "] value [" + value + "]: " + message);
+            }
             if (logErrors) logger.warn(
                 "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
                 attr.name(),
@@ -816,9 +912,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private static boolean looksNumeric(String value) {
             int start = (value.charAt(0) == '-') ? 1 : 0;
-            if (start >= value.length()) return false;
+            if (start >= value.length()) {
+                return false;
+            }
             for (int i = start; i < value.length(); i++) {
-                if (value.charAt(i) < '0' || value.charAt(i) > '9') return false;
+                if (value.charAt(i) < '0' || value.charAt(i) > '9') {
+                    return false;
+                }
             }
             return true;
         }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -114,13 +114,13 @@ import java.util.regex.Pattern;
  *
  * <h2>Examples</h2>
  * <pre>{@code
- *   FROM s3://bucket/data.tsv WITH {"delimiter": "\t", "error_mode": "skip_row", "max_errors": 100}
+ *   EXTERNAL "s3://bucket/data.tsv" WITH {"delimiter": "\t", "error_mode": "skip_row", "max_errors": 100}
  * }</pre>
  * <pre>{@code
- *   FROM s3://bucket/employees.csv WITH {"multi_value_syntax": "brackets"}
+ *   EXTERNAL "s3://bucket/employees.csv" WITH {"multi_value_syntax": "brackets"}
  * }</pre>
  * <pre>{@code
- *   FROM s3://bucket/data.csv WITH {"multi_value_syntax": "brackets", "error_mode": "skip_row"}
+ *   EXTERNAL "s3://bucket/data.csv" WITH {"multi_value_syntax": "brackets", "error_mode": "skip_row"}
  * }</pre>
  *
  * <p>Works with any {@link org.elasticsearch.xpack.esql.datasources.spi.StorageProvider}
@@ -456,6 +456,16 @@ public class CsvFormatReader implements SegmentableFormatReader {
             case "NULL", "N" -> DataType.NULL;
             default -> throw EsqlIllegalArgumentException.illegalDataType(typeName);
         };
+    }
+
+    /**
+     * Returns accumulated warnings from a CSV iterator, for testing.
+     */
+    static List<String> getWarnings(CloseableIterator<Page> iterator) {
+        if (iterator instanceof CsvBatchIterator cbi) {
+            return List.copyOf(cbi.warnings);
+        }
+        return List.of();
     }
 
     private class CsvBatchIterator implements CloseableIterator<Page> {
@@ -862,27 +872,42 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 throw new EsqlIllegalArgumentException(cause, message);
             }
             errorCount++;
-            if (warnings.size() < MAX_WARNINGS) {
-                warnings.add("Row error: " + message);
+            addWarning("Row [" + totalRowCount + "] error: " + message);
+            if (logErrors) {
+                logger.warn(
+                    "Skipping malformed CSV row [{}] (error {}/{}): {}",
+                    totalRowCount,
+                    errorCount,
+                    errorPolicy.maxErrors(),
+                    message
+                );
             }
-            if (logErrors) logger.warn("Skipping malformed CSV row (error {}/{}): {}", errorCount, errorPolicy.maxErrors(), message);
             checkBudget(message, cause);
         }
 
         private void onFieldError(String message, String value, Attribute attr) {
             errorCount++;
-            if (warnings.size() < MAX_WARNINGS) {
-                warnings.add("Field [" + attr.name() + "] value [" + value + "]: " + message);
+            addWarning("Row [" + totalRowCount + "] field [" + attr.name() + "] value [" + value + "]: " + message);
+            if (logErrors) {
+                logger.warn(
+                    "Null-filling unparseable field [{}] value [{}] in row [{}] (error {}/{}): {}",
+                    attr.name(),
+                    value,
+                    totalRowCount,
+                    errorCount,
+                    errorPolicy.maxErrors(),
+                    message
+                );
             }
-            if (logErrors) logger.warn(
-                "Null-filling unparseable field [{}] value [{}] (error {}/{}): {}",
-                attr.name(),
-                value,
-                errorCount,
-                errorPolicy.maxErrors(),
-                message
-            );
             checkBudget(message, null);
+        }
+
+        private void addWarning(String warning) {
+            if (warnings.size() < MAX_WARNINGS) {
+                warnings.add(warning);
+            } else if (warnings.size() == MAX_WARNINGS) {
+                warnings.add("... further warnings suppressed (total errors so far: " + errorCount + ")");
+            }
         }
 
         private void checkBudget(String message, Exception cause) {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Releasables;
@@ -386,9 +387,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
             String name = parts[0].trim();
             String trimmedType = parts[1].trim();
-            String typeName = trimmedType.toUpperCase(java.util.Locale.ROOT);
+            String typeName = trimmedType.toUpperCase(Locale.ROOT);
             DataType dataType = parseDataType(typeName);
-            EsField field = new EsField(name, dataType, java.util.Map.of(), true, EsField.TimeSeriesFieldType.NONE);
+            EsField field = new EsField(name, dataType, Map.of(), true, EsField.TimeSeriesFieldType.NONE);
             attributes.add(new FieldAttribute(Source.EMPTY, name, field));
         }
         return attributes;
@@ -423,6 +424,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final DateTimeFormatter datetimeFormatter;
         private final boolean bracketMultiValues;
         private static final int MAX_WARNINGS = 20;
+        // TODO: propagate warnings to the query response (similar to deprecation warnings in search)
+        // when the compute framework supports it. For now, warnings are collected here and a summary
+        // is logged at INFO level in close().
         private final List<String> warnings = new ArrayList<>();
         private List<Attribute> schema;
         private int[] projectedIdx;
@@ -579,7 +583,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 for (int i = 0; i < columnCount; i++) {
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
-                        org.elasticsearch.compute.data.ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
+                        ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
                         rows.size()
                     );
                 }
@@ -667,10 +671,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private List<String> splitBracketContent(String content) {
             List<String> result = new ArrayList<>();
             StringBuilder current = new StringBuilder();
+            char esc = options.escapeChar();
             int i = 0;
             while (i < content.length()) {
                 char c = content.charAt(i);
-                if (c == '\\' && i + 1 < content.length() && content.charAt(i + 1) == ',') {
+                if (c == esc && i + 1 < content.length() && content.charAt(i + 1) == ',') {
                     current.append(',');
                     i += 2;
                 } else if (c == ',') {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -781,7 +781,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -806,7 +807,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -847,7 +849,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -878,7 +881,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -902,7 +906,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -926,7 +931,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -959,7 +965,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -990,7 +997,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1016,7 +1024,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             "N/A",
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1040,7 +1049,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             "\\N",
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1172,7 +1182,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             formatter,
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1230,6 +1241,349 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertSame(reader, result);
     }
 
+    public void testWithConfigMultiValueSyntax() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[1,2,3]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader configured = baseReader.withConfig(Map.of("multi_value_syntax", "brackets"));
+
+        try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(3, valuesBlock.getValueCount(0));
+            assertEquals(1, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(2, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 1));
+            assertEquals(3, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 2));
+        }
+    }
+
+    // --- Multi-value bracket syntax tests ---
+
+    public void testMultiValueBracketsInteger() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[1,2,3]\"\n2,\"[10,20]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(3, valuesBlock.getValueCount(0));
+            assertEquals(1, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(2, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 1));
+            assertEquals(3, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 2));
+            assertEquals(2, valuesBlock.getValueCount(1));
+            assertEquals(10, valuesBlock.getInt(valuesBlock.getFirstValueIndex(1)));
+            assertEquals(20, valuesBlock.getInt(valuesBlock.getFirstValueIndex(1) + 1));
+        }
+    }
+
+    public void testMultiValueBracketsKeyword() throws IOException {
+        String csv = "id:integer,tags:keyword\n1,\"[hello,world]\"\n2,\"[foo,bar,baz]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            BytesRefBlock valuesBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(new BytesRef("hello"), valuesBlock.getBytesRef(valuesBlock.getFirstValueIndex(0), new BytesRef()));
+            assertEquals(new BytesRef("world"), valuesBlock.getBytesRef(valuesBlock.getFirstValueIndex(0) + 1, new BytesRef()));
+            assertEquals(3, valuesBlock.getValueCount(1));
+        }
+    }
+
+    public void testMultiValueBracketsBoolean() throws IOException {
+        String csv = "id:integer,flags:boolean\n1,\"[true,false]\"\n2,\"[false]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            BooleanBlock valuesBlock = (BooleanBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertTrue(valuesBlock.getBoolean(valuesBlock.getFirstValueIndex(0)));
+            assertFalse(valuesBlock.getBoolean(valuesBlock.getFirstValueIndex(0) + 1));
+            assertEquals(1, valuesBlock.getValueCount(1));
+            assertFalse(valuesBlock.getBoolean(valuesBlock.getFirstValueIndex(1)));
+        }
+    }
+
+    public void testMultiValueBracketsDouble() throws IOException {
+        String csv = "id:integer,scores:double\n1,\"[1.5,-2.3]\"\n2,\"[0.0,3.14]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            DoubleBlock valuesBlock = (DoubleBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(1.5, valuesBlock.getDouble(valuesBlock.getFirstValueIndex(0)), 0.001);
+            assertEquals(-2.3, valuesBlock.getDouble(valuesBlock.getFirstValueIndex(0) + 1), 0.001);
+        }
+    }
+
+    public void testMultiValueBracketsDatetime() throws IOException {
+        String csv = "id:integer,ts:datetime\n1,\"[2024-01-01T00:00:00Z,2024-06-15T12:00:00Z]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            LongBlock tsBlock = (LongBlock) page.getBlock(1);
+            assertEquals(2, tsBlock.getValueCount(0));
+            assertEquals(Instant.parse("2024-01-01T00:00:00Z").toEpochMilli(), tsBlock.getLong(tsBlock.getFirstValueIndex(0)));
+            assertEquals(Instant.parse("2024-06-15T12:00:00Z").toEpochMilli(), tsBlock.getLong(tsBlock.getFirstValueIndex(0) + 1));
+        }
+    }
+
+    public void testMultiValueEmptyBrackets() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[]\"\n2,\"[1,2]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertTrue(valuesBlock.isNull(0));
+            assertEquals(2, valuesBlock.getValueCount(1));
+        }
+    }
+
+    public void testMultiValueSingleElement() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[42]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(1, valuesBlock.getValueCount(0));
+            assertEquals(42, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+        }
+    }
+
+    public void testMultiValueEscapedComma() throws IOException {
+        // Uses pipe to avoid Jackson escaping - tests multi-element split on comma
+        String csv = "id:integer,data:keyword\n1,\"[a|b,c]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            BytesRefBlock dataBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(2, dataBlock.getValueCount(0));
+            assertEquals(new BytesRef("a|b"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0), new BytesRef()));
+            assertEquals(new BytesRef("c"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0) + 1, new BytesRef()));
+        }
+    }
+
+    public void testMultiValueDisabledByDefault() {
+        String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("Failed to parse CSV value"));
+    }
+
+    public void testMultiValueMixedWithScalar() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[1,2]\"\n2,42\n3,\"[10,20,30]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(1, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(2, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 1));
+            assertEquals(1, valuesBlock.getValueCount(1));
+            assertEquals(42, valuesBlock.getInt(valuesBlock.getFirstValueIndex(1)));
+            assertEquals(3, valuesBlock.getValueCount(2));
+            assertEquals(10, valuesBlock.getInt(valuesBlock.getFirstValueIndex(2)));
+        }
+    }
+
+    public void testMultiValueWithErrorPolicyNullField() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[1,bad,3]\"\n2,\"[10,20]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertTrue(valuesBlock.isNull(0));
+            assertEquals(2, valuesBlock.getValueCount(1));
+        }
+    }
+
+    public void testMultiValueWithErrorPolicySkipRow() throws IOException {
+        String csv = "id:integer,values:integer\n1,\"[1,bad,3]\"\n2,\"[10,20]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+        ErrorPolicy skipRow = new ErrorPolicy(10, true);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, skipRow)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(10, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(20, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 1));
+        }
+    }
+
     // --- Randomized Tests ---
 
     public void testRandomizedDelimiterColumnRowBatchCount() throws IOException {
@@ -1259,7 +1613,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.nullValue(),
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
-            CsvFormatOptions.DEFAULT.maxFieldSize()
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -1455,8 +1455,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
-    public void testMultiValueEscapedComma() throws IOException {
-        // Uses pipe to avoid Jackson escaping - tests multi-element split on comma
+    public void testMultiValuePipeSeparatedElements() throws IOException {
         String csv = "id:integer,data:keyword\n1,\"[a|b,c]\"\n";
         CsvFormatOptions options = new CsvFormatOptions(
             ',',
@@ -1479,6 +1478,33 @@ public class CsvFormatReaderTests extends ESTestCase {
             BytesRefBlock dataBlock = (BytesRefBlock) page.getBlock(1);
             assertEquals(2, dataBlock.getValueCount(0));
             assertEquals(new BytesRef("a|b"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0), new BytesRef()));
+            assertEquals(new BytesRef("c"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0) + 1, new BytesRef()));
+        }
+    }
+
+    public void testMultiValueEscapedComma() throws IOException {
+        String csv = "id:integer,data:keyword\n1,\"[a\\\\,b,c]\"\n";
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.BRACKETS
+        );
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            BytesRefBlock dataBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(2, dataBlock.getValueCount(0));
+            assertEquals(new BytesRef("a,b"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0), new BytesRef()));
             assertEquals(new BytesRef("c"), dataBlock.getBytesRef(dataBlock.getFirstValueIndex(0) + 1, new BytesRef()));
         }
     }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -1259,6 +1259,22 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    public void testWithConfigMultiValueSyntaxNone() {
+        String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader configured = baseReader.withConfig(Map.of("multi_value_syntax", "none"));
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("Failed to parse CSV value"));
+    }
+
     // --- Multi-value bracket syntax tests ---
 
     public void testMultiValueBracketsInteger() throws IOException {
@@ -1509,10 +1525,37 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
-    public void testMultiValueDisabledByDefault() {
+    public void testMultiValueEnabledByDefault() throws IOException {
         String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock valuesBlock = (IntBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(1, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(2, valuesBlock.getInt(valuesBlock.getFirstValueIndex(0) + 1));
+        }
+    }
+
+    public void testMultiValueExplicitlyDisabled() {
+        String csv = "id:integer,values:integer\n1,\"[1,2]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatOptions options = new CsvFormatOptions(
+            ',',
+            CsvFormatOptions.DEFAULT.quoteChar(),
+            CsvFormatOptions.DEFAULT.escapeChar(),
+            CsvFormatOptions.DEFAULT.commentPrefix(),
+            CsvFormatOptions.DEFAULT.nullValue(),
+            CsvFormatOptions.DEFAULT.encoding(),
+            CsvFormatOptions.DEFAULT.datetimeFormatter(),
+            CsvFormatOptions.DEFAULT.maxFieldSize(),
+            CsvFormatOptions.MultiValueSyntax.NONE
+        );
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
 
         EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -1567,6 +1567,41 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertTrue(e.getMessage().contains("Failed to parse CSV value"));
     }
 
+    public void testMultiValueBracketsQuotedStrings() throws IOException {
+        String csv = "id:integer,names:keyword\n1,\"[\"\"foo\"\",\"\"bar\"\"]\"\n2,\"[\"\"hello world\"\",\"\"test\"\"]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            BytesRefBlock namesBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(2, namesBlock.getValueCount(0));
+            assertEquals(new BytesRef("\"foo\""), namesBlock.getBytesRef(namesBlock.getFirstValueIndex(0), new BytesRef()));
+            assertEquals(new BytesRef("\"bar\""), namesBlock.getBytesRef(namesBlock.getFirstValueIndex(0) + 1, new BytesRef()));
+            assertEquals(2, namesBlock.getValueCount(1));
+            assertEquals(new BytesRef("\"hello world\""), namesBlock.getBytesRef(namesBlock.getFirstValueIndex(1), new BytesRef()));
+            assertEquals(new BytesRef("\"test\""), namesBlock.getBytesRef(namesBlock.getFirstValueIndex(1) + 1, new BytesRef()));
+        }
+    }
+
+    public void testMultiValueBracketsLong() throws IOException {
+        String csv = "id:integer,values:long\n1,\"[100000000000,200000000000]\"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            LongBlock valuesBlock = (LongBlock) page.getBlock(1);
+            assertEquals(2, valuesBlock.getValueCount(0));
+            assertEquals(100000000000L, valuesBlock.getLong(valuesBlock.getFirstValueIndex(0)));
+            assertEquals(200000000000L, valuesBlock.getLong(valuesBlock.getFirstValueIndex(0) + 1));
+        }
+    }
+
     public void testMultiValueMixedWithScalar() throws IOException {
         String csv = "id:integer,values:integer\n1,\"[1,2]\"\n2,42\n3,\"[10,20,30]\"\n";
         CsvFormatOptions options = new CsvFormatOptions(
@@ -1825,6 +1860,81 @@ public class CsvFormatReaderTests extends ESTestCase {
         System.arraycopy(suffix, 0, data, padding.length, suffix.length);
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         assertEquals(padding.length + 2, boundary);
+    }
+
+    // --- Warning tests ---
+
+    public void testWarningsIncludeRowNumber() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            bad_id,Bob
+            3,Charlie
+            bad_id2,Dan
+            5,Eve
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, true);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, lenient)) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+            List<String> warnings = CsvFormatReader.getWarnings(iterator);
+            assertEquals(2, warnings.size());
+            assertTrue("Warning should include row number, got: " + warnings.get(0), warnings.get(0).startsWith("Row [2]"));
+            assertTrue("Warning should include row number, got: " + warnings.get(1), warnings.get(1).startsWith("Row [4]"));
+        }
+    }
+
+    public void testWarningsIncludeFieldNameInPermissiveMode() throws IOException {
+        String csv = """
+            id:long,score:double
+            1,95.5
+            bad_id,not_double
+            3,80.0
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10, permissive)) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+            List<String> warnings = CsvFormatReader.getWarnings(iterator);
+            assertEquals(2, warnings.size());
+            assertTrue("Warning should include field name, got: " + warnings.get(0), warnings.get(0).contains("field [id]"));
+            assertTrue("Warning should include field name, got: " + warnings.get(1), warnings.get(1).contains("field [score]"));
+            assertTrue("Warning should include row number, got: " + warnings.get(0), warnings.get(0).contains("Row [2]"));
+        }
+    }
+
+    public void testWarningsOverflowMessage() throws IOException {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 1; i <= 30; i++) {
+            csv.append("bad").append(i).append(",Name").append(i).append("\n");
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, false);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 50, lenient)) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+            List<String> warnings = CsvFormatReader.getWarnings(iterator);
+            assertEquals(21, warnings.size());
+            assertTrue("First warning should have row number, got: " + warnings.get(0), warnings.get(0).startsWith("Row [1]"));
+            assertTrue(
+                "Last warning should note suppression, got: " + warnings.get(20),
+                warnings.get(20).contains("further warnings suppressed")
+            );
+        }
     }
 
     private StorageObject createStorageObject(String csvContent) {


### PR DESCRIPTION
Add bracket-based multi-value support (`[a,b,c]`) for CSV fields, enabled
by default via `multi_value_syntax` (values: `brackets`, `none`).

When enabled, values wrapped in brackets are split on commas (respecting
escaped commas via the configured escape character) and each element is
parsed per the declared column type, producing native ESQL multi-value
blocks. Empty brackets `[]` map to null. Scalar and multi-value fields
can be mixed freely within the same column.

Also adds error summary logging at `close()` for non-FAIL_FAST policies
to address the review feedback from #143779 — users see an INFO-level
summary instead of having to check individual WARN log lines.

```
EXTERNAL "s3://bucket/employees.csv"
EXTERNAL "s3://bucket/data.csv" WITH {"multi_value_syntax": "none"}
EXTERNAL "s3://bucket/data.csv" WITH {"multi_value_syntax": "brackets", "error_mode": "skip_row"}
```

Follows the convention used by ClickHouse (`Array()` notation) and the
existing ESQL test CSV framework (`CsvTestUtils`).