### PR TITLE
[Docs] ESQL - Add _source details in the search tutorial

### DIFF
--- a/docs/reference/query-languages/esql/esql-metadata-fields.md
+++ b/docs/reference/query-languages/esql/esql-metadata-fields.md
@@ -85,3 +85,21 @@ FROM products METADATA _score
 :::{tip}
 Refer to [{{esql}} for search](docs-content://solutions/search/esql-for-search.md#esql-for-search-scoring) for more information on relevance scoring and how to use `_score` in your queries.
 :::
+
+### Retrieving _source
+
+Using _`source` is useful when you want to retrieve most or all fields from a document.
+
+You should consider retrieving `_source` instead of individual fields when:
+- You need several fields from a document, and most of them are text fields.
+- You have long text fields in your documents.
+- You want the original document instead of the indexed values for your fields.
+- You have nested objects or arrays that you want to preserve in their original structure.
+
+
+  You probably want to avoid retrieving `_source` when:
+- Your fields are stored as [doc_values](/reference/elasticsearch/mapping-reference/doc-values.md). `doc_values` access is faster than _`source`.
+- Your index uses [synthetic source](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source). Accessing _`source` in synthetic source mode has a performance penalty.
+- The text fields you need are [stored fields](/reference/elasticsearch/mapping-reference/mapping-store.md).
+
+Using `_source` or selecting fields are both valid options, but can have performance and data format implications that you should consider based on your use case.

--- a/docs/reference/query-languages/esql/esql-metadata-fields.md
+++ b/docs/reference/query-languages/esql/esql-metadata-fields.md
@@ -92,7 +92,7 @@ Using _`source` is useful when you want to retrieve most or all fields from a do
 
 You should consider retrieving `_source` instead of individual fields when:
 - You need several fields from a document, and most of them are text fields.
-- You have long text fields in your documents.
+- You have long text fields or geoshape fields in your documents.
 - You want the original document instead of the indexed values for your fields.
 - You have nested objects or arrays that you want to preserve in their original structure.
 

--- a/docs/reference/query-languages/esql/esql-metadata-fields.md
+++ b/docs/reference/query-languages/esql/esql-metadata-fields.md
@@ -97,7 +97,7 @@ You should consider retrieving `_source` instead of individual fields when:
 - You have nested objects or arrays that you want to preserve in their original structure.
 
 
-  You probably want to avoid retrieving `_source` when:
+You might want to avoid retrieving `_source` when:
 - Your fields are stored as [doc_values](/reference/elasticsearch/mapping-reference/doc-values.md). `doc_values` access is faster than _`source`.
 - Your index uses [synthetic source](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source). Accessing _`source` in synthetic source mode has a performance penalty.
 - The text fields you need are [stored fields](/reference/elasticsearch/mapping-reference/mapping-store.md).

--- a/docs/reference/query-languages/esql/esql-search-tutorial.md
+++ b/docs/reference/query-languages/esql/esql-search-tutorial.md
@@ -178,6 +178,28 @@ FROM cooking_blog
 
 This helps reduce the amount of data returned and focuses on the information you need.
 
+Another option is to retrieve the original document source via the `_source` metadata field:
+
+```esql
+FROM cooking_blog METADATA _source
+| WHERE description:"fluffy pancakes"
+| KEEP _source
+| LIMIT 1000
+```
+
+You should consider using `_source` when:
+- You need several fields from a document, and most of them are text fields.
+- You have long text fields in your documents.
+- You want the original document instead of the indexed values for your fields.
+- You have nested objects or arrays that you want to preserve in their original structure.
+
+You probably want to avoid using `_source` when:
+- Your fields are stored as doc values (numeric, keyword, date, boolean). doc values access is faster than _source.
+- Your index uses synthetic source. Accessing _source in synthetic source mode has a performance penalty.
+- The text fields you need are stored fields.
+
+Using `_source` or selecting fields are both valid options, but can have performance and data format implications that you should consider based on your use case.
+
 ### Understand relevance scoring
 
 Search results can be ranked based on how well they match your query. To calculate and use relevance scores, you need to explicitly request the `_score` metadata:

--- a/docs/reference/query-languages/esql/esql-search-tutorial.md
+++ b/docs/reference/query-languages/esql/esql-search-tutorial.md
@@ -187,11 +187,13 @@ FROM cooking_blog METADATA _source
 | LIMIT 1000
 ```
 
-Using _source is useful when you want to retrieve most or all fields from a document.
-The original document is stored together in _source, so fetching it can be more efficient than retrieving many individual fields separately.
+Using `_source` is useful when you want to retrieve most or all fields from a document.
+The original document is stored together in `_source`, so fetching it can be more efficient than retrieving many individual fields separately.
 It also returns the document exactly as indexed, preserving nested objects and arrays.
 
 Selecting individual fields may be more efficient when you only need a small number of fields from each document.
+To learn more, refer to [retrieving _source](/reference/query-languages/esql/esql-metadata-fields.md#retrieving-_source).
+
 
 ### Understand relevance scoring
 

--- a/docs/reference/query-languages/esql/esql-search-tutorial.md
+++ b/docs/reference/query-languages/esql/esql-search-tutorial.md
@@ -187,18 +187,11 @@ FROM cooking_blog METADATA _source
 | LIMIT 1000
 ```
 
-You should consider using `_source` when:
-- You need several fields from a document, and most of them are text fields.
-- You have long text fields in your documents.
-- You want the original document instead of the indexed values for your fields.
-- You have nested objects or arrays that you want to preserve in their original structure.
+Using _source is useful when you want to retrieve most or all fields from a document.
+The original document is stored together in _source, so fetching it can be more efficient than retrieving many individual fields separately.
+It also returns the document exactly as indexed, preserving nested objects and arrays.
 
-You probably want to avoid using `_source` when:
-- Your fields are stored as doc values (numeric, keyword, date, boolean). doc values access is faster than _source.
-- Your index uses synthetic source. Accessing _source in synthetic source mode has a performance penalty.
-- The text fields you need are stored fields.
-
-Using `_source` or selecting fields are both valid options, but can have performance and data format implications that you should consider based on your use case.
+Selecting individual fields may be more efficient when you only need a small number of fields from each document.
 
 ### Understand relevance scoring
 


### PR DESCRIPTION
This PR adds a section to the [ES|QL search tutorial](https://www.elastic.co/docs/reference/query-languages/esql/esql-search-tutorial#control-which-fields-appear-in-results) that includes when it would be useful to use `_source` instead of selecting individual fields.

@jimczi how does this look like from the technical PoV?

@leemthompo I'm thinking to add some / all of this to the [metadata fields section](https://www.elastic.co/docs/reference/query-languages/esql/esql-metadata-fields). WDYT? Should we add all details there and put a link to that on the search tutorial?