### PR TITLE
Fix HistogramUnionState.equals for empty instances

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
@@ -409,7 +409,7 @@ public class HistogramUnionState implements Releasable, Accountable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o instanceof HistogramUnionState == false) return false;
 
         HistogramUnionState that = (HistogramUnionState) o;
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionStateTests.java
@@ -185,6 +185,17 @@ public class HistogramUnionStateTests extends ESTestCase {
         }
     }
 
+    public void testEmptySingletonWriteToReadRoundTripEquals() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        HistogramUnionState.EMPTY.writeTo(out);
+
+        try (HistogramUnionState roundTripped = HistogramUnionState.read(breaker(), out.bytes().streamInput())) {
+            assertThat(roundTripped, equalTo(HistogramUnionState.EMPTY));
+            assertThat(HistogramUnionState.EMPTY, equalTo(roundTripped));
+            assertThat(roundTripped.hashCode(), equalTo(HistogramUnionState.EMPTY.hashCode()));
+        }
+    }
+
     public void testPureTDigestSerializationCompatibility() throws IOException {
         try (RandomState state = randomState(false)) {
 


### PR DESCRIPTION
I was notified by @nicktindall about an apparently rare test failure related to histograms in queryDSL:
```
./gradlew ":server:test" --tests "org.elasticsearch.search.aggregations.metrics.TDigestPercentilesAggregatorTests.testQueryFiltering" -Dtests.seed=7EFB3BA331FB1ED1 -Dtests.locale=sbp -Dtests.timezone=Africa/Khartoum -Druntime.java=25
```

As it turns out, there was a bug in the `HistogramUnionState` class I recently introduced: For empty states, we use a singleton instance. That singleton is in fact a sub-class, preventing mutations. At the same time in `equals` we were checking the class identity, causing deserialzed, empty `HistogramUnionState`s to not be equal to that singleton.