### PR TITLE
[ESQL] Register TSV as a separate format with tab delimiter

### DIFF
--- a/docs/changelog/143906.yaml
+++ b/docs/changelog/143906.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143906
+summary: Register TSV as a separate format with tab delimiter
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
@@ -11,22 +11,25 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Data source plugin that provides CSV format support for ESQL external data sources.
+ * Data source plugin that provides CSV and TSV format support for ESQL external data sources.
  *
- * <p>This plugin provides:
+ * <p>This plugin registers two format readers:
  * <ul>
- *   <li>CSV format reader for reading CSV files from any storage provider</li>
+ *   <li>{@code csv} — comma-delimited ({@code .csv} files)</li>
+ *   <li>{@code tsv} — tab-delimited ({@code .tsv} files)</li>
  * </ul>
  *
- * <p>The CSV format reader uses Jackson's CSV parser for robust CSV parsing with
- * proper quote and escape handling. It supports:
+ * <p>Both readers use Jackson's CSV parser for robust parsing with
+ * proper quote and escape handling. They support:
  * <ul>
- *   <li>Schema discovery from CSV file headers (column_name:type_name format)</li>
+ *   <li>Schema discovery from file headers (column_name:type_name format)</li>
  *   <li>Column projection for efficient reads</li>
  *   <li>Batch reading with configurable batch sizes</li>
  *   <li>Direct conversion to ESQL Page format</li>
@@ -38,17 +41,17 @@ import java.util.Set;
 public class CsvDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     @Override
-    public Set<String> supportedFormats() {
-        return Set.of("csv");
-    }
-
-    @Override
-    public Set<String> supportedExtensions() {
-        return Set.of(".csv", ".tsv");
+    public Set<FormatSpec> formatSpecs() {
+        return Set.of(FormatSpec.of("csv", ".csv"), FormatSpec.of("tsv", ".tsv"));
     }
 
     @Override
     public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
-        return Map.of("csv", (s, blockFactory) -> new CsvFormatReader(blockFactory));
+        return Map.of(
+            "csv",
+            (s, blockFactory) -> new CsvFormatReader(blockFactory, "csv", List.of(".csv")),
+            "tsv",
+            (s, blockFactory) -> new CsvFormatReader(blockFactory, CsvFormatOptions.TSV, "tsv", List.of(".tsv"))
+        );
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -133,14 +133,22 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private final CsvMapper sharedCsvMapper;
 
     private final CsvFormatOptions options;
+    private final String format;
+    private final List<String> extensions;
 
     public CsvFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, CsvFormatOptions.DEFAULT);
+        this(blockFactory, CsvFormatOptions.DEFAULT, "csv", List.of(".csv", ".tsv"));
     }
 
-    private CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options) {
+    public CsvFormatReader(BlockFactory blockFactory, String format, List<String> extensions) {
+        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions);
+    }
+
+    public CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options, String format, List<String> extensions) {
         this.blockFactory = blockFactory;
         this.options = options;
+        this.format = format;
+        this.extensions = extensions;
         this.sharedCsvMapper = createMapper(options);
     }
 
@@ -248,7 +256,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * Returns a new CsvFormatReader configured with the given options.
      */
     public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
-        return new CsvFormatReader(blockFactory, newOptions);
+        return new CsvFormatReader(blockFactory, newOptions, format, extensions);
     }
 
     @Override
@@ -396,12 +404,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     @Override
     public String formatName() {
-        return "csv";
+        return format;
     }
 
     @Override
     public List<String> fileExtensions() {
-        return List.of(".csv", ".tsv");
+        return extensions;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDataSourcePlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
 import java.util.Map;
 import java.util.Set;
@@ -25,13 +26,8 @@ import java.util.Set;
 public class NdJsonDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     @Override
-    public Set<String> supportedFormats() {
-        return Set.of("ndjson");
-    }
-
-    @Override
-    public Set<String> supportedExtensions() {
-        return Set.of(".ndjson", ".jsonl", ".json");
+    public Set<FormatSpec> formatSpecs() {
+        return Set.of(new FormatSpec("ndjson", Set.of(".ndjson", ".jsonl", ".json")));
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
 import java.util.Map;
 import java.util.Set;
@@ -28,13 +29,8 @@ import java.util.Set;
 public class OrcDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     @Override
-    public Set<String> supportedFormats() {
-        return Set.of("orc");
-    }
-
-    @Override
-    public Set<String> supportedExtensions() {
-        return Set.of(".orc");
+    public Set<FormatSpec> formatSpecs() {
+        return Set.of(FormatSpec.of("orc", ".orc"));
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
 import java.util.Map;
 import java.util.Set;
@@ -38,13 +39,8 @@ import java.util.Set;
 public class ParquetDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     @Override
-    public Set<String> supportedFormats() {
-        return Set.of("parquet");
-    }
-
-    @Override
-    public Set<String> supportedExtensions() {
-        return Set.of(".parquet");
+    public Set<FormatSpec> formatSpecs() {
+        return Set.of(FormatSpec.of("parquet", ".parquet"));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceCapabilities.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -61,19 +62,19 @@ public record DataSourceCapabilities(Set<String> schemes, Set<String> formats, S
             for (String scheme : plugin.supportedConnectorSchemes()) {
                 allSchemes.add(scheme.toLowerCase(Locale.ROOT));
             }
-            for (String format : plugin.supportedFormats()) {
-                String lower = format.toLowerCase(Locale.ROOT);
+            for (FormatSpec spec : plugin.formatSpecs()) {
+                String lower = spec.format().toLowerCase(Locale.ROOT);
                 if (allFormats.contains(lower)) {
-                    throw new IllegalArgumentException("Format reader for [" + format + "] is already registered");
+                    throw new IllegalArgumentException("Format reader for [" + spec.format() + "] is already registered");
                 }
                 allFormats.add(lower);
-            }
-            for (String ext : plugin.supportedExtensions()) {
-                String normalized = ext.toLowerCase(Locale.ROOT);
-                if (normalized.startsWith(".") == false) {
-                    normalized = "." + normalized;
+                for (String ext : spec.extensions()) {
+                    String normalized = ext.toLowerCase(Locale.ROOT);
+                    if (normalized.startsWith(".") == false) {
+                        normalized = "." + normalized;
+                    }
+                    allExtensions.add(normalized);
                 }
-                allExtensions.add(normalized);
             }
             for (String catalog : plugin.supportedCatalogs()) {
                 String lower = catalog.toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -124,8 +125,10 @@ public final class DataSourceModule implements Closeable {
                 storageProviderRegistry.registerFactory(scheme, delegating);
             }
 
-            // Format readers: register a delegating factory per declared format
-            for (String format : plugin.supportedFormats()) {
+            // Format readers: register a delegating factory per declared format,
+            // and pre-register extensions so hasExtension() works without triggering lazy init.
+            for (FormatSpec spec : plugin.formatSpecs()) {
+                String format = spec.format();
                 FormatReaderFactory delegating = (s, bf) -> {
                     Map<String, FormatReaderFactory> factories = state.formatFactories();
                     FormatReaderFactory real = factories.get(format);
@@ -141,25 +144,7 @@ public final class DataSourceModule implements Closeable {
                     return real.create(s, bf);
                 };
                 formatReaderRegistry.registerLazy(format, delegating, settings, blockFactory);
-            }
-
-            // Pre-register extensions from capabilities so hasExtension() works without triggering lazy init.
-            // Each extension maps to a single format; cross-product with multiple formats is not supported.
-            Set<String> pluginFormats = plugin.supportedFormats();
-            Set<String> pluginExtensions = plugin.supportedExtensions();
-            if (pluginFormats.size() > 1 && pluginExtensions.isEmpty() == false) {
-                throw new IllegalArgumentException(
-                    "Plugin "
-                        + plugin.getClass().getName()
-                        + " declares multiple formats "
-                        + pluginFormats
-                        + " with extensions "
-                        + pluginExtensions
-                        + "; each plugin must declare at most one format when extensions are present"
-                );
-            }
-            for (String ext : pluginExtensions) {
-                for (String format : pluginFormats) {
+                for (String ext : spec.extensions()) {
                     formatReaderRegistry.registerExtension(ext, format);
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourcePlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourcePlugin.java
@@ -56,17 +56,11 @@ public interface DataSourcePlugin {
     }
 
     /**
-     * Format names this plugin provides (e.g. "csv", "parquet").
-     * Keys must match {@link #formatReaders(Settings)} keys.
+     * Format descriptors this plugin provides. Each {@link FormatSpec} pairs a logical
+     * format name with the file extensions that select it. Format names must match
+     * the keys returned by {@link #formatReaders(Settings)}.
      */
-    default Set<String> supportedFormats() {
-        return Set.of();
-    }
-
-    /**
-     * File extensions this plugin's format readers handle (with leading dot, e.g. ".csv", ".parquet").
-     */
-    default Set<String> supportedExtensions() {
+    default Set<FormatSpec> formatSpecs() {
         return Set.of();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatSpec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatSpec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.util.Set;
+
+/**
+ * Describes a file format this plugin provides: a logical format name and the
+ * file extensions that select it.
+ *
+ * <p>The format name must match a key in the map returned by
+ * {@link DataSourcePlugin#formatReaders}. Multiple extensions may map to the
+ * same format (e.g. {@code .ndjson}, {@code .jsonl}, {@code .json} all select
+ * {@code "ndjson"}), but each extension should map to exactly one format across
+ * all plugins.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * Set.of(
+ *     new FormatSpec("csv",  Set.of(".csv")),
+ *     new FormatSpec("tsv",  Set.of(".tsv"))
+ * )
+ * }</pre>
+ *
+ * @param format     logical format name (e.g. "csv", "tsv", "parquet")
+ * @param extensions file extensions with leading dot (e.g. ".csv", ".parquet")
+ */
+public record FormatSpec(String format, Set<String> extensions) {
+
+    /**
+     * Convenience factory for the common single-extension case.
+     */
+    public static FormatSpec of(String format, String extension) {
+        return new FormatSpec(format, Set.of(extension));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleLazyLoadingTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -208,16 +209,11 @@ public class DataSourceModuleLazyLoadingTests extends ESTestCase {
         assertTrue("grpc should be in capabilities", capabilities.supportsScheme("grpc"));
     }
 
-    public void testMultiFormatWithExtensionsRejected() {
-        DataSourcePlugin badPlugin = new DataSourcePlugin() {
+    public void testMultiFormatWithExplicitExtensions() {
+        DataSourcePlugin multiPlugin = new DataSourcePlugin() {
             @Override
-            public Set<String> supportedFormats() {
-                return Set.of("fmt1", "fmt2");
-            }
-
-            @Override
-            public Set<String> supportedExtensions() {
-                return Set.of(".ext1");
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("fmt1", ".ext1"), FormatSpec.of("fmt2", ".ext2"));
             }
 
             @Override
@@ -226,19 +222,25 @@ public class DataSourceModuleLazyLoadingTests extends ESTestCase {
                     "fmt1",
                     (s, bf) -> new StubFormatReader("fmt1", List.of(".ext1")),
                     "fmt2",
-                    (s, bf) -> new StubFormatReader("fmt2", List.of(".ext1"))
+                    (s, bf) -> new StubFormatReader("fmt2", List.of(".ext2"))
                 );
             }
         };
 
-        List<DataSourcePlugin> plugins = List.of(badPlugin);
+        List<DataSourcePlugin> plugins = List.of(multiPlugin);
         DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
-
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> new DataSourceModule(plugins, capabilities, Settings.EMPTY, blockFactory, EsExecutors.DIRECT_EXECUTOR_SERVICE)
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
-        assertTrue(e.getMessage().contains("multiple formats"));
+
+        assertTrue("Should have fmt1 format", module.formatReaderRegistry().hasFormat("fmt1"));
+        assertTrue("Should have fmt2 format", module.formatReaderRegistry().hasFormat("fmt2"));
+        assertTrue("Should have .ext1 extension", module.formatReaderRegistry().hasExtension(".ext1"));
+        assertTrue("Should have .ext2 extension", module.formatReaderRegistry().hasExtension(".ext2"));
     }
 
     // ===== Spy plugin implementations =====
@@ -258,13 +260,8 @@ public class DataSourceModuleLazyLoadingTests extends ESTestCase {
 
     private static class SpyFormatPlugin implements DataSourcePlugin {
         @Override
-        public Set<String> supportedFormats() {
-            return Set.of("spy");
-        }
-
-        @Override
-        public Set<String> supportedExtensions() {
-            return Set.of(".spy");
+        public Set<FormatSpec> formatSpecs() {
+            return Set.of(FormatSpec.of("spy", ".spy"));
         }
 
         @Override
@@ -276,13 +273,8 @@ public class DataSourceModuleLazyLoadingTests extends ESTestCase {
 
     private static class OtherFormatPlugin implements DataSourcePlugin {
         @Override
-        public Set<String> supportedFormats() {
-            return Set.of("other");
-        }
-
-        @Override
-        public Set<String> supportedExtensions() {
-            return Set.of(".other");
+        public Set<FormatSpec> formatSpecs() {
+            return Set.of(FormatSpec.of("other", ".other"));
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.datasource.gzip.GzipDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -60,13 +61,8 @@ public class DataSourceModuleTests extends ESTestCase {
         }
 
         @Override
-        public Set<String> supportedFormats() {
-            return Set.of("csv");
-        }
-
-        @Override
-        public Set<String> supportedExtensions() {
-            return Set.of(".csv", ".tsv");
+        public Set<FormatSpec> formatSpecs() {
+            return Set.of(FormatSpec.of("csv", ".csv"), FormatSpec.of("tsv", ".tsv"));
         }
 
         @Override
@@ -76,7 +72,7 @@ public class DataSourceModuleTests extends ESTestCase {
 
         @Override
         public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
-            return Map.of("csv", (s, bf) -> new MockCsvFormatReader());
+            return Map.of("csv", (s, bf) -> new MockCsvFormatReader("csv", List.of(".csv")), "tsv", (s, bf) -> new MockTsvFormatReader());
         }
     }
 
@@ -119,10 +115,17 @@ public class DataSourceModuleTests extends ESTestCase {
     }
 
     /**
-     * Mock CSV format reader for testing. Reports same format name and extensions
-     * as the real CsvFormatReader.
+     * Mock CSV format reader for testing.
      */
     private static class MockCsvFormatReader implements FormatReader {
+        private final String format;
+        private final List<String> extensions;
+
+        MockCsvFormatReader(String format, List<String> extensions) {
+            this.format = format;
+            this.extensions = extensions;
+        }
+
         @Override
         public SourceMetadata metadata(StorageObject object) {
             throw new UnsupportedOperationException("Mock reader");
@@ -135,12 +138,40 @@ public class DataSourceModuleTests extends ESTestCase {
 
         @Override
         public String formatName() {
-            return "csv";
+            return format;
         }
 
         @Override
         public List<String> fileExtensions() {
-            return List.of(".csv", ".tsv");
+            return extensions;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Mock TSV format reader for testing.
+     */
+    private static class MockTsvFormatReader implements FormatReader {
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            throw new UnsupportedOperationException("Mock reader");
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize) {
+            throw new UnsupportedOperationException("Mock reader");
+        }
+
+        @Override
+        public String formatName() {
+            return "tsv";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".tsv");
         }
 
         @Override
@@ -207,10 +238,17 @@ public class DataSourceModuleTests extends ESTestCase {
         assertNotNull("CSV reader should be found by .csv extension", csvByExtension);
         assertTrue("CSV reader by extension should be MockCsvFormatReader", csvByExtension instanceof MockCsvFormatReader);
 
-        // Verify TSV extension also works (CSV reader handles TSV)
-        assertTrue("CSV reader should be registered for .tsv extension", registry.hasExtension(".tsv"));
+        // Verify TSV reader is registered separately
+        assertTrue("TSV format reader should be registered by name", registry.hasFormat("tsv"));
+        FormatReader tsvReader = registry.byName("tsv");
+        assertNotNull("TSV format reader should be retrievable by name", tsvReader);
+        assertTrue("TSV reader should be MockTsvFormatReader", tsvReader instanceof MockTsvFormatReader);
+
+        // Verify TSV extension maps to the TSV reader
+        assertTrue("TSV reader should be registered for .tsv extension", registry.hasExtension(".tsv"));
         FormatReader tsvByExtension = registry.byExtension("data.tsv");
-        assertNotNull("CSV reader should be found by .tsv extension", tsvByExtension);
+        assertNotNull("TSV reader should be found by .tsv extension", tsvByExtension);
+        assertTrue("TSV reader by extension should be MockTsvFormatReader", tsvByExtension instanceof MockTsvFormatReader);
     }
 
     /**
@@ -303,7 +341,7 @@ public class DataSourceModuleTests extends ESTestCase {
 
         // file scheme + .csv extension should be handled
         assertTrue("Should handle file:///tmp/data.csv", fileFactory.canHandle("file:///tmp/data.csv"));
-        // file scheme + .tsv extension should be handled (registered by MockCsvFormatReader)
+        // file scheme + .tsv extension should be handled (registered by MockTsvFormatReader)
         assertTrue("Should handle file:///tmp/data.tsv", fileFactory.canHandle("file:///tmp/data.tsv"));
         // Unknown extension should not be handled
         assertFalse("Should not handle file:///tmp/data.xyz", fileFactory.canHandle("file:///tmp/data.xyz"));
@@ -382,11 +420,14 @@ public class DataSourceModuleTests extends ESTestCase {
         DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
 
         FormatReaderRegistry registry = module.formatReaderRegistry();
-        FormatReader csvReader = registry.byName("csv");
 
+        FormatReader csvReader = registry.byName("csv");
         assertEquals("CSV reader should report 'csv' as format name", "csv", csvReader.formatName());
         assertTrue("CSV reader should support .csv extension", csvReader.fileExtensions().contains(".csv"));
-        assertTrue("CSV reader should support .tsv extension", csvReader.fileExtensions().contains(".tsv"));
+
+        FormatReader tsvReader = registry.byName("tsv");
+        assertEquals("TSV reader should report 'tsv' as format name", "tsv", tsvReader.formatName());
+        assertTrue("TSV reader should support .tsv extension", tsvReader.fileExtensions().contains(".tsv"));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -522,13 +523,8 @@ public class ExternalSourceResolverTests extends ESTestCase {
             }
 
             @Override
-            public Set<String> supportedFormats() {
-                return Set.of("parquet");
-            }
-
-            @Override
-            public Set<String> supportedExtensions() {
-                return Set.of(".parquet");
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
             }
 
             @Override


### PR DESCRIPTION
.tsv files previously defaulted to a comma delimiter, requiring users to manually specify `WITH {"delimiter": "\t"}`. This registers a dedicated "tsv" format with a tab delimiter so .tsv files work out of the box.

Also introduces a `FormatSpec` record to replace the separate `supportedFormats()`/`supportedExtensions()` SPI methods with a single `formatSpecs()` that pairs each format name with its file extensions, simplifying the plugin registration API.

Developed using AI-assisted tooling