### PR TITLE
[ESQL] Add column pruning for external datasources

### DIFF
--- a/docs/changelog/143903.yaml
+++ b/docs/changelog/143903.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143903
+summary: Add column pruning for external datasources
+type: enhancement

--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightResultCursor.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightResultCursor.java
@@ -48,7 +48,7 @@ class FlightResultCursor implements ResultCursor {
         int rowCount = root.getRowCount();
         Block[] blocks = new Block[attributes.size()];
         for (int col = 0; col < attributes.size(); col++) {
-            blocks[col] = FlightTypeMapping.toBlock(root.getVector(col), rowCount, blockFactory);
+            blocks[col] = FlightTypeMapping.toBlock(root.getVector(attributes.get(col).name()), rowCount, blockFactory);
         }
         hasNextBatch = advance();
         return new Page(rowCount, blocks);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -83,6 +84,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                     case Eval eval -> pruneColumnsInEval(eval, used, recheck);
                     case Project project -> pruneColumnsInProject(project, used, recheck);
                     case EsRelation esr -> pruneColumnsInEsRelation(esr, used);
+                    case ExternalRelation ext -> pruneColumnsInExternalRelation(ext, used);
                     case Fork fork -> {
                         forkPresent.set(true);
                         yield pruneColumnsInFork(fork, used);
@@ -208,6 +210,16 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
         }
 
         return p;
+    }
+
+    /**
+     * Prunes unused columns from an {@link ExternalRelation}.
+     * Unlike {@link EsRelation} (where {@code InsertFieldExtraction} handles field-level pruning for non-LOOKUP modes),
+     * the attribute list on an external relation directly controls which columns the format reader loads from storage.
+     */
+    private static LogicalPlan pruneColumnsInExternalRelation(ExternalRelation ext, AttributeSet.Builder used) {
+        var remaining = pruneUnusedAndAddReferences(ext.output(), used);
+        return remaining != null ? ext.withAttributes(remaining) : ext;
     }
 
     // TODO: see ResolveUnmapped#patchFork comment

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
@@ -13,14 +13,19 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
@@ -37,6 +42,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -2420,6 +2426,110 @@ public class PruneColumnsTests extends AbstractLogicalPlanOptimizerTests {
         );
         var limit = as(dissect.child(), Limit.class);
         as(limit.child(), LocalRelation.class);
+    }
+
+    // === ExternalRelation pruning tests ===
+
+    public void testPruneColumnsInExternalRelation() {
+        Attribute colA = extAttr("col_a", KEYWORD);
+        Attribute colB = extAttr("col_b", LONG);
+        Attribute colC = extAttr("col_c", INTEGER);
+        ExternalRelation ext = externalRelation(List.of(colA, colB, colC));
+
+        // Project only col_a — col_b and col_c should be pruned
+        LogicalPlan plan = new Project(EMPTY, ext, List.of(colA));
+        LogicalPlan result = new PruneColumns().apply(plan);
+
+        var project = as(result, Project.class);
+        var prunedExt = as(project.child(), ExternalRelation.class);
+        assertThat(prunedExt.output(), hasSize(1));
+        assertThat(Expressions.names(prunedExt.output()), contains("col_a"));
+    }
+
+    public void testNoPruningWhenAllColumnsUsedInExternalRelation() {
+        Attribute colA = extAttr("col_a", KEYWORD);
+        Attribute colB = extAttr("col_b", LONG);
+        ExternalRelation ext = externalRelation(List.of(colA, colB));
+
+        // Project all columns — nothing should be pruned
+        LogicalPlan plan = new Project(EMPTY, ext, List.of(colA, colB));
+        LogicalPlan result = new PruneColumns().apply(plan);
+
+        var project = as(result, Project.class);
+        var prunedExt = as(project.child(), ExternalRelation.class);
+        assertThat(prunedExt.output(), hasSize(2));
+        assertThat(Expressions.names(prunedExt.output()), contains("col_a", "col_b"));
+    }
+
+    public void testPruneColumnsInExternalRelationThroughEval() {
+        Attribute colA = extAttr("col_a", LONG);
+        Attribute colB = extAttr("col_b", LONG);
+        ExternalRelation ext = externalRelation(List.of(colA, colB));
+
+        // Eval references col_a, Project keeps only the computed field — col_b should be pruned
+        Alias computed = new Alias(EMPTY, "computed", colA);
+        Eval eval = new Eval(EMPTY, ext, List.of(computed));
+        LogicalPlan plan = new Project(EMPTY, eval, List.of(computed.toAttribute()));
+        LogicalPlan result = new PruneColumns().apply(plan);
+
+        var project = as(result, Project.class);
+        var resultEval = as(project.child(), Eval.class);
+        var prunedExt = as(resultEval.child(), ExternalRelation.class);
+        assertThat(prunedExt.output(), hasSize(1));
+        assertThat(Expressions.names(prunedExt.output()), contains("col_a"));
+    }
+
+    public void testPruneColumnsInExternalRelationWithFilter() {
+        Attribute colA = extAttr("col_a", KEYWORD);
+        Attribute colB = extAttr("col_b", LONG);
+        Attribute colC = extAttr("col_c", INTEGER);
+        ExternalRelation ext = externalRelation(List.of(colA, colB, colC));
+
+        // Filter references col_b, Project keeps col_a — both col_a and col_b should be retained, col_c pruned
+        var condition = new GreaterThan(EMPTY, colB, new Literal(EMPTY, 10L, LONG), null);
+        Filter filter = new Filter(EMPTY, ext, condition);
+        LogicalPlan plan = new Project(EMPTY, filter, List.of(colA));
+        LogicalPlan result = new PruneColumns().apply(plan);
+
+        var project = as(result, Project.class);
+        var resultFilter = as(project.child(), Filter.class);
+        var prunedExt = as(resultFilter.child(), ExternalRelation.class);
+        assertThat(prunedExt.output(), hasSize(2));
+        assertThat(Expressions.names(prunedExt.output()), contains("col_a", "col_b"));
+    }
+
+    private static Attribute extAttr(String name, DataType type) {
+        return new FieldAttribute(EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static ExternalRelation externalRelation(List<Attribute> attributes) {
+        SourceMetadata metadata = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return attributes;
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "s3://bucket/data.parquet";
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                return o instanceof SourceMetadata;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+        return new ExternalRelation(EMPTY, "s3://bucket/data.parquet", metadata, attributes);
     }
 
 }


### PR DESCRIPTION
The `PruneColumns` optimizer rule did not handle `ExternalRelation`, so the attribute list was never narrowed. Every query read all columns from storage even when only a few were needed.

For columnar formats (Parquet, ORC) this means unnecessary disk I/O — skipping unneeded columns can reduce reads by 5-20x on wide schemas. For row-oriented formats (CSV, NDJSON) it avoids materializing unwanted columns into blocks, saving memory.

The plumbing from `ExternalSourceExec.attributes` through `LocalExecutionPlanner` to `FormatReader.read(projectedColumns)` already works — the gap was purely in the optimizer. This adds an `ExternalRelation` case to `PruneColumns` that uses `withAttributes()` to narrow the output to only the columns referenced downstream.

Developed using AI-assisted tooling.