### PR TITLE
[ESQL] Push stats to external source via metadata

### DIFF
--- a/docs/changelog/143940.yaml
+++ b/docs/changelog/143940.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 143940
+summary: Push stats to external source via metadata
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -15,9 +15,13 @@ import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.DoubleColumnStatistics;
+import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
+import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -34,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -44,6 +49,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * {@link FormatReader} implementation for Apache ORC files.
@@ -71,18 +78,98 @@ public class OrcFormatReader implements FormatReader {
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
-        List<Attribute> schema = readSchema(object);
-        return new SimpleSourceMetadata(schema, formatName(), object.path().toString());
-    }
-
-    private static List<Attribute> readSchema(StorageObject object) throws IOException {
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
         OrcFile.ReaderOptions options = OrcFile.readerOptions(new Configuration(false)).filesystem(fs);
         try (Reader reader = OrcFile.createReader(path, options)) {
             TypeDescription schema = reader.getSchema();
-            return convertOrcSchemaToAttributes(schema);
+            List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
+            SourceStatistics statistics = extractStatistics(reader, schema);
+            return new SimpleSourceMetadata(attributes, formatName(), object.path().toString(), statistics, null);
         }
+    }
+
+    private static SourceStatistics extractStatistics(Reader reader, TypeDescription schema) {
+        long rowCount = reader.getNumberOfRows();
+        long sizeInBytes = reader.getContentLength();
+        ColumnStatistics[] orcStats = reader.getStatistics();
+        List<String> fieldNames = schema.getFieldNames();
+        List<TypeDescription> children = schema.getChildren();
+
+        Map<String, SourceStatistics.ColumnStatistics> columnStats = new HashMap<>();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            String name = fieldNames.get(i);
+            int colId = children.get(i).getId();
+            if (colId >= orcStats.length) {
+                continue;
+            }
+            ColumnStatistics cs = orcStats[colId];
+            long totalValues = cs.getNumberOfValues();
+            long nullCount = rowCount - totalValues;
+            Object minVal = extractOrcMin(cs);
+            Object maxVal = extractOrcMax(cs);
+
+            columnStats.put(name, new SourceStatistics.ColumnStatistics() {
+                @Override
+                public OptionalLong nullCount() {
+                    return OptionalLong.of(nullCount);
+                }
+
+                @Override
+                public OptionalLong distinctCount() {
+                    return OptionalLong.empty();
+                }
+
+                @Override
+                public Optional<Object> minValue() {
+                    return Optional.ofNullable(minVal);
+                }
+
+                @Override
+                public Optional<Object> maxValue() {
+                    return Optional.ofNullable(maxVal);
+                }
+            });
+        }
+
+        return new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(rowCount);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.of(sizeInBytes);
+            }
+
+            @Override
+            public Optional<Map<String, SourceStatistics.ColumnStatistics>> columnStatistics() {
+                return columnStats.isEmpty() ? Optional.empty() : Optional.of(columnStats);
+            }
+        };
+    }
+
+    private static Object extractOrcMin(ColumnStatistics cs) {
+        if (cs instanceof IntegerColumnStatistics intStats) {
+            return intStats.getMinimum();
+        } else if (cs instanceof DoubleColumnStatistics dblStats) {
+            return dblStats.getMinimum();
+        } else if (cs instanceof StringColumnStatistics strStats) {
+            return strStats.getMinimum();
+        }
+        return null;
+    }
+
+    private static Object extractOrcMax(ColumnStatistics cs) {
+        if (cs instanceof IntegerColumnStatistics intStats) {
+            return intStats.getMaximum();
+        } else if (cs instanceof DoubleColumnStatistics dblStats) {
+            return dblStats.getMaximum();
+        } else if (cs instanceof StringColumnStatistics strStats) {
+            return strStats.getMaximum();
+        }
+        return null;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -13,8 +13,10 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.api.Converter;
@@ -38,6 +40,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -47,6 +50,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * FormatReader implementation for Parquet files.
@@ -72,24 +77,113 @@ public class ParquetFormatReader implements FormatReader {
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
-        List<Attribute> schema = readSchema(object);
-        return new SimpleSourceMetadata(schema, formatName(), object.path().toString());
-    }
-
-    private List<Attribute> readSchema(StorageObject object) throws IOException {
-        // Adapt StorageObject to Parquet InputFile
         InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
-
-        // Build ParquetReadOptions with SKIP_ROW_GROUPS to only read schema metadata
-        ParquetReadOptions options = ParquetReadOptions.builder().withMetadataFilter(ParquetMetadataConverter.SKIP_ROW_GROUPS).build();
+        ParquetReadOptions options = ParquetReadOptions.builder().build();
 
         try (ParquetFileReader reader = ParquetFileReader.open(parquetInputFile, options)) {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
-
-            // Convert Parquet schema directly to ESQL Attributes
-            return convertParquetSchemaToAttributes(parquetSchema);
+            List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
+            SourceStatistics statistics = extractStatistics(reader, parquetSchema);
+            return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
         }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private SourceStatistics extractStatistics(ParquetFileReader reader, MessageType schema) {
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        if (rowGroups.isEmpty()) {
+            return null;
+        }
+
+        long totalRows = 0;
+        long totalSize = 0;
+        Map<String, long[]> nullCounts = new HashMap<>();
+        Map<String, Comparable[]> mins = new HashMap<>();
+        Map<String, Comparable[]> maxs = new HashMap<>();
+
+        for (BlockMetaData rowGroup : rowGroups) {
+            totalRows += rowGroup.getRowCount();
+            totalSize += rowGroup.getTotalByteSize();
+            for (ColumnChunkMetaData col : rowGroup.getColumns()) {
+                String colName = col.getPath().toDotString();
+                Statistics stats = col.getStatistics();
+                if (stats == null || stats.isEmpty()) {
+                    continue;
+                }
+                nullCounts.merge(colName, new long[] { stats.getNumNulls() }, (a, b) -> {
+                    a[0] += b[0];
+                    return a;
+                });
+                if (stats.hasNonNullValue()) {
+                    mins.merge(colName, new Comparable[] { stats.genericGetMin() }, (a, b) -> {
+                        @SuppressWarnings("unchecked")
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp > 0) a[0] = b[0];
+                        return a;
+                    });
+                    maxs.merge(colName, new Comparable[] { stats.genericGetMax() }, (a, b) -> {
+                        @SuppressWarnings("unchecked")
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp < 0) a[0] = b[0];
+                        return a;
+                    });
+                }
+            }
+        }
+
+        final long rowCount = totalRows;
+        final long sizeBytes = totalSize;
+        Map<String, SourceStatistics.ColumnStatistics> columnStats = new HashMap<>();
+        for (Type field : schema.getFields()) {
+            String name = field.getName();
+            long[] nc = nullCounts.get(name);
+            Comparable[] mn = mins.get(name);
+            Comparable[] mx = maxs.get(name);
+            if (nc != null || mn != null || mx != null) {
+                final long nullCount = nc != null ? nc[0] : 0;
+                final Object minVal = mn != null ? mn[0] : null;
+                final Object maxVal = mx != null ? mx[0] : null;
+                columnStats.put(name, new SourceStatistics.ColumnStatistics() {
+                    @Override
+                    public OptionalLong nullCount() {
+                        return OptionalLong.of(nullCount);
+                    }
+
+                    @Override
+                    public OptionalLong distinctCount() {
+                        return OptionalLong.empty();
+                    }
+
+                    @Override
+                    public Optional<Object> minValue() {
+                        return Optional.ofNullable(minVal);
+                    }
+
+                    @Override
+                    public Optional<Object> maxValue() {
+                        return Optional.ofNullable(maxVal);
+                    }
+                });
+            }
+        }
+
+        return new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(rowCount);
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.of(sizeBytes);
+            }
+
+            @Override
+            public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                return columnStats.isEmpty() ? Optional.empty() : Optional.of(columnStats);
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Serializes and deserializes {@link SourceStatistics} to/from a flat {@code Map<String, Object>}
+ * using well-known keys. This allows statistics to flow through the opaque {@code sourceMetadata}
+ * map in {@link org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec} without requiring
+ * new fields or serialization format changes.
+ */
+public final class SourceStatisticsSerializer {
+
+    public static final String STATS_ROW_COUNT = "_stats.row_count";
+    public static final String STATS_SIZE_BYTES = "_stats.size_bytes";
+    private static final String STATS_COL_PREFIX = "_stats.columns.";
+    private static final String NULL_COUNT_SUFFIX = ".null_count";
+    private static final String MIN_SUFFIX = ".min";
+    private static final String MAX_SUFFIX = ".max";
+
+    private SourceStatisticsSerializer() {}
+
+    /**
+     * Merges statistics entries into a new map that includes both the original sourceMetadata
+     * entries and the serialized statistics. Returns the original map if statistics are absent.
+     */
+    public static Map<String, Object> embedStatistics(Map<String, Object> sourceMetadata, SourceStatistics statistics) {
+        if (statistics == null) {
+            return sourceMetadata;
+        }
+        Map<String, Object> result = new HashMap<>(sourceMetadata);
+        statistics.rowCount().ifPresent(rc -> result.put(STATS_ROW_COUNT, rc));
+        statistics.sizeInBytes().ifPresent(sb -> result.put(STATS_SIZE_BYTES, sb));
+        statistics.columnStatistics().ifPresent(cols -> {
+            for (Map.Entry<String, SourceStatistics.ColumnStatistics> entry : cols.entrySet()) {
+                String prefix = STATS_COL_PREFIX + entry.getKey();
+                SourceStatistics.ColumnStatistics cs = entry.getValue();
+                cs.nullCount().ifPresent(nc -> result.put(prefix + NULL_COUNT_SUFFIX, nc));
+                cs.minValue().ifPresent(mv -> result.put(prefix + MIN_SUFFIX, mv));
+                cs.maxValue().ifPresent(mv -> result.put(prefix + MAX_SUFFIX, mv));
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Extracts statistics from the sourceMetadata map. Returns empty if no statistics keys are present.
+     */
+    public static Optional<SourceStatistics> extractStatistics(Map<String, Object> sourceMetadata) {
+        if (sourceMetadata == null || sourceMetadata.containsKey(STATS_ROW_COUNT) == false) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return toLong(sourceMetadata.get(STATS_ROW_COUNT));
+            }
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return toLong(sourceMetadata.get(STATS_SIZE_BYTES));
+            }
+
+            @Override
+            public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                Map<String, ColumnStatistics> cols = new HashMap<>();
+                for (String key : sourceMetadata.keySet()) {
+                    if (key.startsWith(STATS_COL_PREFIX) == false) {
+                        continue;
+                    }
+                    String rest = key.substring(STATS_COL_PREFIX.length());
+                    int dotIdx = rest.lastIndexOf('.');
+                    if (dotIdx <= 0) {
+                        continue;
+                    }
+                    String colName = rest.substring(0, dotIdx);
+                    cols.computeIfAbsent(colName, n -> new DeserializedColumnStatistics(sourceMetadata, n));
+                }
+                return cols.isEmpty() ? Optional.empty() : Optional.of(cols);
+            }
+        });
+    }
+
+    /**
+     * Extracts the row count directly from the sourceMetadata map without constructing a full
+     * SourceStatistics object.
+     */
+    public static OptionalLong extractRowCount(Map<String, Object> sourceMetadata) {
+        if (sourceMetadata == null) {
+            return OptionalLong.empty();
+        }
+        return toLong(sourceMetadata.get(STATS_ROW_COUNT));
+    }
+
+    /**
+     * Extracts the null count for a specific column directly from the sourceMetadata map.
+     */
+    public static OptionalLong extractColumnNullCount(Map<String, Object> sourceMetadata, String columnName) {
+        if (sourceMetadata == null) {
+            return OptionalLong.empty();
+        }
+        return toLong(sourceMetadata.get(STATS_COL_PREFIX + columnName + NULL_COUNT_SUFFIX));
+    }
+
+    /**
+     * Extracts the min value for a specific column directly from the sourceMetadata map.
+     */
+    public static Optional<Object> extractColumnMin(Map<String, Object> sourceMetadata, String columnName) {
+        if (sourceMetadata == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(sourceMetadata.get(STATS_COL_PREFIX + columnName + MIN_SUFFIX));
+    }
+
+    /**
+     * Extracts the max value for a specific column directly from the sourceMetadata map.
+     */
+    public static Optional<Object> extractColumnMax(Map<String, Object> sourceMetadata, String columnName) {
+        if (sourceMetadata == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(sourceMetadata.get(STATS_COL_PREFIX + columnName + MAX_SUFFIX));
+    }
+
+    private static OptionalLong toLong(Object value) {
+        if (value instanceof Number n) {
+            return OptionalLong.of(n.longValue());
+        }
+        return OptionalLong.empty();
+    }
+
+    private static class DeserializedColumnStatistics implements SourceStatistics.ColumnStatistics {
+        private final Map<String, Object> map;
+        private final String colName;
+
+        DeserializedColumnStatistics(Map<String, Object> map, String colName) {
+            this.map = map;
+            this.colName = colName;
+        }
+
+        @Override
+        public OptionalLong nullCount() {
+            return extractColumnNullCount(map, colName);
+        }
+
+        @Override
+        public OptionalLong distinctCount() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public Optional<Object> minValue() {
+            return extractColumnMin(map, colName);
+        }
+
+        @Override
+        public Optional<Object> maxValue() {
+            return extractColumnMax(map, colName);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersTo
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushSampleToSource;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushStatsToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushStatsToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushTopNToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceRoundToWithQueryAndTags;
@@ -82,6 +83,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         esSourceRules.add(new ReplaceSampledStatsByExactStats());
         if (optimizeForEsSource) {
             esSourceRules.add(new PushStatsToSource());
+            esSourceRules.add(new PushStatsToExternalSource());
             esSourceRules.add(new EnableSpatialDistancePushdown());
         }
         esSourceRules.add(new ReplaceSampledStatsBySampleAndStats());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Pushes ungrouped aggregate functions (COUNT, MIN, MAX) to external sources when the
+ * required statistics are available in the file metadata. Replaces the AggregateExec +
+ * ExternalSourceExec subtree with a LocalSourceExec containing pre-computed results.
+ * <p>
+ * Currently supports single-file queries only (no splits or exactly one split).
+ * Multi-file queries fall through to normal execution.
+ * <p>
+ * Note: MIN/MAX pushdown uses raw values from file metadata. For DATE/TIMESTAMP columns,
+ * the raw values may not match ESQL's millisecond representation. A future enhancement
+ * should convert these values using the column's data type.
+ */
+public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerRule<AggregateExec> {
+
+    @Override
+    protected PhysicalPlan rule(AggregateExec aggregateExec) {
+        if (aggregateExec.child() instanceof ExternalSourceExec == false) {
+            return aggregateExec;
+        }
+        ExternalSourceExec externalExec = (ExternalSourceExec) aggregateExec.child();
+        if (aggregateExec.groupings().isEmpty() == false) {
+            return aggregateExec;
+        }
+        if (externalExec.splits().size() > 1) {
+            return aggregateExec;
+        }
+
+        Map<String, Object> sourceMetadata = externalExec.sourceMetadata();
+        List<? extends NamedExpression> aggregates = aggregateExec.aggregates();
+
+        List<Object> values = new ArrayList<>(aggregates.size());
+        List<Attribute> outputAttrs = new ArrayList<>(aggregates.size());
+
+        for (NamedExpression agg : aggregates) {
+            if (agg instanceof Alias == false) {
+                return aggregateExec;
+            }
+            Alias alias = (Alias) agg;
+            Expression child = alias.child();
+            Object value = resolveFromMetadata(child, sourceMetadata);
+            if (value == null) {
+                return aggregateExec;
+            }
+            values.add(value);
+            outputAttrs.add(agg.toAttribute());
+        }
+
+        Block[] blocks = buildBlocks(values);
+        return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
+    }
+
+    private static Object resolveFromMetadata(Expression aggFunction, Map<String, Object> sourceMetadata) {
+        if (aggFunction instanceof Count count) {
+            return resolveCount(count, sourceMetadata);
+        } else if (aggFunction instanceof Min min) {
+            return resolveMin(min, sourceMetadata);
+        } else if (aggFunction instanceof Max max) {
+            return resolveMax(max, sourceMetadata);
+        }
+        return null;
+    }
+
+    private static Object resolveCount(Count count, Map<String, Object> sourceMetadata) {
+        if (count.hasFilter()) {
+            return null;
+        }
+        Expression target = count.field();
+        if (target.foldable()) {
+            OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+            return rc.isPresent() ? rc.getAsLong() : null;
+        }
+        if (target instanceof ReferenceAttribute ref) {
+            OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+            OptionalLong nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
+            if (rc.isPresent() && nc.isPresent()) {
+                return rc.getAsLong() - nc.getAsLong();
+            }
+        }
+        return null;
+    }
+
+    private static Object resolveMin(Min min, Map<String, Object> sourceMetadata) {
+        if (min.hasFilter()) {
+            return null;
+        }
+        Expression target = min.field();
+        if (target instanceof ReferenceAttribute ref) {
+            Optional<Object> minVal = SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
+            return minVal.orElse(null);
+        }
+        return null;
+    }
+
+    private static Object resolveMax(Max max, Map<String, Object> sourceMetadata) {
+        if (max.hasFilter()) {
+            return null;
+        }
+        Expression target = max.field();
+        if (target instanceof ReferenceAttribute ref) {
+            Optional<Object> maxVal = SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
+            return maxVal.orElse(null);
+        }
+        return null;
+    }
+
+    private static Block[] buildBlocks(List<Object> values) {
+        BlockFactory blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        Block[] blocks = new Block[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
+            if (value instanceof Long l) {
+                blocks[i] = blockFactory.newConstantLongBlockWith(l, 1);
+            } else if (value instanceof Integer n) {
+                blocks[i] = blockFactory.newConstantIntBlockWith(n, 1);
+            } else if (value instanceof Double d) {
+                blocks[i] = blockFactory.newConstantDoubleBlockWith(d, 1);
+            } else if (value instanceof Boolean b) {
+                blocks[i] = blockFactory.newConstantBooleanBlockWith(b, 1);
+            } else if (value instanceof String s) {
+                blocks[i] = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
+            } else if (value instanceof Number n) {
+                blocks[i] = blockFactory.newConstantLongBlockWith(n.longValue(), 1);
+            } else {
+                blocks[i] = blockFactory.newConstantNullBlock(1);
+            }
+        }
+        return blocks;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.datasources.FileSet;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
@@ -143,13 +144,16 @@ public class ExternalRelation extends LeafPlan implements ExecutesOn.Coordinator
     }
 
     public ExternalSourceExec toPhysicalExec() {
+        Map<String, Object> enrichedMetadata = metadata.statistics()
+            .map(stats -> SourceStatisticsSerializer.embedStatistics(metadata.sourceMetadata(), stats))
+            .orElse(metadata.sourceMetadata());
         return new ExternalSourceExec(
             source(),
             sourcePath,
             metadata.sourceType(),
             output,
             metadata.config(),
-            metadata.sourceMetadata(),
+            enrichedMetadata,
             null,
             null,
             fileSet

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class PushStatsToExternalSourceTests extends ESTestCase {
+
+    public void testCountStarPushedDown() {
+        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
+        AggregateExec agg = aggregateExec(externalSource(metadata), countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        assertEquals(1, local.output().size());
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        assertEquals(1, page.getPositionCount());
+        Block block = page.getBlock(0);
+        assertThat(block, instanceOf(LongBlock.class));
+        assertEquals(1000L, ((LongBlock) block).getLong(0));
+    }
+
+    public void testCountFieldPushedDown() {
+        Map<String, Object> metadata = statsMetadata(1000L, "age", 50L, null);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        AggregateExec agg = aggregateExec(externalSource(metadata), countFieldAlias(field));
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        Page page = local.supplier().get();
+        assertEquals(950L, ((LongBlock) page.getBlock(0)).getLong(0));
+    }
+
+    public void testCountFieldWithoutNullCountNotPushed() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        AggregateExec agg = aggregateExec(externalSource(metadata), countFieldAlias(field));
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testMinPushedDown() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
+        metadata.put("_stats.columns.age.min", 18);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Alias minAlias = new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, field));
+        AggregateExec agg = aggregateExec(externalSource(metadata), minAlias);
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+    }
+
+    public void testMaxPushedDown() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
+        metadata.put("_stats.columns.age.max", 99);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Alias maxAlias = new Alias(Source.EMPTY, "m", new Max(Source.EMPTY, field));
+        AggregateExec agg = aggregateExec(externalSource(metadata), maxAlias);
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+    }
+
+    public void testMultipleAggsPushedDown() {
+        Map<String, Object> metadata = statsMetadata(500L, "score", 10L, null);
+        metadata.put("_stats.columns.score.min", 1.0);
+        metadata.put("_stats.columns.score.max", 100.0);
+
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "score", DataType.DOUBLE);
+        Alias countAlias = countStarAlias();
+        Alias minAlias = new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, field));
+        Alias maxAlias = new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, field));
+
+        AggregateExec agg = aggregateExec(externalSource(metadata), countAlias, minAlias, maxAlias);
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        assertEquals(3, local.output().size());
+    }
+
+    public void testNotPushedWithGroupings() {
+        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
+        ExternalSourceExec ext = externalSource(metadata);
+        ReferenceAttribute groupField = new ReferenceAttribute(Source.EMPTY, "dept", DataType.KEYWORD);
+        AggregateExec agg = new AggregateExec(
+            Source.EMPTY,
+            ext,
+            List.of(groupField),
+            List.of(countStarAlias()),
+            AggregatorMode.SINGLE,
+            List.of(),
+            null
+        );
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testNotPushedWithoutStats() {
+        Map<String, Object> metadata = Map.of();
+        AggregateExec agg = aggregateExec(externalSource(metadata), countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testNotPushedWithMultipleSplits() {
+        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
+        List<Attribute> attrs = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
+        ExternalSourceExec ext = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            attrs,
+            Map.of(),
+            metadata,
+            null,
+            -1,
+            null,
+            null,
+            List.of(
+                new FileSplit("parquet", StoragePath.of("file:///split1.parquet"), 0, 100, "parquet", Map.of(), Map.of()),
+                new FileSplit("parquet", StoragePath.of("file:///split2.parquet"), 0, 100, "parquet", Map.of(), Map.of())
+            )
+        );
+        AggregateExec agg = aggregateExec(ext, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testPushedWithSingleSplit() {
+        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
+        List<Attribute> attrs = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
+        ExternalSourceExec ext = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            attrs,
+            Map.of(),
+            metadata,
+            null,
+            -1,
+            null,
+            null,
+            List.of(new FileSplit("parquet", StoragePath.of("file:///test.parquet"), 0, 100, "parquet", Map.of(), Map.of()))
+        );
+        AggregateExec agg = aggregateExec(ext, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+    }
+
+    public void testMinWithoutStatsNotPushed() {
+        Map<String, Object> metadata = statsMetadata(100L, null, null, null);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Alias minAlias = new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, field));
+        AggregateExec agg = aggregateExec(externalSource(metadata), minAlias);
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testMaxWithoutStatsNotPushed() {
+        Map<String, Object> metadata = statsMetadata(100L, null, null, null);
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Alias maxAlias = new Alias(Source.EMPTY, "m", new Max(Source.EMPTY, field));
+        AggregateExec agg = aggregateExec(externalSource(metadata), maxAlias);
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testSerializerRoundTrip() {
+        Map<String, Object> original = new HashMap<>();
+        original.put("existing_key", "value");
+
+        Map<String, Object> enriched = SourceStatisticsSerializer.embedStatistics(
+            original,
+            new org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics() {
+                @Override
+                public java.util.OptionalLong rowCount() {
+                    return java.util.OptionalLong.of(42);
+                }
+
+                @Override
+                public java.util.OptionalLong sizeInBytes() {
+                    return java.util.OptionalLong.of(1024);
+                }
+
+                @Override
+                public
+                    java.util.Optional<Map<String, org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics.ColumnStatistics>>
+                    columnStatistics() {
+                    return java.util.Optional.of(
+                        Map.of("col1", new org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics.ColumnStatistics() {
+                            @Override
+                            public java.util.OptionalLong nullCount() {
+                                return java.util.OptionalLong.of(5);
+                            }
+
+                            @Override
+                            public java.util.OptionalLong distinctCount() {
+                                return java.util.OptionalLong.empty();
+                            }
+
+                            @Override
+                            public java.util.Optional<Object> minValue() {
+                                return java.util.Optional.of(10);
+                            }
+
+                            @Override
+                            public java.util.Optional<Object> maxValue() {
+                                return java.util.Optional.of(100);
+                            }
+                        })
+                    );
+                }
+            }
+        );
+
+        assertEquals("value", enriched.get("existing_key"));
+        assertEquals(42L, enriched.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals(1024L, enriched.get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
+        assertEquals(java.util.OptionalLong.of(42), SourceStatisticsSerializer.extractRowCount(enriched));
+        assertEquals(java.util.OptionalLong.of(5), SourceStatisticsSerializer.extractColumnNullCount(enriched, "col1"));
+        assertEquals(java.util.Optional.of(10), SourceStatisticsSerializer.extractColumnMin(enriched, "col1"));
+        assertEquals(java.util.Optional.of(100), SourceStatisticsSerializer.extractColumnMax(enriched, "col1"));
+    }
+
+    // --- helpers ---
+
+    private static ExternalSourceExec externalSource(Map<String, Object> sourceMetadata) {
+        List<Attribute> attrs = List.of(
+            new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, "score", DataType.DOUBLE)
+        );
+        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", attrs, Map.of(), sourceMetadata, null);
+    }
+
+    private static AggregateExec aggregateExec(ExternalSourceExec child, NamedExpression... aggregates) {
+        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), AggregatorMode.SINGLE, List.of(), null);
+    }
+
+    private static Alias countStarAlias() {
+        return new Alias(Source.EMPTY, "c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+    }
+
+    private static Alias countFieldAlias(ReferenceAttribute field) {
+        return new Alias(Source.EMPTY, "c", new Count(Source.EMPTY, field));
+    }
+
+    private static Map<String, Object> statsMetadata(Long rowCount, String colName, Long nullCount, Long sizeBytes) {
+        Map<String, Object> metadata = new HashMap<>();
+        if (rowCount != null) {
+            metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
+        }
+        if (sizeBytes != null) {
+            metadata.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, sizeBytes);
+        }
+        if (colName != null && nullCount != null) {
+            metadata.put("_stats.columns." + colName + ".null_count", nullCount);
+        }
+        return metadata;
+    }
+
+    private static PhysicalPlan applyRule(AggregateExec agg) {
+        PushStatsToExternalSource rule = new PushStatsToExternalSource();
+        return rule.apply(agg);
+    }
+}


### PR DESCRIPTION
Add PushStatsToExternalSource optimizer rule that answers
ungrouped COUNT(*), COUNT(field), MIN(field), MAX(field)
from file metadata statistics without scanning data.

Parquet and ORC format readers now extract row counts,
null counts, and column min/max from file metadata.
Statistics flow through the sourceMetadata map using
SourceStatisticsSerializer, avoiding serialization changes.

Developed using AI-assisted tooling.