### PR TITLE
CPS fix: correctly handle PIT delete when nodes are spread across the origin and linked projects

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportClosePointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportClosePointInTimeAction.java
@@ -81,7 +81,21 @@ public class TransportClosePointInTimeAction extends HandledTransportAction<Clos
         if (clusters.isEmpty()) {
             lookupListener.onResponse((cluster, nodeId) -> nodes.get(nodeId));
         } else {
-            searchTransportService.getRemoteClusterService().collectNodes(clusters, lookupListener);
+            searchTransportService.getRemoteClusterService().collectNodes(clusters, new ActionListener<>() {
+                @Override
+                public void onResponse(BiFunction<String, String, DiscoveryNode> nodeFunction) {
+                    lookupListener.onResponse(
+                        (clusterAlias, nodeId) -> Strings.isEmpty(clusterAlias)
+                            ? nodes.get(nodeId)
+                            : nodeFunction.apply(clusterAlias, nodeId)
+                    );
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
         }
         lookupListener.addListener(listener.delegateFailure((l, nodeLookup) -> {
             final var successes = new AtomicInteger();


### PR DESCRIPTION
The `SearchContextIdForNode` that we gather for populating `clusters` in `closeContexts()` filters out info related to the origin. However, when we actually need to free the contexts, `nodeLookup#apply()` returns `null` because the underlying lookup function grabs the nodes we need (via the `clusterAlias` and `nodeId`) by enumerating the connections established:

```java
final DiscoveryNode node = nodeLookup.apply(contextId.getClusterAlias(), contextId.getNode());
if (node != null) {
    // Free context
}
```

Since context IDs are extracted from the PIT request and can include nodes belonging to the origin and linked projects, at some point, `getClusterAlias()` returns `""`. When that happens, `node` here is `null`, effectively not freeing up some contexts. This is why `num_freed` in the response returned upon hitting `DELETE /_pit` is always less than the total shards in the response upon creating a PIT.

The fix proposed here is to selectively pick up a node based on the cluster alias.