### PR TITLE
Disable synthetic _id in SourceFieldMapper tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -730,11 +730,14 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
 
     public void testRecoverySourceWithTimeSeries() throws IOException {
         {
-            Settings settings = Settings.builder()
+            Settings.Builder settings = Settings.builder()
                 .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
-                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field")
-                .build();
-            MapperService mapperService = createMapperService(settings, fieldMapping(b -> {
+                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field");
+            if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG) {
+                // Synthetic _ids are not relevant to this test and the "123" id used is not synthetic-id-conformant
+                settings.put(IndexSettings.SYNTHETIC_ID.getKey(), false);
+            }
+            MapperService mapperService = createMapperService(settings.build(), fieldMapping(b -> {
                 b.field("type", "keyword");
                 b.field("time_series_dimension", true);
             }));
@@ -743,12 +746,15 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
             assertNull(doc.rootDoc().getField("_recovery_source"));
         }
         {
-            Settings settings = Settings.builder()
+            Settings.Builder settings = Settings.builder()
                 .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
                 .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field")
-                .put(INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
-                .build();
-            MapperService mapperService = createMapperService(settings, fieldMapping(b -> {
+                .put(INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+            if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG) {
+                // Synthetic _ids are not relevant to this test and the "123" id used is not synthetic-id-conformant
+                settings.put(IndexSettings.SYNTHETIC_ID.getKey(), false);
+            }
+            MapperService mapperService = createMapperService(settings.build(), fieldMapping(b -> {
                 b.field("type", "keyword");
                 b.field("time_series_dimension", true);
             }));
@@ -777,22 +783,28 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
                 }
             """;
         {
-            Settings settings = Settings.builder()
+            Settings.Builder settings = Settings.builder()
                 .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
-                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field")
-                .build();
-            MapperService mapperService = createMapperService(settings, mappings);
+                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field");
+            if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG) {
+                // Synthetic _ids are not relevant to this test and the "123" id used is not synthetic-id-conformant
+                settings.put(IndexSettings.SYNTHETIC_ID.getKey(), false);
+            }
+            MapperService mapperService = createMapperService(settings.build(), mappings);
             DocumentMapper docMapper = mapperService.documentMapper();
             ParsedDocument doc = docMapper.parse(source("123", b -> b.field("@timestamp", "2012-02-13").field("field", "value1"), null));
             assertNull(doc.rootDoc().getField("_recovery_source"));
         }
         {
-            Settings settings = Settings.builder()
+            Settings.Builder settings = Settings.builder()
                 .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
                 .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field")
-                .put(INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
-                .build();
-            MapperService mapperService = createMapperService(settings, mappings);
+                .put(INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+            if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG) {
+                // Synthetic _ids are not relevant to this test and the "123" id used is not synthetic-id-conformant
+                settings.put(IndexSettings.SYNTHETIC_ID.getKey(), false);
+            }
+            MapperService mapperService = createMapperService(settings.build(), mappings);
             DocumentMapper docMapper = mapperService.documentMapper();
             ParsedDocument doc = docMapper.parse(
                 source("123", b -> b.field("@timestamp", "2012-02-13").field("field", randomAlphaOfLength(5)), null)


### PR DESCRIPTION
When the TSDB synthetic ID feature flag is enabled, 
disable synthetic _id in recovery source tests since the 
hardcoded "123" id is not synthetic-id-conformant and 
synthetic ids are not relevant to these tests.

Relates #142366