### PR TITLE
Add BodyPostProcessor to IndexingPressureAwareContentAggregator

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregator.java
+++ b/server/src/main/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregator.java
@@ -16,7 +16,9 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexingPressure;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * Accumulates a streamed HTTP request body while tracking memory usage via {@link IndexingPressure}.
@@ -34,6 +36,26 @@ import java.util.ArrayList;
  * (as a {@link Releasable}) for the caller to release when appropriate.
  */
 public class IndexingPressureAwareContentAggregator implements BaseRestHandler.RequestBodyChunkConsumer {
+
+    /**
+     * Transforms the accumulated request body before it is handed to the {@link CompletionHandler}.
+     * Implementations must release the input reference when they produce new output.
+     */
+    @FunctionalInterface
+    public interface BodyPostProcessor {
+
+        BodyPostProcessor NOOP = (body, size) -> body;
+
+        /**
+         * Post-processes the accumulated request body (e.g. decompression).
+         *
+         * @param body the accumulated raw body
+         * @param maxSize the maximum permitted size for the result
+         * @return the post-processed body; must not exceed {@code maxSize}
+         * @throws IOException on processing failure
+         */
+        ReleasableBytesReference process(ReleasableBytesReference body, long maxSize) throws IOException;
+    }
 
     /**
      * Callback for request body accumulation lifecycle events.
@@ -61,6 +83,7 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
     private final IndexingPressure.Coordinating coordinating;
     private final long maxRequestSize;
     private final CompletionHandler completionHandler;
+    private final BodyPostProcessor bodyPostProcessor;
 
     private ArrayList<ReleasableBytesReference> chunks;
     private long accumulatedSize;
@@ -70,12 +93,14 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
         RestRequest request,
         IndexingPressure.Coordinating coordinating,
         long maxRequestSize,
-        CompletionHandler completionHandler
+        CompletionHandler completionHandler,
+        BodyPostProcessor bodyPostProcessor
     ) {
         this.request = request;
         this.coordinating = coordinating;
         this.maxRequestSize = maxRequestSize;
         this.completionHandler = completionHandler;
+        this.bodyPostProcessor = Objects.requireNonNull(bodyPostProcessor);
     }
 
     @Override
@@ -91,21 +116,10 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
         }
 
         accumulatedSize += chunk.length();
-        if (accumulatedSize > maxRequestSize) {
-            chunk.close();
-            closed = true;
-            if (chunks != null) {
-                Releasables.close(chunks);
-                chunks = null;
-            }
-            coordinating.close();
-            completionHandler.onFailure(
-                channel,
-                new ElasticsearchStatusException(
-                    "request body too large, max [" + maxRequestSize + "] bytes",
-                    RestStatus.REQUEST_ENTITY_TOO_LARGE
-                )
-            );
+        try {
+            assertBelowLimit();
+        } catch (Exception e) {
+            closeOnFailure(channel, e, chunk);
             return;
         }
 
@@ -126,14 +140,42 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
             }
             chunks = null;
 
+            try {
+                fullBody = bodyPostProcessor.process(fullBody, maxRequestSize);
+                accumulatedSize = fullBody.length();
+                assertBelowLimit();
+            } catch (Exception e) {
+                closeOnFailure(channel, e, fullBody);
+                return;
+            }
+
             long excess = maxRequestSize - accumulatedSize;
             if (excess > 0) {
                 coordinating.reduceBytes(excess);
             }
-
             closed = true;
             completionHandler.onComplete(channel, fullBody, coordinating);
         }
+    }
+
+    private void assertBelowLimit() {
+        if (accumulatedSize > maxRequestSize) {
+            throw new ElasticsearchStatusException(
+                "request body too large, max [" + maxRequestSize + "] bytes",
+                RestStatus.REQUEST_ENTITY_TOO_LARGE
+            );
+        }
+    }
+
+    private void closeOnFailure(RestChannel channel, Exception e, Releasable releasable) {
+        releasable.close();
+        if (chunks != null) {
+            Releasables.close(chunks);
+            chunks = null;
+        }
+        closed = true;
+        coordinating.close();
+        completionHandler.onFailure(channel, e);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregatorTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.rest;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -21,6 +22,7 @@ import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.After;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -177,6 +179,60 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
         assertEquals(0, indexingPressure.stats().getCurrentCoordinatingBytes());
     }
 
+    public void testPostProcessorExpandsContent() {
+        long maxSize = 1024;
+        int compressedSize = 50;
+        int expandedSize = 200;
+        byte[] expanded = randomByteArrayOfLength(expandedSize);
+
+        initAggregator(maxSize, (body, max) -> {
+            body.close();
+            return new ReleasableBytesReference(new BytesArray(expanded), () -> {});
+        });
+
+        assertEquals(maxSize, indexingPressure.stats().getCurrentCoordinatingBytes());
+
+        var chunk = randomReleasableBytesReference(compressedSize);
+        stream.sendNext(chunk, true);
+
+        assertNotNull(contentRef.get());
+        assertEquals(expandedSize, contentRef.get().length());
+        assertEquals(expandedSize, indexingPressure.stats().getCurrentCoordinatingBytes());
+
+        pressureRef.get().close();
+        assertEquals(0, indexingPressure.stats().getCurrentCoordinatingBytes());
+    }
+
+    public void testPostProcessorResultExceedsMaxSize() {
+        long maxSize = 100;
+        int compressedSize = 50;
+        int expandedSize = 200;
+        byte[] expanded = randomByteArrayOfLength(expandedSize);
+
+        initAggregator(maxSize, (body, max) -> {
+            body.close();
+            return new ReleasableBytesReference(new BytesArray(expanded), () -> {});
+        });
+
+        var chunk = randomReleasableBytesReference(compressedSize);
+        stream.sendNext(chunk, true);
+
+        assertTooLargeRejected();
+    }
+
+    public void testPostProcessorThrowsReleasesResources() {
+        long maxSize = 1024;
+        initAggregator(maxSize, (body, max) -> { throw new IOException("decompression failed"); });
+
+        var chunk = randomReleasableBytesReference(64);
+        stream.sendNext(chunk, true);
+
+        assertNull(contentRef.get());
+        assertNotNull(channel.capturedResponse());
+        assertFalse(chunk.hasReferences());
+        assertEquals(0, indexingPressure.stats().getCurrentCoordinatingBytes());
+    }
+
     private RestRequest newStreamedRequest(FakeHttpBodyStream stream) {
         var httpRequest = new FakeRestRequest.FakeHttpRequest(
             RestRequest.Method.POST,
@@ -195,6 +251,10 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
     }
 
     private void initAggregator(long maxSize) {
+        initAggregator(maxSize, IndexingPressureAwareContentAggregator.BodyPostProcessor.NOOP);
+    }
+
+    private void initAggregator(long maxSize, IndexingPressureAwareContentAggregator.BodyPostProcessor postProcessor) {
         var request = newStreamedRequest(stream);
         channel = new FakeRestChannel(request, true, 1);
         var coordinating = indexingPressure.markCoordinatingOperationStarted(1, maxSize, false);
@@ -213,7 +273,8 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
                 public void onFailure(RestChannel ch, Exception e) {
                     ch.sendResponse(new RestResponse(RestStatus.REQUEST_ENTITY_TOO_LARGE, e.getMessage()));
                 }
-            }
+            },
+            postProcessor
         );
         stream.setHandler(new HttpBody.ChunkHandler() {
             @Override

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteRestAction.java
@@ -122,7 +122,8 @@ public class PrometheusRemoteWriteRestAction extends BaseRestHandler {
                         new RestResponse(ExceptionsHelper.status(e), RestResponse.TEXT_CONTENT_TYPE, new BytesArray(e.getMessage()))
                     );
                 }
-            }
+            },
+            IndexingPressureAwareContentAggregator.BodyPostProcessor.NOOP
         );
     }
 }


### PR DESCRIPTION
## Summary
- Introduces a `BodyPostProcessor` functional interface in `IndexingPressureAwareContentAggregator` that allows transforming the accumulated request body (e.g. decompression) before handing it to the `CompletionHandler`.
- Refactors size-limit checking into `assertBelowLimit()` and error handling into `closeOnFailure()` to support post-processing that may change the body size.
- Adds unit tests for post-processor expansion, size limit enforcement after post-processing, and resource cleanup on post-processor failure.

Prerequisite of https://github.com/elastic/elasticsearch/pull/143994