### PR TITLE
[ES|QL|DS] Parquet row-group level split parallelism

### DIFF
--- a/docs/changelog/144018.yaml
+++ b/docs/changelog/144018.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144018
+summary: "[ES|QL|DS] Parquet row-group level split parallelism"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -37,7 +37,9 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
@@ -67,7 +69,7 @@ import java.util.OptionalLong;
  *   <li>Direct conversion from Parquet to ESQL blocks</li>
  * </ul>
  */
-public class ParquetFormatReader implements FormatReader {
+public class ParquetFormatReader implements RangeAwareFormatReader {
 
     private final BlockFactory blockFactory;
 
@@ -270,6 +272,67 @@ public class ParquetFormatReader implements FormatReader {
     @Override
     public void close() throws IOException {
         // No resources to close at the reader level
+    }
+
+    @Override
+    public List<long[]> discoverSplitRanges(StorageObject object) throws IOException {
+        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetReadOptions options = ParquetReadOptions.builder().build();
+        try (ParquetFileReader reader = ParquetFileReader.open(parquetInputFile, options)) {
+            List<BlockMetaData> rowGroups = reader.getRowGroups();
+            if (rowGroups.size() <= 1) {
+                return List.of();
+            }
+            List<long[]> ranges = new ArrayList<>(rowGroups.size());
+            for (BlockMetaData block : rowGroups) {
+                ranges.add(new long[] { block.getStartingPos(), block.getTotalByteSize() });
+            }
+            return ranges;
+        }
+    }
+
+    /**
+     * Reads only row groups whose starting position falls within {@code [rangeStart, rangeEnd)}.
+     * errorPolicy is accepted for interface compliance but not applied — Parquet errors are
+     * structural (corrupt page, schema mismatch) rather than row-level.
+     */
+    @Override
+    public CloseableIterator<Page> readRange(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetReadOptions options = ParquetReadOptions.builder().withRange(rangeStart, rangeEnd).build();
+        ParquetFileReader reader = ParquetFileReader.open(parquetInputFile, options);
+
+        FileMetaData fileMetaData = reader.getFileMetaData();
+        MessageType parquetSchema = fileMetaData.getSchema();
+        List<Attribute> attributes = convertParquetSchemaToAttributes(parquetSchema);
+
+        List<Attribute> projectedAttributes;
+        if (projectedColumns == null || projectedColumns.isEmpty()) {
+            projectedAttributes = attributes;
+        } else {
+            projectedAttributes = new ArrayList<>();
+            Map<String, Attribute> attributeMap = new HashMap<>();
+            for (Attribute attr : attributes) {
+                attributeMap.put(attr.name(), attr);
+            }
+            for (String columnName : projectedColumns) {
+                Attribute attr = attributeMap.get(columnName);
+                attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
+                projectedAttributes.add(attr);
+            }
+        }
+
+        MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
+        String createdBy = fileMetaData.getCreatedBy();
+        return new ParquetColumnIterator(reader, projectedSchema, projectedAttributes, batchSize, blockFactory, NO_LIMIT, createdBy);
     }
 
     private static MessageType buildProjectedSchema(MessageType fullSchema, List<Attribute> projectedAttributes) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -619,22 +620,150 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals("parquet", metadata.sourceType());
     }
 
+    public void testDiscoverSplitRangesMultipleRowGroups() throws Exception {
+        byte[] parquetData = createWideMultiRowGroupFile(500);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Expected multiple ranges for multi-row-group file, got " + ranges.size(), ranges.size() > 1);
+
+        for (long[] range : ranges) {
+            assertTrue("Range offset must be non-negative", range[0] >= 0);
+            assertTrue("Range length must be positive", range[1] > 0);
+        }
+    }
+
+    public void testDiscoverSplitRangesSingleRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group group = factory.newGroup();
+            group.add("id", 1L);
+            return List.of(group);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Single row group file should return empty ranges", ranges.isEmpty());
+    }
+
+    public void testReadRangeSelectsCorrectRowGroups() throws Exception {
+        byte[] parquetData = createWideMultiRowGroupFile(500);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Need at least 2 ranges for this test, got " + ranges.size(), ranges.size() >= 2);
+
+        int totalRowsFromRanges = 0;
+        for (long[] range : ranges) {
+            long rangeStart = range[0];
+            long rangeEnd = rangeStart + range[1];
+            try (
+                CloseableIterator<Page> iterator = reader.readRange(
+                    storageObject,
+                    null,
+                    1000,
+                    rangeStart,
+                    rangeEnd,
+                    List.of(),
+                    ErrorPolicy.STRICT
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    Page page = iterator.next();
+                    totalRowsFromRanges += page.getPositionCount();
+                }
+            }
+        }
+
+        int totalRowsDirect = 0;
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1000)) {
+            while (iterator.hasNext()) {
+                totalRowsDirect += iterator.next().getPositionCount();
+            }
+        }
+        assertEquals("Reading all ranges should produce the same total as a full read", totalRowsDirect, totalRowsFromRanges);
+    }
+
     @FunctionalInterface
     private interface GroupCreator {
         List<Group> create(SimpleGroupFactory factory);
     }
 
+    /**
+     * Creates a Parquet file with wide rows (INT64 id + 200-char BINARY payload) and a small
+     * row group size to guarantee multiple row groups in the output.
+     */
+    private byte[] createWideMultiRowGroupFile(int numRows) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("payload")
+            .named("test_schema");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+        String padding = "x".repeat(200);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(4 * 1024L)
+                .withPageSize(512)
+                .build()
+        ) {
+            for (int i = 0; i < numRows; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                g.add("payload", "row-" + i + "-" + padding);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
     private byte[] createParquetFile(MessageType schema, GroupCreator groupCreator) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        OutputFile outputFile = new OutputFile() {
+        OutputFile outputFile = createOutputFile(outputStream);
+
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
             @Override
-            public PositionOutputStream create(long blockSizeHint) throws IOException {
+            public PositionOutputStream create(long blockSizeHint) {
                 return new PositionOutputStream() {
                     private long position = 0;
 
                     @Override
-                    public long getPos() throws IOException {
+                    public long getPos() {
                         return position;
                     }
 
@@ -658,7 +787,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             }
 
             @Override
-            public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
                 return create(blockSizeHint);
             }
 
@@ -677,23 +806,6 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 return "memory://test.parquet";
             }
         };
-
-        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
-        List<Group> groups = groupCreator.create(groupFactory);
-
-        try (
-            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
-                .withType(schema)
-                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
-                .build()
-        ) {
-
-            for (Group group : groups) {
-                writer.write(group);
-            }
-        }
-
-        return outputStream.toByteArray();
     }
 
     private StorageObject createStorageObject(byte[] data) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -376,25 +377,36 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                                 );
                             }
                             List<String> cols = projectedColumns(injector);
-                            StorageObject obj = storageProvider.newObject(fileSplit.path(), fileSplit.length());
-                            boolean skipFirstLine = false;
-                            boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
-                            if (fileSplit.offset() > 0) {
-                                obj = new RangeStorageObject(obj, fileSplit.offset(), fileSplit.length());
-                                boolean isFirstSplit = "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
-                                skipFirstLine = isFirstSplit == false;
-                            }
-                            try (
-                                CloseableIterator<Page> pages = formatReader.readSplit(
-                                    obj,
+
+                            boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+                            CloseableIterator<Page> pages;
+                            if (isRangeSplit && formatReader instanceof RangeAwareFormatReader rangeReader) {
+                                String fileLengthStr = (String) fileSplit.config().get(FileSplitProvider.FILE_LENGTH_KEY);
+                                StorageObject fullObj = fileLengthStr != null
+                                    ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
+                                    : storageProvider.newObject(fileSplit.path());
+                                long rangeEnd = fileSplit.offset() + fileSplit.length();
+                                pages = rangeReader.readRange(
+                                    fullObj,
                                     cols,
                                     batchSize,
-                                    skipFirstLine,
-                                    lastSplit,
+                                    fileSplit.offset(),
+                                    rangeEnd,
                                     attributes,
                                     errorPolicy
-                                )
-                            ) {
+                                );
+                            } else {
+                                StorageObject obj = storageProvider.newObject(fileSplit.path(), fileSplit.length());
+                                boolean skipFirstLine = false;
+                                boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+                                if (fileSplit.offset() > 0) {
+                                    obj = new RangeStorageObject(obj, fileSplit.offset(), fileSplit.length());
+                                    boolean isFirstSplit = "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+                                    skipFirstLine = isFirstSplit == false;
+                                }
+                                pages = formatReader.readSplit(obj, cols, batchSize, skipFirstLine, lastSplit, attributes, errorPolicy);
+                            }
+                            try (pages) {
                                 int consumed = drainPagesWithBudget(pages, buffer, injector);
                                 if (rowLimit != FormatReader.NO_LIMIT) {
                                     rowsRemaining -= consumed;
@@ -616,7 +628,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     @Override
     public String describe() {
         String asyncMode;
-        if (formatReader instanceof SegmentableFormatReader && parsingParallelism > 1) {
+        if (formatReader instanceof RangeAwareFormatReader) {
+            asyncMode = "range-split";
+        } else if (formatReader instanceof SegmentableFormatReader && parsingParallelism > 1) {
             asyncMode = "parallel-parse(" + parsingParallelism + ")";
         } else if (formatReader.supportsNativeAsync()) {
             asyncMode = "native-async";

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -112,7 +112,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
 
     @Override
     public SplitProvider splitProvider() {
-        return new FileSplitProvider(FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE, codecRegistry, storageRegistry, settings);
+        return new FileSplitProvider(FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE, codecRegistry, storageRegistry, formatRegistry, settings);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -16,8 +16,10 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FrameIndex;
 import org.elasticsearch.xpack.esql.datasources.spi.IndexedDecompressionCodec;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
@@ -56,17 +58,21 @@ public class FileSplitProvider implements SplitProvider {
     static final String FIRST_SPLIT_KEY = "_first_split";
     static final String LAST_SPLIT_KEY = "_last_split";
 
+    static final String RANGE_SPLIT_KEY = "_range_split";
+    static final String FILE_LENGTH_KEY = "_file_length";
+
     private final long targetSplitSizeBytes;
     private final DecompressionCodecRegistry codecRegistry;
     private final StorageProviderRegistry storageRegistry;
+    private final FormatReaderRegistry formatRegistry;
     private final Settings settings;
 
     public FileSplitProvider() {
-        this(DEFAULT_TARGET_SPLIT_SIZE, null, null, Settings.EMPTY);
+        this(DEFAULT_TARGET_SPLIT_SIZE, null, null, null, Settings.EMPTY);
     }
 
     public FileSplitProvider(long targetSplitSizeBytes) {
-        this(targetSplitSizeBytes, null, null, Settings.EMPTY);
+        this(targetSplitSizeBytes, null, null, null, Settings.EMPTY);
     }
 
     public FileSplitProvider(
@@ -75,9 +81,20 @@ public class FileSplitProvider implements SplitProvider {
         StorageProviderRegistry storageRegistry,
         Settings settings
     ) {
+        this(targetSplitSizeBytes, codecRegistry, storageRegistry, null, settings);
+    }
+
+    public FileSplitProvider(
+        long targetSplitSizeBytes,
+        DecompressionCodecRegistry codecRegistry,
+        StorageProviderRegistry storageRegistry,
+        FormatReaderRegistry formatRegistry,
+        Settings settings
+    ) {
         this.targetSplitSizeBytes = targetSplitSizeBytes;
         this.codecRegistry = codecRegistry;
         this.storageRegistry = storageRegistry;
+        this.formatRegistry = formatRegistry;
         this.settings = settings != null ? settings : Settings.EMPTY;
     }
 
@@ -125,6 +142,10 @@ public class FileSplitProvider implements SplitProvider {
             // This is independent of targetSplitSizeBytes — compressed files with splittable
             // codecs are always split at block boundaries when possible.
             if (tryBlockAlignedSplits(filePath, fileLength, format, config, partitionValues, splits)) {
+                continue;
+            }
+
+            if (tryRangeAwareSplits(filePath, fileLength, format, config, partitionValues, splits)) {
                 continue;
             }
 
@@ -235,6 +256,65 @@ public class FileSplitProvider implements SplitProvider {
             return true;
         } catch (IOException e) {
             LOGGER.warn("Failed to scan block boundaries for [{}], falling back to single split", filePath, e);
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to create range-aware splits for columnar formats (e.g. Parquet row groups).
+     * The format reader reads file metadata (e.g. Parquet footer) to discover independently
+     * readable byte ranges. Returns true if range-aware splits were created.
+     */
+    private boolean tryRangeAwareSplits(
+        StoragePath filePath,
+        long fileLength,
+        String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        List<ExternalSplit> splits
+    ) {
+        if (formatRegistry == null || storageRegistry == null || format == null) {
+            return false;
+        }
+
+        FormatReader reader;
+        try {
+            reader = formatRegistry.byExtension(filePath.objectName());
+        } catch (Exception e) {
+            return false;
+        }
+
+        if (reader instanceof RangeAwareFormatReader == false) {
+            return false;
+        }
+        RangeAwareFormatReader rangeReader = (RangeAwareFormatReader) reader;
+
+        try {
+            StorageProvider provider;
+            if (config != null && config.isEmpty() == false) {
+                provider = storageRegistry.createProvider(filePath.scheme(), settings, config);
+            } else {
+                provider = storageRegistry.provider(filePath);
+            }
+            StorageObject object = provider.newObject(filePath, fileLength);
+
+            List<long[]> ranges = rangeReader.discoverSplitRanges(object);
+            if (ranges.isEmpty()) {
+                return false;
+            }
+
+            Map<String, Object> splitConfig = new HashMap<>(config);
+            splitConfig.put(RANGE_SPLIT_KEY, "true");
+            splitConfig.put(FILE_LENGTH_KEY, Long.toString(fileLength));
+
+            for (long[] range : ranges) {
+                long offset = range[0];
+                long length = range[1];
+                splits.add(new FileSplit("file", filePath, offset, length, format, splitConfig, partitionValues));
+            }
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("Failed to discover split ranges for [{}], falling back to single split", filePath, e);
             return false;
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Extension of {@link FormatReader} for columnar formats (Parquet, ORC) that support
+ * row-group-level split parallelism.
+ * <p>
+ * Unlike line-oriented formats that use {@link SegmentableFormatReader} with byte-range
+ * views, columnar formats need full-file access (e.g. Parquet's footer is at EOF) but
+ * can selectively read row groups within a byte range. This interface separates the
+ * range specification from the file access, allowing the reader to open the full file
+ * and use format-native range filtering (e.g. {@code ParquetReadOptions.withRange()}).
+ * <p>
+ * The split discovery flow:
+ * <ol>
+ *   <li>{@link #discoverSplitRanges} reads file metadata (e.g. Parquet footer) and
+ *       returns byte ranges for each independently readable unit (e.g. row group).</li>
+ *   <li>The framework creates one split per range, distributed across drivers/nodes.</li>
+ *   <li>At read time, {@link #readRange} receives the full-file object and the assigned
+ *       byte range, reading only the relevant row groups.</li>
+ * </ol>
+ */
+public interface RangeAwareFormatReader extends FormatReader {
+
+    /**
+     * Discovers independently readable byte ranges within a file by reading its metadata.
+     * Each range typically corresponds to one row group (Parquet) or stripe (ORC).
+     * <p>
+     * Returns a list of {@code [startOffset, length]} pairs. An empty list means the
+     * file cannot be split (e.g. single row group) and should be read as a whole.
+     *
+     * @param object the storage object representing the full file
+     * @return list of byte ranges, each as {@code [offset, length]}
+     */
+    List<long[]> discoverSplitRanges(StorageObject object) throws IOException;
+
+    /**
+     * Reads only the row groups / stripes that fall within the given byte range.
+     * The storage object must represent the full file (not a range-limited view),
+     * because columnar formats need access to file-level metadata (e.g. footer).
+     *
+     * @param object            the full-file storage object
+     * @param projectedColumns  columns to project
+     * @param batchSize         rows per page
+     * @param rangeStart        start byte offset of the assigned range
+     * @param rangeEnd          end byte offset (exclusive) of the assigned range
+     * @param resolvedAttributes schema attributes resolved from metadata
+     * @param errorPolicy       error handling policy
+     * @return an iterator that yields pages from the matching row groups
+     */
+    CloseableIterator<Page> readRange(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException;
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -8,23 +8,33 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -435,6 +445,198 @@ public class FileSplitProviderTests extends ESTestCase {
             totalBytes += ((FileSplit) split).length();
         }
         assertEquals(fileSize, totalBytes);
+    }
+
+    public void testRangeAwareSplitsForParquet() {
+        long[][] fakeRanges = { { 100, 500 }, { 700, 600 }, { 1400, 400 } };
+
+        RangeAwareFormatReader mockReader = createMockRangeReader(List.of(fakeRanges[0], fakeRanges[1], fakeRanges[2]));
+
+        FormatReaderRegistry formatRegistry = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        formatRegistry.registerLazy("parquet", (s, bf) -> mockReader, Settings.EMPTY, null);
+        formatRegistry.byName("parquet");
+
+        StorageProviderRegistry storageRegistry = createMockStorageRegistry();
+
+        FileSplitProvider splitter = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            new DecompressionCodecRegistry(),
+            storageRegistry,
+            formatRegistry,
+            Settings.EMPTY
+        );
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.parquet"), 2000, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.parquet");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals(3, splits.size());
+        for (int i = 0; i < splits.size(); i++) {
+            FileSplit fs = (FileSplit) splits.get(i);
+            assertEquals(fakeRanges[i][0], fs.offset());
+            assertEquals(fakeRanges[i][1], fs.length());
+            assertEquals("true", fs.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+            assertEquals("2000", fs.config().get(FileSplitProvider.FILE_LENGTH_KEY));
+        }
+    }
+
+    public void testRangeAwareFallbackForSingleRowGroup() {
+        RangeAwareFormatReader mockReader = createMockRangeReader(List.of());
+
+        FormatReaderRegistry formatRegistry = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        formatRegistry.registerLazy("parquet", (s, bf) -> mockReader, Settings.EMPTY, null);
+        formatRegistry.byName("parquet");
+
+        StorageProviderRegistry storageRegistry = createMockStorageRegistry();
+
+        FileSplitProvider splitter = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            new DecompressionCodecRegistry(),
+            storageRegistry,
+            formatRegistry,
+            Settings.EMPTY
+        );
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/small.parquet"), 500, Instant.EPOCH);
+        FileSet fileSet = new FileSet(List.of(entry), "s3://b/*.parquet");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileSet, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals("Single row group should produce single split", 1, splits.size());
+        FileSplit fs = (FileSplit) splits.get(0);
+        assertEquals(0, fs.offset());
+        assertEquals(500, fs.length());
+        assertNull("Single split should not have RANGE_SPLIT_KEY", fs.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+    }
+
+    private static RangeAwareFormatReader createMockRangeReader(List<long[]> ranges) {
+        return new RangeAwareFormatReader() {
+            @Override
+            public List<long[]> discoverSplitRanges(StorageObject object) {
+                return ranges;
+            }
+
+            @Override
+            public CloseableIterator<Page> readRange(
+                StorageObject object,
+                List<String> projectedColumns,
+                int batchSize,
+                long rangeStart,
+                long rangeEnd,
+                List<Attribute> resolvedAttributes,
+                ErrorPolicy errorPolicy
+            ) {
+                throw new UnsupportedOperationException("not called during split discovery");
+            }
+
+            @Override
+            public SourceMetadata metadata(StorageObject object) {
+                return null;
+            }
+
+            @Override
+            public CloseableIterator<Page> read(StorageObject object, List<String> projectedColumns, int batchSize) {
+                return null;
+            }
+
+            @Override
+            public String formatName() {
+                return "parquet";
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(".parquet", ".parq");
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static StorageProviderRegistry createMockStorageRegistry() {
+        StorageProviderRegistry registry = new StorageProviderRegistry(Settings.EMPTY);
+        registry.registerFactory("s3", settings -> new StorageProvider() {
+            @Override
+            public StorageObject newObject(StoragePath path) {
+                return newObject(path, 0);
+            }
+
+            @Override
+            public StorageObject newObject(StoragePath path, long length) {
+                return newObject(path, length, Instant.EPOCH);
+            }
+
+            @Override
+            public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+                return new StorageObject() {
+                    @Override
+                    public InputStream newStream() {
+                        return new ByteArrayInputStream(new byte[0]);
+                    }
+
+                    @Override
+                    public InputStream newStream(long position, long len) {
+                        return new ByteArrayInputStream(new byte[0]);
+                    }
+
+                    @Override
+                    public long length() {
+                        return length;
+                    }
+
+                    @Override
+                    public Instant lastModified() {
+                        return lastModified;
+                    }
+
+                    @Override
+                    public boolean exists() {
+                        return true;
+                    }
+
+                    @Override
+                    public StoragePath path() {
+                        return path;
+                    }
+                };
+            }
+
+            @Override
+            public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+                return new StorageIterator() {
+                    @Override
+                    public boolean hasNext() {
+                        return false;
+                    }
+
+                    @Override
+                    public StorageEntry next() {
+                        throw new java.util.NoSuchElementException();
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+            }
+
+            @Override
+            public boolean exists(StoragePath path) {
+                return true;
+            }
+
+            @Override
+            public List<String> supportedSchemes() {
+                return List.of("s3");
+            }
+
+            @Override
+            public void close() {}
+        });
+        return registry;
     }
 
     // -- helpers --


### PR DESCRIPTION
Parquet files were always read as a single split per file regardless of how many row groups they contained. For large files with many row groups, each row group is an independently readable unit that can be processed by a different driver or data node. This adds a `RangeAwareFormatReader` SPI interface and wires `ParquetFormatReader` through it so that split discovery reads the Parquet footer and creates one `FileSplit` per row group, dispatched through the existing `ExternalSliceQueue` / multi-driver infrastructure.

Unlike line-oriented formats that use `RangeStorageObject` byte-range views, Parquet needs full-file access (footer is at EOF) but can selectively read row groups via `ParquetReadOptions.withRange()`. The `RangeAwareFormatReader` interface separates the range specification from file access, keeping the SPI clean and extensible for ORC.

Developed using AI-assisted tooling