### PR TITLE
[9.3] Fix cancellation race in CancellableRateLimitedFluxIterator (#141974)

### DIFF
--- a/docs/changelog/141974.yaml
+++ b/docs/changelog/141974.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 141974
+summary: Fix cancellation race in `CancellableRateLimitedFluxIterator`
+type: bug


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix cancellation race in CancellableRateLimitedFluxIterator (#141974)](https://github.com/elastic/elasticsearch/pull/141974)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)