### PR TITLE
ESQL: Lower overhead in topn oom race

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOomRaceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOomRaceTests.java
@@ -78,9 +78,9 @@ public class TopNOomRaceTests extends ESTestCase {
     }
 
     public void testRace() {
-        int driverCount = 6;
-        double usedByEachThread = .3;
-        ByteSizeValue limit = ByteSizeValue.ofBytes(Runtime.getRuntime().totalMemory() - ByteSizeValue.ofMb(30).getBytes());
+        int driverCount = 2;
+        double usedByEachThread = .7;
+        ByteSizeValue limit = ByteSizeValue.ofBytes(Runtime.getRuntime().totalMemory() - ByteSizeValue.ofMb(60).getBytes());
         int approxObjectRefsPerFilledRow = 5;
         // One byte for the null/non-null marker
         int approxSizePerFilledRow = RamUsageEstimator.NUM_BYTES_OBJECT_REF * approxObjectRefsPerFilledRow + repeats * (1 + Integer.BYTES);


### PR DESCRIPTION
The test we use for checking for topn ooms fails every once in a while because with test *stuff* in memory. This lowers the test overhead and gives us a little more room.
