### PR TITLE
ESQL: Fix review feedback and add test coverage for PR #143703

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ParallelParsingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ParallelParsingBenchmark.java
@@ -49,6 +49,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -91,7 +92,7 @@ public class ParallelParsingBenchmark {
     public void setup() {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {
-            sb.append("line-").append(String.format("%08d", i)).append(",value-").append(i % 1000).append("\n");
+            sb.append("line-").append(String.format(Locale.ROOT, "%08d", i)).append(",value-").append(i % 1000).append("\n");
         }
         fileData = sb.toString().getBytes(StandardCharsets.UTF_8);
         executor = Executors.newFixedThreadPool(Math.max(parallelism, 1));

--- a/docs/changelog/143900.yaml
+++ b/docs/changelog/143900.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143900
+summary: "Fix review feedback and add test coverage for PR #143703"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1333,6 +1334,73 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         }
         assertEquals(numRows, totalRows);
+    }
+
+    // --- findNextRecordBoundary tests ---
+
+    public void testFindNextRecordBoundarySimpleNewline() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "field1,field2\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryCRLF() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "field1,field2\r\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals("field1,field2\r\n".indexOf('\n') + 1, boundary);
+    }
+
+    public void testFindNextRecordBoundaryNewlineInsideQuotes() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "\"field\nwith\nnewlines\",other\nreal_boundary\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        int expected = "\"field\nwith\nnewlines\",other\n".length();
+        assertEquals(expected, boundary);
+    }
+
+    public void testFindNextRecordBoundaryEscapedQuotes() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "\"value with \"\"escaped\"\" quotes\"\nrest\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        int expected = "\"value with \"\"escaped\"\" quotes\"\n".length();
+        assertEquals(expected, boundary);
+    }
+
+    public void testFindNextRecordBoundaryEofNoNewline() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "field1,field2".getBytes(StandardCharsets.UTF_8);
+        assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryEmptyStream() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
+    }
+
+    public void testFindNextRecordBoundaryAtBufferBoundary() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] padding = new byte[8191];
+        Arrays.fill(padding, (byte) 'x');
+        byte[] suffix = "\nmore\n".getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[padding.length + suffix.length];
+        System.arraycopy(padding, 0, data, 0, padding.length);
+        System.arraycopy(suffix, 0, data, padding.length, suffix.length);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals(8192, boundary);
+    }
+
+    public void testFindNextRecordBoundaryQuoteAtBufferEdge() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] padding = new byte[8191];
+        Arrays.fill(padding, (byte) 'a');
+        padding[0] = (byte) '"';
+        byte[] suffix = "\"\nrest\n".getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[padding.length + suffix.length];
+        System.arraycopy(padding, 0, data, 0, padding.length);
+        System.arraycopy(suffix, 0, data, padding.length, suffix.length);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals(padding.length + 2, boundary);
     }
 
     private StorageObject createStorageObject(String csvContent) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -23,9 +23,12 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.hamcrest.Matchers;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class NdJsonPageIteratorTests extends ESTestCase {
@@ -178,6 +181,50 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 assertEquals(3, page.getPositionCount());
             }
         }
+    }
+
+    // --- findNextRecordBoundary tests ---
+
+    public void testFindNextRecordBoundaryNewline() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        byte[] data = "{\"key\":\"value\"}\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryCRLF() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        byte[] data = "{\"key\":\"value\"}\r\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(data.length, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryCROnly() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        byte[] data = "{\"key\":\"value\"}\rmore".getBytes(StandardCharsets.UTF_8);
+        int expected = "{\"key\":\"value\"}\r".length();
+        assertEquals(expected, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryCRLFAtBufferEdge() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        byte[] padding = new byte[8191];
+        Arrays.fill(padding, (byte) 'x');
+        byte[] suffix = "\r\nmore\n".getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[padding.length + suffix.length];
+        System.arraycopy(padding, 0, data, 0, padding.length);
+        System.arraycopy(suffix, 0, data, padding.length, suffix.length);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals(8193, boundary);
+    }
+
+    public void testFindNextRecordBoundaryEofNoNewline() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        byte[] data = "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+        assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(data)));
+    }
+
+    public void testFindNextRecordBoundaryEmptyStream() throws IOException {
+        var reader = new NdJsonFormatReader(blockFactory);
+        assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
     }
 
     private int blockIdx(SourceMetadata meta, String name) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
@@ -114,6 +114,59 @@ public class RangeStorageObjectTests extends ESTestCase {
         assertEquals(0, buf.position());
     }
 
+    public void testReadBytesNonZeroPosition() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        ByteBuffer buf = ByteBuffer.allocate(4);
+        int bytesRead = range.readBytes(2, buf);
+        assertEquals(4, bytesRead);
+        buf.flip();
+        byte[] result = new byte[4];
+        buf.get(result);
+        assertEquals("rld!", new String(result, StandardCharsets.UTF_8));
+    }
+
+    public void testReadBytesBufferLargerThanRemaining() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        ByteBuffer buf = ByteBuffer.allocate(20);
+        int bytesRead = range.readBytes(0, buf);
+        assertTrue("Should read some bytes", bytesRead > 0);
+        buf.flip();
+        byte[] result = new byte[bytesRead];
+        buf.get(result);
+        String read = new String(result, StandardCharsets.UTF_8);
+        assertTrue("Should start with 'World!'", read.startsWith("World!"));
+    }
+
+    public void testReadBytesBufferExactSize() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        ByteBuffer buf = ByteBuffer.allocate(3);
+        int bytesRead = range.readBytes(0, buf);
+        assertEquals(3, bytesRead);
+        buf.flip();
+        byte[] result = new byte[3];
+        buf.get(result);
+        assertEquals("Wor", new String(result, StandardCharsets.UTF_8));
+    }
+
+    public void testReadBytesPartialReadFromMiddle() throws IOException {
+        StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        ByteBuffer buf = ByteBuffer.allocate(2);
+        int bytesRead = range.readBytes(4, buf);
+        assertEquals(2, bytesRead);
+        buf.flip();
+        byte[] result = new byte[2];
+        buf.get(result);
+        assertEquals("d!", new String(result, StandardCharsets.UTF_8));
+    }
+
     public void testNegativeOffsetThrows() {
         StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RangeStorageObject(delegate, -1, 10));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnBlockConversionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnBlockConversionsTests.java
@@ -152,6 +152,49 @@ public class ColumnBlockConversionsTests extends ESTestCase {
         }
     }
 
+    public void testIntColumnRepeatingNull() {
+        long[] values = { 0L };
+        boolean[] isNull = { true };
+        Block block = ColumnBlockConversions.intColumnFromLongs(blockFactory, values, 3, false, true, isNull);
+        try {
+            assertEquals(3, block.getPositionCount());
+            for (int i = 0; i < 3; i++) {
+                assertTrue(block.isNull(i));
+            }
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testIntColumnCopiesArray() {
+        long[] values = { 10L, 20L, 30L };
+        Block block = ColumnBlockConversions.intColumnFromLongs(blockFactory, values, 3, true, false, null);
+        try {
+            values[0] = 999L;
+            IntBlock ib = (IntBlock) block;
+            assertEquals(10, ib.getInt(0));
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testIntColumnLargerArrayThanRowCount() {
+        long[] values = new long[100];
+        for (int i = 0; i < 100; i++) {
+            values[i] = i;
+        }
+        Block block = ColumnBlockConversions.intColumnFromLongs(blockFactory, values, 10, true, false, null);
+        try {
+            assertEquals(10, block.getPositionCount());
+            IntBlock ib = (IntBlock) block;
+            for (int i = 0; i < 10; i++) {
+                assertEquals(i, ib.getInt(i));
+            }
+        } finally {
+            block.close();
+        }
+    }
+
     // --- doubleColumn ---
 
     public void testDoubleColumnNoNulls() {
@@ -255,6 +298,51 @@ public class ColumnBlockConversionsTests extends ESTestCase {
         }
     }
 
+    public void testBooleanColumnRepeatingNull() {
+        long[] values = { 0L };
+        boolean[] isNull = { true };
+        Block block = ColumnBlockConversions.booleanColumnFromLongs(blockFactory, values, 3, false, true, isNull);
+        try {
+            assertEquals(3, block.getPositionCount());
+            for (int i = 0; i < 3; i++) {
+                assertTrue(block.isNull(i));
+            }
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testBooleanColumnCopiesArray() {
+        long[] values = { 1L, 0L, 1L };
+        Block block = ColumnBlockConversions.booleanColumnFromLongs(blockFactory, values, 3, true, false, null);
+        try {
+            values[0] = 0L;
+            BooleanBlock bb = (BooleanBlock) block;
+            assertTrue(bb.getBoolean(0));
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testBooleanColumnLargerArrayThanRowCount() {
+        long[] values = new long[50];
+        for (int i = 0; i < 50; i++) {
+            values[i] = i % 2;
+        }
+        Block block = ColumnBlockConversions.booleanColumnFromLongs(blockFactory, values, 5, true, false, null);
+        try {
+            assertEquals(5, block.getPositionCount());
+            BooleanBlock bb = (BooleanBlock) block;
+            assertFalse(bb.getBoolean(0));
+            assertTrue(bb.getBoolean(1));
+            assertFalse(bb.getBoolean(2));
+            assertTrue(bb.getBoolean(3));
+            assertFalse(bb.getBoolean(4));
+        } finally {
+            block.close();
+        }
+    }
+
     // --- doubleColumnFromLongs ---
 
     public void testDoubleColumnFromLongsNoNulls() {
@@ -293,6 +381,49 @@ public class ColumnBlockConversionsTests extends ESTestCase {
             DoubleBlock db = (DoubleBlock) block;
             for (int i = 0; i < 3; i++) {
                 assertEquals(42.0, db.getDouble(db.getFirstValueIndex(i)), 0.0);
+            }
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testDoubleColumnFromLongsRepeatingNull() {
+        long[] values = { 0L };
+        boolean[] isNull = { true };
+        Block block = ColumnBlockConversions.doubleColumnFromLongs(blockFactory, values, 3, false, true, isNull);
+        try {
+            assertEquals(3, block.getPositionCount());
+            for (int i = 0; i < 3; i++) {
+                assertTrue(block.isNull(i));
+            }
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testDoubleColumnFromLongsCopiesArray() {
+        long[] values = { 10L, 20L, 30L };
+        Block block = ColumnBlockConversions.doubleColumnFromLongs(blockFactory, values, 3, true, false, null);
+        try {
+            values[0] = 999L;
+            DoubleBlock db = (DoubleBlock) block;
+            assertEquals(10.0, db.getDouble(0), 0.0);
+        } finally {
+            block.close();
+        }
+    }
+
+    public void testDoubleColumnFromLongsLargerArrayThanRowCount() {
+        long[] values = new long[100];
+        for (int i = 0; i < 100; i++) {
+            values[i] = i * 10;
+        }
+        Block block = ColumnBlockConversions.doubleColumnFromLongs(blockFactory, values, 5, true, false, null);
+        try {
+            assertEquals(5, block.getPositionCount());
+            DoubleBlock db = (DoubleBlock) block;
+            for (int i = 0; i < 5; i++) {
+                assertEquals((double) (i * 10), db.getDouble(i), 0.0);
             }
         } finally {
             block.close();


### PR DESCRIPTION
Address review feedback from bpintea on PR #143703 and close test
coverage gaps identified in the columnar I/O and parallel parsing
changes.

Fix `String.format` to use `Locale.ROOT` in `ParallelParsingBenchmark`
(bpintea review comment). Add dedicated unit tests for the
`findNextRecordBoundary` implementations in `CsvFormatReader` (RFC 4180
quote-aware boundary detection, escaped quotes, buffer edge cases) and
`NdJsonFormatReader` (newline, CRLF, CR-only, buffer split). Extend
`ColumnBlockConversionsTests` with parity edge cases for
`intColumnFromLongs`, `booleanColumnFromLongs`, and
`doubleColumnFromLongs` (repeating null, array copy independence, larger
array than row count). Add `RangeStorageObjectTests` scenarios for
`readBytes` with non-zero position, exact-size buffers, and partial
reads from the middle of a range.

Developed using AI-assisted tooling.