### PR TITLE
Update disk bbq defaults

### DIFF
--- a/docs/changelog/144056.yaml
+++ b/docs/changelog/144056.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 144056
+summary: Update disk bbq defaults
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormat.java
@@ -75,7 +75,7 @@ public class ES940DiskBBQVectorsFormat extends KnnVectorsFormat {
         bfloat16VectorFormat
     );
 
-    public static final int DEFAULT_VECTORS_PER_CLUSTER = 384;
+    public static final int DEFAULT_VECTORS_PER_CLUSTER = 256;
     private static final int DEFAULT_FLAT_VECTOR_THRESHOLD_MULTIPLIER = 3;
 
     /**
@@ -89,9 +89,9 @@ public class ES940DiskBBQVectorsFormat extends KnnVectorsFormat {
 
     public static final int MIN_VECTORS_PER_CLUSTER = 64;
     public static final int MAX_VECTORS_PER_CLUSTER = 1 << 16; // 65536
-    public static final int DEFAULT_CENTROIDS_PER_PARENT_CLUSTER = 16;
+    public static final int DEFAULT_CENTROIDS_PER_PARENT_CLUSTER = 128;
     public static final int MIN_CENTROIDS_PER_PARENT_CLUSTER = 2;
-    public static final int MAX_CENTROIDS_PER_PARENT_CLUSTER = DEFAULT_VECTORS_PER_CLUSTER; // 384
+    public static final int MAX_CENTROIDS_PER_PARENT_CLUSTER = MAX_VECTORS_PER_CLUSTER;
     public static final int DEFAULT_PRECONDITIONING_BLOCK_DIMENSION = 32;
     public static final int MIN_PRECONDITIONING_BLOCK_DIMS = 8;
     public static final int MAX_PRECONDITIONING_BLOCK_DIMS = 384;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormat.java
@@ -76,7 +76,7 @@ public class ESNextDiskBBQVectorsFormat extends KnnVectorsFormat {
         bfloat16VectorFormat
     );
 
-    public static final int DEFAULT_VECTORS_PER_CLUSTER = 384;
+    public static final int DEFAULT_VECTORS_PER_CLUSTER = 256;
     private static final int DEFAULT_FLAT_VECTOR_THRESHOLD_MULTIPLIER = 3;
 
     /**
@@ -90,9 +90,9 @@ public class ESNextDiskBBQVectorsFormat extends KnnVectorsFormat {
 
     public static final int MIN_VECTORS_PER_CLUSTER = 64;
     public static final int MAX_VECTORS_PER_CLUSTER = 1 << 16; // 65536
-    public static final int DEFAULT_CENTROIDS_PER_PARENT_CLUSTER = 16;
+    public static final int DEFAULT_CENTROIDS_PER_PARENT_CLUSTER = 128;
     public static final int MIN_CENTROIDS_PER_PARENT_CLUSTER = 2;
-    public static final int MAX_CENTROIDS_PER_PARENT_CLUSTER = DEFAULT_VECTORS_PER_CLUSTER; // 384
+    public static final int MAX_CENTROIDS_PER_PARENT_CLUSTER = MAX_VECTORS_PER_CLUSTER;
     public static final int DEFAULT_PRECONDITIONING_BLOCK_DIMENSION = 32;
     public static final int MIN_PRECONDITIONING_BLOCK_DIMS = 8;
     public static final int MAX_PRECONDITIONING_BLOCK_DIMS = 384;


### PR DESCRIPTION
Benchmarking seems to indicate that this is the current best trade-off given our new performance capabilities with the native code scorers.

Running additional benchmarking to make sure.