### PR TITLE
[9.3] Expand DLM user to allow interaction with .workflows-events (#143958)

### DIFF
--- a/docs/changelog/143958.yaml
+++ b/docs/changelog/143958.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 143958
+summary: Expand DLM user to allow interaction with .workflows-events
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -181,8 +181,8 @@ public class InternalUsers {
                         ".fleet-actions-results",
                         // System data streams for storing uploaded file data for Agent diagnostics and Endpoint response actions
                         ".fleet-fileds*",
-                        // System data stream for kibana workflows logs
-                        ".workflows-execution-data-stream-logs"
+                        // System data stream for kibana workflows
+                        ".workflows*"
                     )
                     .privileges(
                         filterNonNull(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -253,11 +253,7 @@ public class InternalUsersTests extends ESTestCase {
         assertThat(role.application(), is(ApplicationPermission.NONE));
         assertThat(role.remoteIndices(), is(RemoteIndicesPermission.NONE));
 
-        final List<String> allowedSystemDataStreams = Arrays.asList(
-            ".fleet-actions-results",
-            ".fleet-fileds*",
-            ".workflows-execution-data-stream-logs"
-        );
+        final List<String> allowedSystemDataStreams = Arrays.asList(".fleet-actions-results", ".fleet-fileds*", ".workflows*");
         for (var group : role.indices().groups()) {
             if (group.allowRestrictedIndices()) {
                 assertThat(group.indices(), arrayContaining(allowedSystemDataStreams.toArray(new String[0])));


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Expand DLM user to allow interaction with .workflows-events (#143958)