### PR TITLE
Enable extended doc_values params feature flag in RandomizedRollingUpgradeIT

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
@@ -38,7 +39,8 @@ public class Clusters {
             .module("x-pack-aggregate-metric")
             .module("x-pack-stack")
             .setting("xpack.security.autoconfiguration.enabled", "false")
-            .setting("xpack.license.self_generated.type", useTrial ? "trial" : "basic");
+            .setting("xpack.license.self_generated.type", useTrial ? "trial" : "basic")
+            .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS);
 
         return cluster.build();
     }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/142048.

The reason for the test occasionally failing is due to this function [here](https://github.com/elastic/elasticsearch/blob/252fb2672b34f04775d68ad69f50d3822ae8a150/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java#L314-L329). Because the [EXTENDED_DOC_VALUES_PARAMS](https://github.com/elastic/elasticsearch/blob/ed4cee31ce1f16e2488a3d51ecca0b3c3882d520/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java#L31) feature flag and the [STORE_HIGH_CARDINALITY_KEYWORDS_IN_BINARY_DOC_VALUES](https://github.com/elastic/elasticsearch/blob/ed4cee31ce1f16e2488a3d51ecca0b3c3882d520/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java#L68) Mapper feature are decoupled, the function incorrectly assumes that extended doc_values can be generated, while the old cluster doesn't support them. This results in the following error:

```
RandomizedRollingUpgradeIT > testIndexingSyntheticSource FAILED
    org.elasticsearch.client.ResponseException: method [PUT], host [http://[::1]:33063], URI [/test-index-synthetic-1], status line [HTTP/1.1 400 Bad Request]
    {"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Failed to parse mapping: Could not convert [doc_values] to boolean"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping: Could not convert [doc_values] to boolean","caused_by":{"type":"illegal_argument_exception","reason":"Could not convert [doc_values] to boolean","caused_by":{"type":"illegal_argument_exception","reason":"Failed to parse value [{cardinality=high}] as only [true] or [false] are allowed."}}},"status":400}
        at __randomizedtesting.SeedInfo.seed([9617804EE6C9E568:7DFFAC6E94878DDE]:0)
        at app//org.elasticsearch.client.RestClient.convertResponse(RestClient.java:351)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:317)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:292)
        at app//org.elasticsearch.test.rest.ESRestTestCase.createIndex(ESRestTestCase.java:2060)
        at app//org.elasticsearch.test.rest.ESRestTestCase.createIndex(ESRestTestCase.java:2018)
        at app//org.elasticsearch.test.rest.ESRestTestCase.createIndex(ESRestTestCase.java:2013)
        at app//org.elasticsearch.test.rest.ESRestTestCase.createIndex(ESRestTestCase.java:2009)
        at app//org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT.createIndex(RandomizedRollingUpgradeIT.java:110)
        at app//org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT.testIndexing(RandomizedRollingUpgradeIT.java:130)
        at app//org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT.testIndexingSyntheticSource(RandomizedRollingUpgradeIT.java:157)
```