### PR TITLE
[#142080] Align cat indices default expand_wildcards with API spec

### DIFF
--- a/docs/changelog/143986.yaml
+++ b/docs/changelog/143986.yaml
@@ -1,0 +1,6 @@
+pr: 143986
+summary: Align cat indices default expand_wildcards behavior with the API spec
+area: CAT APIs
+type: bug
+issues:
+  - 142080

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
@@ -17,14 +17,6 @@
         index: i*
   - match:
       $body: |
-        /^$/
-
-  - do:
-      cat.indices:
-        index: i*
-        expand_wildcards: ["all"]
-  - match:
-      $body: |
         /^(green  \s+
            open   \s+
            index1 \s+
@@ -38,6 +30,14 @@
            (\d+|\d+[.]\d+)(kb|b) \s*
          )
          $/
+
+  - do:
+      cat.indices:
+        index: i*
+        expand_wildcards: ["open", "closed"]
+  - match:
+      $body: |
+        /^$/
 
 ---
 "Test cat indices output for dot-hidden index and dot-prefixed pattern":
@@ -59,7 +59,21 @@
       cat.indices: {}
   - match:
       $body: |
-        /^$/
+        /^(.*           # Accounts for system indices that get automatically generated
+           green  \s+
+           open   \s+
+           \.index1 \s+
+           ([a-zA-Z0-9=/_+]|[\\\-]){22} \s+
+           1      \s+
+           0      \s+
+           0      \s+
+           0      \s+
+           (\d+|\d+[.]\d+)(kb|b) \s+
+           (\d+|\d+[.]\d+)(kb|b) \s+
+           (\d+|\d+[.]\d+)(kb|b) \s*
+           .*           # Accounts for system indices that get automatically generated
+         )
+         $/
 
   - do:
       cat.indices:
@@ -101,16 +115,8 @@
       cat.indices:
         index: "i*"
         # Can't use a bare wildcard here because Security replaces wildcards
-        # it with all matching authorized indices/aliases, including the visible
+        # with all matching authorized indices/aliases, including the visible
         # alias
-  - match:
-      $body: |
-        /^$/
-
-  - do:
-      cat.indices:
-        index: "i*"
-        expand_wildcards: ["open", "hidden"]
   - match:
       $body: |
         /^(green  \s+
@@ -126,6 +132,14 @@
            (\d+|\d+[.]\d+)(kb|b) \s*
          )
          $/
+
+  - do:
+      cat.indices:
+        index: "i*"
+        expand_wildcards: ["open", "closed"]
+  - match:
+      $body: |
+        /^$/
 
   - do:
       cat.indices:
@@ -169,14 +183,6 @@
 
   - match:
       $body: |
-        /^$/
-
-  - do:
-      cat.indices:
-        index: i*
-        expand_wildcards: ["all"]
-  - match:
-      $body: |
         /^(green  \s+
            open   \s+
            index1 \s+
@@ -190,6 +196,14 @@
            (\d+|\d+[.]\d+)(kb|b) \s*
          )
          $/
+
+  - do:
+      cat.indices:
+        index: i*
+        expand_wildcards: ["open", "closed"]
+  - match:
+      $body: |
+        /^$/
 
   - do:
       cat.indices:
@@ -231,7 +245,21 @@
       cat.indices: {}
   - match:
       $body: |
-        /^$/
+        /^(.*           # Accounts for system indices that get automatically generated
+           green  \s+
+           open   \s+
+           index1 \s+
+           ([a-zA-Z0-9=/_+]|[\\\-]){22} \s+
+           1      \s+
+           0      \s+
+           0      \s+
+           0      \s+
+           (\d+|\d+[.]\d+)(kb|b) \s+
+           (\d+|\d+[.]\d+)(kb|b) \s+
+           (\d+|\d+[.]\d+)(kb|b) \s*
+           .*           # Accounts for system indices that get automatically generated
+         )
+         $/
   - do:
       cat.indices:
         index: ".*"

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -85,7 +85,7 @@ public class RestIndicesAction extends AbstractCatAction {
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, IndicesOptions.strictExpand());
+        final IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, IndicesOptions.strictExpandHidden());
         final TimeValue masterNodeTimeout = getMasterNodeTimeout(request);
         final boolean includeUnloadedSegments = request.paramAsBoolean("include_unloaded_segments", false);
 


### PR DESCRIPTION
## Summary

Align the default `expand_wildcards` behavior in `/_cat/indices` with the API spec by using hidden-aware default indices options.

The REST API spec already documents the default as `all`, but `RestIndicesAction` was still parsing requests with `IndicesOptions.strictExpand()`, which excludes hidden indices unless `expand_wildcards=all` is explicitly provided.

This change updates the default request parsing to include hidden indices and adjusts the REST YAML tests accordingly.

Closes #142080