### PR TITLE
[ES|QL] Allow testLoadDocSequenceReturnsCorrectResultsText to circuit break

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackSubqueryIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackSubqueryIT.java
@@ -245,18 +245,27 @@ public class HeapAttackSubqueryIT extends HeapAttackTestCase {
             columns.add(column);
         }
 
-        Map<?, ?> response = buildSubqueriesWithSortInMainQuery(MAX_SUBQUERIES, "manybigfields", "f000");
-        assertEquals(columns, response.get("columns"));
+        // serverless triggers CBE occasionally.
+        try {
+            Map<?, ?> response = buildSubqueriesWithSortInMainQuery(MAX_SUBQUERIES, "manybigfields", "f000");
+            assertEquals(columns, response.get("columns"));
 
-        List<?> values = (List<?>) response.get("values");
-        assertEquals(docs * MAX_SUBQUERIES, values.size());
+            List<?> values = (List<?>) response.get("values");
+            assertEquals(docs * MAX_SUBQUERIES, values.size());
 
-        for (Object rowObj : values) {
-            List<?> row = (List<?>) rowObj;
-            assertEquals(1000, row.size());
-            for (int f = 0; f < 1000; f++) {
-                assertEquals(Integer.toString(f % 10).repeat(1024), row.get(f));
+            for (Object rowObj : values) {
+                List<?> row = (List<?>) rowObj;
+                assertEquals(1000, row.size());
+                for (int f = 0; f < 1000; f++) {
+                    assertEquals(Integer.toString(f % 10).repeat(1024), row.get(f));
+                }
             }
+        } catch (ResponseException e) {
+            Map<?, ?> map = responseAsMap(e.getResponse());
+            assertMap(
+                map,
+                matchesMap().entry("status", 429).entry("error", matchesMap().extraOk().entry("type", "circuit_breaking_exception"))
+            );
         }
     }
 


### PR DESCRIPTION
Allow this test to circuit break in serverless occasionally. 

Fixes: https://github.com/elastic/elasticsearch-serverless/issues/5828