### PR TITLE
Refactored SortedNumericDocValuesSyntheticFieldLoader into a Layer

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -41,7 +41,7 @@ import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.SimpleMappedFieldType;
-import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -858,17 +858,17 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed.value(),
-                indexSettings.getIndexVersionCreated()
-            ) {
-                @Override
-                protected void writeValue(XContentBuilder b, long value) throws IOException {
-                    b.value(decodeForSyntheticSource(value, scalingFactor));
-                }
-            };
+            var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+            layers.add(
+                new SortedNumericDocValuesSyntheticFieldLoaderLayer(
+                    fullPath(),
+                    (b, value) -> b.value(decodeForSyntheticSource(value, scalingFactor))
+                )
+            );
+            if (ignoreMalformed.value()) {
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+            }
+            return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -663,17 +663,12 @@ public class BooleanFieldMapper extends FieldMapper {
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed.value(),
-                indexSettings.getIndexVersionCreated()
-            ) {
-                @Override
-                protected void writeValue(XContentBuilder b, long value) throws IOException {
-                    b.value(value == 1);
-                }
-            };
+            var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+            layers.add(new SortedNumericDocValuesSyntheticFieldLoaderLayer(fullPath(), (b, value) -> b.value(value == 1)));
+            if (ignoreMalformed.value()) {
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+            }
+            return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -61,7 +61,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -71,6 +70,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -1259,19 +1259,19 @@ public final class DateFieldMapper extends FieldMapper {
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (hasDocValues) {
-            return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(
-                    fullPath(),
-                    leafName(),
-                    ignoreMalformed,
-                    indexSettings.getIndexVersionCreated()
-                ) {
-                    @Override
-                    protected void writeValue(XContentBuilder b, long value) throws IOException {
-                        b.value(fieldType().format(value, fieldType().dateTimeFormatter()));
-                    }
+            return new SyntheticSourceSupport.Native(() -> {
+                var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+                layers.add(
+                    new SortedNumericDocValuesSyntheticFieldLoaderLayer(
+                        fullPath(),
+                        (b, value) -> b.value(fieldType().format(value, fieldType().dateTimeFormatter()))
+                    )
+                );
+                if (ignoreMalformed) {
+                    layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
                 }
-            );
+                return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
+            });
         }
 
         return super.syntheticSourceSupport();

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xcontent.XContentString;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -655,22 +656,18 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (fieldType().hasDocValues()) {
-            return new SyntheticSourceSupport.Native(
-                () -> new SortedNumericDocValuesSyntheticFieldLoader(
-                    fullPath(),
-                    leafName(),
-                    ignoreMalformed(),
-                    indexSettings.getIndexVersionCreated()
-                ) {
-                    final GeoPoint point = new GeoPoint();
-
-                    @Override
-                    protected void writeValue(XContentBuilder b, long value) throws IOException {
-                        point.reset(GeoEncodingUtils.decodeLatitude((int) (value >>> 32)), GeoEncodingUtils.decodeLongitude((int) value));
-                        point.toXContent(b, ToXContent.EMPTY_PARAMS);
-                    }
+            return new SyntheticSourceSupport.Native(() -> {
+                final GeoPoint point = new GeoPoint();
+                var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+                layers.add(new SortedNumericDocValuesSyntheticFieldLoaderLayer(fullPath(), (b, value) -> {
+                    point.reset(GeoEncodingUtils.decodeLatitude((int) (value >>> 32)), GeoEncodingUtils.decodeLongitude((int) value));
+                    point.toXContent(b, ToXContent.EMPTY_PARAMS);
+                }));
+                if (ignoreMalformed()) {
+                    layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
                 }
-            );
+                return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
+            });
         }
 
         return super.syntheticSourceSupport();

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1861,12 +1861,12 @@ public class NumberFieldMapper extends FieldMapper {
             boolean ignoreMalformed,
             IndexVersion indexVersion
         ) {
-            return new SortedNumericDocValuesSyntheticFieldLoader(fieldName, fieldSimpleName, ignoreMalformed, indexVersion) {
-                @Override
-                public void writeValue(XContentBuilder b, long value) throws IOException {
-                    NumberType.this.writeValue(b, value);
-                }
-            };
+            var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+            layers.add(new SortedNumericDocValuesSyntheticFieldLoaderLayer(fieldName, NumberType.this::writeValue));
+            if (ignoreMalformed) {
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fieldName, indexVersion));
+            }
+            return new CompositeSyntheticFieldLoader(fieldSimpleName, fieldName, layers);
         }
 
         abstract BlockLoader blockLoaderFromDocValues(String fieldName);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoaderLayer.java
@@ -13,83 +13,37 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
- * Load {@code _source} fields from {@link SortedNumericDocValues}.
+ * A {@link CompositeSyntheticFieldLoader.DocValuesLayer} that loads values from {@link SortedNumericDocValues}.
  */
-public abstract class SortedNumericDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+public class SortedNumericDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
+
     private final String name;
-    private final String simpleName;
+    private final SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer.NumericValueWriter valueWriter;
+    private Values docValues = NO_VALUES;
 
-    /**
-     * Optionally loads malformed values from stored fields.
-     */
-    private final IgnoreMalformedStoredValues ignoreMalformedValues;
-
-    private Values values = NO_VALUES;
-
-    /**
-     * Build a loader from doc values and, optionally, a stored field for malformed values.
-     * @param name the name of the field to load from doc values
-     * @param simpleName the name to give the field in the rendered {@code _source}
-     * @param loadIgnoreMalformedValues should we load values skipped by {@code ignore_malformed}
-     */
-    protected SortedNumericDocValuesSyntheticFieldLoader(String name, String simpleName, boolean loadIgnoreMalformedValues) {
-        this(name, simpleName, loadIgnoreMalformedValues ? IgnoreMalformedStoredValues.stored(name) : IgnoreMalformedStoredValues.empty());
-    }
-
-    protected SortedNumericDocValuesSyntheticFieldLoader(
+    public SortedNumericDocValuesSyntheticFieldLoaderLayer(
         String name,
-        String simpleName,
-        boolean loadIgnoreMalformedValues,
-        IndexVersion indexVersion
+        SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer.NumericValueWriter valueWriter
     ) {
-        this(
-            name,
-            simpleName,
-            loadIgnoreMalformedValues
-                ? IgnoreMalformedStoredValues.forSyntheticSource(name, indexVersion)
-                : IgnoreMalformedStoredValues.empty()
-        );
-    }
-
-    private SortedNumericDocValuesSyntheticFieldLoader(String name, String simpleName, IgnoreMalformedStoredValues ignoreMalformedValues) {
         this.name = name;
-        this.simpleName = simpleName;
-        this.ignoreMalformedValues = ignoreMalformedValues;
+        this.valueWriter = valueWriter;
     }
-
-    protected abstract void writeValue(XContentBuilder b, long value) throws IOException;
 
     @Override
-    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        return ignoreMalformedValues.storedFieldLoaders();
+    public String fieldName() {
+        return name;
     }
 
     @Override
     public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
-        DocValuesLoader fieldLoader = fieldDocValuesLoader(reader, docIdsInLeaf);
-        DocValuesLoader malformedLoader = ignoreMalformedValues.docValuesLoader(reader);
-
-        if (fieldLoader != null && malformedLoader != null) {
-            return docId -> fieldLoader.advanceToDoc(docId) | malformedLoader.advanceToDoc(docId);
-        } else if (malformedLoader != null) {
-            return malformedLoader;
-        } else {
-            return fieldLoader;
-        }
-    }
-
-    private DocValuesLoader fieldDocValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
         SortedNumericDocValues dv = docValuesOrNull(reader, name);
         if (dv == null) {
-            values = NO_VALUES;
+            docValues = NO_VALUES;
             return null;
         }
         if (docIdsInLeaf != null && docIdsInLeaf.length > 1) {
@@ -101,47 +55,28 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
             NumericDocValues single = DocValues.unwrapSingleton(dv);
             if (single != null) {
                 SingletonDocValuesLoader loader = buildSingletonDocValuesLoader(single, docIdsInLeaf);
-                values = loader == null ? NO_VALUES : loader;
+                docValues = loader == null ? NO_VALUES : loader;
                 return loader;
             }
         }
         ImmediateDocValuesLoader loader = new ImmediateDocValuesLoader(dv);
-        values = loader;
+        docValues = loader;
         return loader;
     }
 
     @Override
     public boolean hasValue() {
-        return values.count() > 0 || ignoreMalformedValues.count() > 0;
+        return docValues.count() > 0;
+    }
+
+    @Override
+    public long valueCount() {
+        return docValues.count();
     }
 
     @Override
     public void write(XContentBuilder b) throws IOException {
-        switch (values.count() + ignoreMalformedValues.count()) {
-            case 0:
-                return;
-            case 1:
-                b.field(simpleName);
-                if (values.count() > 0) {
-                    assert values.count() == 1;
-                    assert ignoreMalformedValues.count() == 0;
-                    values.write(b);
-                } else {
-                    assert ignoreMalformedValues.count() == 1;
-                    ignoreMalformedValues.write(b);
-                }
-                return;
-            default:
-                b.startArray(simpleName);
-                values.write(b);
-                ignoreMalformedValues.write(b);
-                b.endArray();
-        }
-    }
-
-    @Override
-    public void reset() {
-        ignoreMalformedValues.reset();
+        docValues.write(b);
     }
 
     private interface Values {
@@ -184,7 +119,7 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
                 return;
             }
             for (int i = 0; i < dv.docValueCount(); i++) {
-                writeValue(b, dv.nextValue());
+                valueWriter.writeLongValue(b, dv.nextValue());
             }
         }
     }
@@ -257,7 +192,7 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
             if (hasValue[idx] == false) {
                 return;
             }
-            writeValue(b, values[idx]);
+            valueWriter.writeLongValue(b, values[idx]);
         }
     }
 
@@ -277,10 +212,5 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
             return DocValues.singleton(single);
         }
         return null;
-    }
-
-    @Override
-    public String fieldName() {
-        return name;
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.SimpleMappedFieldType;
-import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
@@ -841,7 +841,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
             metricDocValues.clear();
             for (Metric m : metrics) {
                 String fieldName = subfieldName(name, m);
-                SortedNumericDocValues dv = SortedNumericDocValuesSyntheticFieldLoader.docValuesOrNull(reader, fieldName);
+                SortedNumericDocValues dv = SortedNumericDocValuesSyntheticFieldLoaderLayer.docValuesOrNull(reader, fieldName);
                 if (dv != null) {
                     metricDocValues.put(m, dv);
                 }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.ConstantFieldType;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -41,7 +42,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.ConstantBytes;
@@ -377,11 +378,12 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             return new SyntheticSourceSupport.Native(() -> SourceLoader.SyntheticFieldLoader.NOTHING);
         }
 
-        return new SyntheticSourceSupport.Native(() -> new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), false) {
-            @Override
-            protected void writeValue(XContentBuilder b, long ignored) throws IOException {
-                b.value(const_value);
-            }
-        });
+        return new SyntheticSourceSupport.Native(
+            () -> new CompositeSyntheticFieldLoader(
+                leafName(),
+                fullPath(),
+                new SortedNumericDocValuesSyntheticFieldLoaderLayer(fullPath(), (b, ignored) -> b.value(const_value))
+            )
+        );
     }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.SimpleMappedFieldType;
-import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -905,17 +905,17 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             }
             return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         } else {
-            return new SortedNumericDocValuesSyntheticFieldLoader(
-                fullPath(),
-                leafName(),
-                ignoreMalformed(),
-                indexSettings.getIndexVersionCreated()
-            ) {
-                @Override
-                protected void writeValue(XContentBuilder b, long value) throws IOException {
-                    b.value(DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value));
-                }
-            };
+            var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
+            layers.add(
+                new SortedNumericDocValuesSyntheticFieldLoaderLayer(
+                    fullPath(),
+                    (b, value) -> b.value(DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value))
+                )
+            );
+            if (ignoreMalformed()) {
+                layers.add(CompositeSyntheticFieldLoader.malformedValuesLayer(fullPath(), indexSettings.getIndexVersionCreated()));
+            }
+            return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
         }
     }
 


### PR DESCRIPTION
This is a follow up for [this comment](https://github.com/elastic/elasticsearch/pull/142357/changes#r2843613756).

Functionally, there are no changes - all of `SortedNumericDocValuesSyntheticFieldLoader` has essentially been moved to `SortedNumericDocValuesSyntheticFieldLoaderLayer`.

The point of this refactor is consistency. After changing the storage format for malformed values from stored fields to binary doc values, it became apparent that all field mappers use a `CompositeSyntheticFieldLoader` to handle the extra malformed value field loading. All, with the exception of ones using `SortedNumericDocValuesSyntheticFieldLoader`. Since there was no `Layer` alternative, we had to bundle binary doc values into `SortedNumericDocValuesSyntheticFieldLoader`, which is inconsistent and ugly. This PR addresses that.