### PR TITLE
[9.2] apm-server: update monitor mappings to include new TBS metrics (#140700)

### DIFF
--- a/docs/changelog/140700.yaml
+++ b/docs/changelog/140700.yaml
@@ -1,0 +1,5 @@
+pr: 140700
+summary: "Apm-server: update monitor mappings to include new TBS metrics"
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
@@ -820,6 +820,18 @@
                                 },
                                 "value_log_size": {
                                   "type": "long"
+                                },
+                                "storage_limit": {
+                                  "type": "long"
+                                },
+                                "disk_used": {
+                                  "type": "long"
+                                },
+                                "disk_total": {
+                                  "type": "long"
+                                },
+                                "disk_usage_threshold_pct": {
+                                  "type": "float"
                                 }
                               }
                             }
@@ -2301,6 +2313,22 @@
                                 "value_log_size": {
                                   "type": "alias",
                                   "path": "beat.stats.apm_server.sampling.tail.storage.value_log_size"
+                                },
+                                "storage_limit": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.storage_limit"
+                                },
+                                "disk_used": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.disk_used"
+                                },
+                                "disk_total": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.disk_total"
+                                },
+                                "disk_usage_threshold_pct": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.disk_usage_threshold_pct"
                                 }
                               }
                             }

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
@@ -1000,6 +1000,18 @@
                                 },
                                 "value_log_size": {
                                   "type": "long"
+                                },
+                                "storage_limit": {
+                                  "type": "long"
+                                },
+                                "disk_used": {
+                                  "type": "long"
+                                },
+                                "disk_total": {
+                                  "type": "long"
+                                },
+                                "disk_usage_threshold_pct": {
+                                  "type": "float"
                                 }
                               }
                             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 21;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 23;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [apm-server: update monitor mappings to include new TBS metrics (#140700)](https://github.com/elastic/elasticsearch/pull/140700)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)