### PR TITLE
Log the stacktrace when we encounter a deprecation warning for `default_metric`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -333,18 +333,12 @@ tests:
 - class: org.elasticsearch.xpack.search.AsyncSearchTaskTests
   method: testWithFailure
   issue: https://github.com/elastic/elasticsearch/issues/142821
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/40_tsdb/to_aggregate_metric_double with multi_values}
-  issue: https://github.com/elastic/elasticsearch/issues/142964
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/142079
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testTsIndexConflictingTypes {null}
-  issue: https://github.com/elastic/elasticsearch/issues/142410
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackSubqueryIT
   method: testManyRandomKeywordFieldsInSubqueryIntermediateResults
   issue: https://github.com/elastic/elasticsearch/issues/143314
@@ -360,9 +354,6 @@ tests:
 - class: org.elasticsearch.index.store.StoreDirectoryMetricsIT
   method: testDirectoryMetrics
   issue: https://github.com/elastic/elasticsearch/issues/143419
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/40_tsdb/TS Command grouping on text field}
-  issue: https://github.com/elastic/elasticsearch/issues/142544
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/143551
@@ -381,9 +372,6 @@ tests:
 - class: org.elasticsearch.compute.lucene.query.LuceneTopNSourceOperatorTests
   method: testAccumulateSearchLoad
   issue: https://github.com/elastic/elasticsearch/issues/143708
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testTsIndexConflictingTypes {NONE}
-  issue: https://github.com/elastic/elasticsearch/issues/142477
 - class: org.elasticsearch.xpack.sql.qa.security.CliApiKeyIT
   method: testCliConnectionWithInvalidApiKey
   issue: https://github.com/elastic/elasticsearch/issues/143646

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1940,11 +1940,10 @@ public abstract class FieldMapper extends Mapper {
                     );
                 }
                 if (parameter.deprecated) {
-                    // Needed for the https://github.com/elastic/elasticsearch/issues/143884
-                    // Remove after issue is closed.
-                    if (logger.isDebugEnabled() && "aggregate_metric_double".equals(contentType()) && "default_metric".equals(propName)) {
+                    // Remove the stack track trace logging after https://github.com/elastic/elasticsearch/issues/143884
+                    if (logger.isDebugEnabled() && "default_metric".equals(propName)) {
                         logger.debug(
-                            "Parsing [aggregate_metric_double] with deprecated [default_metric] config",
+                            "Parsing [" + contentType() + "] with deprecated [default_metric] config",
                             new ElasticsearchException("Stack trace retrieval")
                         );
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.TriFunction;
@@ -1939,6 +1940,14 @@ public abstract class FieldMapper extends Mapper {
                     );
                 }
                 if (parameter.deprecated) {
+                    // Needed for the https://github.com/elastic/elasticsearch/issues/143884
+                    // Remove after issue is closed.
+                    if (logger.isDebugEnabled() && "aggregate_metric_double".equals(contentType()) && "default_metric".equals(propName)) {
+                        logger.debug(
+                            "Parsing [aggregate_metric_double] with deprecated [default_metric] config",
+                            new ElasticsearchException("Stack trace retrieval")
+                        );
+                    }
                     deprecationLogger.warn(
                         DeprecationCategory.API,
                         propName,

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -23,7 +23,9 @@ public class Clusters {
             .withNode(node -> node.version(oldVersionString, isDetachedVersion))
             .withNode(node -> node.version(Version.CURRENT))
             .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
+            .setting("xpack.license.self_generated.type", "trial")
+            // Remove after https://github.com/elastic/elasticsearch/issues/143884 (only the current version will log the stack trace)
+            .setting("logger.org.elasticsearch.index.mapper.FieldMapper", "DEBUG");
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FieldExtractorIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FieldExtractorIT.java
@@ -18,7 +18,10 @@ import org.junit.ClassRule;
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class FieldExtractorIT extends FieldExtractorTestCase {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> {});
+    public static ElasticsearchCluster cluster = Clusters.testCluster(
+        // Remove after https://github.com/elastic/elasticsearch/issues/143884
+        spec -> spec.setting("logger.org.elasticsearch.index.mapper.FieldMapper", "DEBUG")
+    );
 
     public FieldExtractorIT(MappedFieldType.FieldExtractPreference preference) {
         super(preference);

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -1427,9 +1427,15 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
                 }
                 """);
         } catch (WarningFailureException warningException) {
-            Map<String, Object> indexMapping = ESRestTestCase.getIndexMapping("metrics-long");
-            logger.error("Received warning when creating index [metrics-long] with mapping [{}]", indexMapping);
-            throw warningException;
+            // Remove try-catch after https://github.com/elastic/elasticsearch/issues/143884
+            List<String> warnings = warningException.getResponse().getWarnings();
+            if (warnings.size() == 1
+                && warnings.getFirst().equals("Parameter [default_metric] is deprecated and will be removed in a future version")) {
+                Map<String, Object> indexMapping = ESRestTestCase.getIndexMapping("metrics-long");
+                logger.error("Received warning when creating index [metrics-long] with mapping [{}]", indexMapping);
+            } else {
+                throw warningException;
+            }
         }
         ESRestTestCase.createIndex("metrics-long_dimension", settings, """
             "properties": {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -1412,6 +1412,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
               }
             }
             """, null, DEPRECATED_DEFAULT_METRIC_WARNING_HANDLER);
+        // Remove try-catch after https://github.com/elastic/elasticsearch/issues/143884
         try {
             ESRestTestCase.createIndex("metrics-long", settings, """
                 "properties": {
@@ -1427,10 +1428,9 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
                 }
                 """);
         } catch (WarningFailureException warningException) {
-            // Remove try-catch after https://github.com/elastic/elasticsearch/issues/143884
             List<String> warnings = warningException.getResponse().getWarnings();
-            if (warnings.size() == 1
-                && warnings.getFirst().equals("Parameter [default_metric] is deprecated and will be removed in a future version")) {
+            if (warnings.stream()
+                .anyMatch(warning -> warning.equals("Parameter [default_metric] is deprecated and will be removed in a future version"))) {
                 Map<String, Object> indexMapping = ESRestTestCase.getIndexMapping("metrics-long");
                 logger.error("Received warning when creating index [metrics-long] with mapping [{}]", indexMapping);
             }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -1433,9 +1433,8 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
                 && warnings.getFirst().equals("Parameter [default_metric] is deprecated and will be removed in a future version")) {
                 Map<String, Object> indexMapping = ESRestTestCase.getIndexMapping("metrics-long");
                 logger.error("Received warning when creating index [metrics-long] with mapping [{}]", indexMapping);
-            } else {
-                throw warningException;
             }
+            throw warningException;
         }
         ESRestTestCase.createIndex("metrics-long_dimension", settings, """
             "properties": {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -1,6 +1,15 @@
 setup:
   - requires:
       test_runner_features: [allowed_warnings_regex, allowed_warnings]
+  # Remove enabling debug logging after https://github.com/elastic/elasticsearch/issues/143884
+  - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.index.mapper.FieldMapper": "DEBUG"
+            }
+          }
   - do:
       indices.create:
           index: test
@@ -688,18 +697,7 @@ to_aggregate_metric_double with multi_values:
           capabilities: [ aggregate_metric_double_v0 ]
       reason: "Support for to_aggregate_metric_double function"
 
-  # Remove after https://github.com/elastic/elasticsearch/issues/143884
   - do:
-      cluster.put_settings:
-        body: >
-          {
-            "persistent": {
-              "logger.org.elasticsearch.index.mapper.FieldMapper": "DEBUG"
-            }
-          }
-  - do:
-      allowed_warnings:
-        - "Parameter [default_metric] is deprecated and will be removed in a future version"
       indices.create:
         index: convert_test
         body:
@@ -773,18 +771,7 @@ TS Command grouping on text field:
           capabilities: [ ts_permit_text_becoming_keyword_when_grouped_on, ts_command_v0 ]
       reason: "fix grouping on text fields with TS command"
 
-  # Remove after https://github.com/elastic/elasticsearch/issues/143884
   - do:
-      cluster.put_settings:
-        body: >
-          {
-            "persistent": {
-              "logger.org.elasticsearch.index.mapper.FieldMapper": "DEBUG"
-            }
-          }
-  - do:
-      allowed_warnings:
-        - "Parameter [default_metric] is deprecated and will be removed in a future version"
       indices.create:
         index: test-text-field
         body:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -688,7 +688,18 @@ to_aggregate_metric_double with multi_values:
           capabilities: [ aggregate_metric_double_v0 ]
       reason: "Support for to_aggregate_metric_double function"
 
+  # Remove after https://github.com/elastic/elasticsearch/issues/143884
   - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.index.mapper.FieldMapper": "DEBUG"
+            }
+          }
+  - do:
+      allowed_warnings:
+        - "Parameter [default_metric] is deprecated and will be removed in a future version"
       indices.create:
         index: convert_test
         body:
@@ -762,7 +773,18 @@ TS Command grouping on text field:
           capabilities: [ ts_permit_text_becoming_keyword_when_grouped_on, ts_command_v0 ]
       reason: "fix grouping on text fields with TS command"
 
+  # Remove after https://github.com/elastic/elasticsearch/issues/143884
   - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.index.mapper.FieldMapper": "DEBUG"
+            }
+          }
+  - do:
+      allowed_warnings:
+        - "Parameter [default_metric] is deprecated and will be removed in a future version"
       indices.create:
         index: test-text-field
         body:


### PR DESCRIPTION
While we investigate https://github.com/elastic/elasticsearch/issues/143884, we enhance log the stack trace during debug mode but we also allow the unexpected warning in our ci, so the tests will not remain muted for too long.

When https://github.com/elastic/elasticsearch/issues/143884 is closed, this PR needs to be reverted (apart from the test unmuting).