### PR TITLE
Allow ID writes on seq_no disabled backing indices

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollSeqNoSettingIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollSeqNoSettingIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.bulk.TransportShardBulkAction;
@@ -25,11 +26,14 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -38,20 +42,22 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexTestCase;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.junit.After;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.LongPredicate;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
 
@@ -199,23 +205,28 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
         int numDocs = between(1, 5);
         indexDocs(dsName, numDocs);
         refresh(dsName);
+        var dataStream = getDataStream(dsName);
 
         CountDownLatch searchLatch = assertSearchSeqNoFlag(false);
+        CountDownLatch bulkLatch = assertBulkShardRequestsMatch(
+            dataStream.getWriteIndex().getName(),
+            seqNo -> seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO
+        );
         var updateByQuery = updateByQuery().source(dsName);
         if (randomBoolean()) {
             updateByQuery.source().seqNoAndPrimaryTerm(randomBoolean());
         }
         BulkByScrollResponse response = updateByQuery.get();
-        // TODO: fix this once overwrites are allowed for backing indices
-        assertThat(response.getBulkFailures().size(), greaterThan(0));
-        assertThat(response.getBulkFailures().get(0).getMessage(), containsString("no if_primary_term and if_seq_no set"));
+        assertThat(response, matcher().updated(numDocs));
         safeAwait(searchLatch);
+        safeAwait(bulkLatch);
     }
 
     /**
      * When backing indices have mixed settings, the resolver disables seq_no because search hits
      * from backing indices with seq_no disabled will not carry valid sequence numbers.
-     * The write fails at the data stream level, but we verify the failure confirms the intent.
+     * Because at least one backing index has seq_no disabled, writes with explicit IDs to all
+     * backing indices are allowed without OCC.
      */
     public void testDataStreamWithMixedBackingIndices() throws Exception {
         assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
@@ -230,23 +241,29 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
         int numDocs2 = between(1, 5);
         indexDocs(dsName, numDocs2);
         refresh(dsName);
+        var dataStream = getDataStream(dsName);
 
         CountDownLatch searchLatch = assertSearchSeqNoFlag(false);
+        var bulkLatches = new ArrayList<CountDownLatch>();
+        for (Index index : dataStream.getIndices()) {
+            CountDownLatch bulkLatch = assertBulkShardRequestsMatch(index.getName(), seqNo -> seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO);
+            bulkLatches.add(bulkLatch);
+        }
         var updateByQuery = updateByQuery().source(dsName);
         if (randomBoolean()) {
             updateByQuery.source().seqNoAndPrimaryTerm(randomBoolean());
         }
         BulkByScrollResponse response = updateByQuery.get();
-        // TODO: fix this once overwrites are allowed for backing indices
-        assertThat(response.getBulkFailures().size(), greaterThan(0));
-        assertThat(response.getBulkFailures().get(0).getMessage(), containsString("no if_primary_term and if_seq_no set"));
+        assertThat(response, matcher().updated(numDocs + numDocs2));
         safeAwait(searchLatch);
+        bulkLatches.forEach(ESTestCase::safeAwait);
     }
 
     /**
      * A mixed data stream (resolves to disabled) and a regular index with seq_no also disabled share
      * the same resolved setting, so the operation is accepted. The regular index doc is updated without
-     * OCC, while the data stream docs produce bulk failures due to data stream write protection.
+     * OCC. Because at least one backing index has seq_no disabled, writes with explicit IDs to all
+     * backing indices are allowed without OCC.
      */
     public void testMixedDataStreamAndRegularIndexWithSameResolvedSetting() throws Exception {
         assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
@@ -272,7 +289,7 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
             updateByQuery.source().seqNoAndPrimaryTerm(randomBoolean());
         }
         BulkByScrollResponse response = updateByQuery.get();
-        assertThat(response.getUpdated(), greaterThan(0L));
+        assertThat(response, matcher().updated(1 + numDocs + numDocs2));
         safeAwait(searchLatch);
         safeAwait(bulkLatch);
     }
@@ -417,5 +434,17 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
             builder.put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY);
         }
         return builder.build();
+    }
+
+    private DataStream getDataStream(String dataStreamName) throws ExecutionException, InterruptedException {
+        return client().admin()
+            .cluster()
+            .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT))
+            .get()
+            .getState()
+            .getMetadata()
+            .getProject(ProjectId.DEFAULT)
+            .dataStreams()
+            .get(dataStreamName);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
@@ -10,19 +10,31 @@
 package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.datastreams.CreateDataStreamAction;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.OCCNotSupportedException;
 import org.elasticsearch.index.engine.UpdateNotSupportedException;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.containsString;
@@ -33,6 +45,12 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopyNoNullElements(super.nodePlugins(), DataStreamsPlugin.class);
+    }
+
     public void testBulkWithMixedOperationsAcrossSeqNoDisabledAndEnabledIndices() {
         assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
 
@@ -213,6 +231,55 @@ public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
         }
     }
 
+    public void testBulkIndexToDataStreamBackingIndexBypassesCreateRestriction() throws Exception {
+        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
+
+        String dataStreamName = "test-ds-overwrite";
+        createDataStreamWithTemplate(dataStreamName, disableSeqNoTemplateSettings(true));
+
+        var createResponse = client().prepareBulk()
+            .add(prepareIndex(dataStreamName).setSource(Map.of("@timestamp", "2020-01-01")).setCreate(true))
+            .get();
+        assertNoFailures(createResponse);
+        assertThat(createResponse.getItems().length, equalTo(1));
+
+        var createdId = createResponse.getItems()[0].getResponse().getId();
+        var backingIndex = createResponse.getItems()[0].getIndex();
+        assertThat(createdId, is(notNullValue()));
+
+        // CREATE without an id targeting the backing index directly is still rejected
+        var createAppendResponse = client().prepareBulk()
+            .add(prepareIndex(backingIndex).setSource(Map.of("@timestamp", "2020-01-01")).setCreate(true))
+            .get();
+        assertThat(createAppendResponse.hasFailures(), is(true));
+        assertThat(
+            createAppendResponse.getItems()[0].getFailureMessage(),
+            containsString("op_type=create targeting backing indices is disallowed")
+        );
+
+        // INDEX without an id targeting the backing index directly is still rejected
+        var indexAppendResponse = client().prepareBulk()
+            .add(prepareIndex(backingIndex).setSource(Map.of("@timestamp", "2020-01-01")))
+            .get();
+        assertThat(indexAppendResponse.hasFailures(), is(true));
+        assertThat(
+            indexAppendResponse.getItems()[0].getFailureMessage(),
+            containsString("op_type=index and no if_primary_term and if_seq_no set targeting backing indices is disallowed")
+        );
+
+        // INDEX with an id targeting the backing index is allowed for seq_no disabled indices
+        var overwriteResponse = client().prepareBulk()
+            .add(prepareIndex(backingIndex).setId(createdId).setSource(Map.of("@timestamp", "2020-01-01", "value", "overwritten")))
+            .get();
+        assertNoFailures(overwriteResponse);
+
+        // Ensure that the document was overwritten
+        indicesAdmin().prepareRefresh(backingIndex).get();
+        var getResponse = client().prepareGet(backingIndex, createdId).get();
+        assertTrue(getResponse.isExists());
+        assertThat(getResponse.getSource().get("value"), equalTo("overwritten"));
+    }
+
     public void testSingleUpdateOnSeqNoDisabledIndexIsRejected() {
         assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         createIndex(
@@ -236,5 +303,47 @@ public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
         var getResponse = client().prepareGet("test", "1").get();
         assertTrue(getResponse.isExists());
         assertThat(getResponse.getSource().get("value"), equalTo("original"));
+    }
+
+    private void createDataStreamWithTemplate(String dsName, Settings settings) throws Exception {
+        putDataStreamTemplate(dsName, settings);
+        CreateDataStreamAction.Request createRequest = new CreateDataStreamAction.Request(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            dsName
+        );
+        assertAcked(client().execute(CreateDataStreamAction.INSTANCE, createRequest));
+    }
+
+    private void putDataStreamTemplate(String dsName, Settings settings) throws Exception {
+        TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request(
+            dsName + "-template"
+        );
+        String mapping = """
+            {
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    }
+                }
+            }
+            """;
+        Settings templateSettings = indexSettings(1, 0).put(settings).build();
+        request.indexTemplate(
+            ComposableIndexTemplate.builder()
+                .indexPatterns(List.of(dsName + "*"))
+                .template(new Template(templateSettings, CompressedXContent.fromJSON(mapping), null))
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+                .build()
+        );
+        assertAcked(client().execute(TransportPutComposableIndexTemplateAction.TYPE, request));
+    }
+
+    private static Settings disableSeqNoTemplateSettings(boolean disableSequenceNumbers) {
+        Settings.Builder builder = Settings.builder().put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), disableSequenceNumbers);
+        if (disableSequenceNumbers) {
+            builder.put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY);
+        }
+        return builder.build();
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -323,7 +323,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 indexOperationValidator.accept(ia, docWriteRequest);
 
                 TransportBulkAction.prohibitCustomRoutingOnDataStream(docWriteRequest, ia);
-                TransportBulkAction.prohibitAppendWritesInBackingIndices(docWriteRequest, ia);
+                TransportBulkAction.prohibitAppendWritesInBackingIndices(docWriteRequest, ia, project::index);
                 docWriteRequest.routing(project.resolveWriteIndexRouting(docWriteRequest.routing(), docWriteRequest.index()));
 
                 final Index concreteIndex = docWriteRequest.getConcreteWriteIndex(ia, project);

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamFailureStoreSettings;
 import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
@@ -46,6 +47,8 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.SystemIndices;
@@ -510,7 +513,11 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
         }
     }
 
-    static void prohibitAppendWritesInBackingIndices(DocWriteRequest<?> writeRequest, IndexAbstraction indexAbstraction) {
+    static void prohibitAppendWritesInBackingIndices(
+        DocWriteRequest<?> writeRequest,
+        IndexAbstraction indexAbstraction,
+        Function<Index, IndexMetadata> indexMetadataProvider
+    ) {
         DocWriteRequest.OpType opType = writeRequest.opType();
         if ((opType == DocWriteRequest.OpType.CREATE || opType == DocWriteRequest.OpType.INDEX) == false) {
             // op type not create or index, then bail early
@@ -544,6 +551,19 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
                     + "] instead"
             );
         }
+
+        // When sequence numbers are disabled, OCC (if_seq_no/if_primary_term) cannot be used,
+        // so we allow writes with an explicit document ID directly to backing indices.
+        // First check the target index itself (fast path), then check sibling backing indices
+        // to handle mixed data streams where OCC is disabled for the entire operation.
+        if (writeRequest.id() != null && IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
+            IndexMetadata targetMetadata = indexMetadataProvider.apply(indexAbstraction.getWriteIndex());
+            if ((targetMetadata != null && IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(targetMetadata.getSettings()))
+                || hasAnyBackingIndexWithSeqNoDisabled(dataStream, indexMetadataProvider)) {
+                return;
+            }
+        }
+
         if (writeRequest.ifPrimaryTerm() == UNASSIGNED_PRIMARY_TERM && writeRequest.ifSeqNo() == UNASSIGNED_SEQ_NO) {
             throw new IllegalArgumentException(
                 "index request with op_type=index and no if_primary_term and if_seq_no set "
@@ -552,6 +572,16 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
                     + "] instead"
             );
         }
+    }
+
+    static boolean hasAnyBackingIndexWithSeqNoDisabled(DataStream dataStream, Function<Index, IndexMetadata> indexMetadataProvider) {
+        for (Index backingIndex : dataStream.getIndices()) {
+            IndexMetadata im = indexMetadataProvider.apply(backingIndex);
+            if (im != null && IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(im.getSettings())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static void prohibitCustomRoutingOnDataStream(DocWriteRequest<?> writeRequest, IndexAbstraction indexAbstraction) {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -57,10 +57,12 @@ import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
@@ -83,9 +85,11 @@ import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static org.elasticsearch.action.bulk.TransportBulkAction.prohibitCustomRoutingOnDataStream;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -261,13 +265,15 @@ public class TransportBulkActionTests extends ESTestCase {
         String dataStreamName = "logs-foobar";
         final var dataStream = DataStreamTestHelper.newInstance(dataStreamName, DataStreamTestHelper.randomNonEmptyIndexInstances());
         final String backingIndexName = dataStream.getWriteIndex().getName();
-        final var backingIndex = new ConcreteIndex(indexMetadata(backingIndexName).build(), dataStream);
+        final var backingIndexMetadata = indexMetadata(backingIndexName).build();
+        final var backingIndex = new ConcreteIndex(backingIndexMetadata, dataStream);
+        Function<Index, IndexMetadata> metadataProvider = idx -> backingIndexMetadata;
 
         // Testing create op against backing index fails:
         IndexRequest invalidRequest1 = new IndexRequest(backingIndexName).opType(DocWriteRequest.OpType.CREATE);
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(invalidRequest1, backingIndex)
+            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(invalidRequest1, backingIndex, metadataProvider)
         );
         assertThat(
             e.getMessage(),
@@ -281,7 +287,7 @@ public class TransportBulkActionTests extends ESTestCase {
         IndexRequest invalidRequest2 = new IndexRequest(backingIndexName).opType(DocWriteRequest.OpType.INDEX);
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(invalidRequest2, backingIndex)
+            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(invalidRequest2, backingIndex, metadataProvider)
         );
         assertThat(
             e.getMessage(),
@@ -295,28 +301,82 @@ public class TransportBulkActionTests extends ESTestCase {
         DocWriteRequest<?> validRequest = new IndexRequest(backingIndexName).opType(DocWriteRequest.OpType.INDEX)
             .setIfSeqNo(1)
             .setIfPrimaryTerm(1);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex, metadataProvider);
         validRequest = new DeleteRequest(backingIndexName);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex, metadataProvider);
         validRequest = new UpdateRequest(backingIndexName, "_id");
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, backingIndex, metadataProvider);
 
         // Testing append only write via ds name
         validRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, dataStream);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, dataStream, idx -> null);
 
         validRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.INDEX);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, dataStream);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, dataStream, idx -> null);
 
         // Append only for a backing index that doesn't exist is allowed:
         validRequest = new IndexRequest(DataStream.getDefaultBackingIndexName("logs-barbaz", 1)).opType(DocWriteRequest.OpType.CREATE);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null, idx -> null);
 
         // Some other index names:
         validRequest = new IndexRequest("my-index").opType(DocWriteRequest.OpType.CREATE);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null, idx -> null);
         validRequest = new IndexRequest("foobar").opType(DocWriteRequest.OpType.CREATE);
-        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(validRequest, null, idx -> null);
+    }
+
+    public void testProhibitAppendWritesInBackingIndicesSkippedForSeqNoDisabled() throws Exception {
+        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
+
+        String dataStreamName = "logs-foobar";
+        Index seqNoDisabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 1), IndexMetadata.INDEX_UUID_NA_VALUE);
+        Index seqNoEnabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 2), IndexMetadata.INDEX_UUID_NA_VALUE);
+        final var seqNoDisabledMetadata = indexMetadata(seqNoDisabledIdx.getName()).settings(
+            settings(IndexVersions.DISABLE_SEQUENCE_NUMBERS).put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+                .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY)
+        ).numberOfShards(1).numberOfReplicas(1).build();
+        final var seqNoEnabledMetadata = indexMetadata(seqNoEnabledIdx.getName()).build();
+        Function<Index, IndexMetadata> metadataProvider = Map.of(
+            seqNoDisabledIdx,
+            seqNoDisabledMetadata,
+            seqNoEnabledIdx,
+            seqNoEnabledMetadata
+        )::get;
+
+        boolean targetHasSeqNoDisabled = randomBoolean();
+        final Index targetIdx;
+        final List<Index> backingIndices;
+        if (targetHasSeqNoDisabled) {
+            targetIdx = seqNoDisabledIdx;
+            backingIndices = randomBoolean() ? List.of(seqNoDisabledIdx) : List.of(seqNoDisabledIdx, seqNoEnabledIdx);
+        } else {
+            targetIdx = seqNoEnabledIdx;
+            backingIndices = List.of(seqNoDisabledIdx, seqNoEnabledIdx);
+        }
+
+        final var dataStream = DataStreamTestHelper.newInstance(dataStreamName, backingIndices);
+        final var targetBackingIndex = new ConcreteIndex(metadataProvider.apply(targetIdx), dataStream);
+        final var targetBackingIndexName = targetIdx.getName();
+
+        // INDEX with an id is allowed:
+        IndexRequest request = new IndexRequest(targetBackingIndexName).id("doc-1").opType(DocWriteRequest.OpType.INDEX);
+        TransportBulkAction.prohibitAppendWritesInBackingIndices(request, targetBackingIndex, metadataProvider);
+
+        // CREATE is still rejected:
+        IndexRequest noIdCreate = new IndexRequest(targetBackingIndexName).opType(DocWriteRequest.OpType.CREATE);
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(noIdCreate, targetBackingIndex, metadataProvider)
+        );
+        assertThat(e.getMessage(), containsString("op_type=create targeting backing indices is disallowed"));
+
+        // INDEX without an id is still rejected:
+        IndexRequest noIdIndex = new IndexRequest(targetBackingIndexName).opType(DocWriteRequest.OpType.INDEX);
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(noIdIndex, targetBackingIndex, metadataProvider)
+        );
+        assertThat(e.getMessage(), containsString("op_type=index and no if_primary_term and if_seq_no set targeting backing indices"));
     }
 
     public void testProhibitCustomRoutingOnDataStream() throws Exception {


### PR DESCRIPTION
When sequence numbers are disabled on a data stream backing index, 
OCC (if_seq_no/if_primary_term) cannot be used. This relaxes the 
append-only restriction for INDEX ops with an explicit document id
targeting backing indices where seq_no is disabled, either on the target 
index itself or on any sibling backing index in the data stream.