### PR TITLE
[ESQL] Fix Parquet type support gaps

### DIFF
--- a/docs/changelog/144059.yaml
+++ b/docs/changelog/144059.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144059
+summary: Fix Parquet type support gaps
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -19,6 +19,7 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
@@ -46,6 +47,9 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -361,29 +365,85 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     private DataType convertParquetTypeToEsql(Type parquetType) {
         if (parquetType.isPrimitive() == false) {
-            return DataType.UNSUPPORTED; // Complex types not yet supported
+            return convertGroupTypeToEsql(parquetType.asGroupType());
         }
         PrimitiveType primitive = parquetType.asPrimitiveType();
         LogicalTypeAnnotation logical = primitive.getLogicalTypeAnnotation();
 
         return switch (primitive.getPrimitiveTypeName()) {
             case BOOLEAN -> DataType.BOOLEAN;
-            case INT32 -> logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation ? DataType.DATETIME : DataType.INTEGER;
-            case INT64 -> logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ? DataType.DATETIME : DataType.LONG;
+            case INT32 -> {
+                if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+                    yield DataType.DATETIME;
+                } else if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    yield DataType.DOUBLE;
+                }
+                yield DataType.INTEGER;
+            }
+            case INT64 -> {
+                if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
+                    yield DataType.DATETIME;
+                } else if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    yield DataType.DOUBLE;
+                }
+                yield DataType.LONG;
+            }
+            case INT96 -> DataType.DATETIME;
             case FLOAT, DOUBLE -> DataType.DOUBLE;
             case BINARY, FIXED_LEN_BYTE_ARRAY -> {
-                // Check for STRING logical type
-                if (logical instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
-                    yield DataType.KEYWORD;
+                if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    yield DataType.DOUBLE;
                 }
-                // Default binary to keyword
+                if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+                    yield DataType.DOUBLE;
+                }
                 yield DataType.KEYWORD;
             }
             default -> DataType.UNSUPPORTED;
         };
     }
 
+    /**
+     * Handles Parquet group types. Supports LIST of primitives by extracting the element type.
+     */
+    private DataType convertGroupTypeToEsql(GroupType groupType) {
+        LogicalTypeAnnotation logical = groupType.getLogicalTypeAnnotation();
+        if (logical instanceof LogicalTypeAnnotation.ListLogicalTypeAnnotation && groupType.getFieldCount() == 1) {
+            GroupType repeatedGroup = groupType.getType(0).asGroupType();
+            if (repeatedGroup.getFieldCount() == 1) {
+                Type elementType = repeatedGroup.getType(0);
+                if (elementType.isPrimitive()) {
+                    return convertParquetTypeToEsql(elementType);
+                }
+            }
+        }
+        return DataType.UNSUPPORTED;
+    }
+
     private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+    /** Julian day number for Unix epoch (1970-01-01). */
+    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    /**
+     * Formats a 16-byte UUID in big-endian layout as the standard 8-4-4-4-12 hex string.
+     */
+    static String formatUuid(byte[] bytes) {
+        if (bytes == null || bytes.length < 16) {
+            throw new IllegalArgumentException("UUID requires 16 bytes, got " + (bytes == null ? "null" : bytes.length));
+        }
+        StringBuilder sb = new StringBuilder(36);
+        for (int i = 0; i < 16; i++) {
+            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
+            sb.append(HEX[bytes[i] & 0xF]);
+            if (i == 3 || i == 5 || i == 7 || i == 9) {
+                sb.append('-');
+            }
+        }
+        return sb.toString();
+    }
 
     /**
      * Column-at-a-time Parquet iterator. Uses {@link ColumnReadStoreImpl} and {@link ColumnReader}
@@ -435,11 +495,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 }
                 ColumnDescriptor desc = descByName.get(attr.name());
                 if (desc != null) {
+                    LogicalTypeAnnotation logicalType = desc.getPrimitiveType().getLogicalTypeAnnotation();
                     columnInfos[i] = new ColumnInfo(
                         desc,
                         desc.getPrimitiveType().getPrimitiveTypeName(),
                         attr.dataType(),
-                        desc.getMaxDefinitionLevel()
+                        desc.getMaxDefinitionLevel(),
+                        desc.getMaxRepetitionLevel(),
+                        logicalType
                     );
                 }
             }
@@ -520,13 +583,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead) {
+            if (info.maxRepLevel > 0) {
+                return readListColumn(cr, info, rowsToRead);
+            }
             return switch (info.esqlType) {
                 case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel, rowsToRead);
                 case INTEGER -> readIntColumn(cr, info.maxDefLevel, rowsToRead);
                 case LONG -> readLongColumn(cr, info.maxDefLevel, rowsToRead);
-                case DOUBLE -> readDoubleColumn(cr, info.parquetType, info.maxDefLevel, rowsToRead);
-                case KEYWORD, TEXT -> readBytesRefColumn(cr, info.maxDefLevel, rowsToRead);
-                case DATETIME -> readDatetimeColumn(cr, info.parquetType, info.maxDefLevel, rowsToRead);
+                case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
+                case KEYWORD, TEXT -> readBytesRefColumn(cr, info, rowsToRead);
+                case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
                 default -> {
                     skipValues(cr, rowsToRead);
                     yield blockFactory.newConstantNullBlock(rowsToRead);
@@ -588,13 +654,20 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
         }
 
-        private Block readDoubleColumn(ColumnReader cr, PrimitiveType.PrimitiveTypeName pType, int maxDef, int rows) {
+        private Block readDoubleColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            LogicalTypeAnnotation logical = info.logicalType;
+            if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
+                return readDecimalAsDoubleColumn(cr, info, decimal.getScale(), rows);
+            }
+            if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+                return readFloat16Column(cr, info.maxDefLevel, rows);
+            }
             double[] values = new double[rows];
-            boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isFloat = pType == PrimitiveType.PrimitiveTypeName.FLOAT;
+            boolean isFloat = info.parquetType == PrimitiveType.PrimitiveTypeName.FLOAT;
             for (int i = 0; i < rows; i++) {
-                if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
                     isNull[i] = true;
                     noNulls = false;
                 } else {
@@ -605,11 +678,54 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
         }
 
-        private Block readBytesRefColumn(ColumnReader cr, int maxDef, int rows) {
+        private Block readDecimalAsDoubleColumn(ColumnReader cr, ColumnInfo info, int scale, int rows) {
+            double[] values = new double[rows];
+            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean noNulls = true;
+            for (int i = 0; i < rows; i++) {
+                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                    isNull[i] = true;
+                    noNulls = false;
+                } else {
+                    BigInteger unscaled = switch (info.parquetType) {
+                        case INT32 -> BigInteger.valueOf(cr.getInteger());
+                        case INT64 -> BigInteger.valueOf(cr.getLong());
+                        case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
+                        default -> throw new IllegalStateException("Unexpected DECIMAL backing type: " + info.parquetType);
+                    };
+                    values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
+                }
+                cr.consume();
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
+        }
+
+        private Block readFloat16Column(ColumnReader cr, int maxDef, int rows) {
+            double[] values = new double[rows];
+            boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+            boolean noNulls = true;
+            for (int i = 0; i < rows; i++) {
+                if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                    isNull[i] = true;
+                    noNulls = false;
+                } else {
+                    byte[] bytes = cr.getBinary().getBytes();
+                    short float16Bits = (short) ((bytes[1] & 0xFF) << 8 | (bytes[0] & 0xFF));
+                    values[i] = Float.float16ToFloat(float16Bits);
+                }
+                cr.consume();
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
+        }
+
+        private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            boolean isUuid = info.logicalType instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
             try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
                 for (int i = 0; i < rows; i++) {
-                    if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                    if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
                         builder.appendNull();
+                    } else if (isUuid) {
+                        builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
                     } else {
                         builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
                     }
@@ -619,23 +735,333 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
         }
 
-        private Block readDatetimeColumn(ColumnReader cr, PrimitiveType.PrimitiveTypeName pType, int maxDef, int rows) {
+        private Block readDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            if (info.parquetType == PrimitiveType.PrimitiveTypeName.INT96) {
+                return readInt96TimestampColumn(cr, info.maxDefLevel, rows);
+            }
             long[] values = new long[rows];
-            boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isDate = pType == PrimitiveType.PrimitiveTypeName.INT32;
+            boolean isDate = info.parquetType == PrimitiveType.PrimitiveTypeName.INT32;
             for (int i = 0; i < rows; i++) {
-                if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
                     isNull[i] = true;
                     noNulls = false;
                 } else if (isDate) {
                     values[i] = cr.getInteger() * MILLIS_PER_DAY;
                 } else {
-                    values[i] = cr.getLong();
+                    long raw = cr.getLong();
+                    values[i] = convertTimestampToMillis(raw, info.logicalType);
                 }
                 cr.consume();
             }
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+        }
+
+        private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
+            if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+                return switch (ts.getUnit()) {
+                    case MILLIS -> raw;
+                    case MICROS -> raw / 1_000;
+                    case NANOS -> raw / 1_000_000;
+                };
+            }
+            return raw;
+        }
+
+        /**
+         * Converts a Parquet INT96 value (12 bytes: 8 bytes nanos-of-day LE + 4 bytes Julian day LE)
+         * to epoch milliseconds.
+         */
+        private Block readInt96TimestampColumn(ColumnReader cr, int maxDef, int rows) {
+            long[] values = new long[rows];
+            boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+            boolean noNulls = true;
+            for (int i = 0; i < rows; i++) {
+                if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                    isNull[i] = true;
+                    noNulls = false;
+                } else {
+                    Binary bin = cr.getBinary();
+                    ByteBuffer buf = ByteBuffer.wrap(bin.getBytes()).order(ByteOrder.LITTLE_ENDIAN);
+                    long nanosOfDay = buf.getLong();
+                    int julianDay = buf.getInt();
+                    long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
+                    values[i] = epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
+                }
+                cr.consume();
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+        }
+
+        /**
+         * Reads a LIST column using repetition levels to determine list boundaries,
+         * producing multi-valued ESQL blocks. Handles null lists, empty lists, and
+         * null elements within lists correctly.
+         */
+        private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            DataType elementType = info.esqlType;
+            int maxDef = info.maxDefLevel;
+            return switch (elementType) {
+                case INTEGER -> readListIntColumn(cr, maxDef, rows);
+                case LONG -> readListLongColumn(cr, maxDef, rows);
+                case DOUBLE -> readListDoubleColumn(cr, maxDef, rows);
+                case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows);
+                case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows);
+                case DATETIME -> readListDatetimeColumn(cr, info, rows);
+                default -> {
+                    skipListValues(cr, maxDef, rows);
+                    yield blockFactory.newConstantNullBlock(rows);
+                }
+            };
+        }
+
+        /**
+         * Skips all Parquet values for the given number of rows in a LIST column,
+         * respecting repetition levels to consume entire lists per row.
+         */
+        private static void skipListValues(ColumnReader cr, int maxDef, int rows) {
+            for (int row = 0; row < rows; row++) {
+                cr.consume();
+                while (cr.getCurrentRepetitionLevel() > 0) {
+                    cr.consume();
+                }
+            }
+        }
+
+        private Block readListIntColumn(ColumnReader cr, int maxDef, int rows) {
+            try (var builder = blockFactory.newIntBlockBuilder(rows)) {
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendInt(cr.getInteger());
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendInt(cr.getInteger());
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendInt(cr.getInteger());
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private Block readListLongColumn(ColumnReader cr, int maxDef, int rows) {
+            try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendLong(cr.getLong());
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendLong(cr.getLong());
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendLong(cr.getLong());
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows) {
+            try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendDouble(cr.getDouble());
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendDouble(cr.getDouble());
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendDouble(cr.getDouble());
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows) {
+            try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendBoolean(cr.getBoolean());
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendBoolean(cr.getBoolean());
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendBoolean(cr.getBoolean());
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows) {
+            try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+                int maxDef = info.maxDefLevel;
+                for (int row = 0; row < rows; row++) {
+                    int def = cr.getCurrentDefinitionLevel();
+                    if (def >= maxDef) {
+                        builder.beginPositionEntry();
+                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                        cr.consume();
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                            }
+                            cr.consume();
+                        }
+                        builder.endPositionEntry();
+                    } else {
+                        cr.consume();
+                        boolean hasValues = false;
+                        while (cr.getCurrentRepetitionLevel() > 0) {
+                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                                if (hasValues == false) {
+                                    builder.beginPositionEntry();
+                                    hasValues = true;
+                                }
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                            }
+                            cr.consume();
+                        }
+                        if (hasValues) {
+                            builder.endPositionEntry();
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                }
+                return builder.build();
+            }
         }
 
         private static void skipValues(ColumnReader cr, int rows) {
@@ -664,7 +1090,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ColumnDescriptor descriptor,
         PrimitiveType.PrimitiveTypeName parquetType,
         DataType esqlType,
-        int maxDefLevel
+        int maxDefLevel,
+        int maxRepLevel,
+        LogicalTypeAnnotation logicalType
     ) {}
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -9,15 +9,18 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.NanoTime;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
@@ -42,9 +45,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class ParquetFormatReaderTests extends ESTestCase {
 
@@ -604,6 +610,475 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
     }
 
+    // --- DECIMAL tests ---
+
+    public void testReadDecimalInt32Column() throws Exception {
+        // DECIMAL(9, 2) backed by INT32: value 12345 represents 123.45
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .named("price")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("price", 12345); // 123.45
+            Group g2 = factory.newGroup();
+            g2.add("price", -9900); // -99.00
+            Group g3 = factory.newGroup();
+            g3.add("price", 0);
+            return List.of(g1, g2, g3);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            DoubleBlock block = (DoubleBlock) page.getBlock(0);
+            assertEquals(123.45, block.getDouble(0), 0.001);
+            assertEquals(-99.00, block.getDouble(1), 0.001);
+            assertEquals(0.0, block.getDouble(2), 0.001);
+        }
+    }
+
+    public void testReadDecimalInt64Column() throws Exception {
+        // DECIMAL(18, 4) backed by INT64: value 123456789 represents 12345.6789
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.decimalType(4, 18))
+            .named("amount")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("amount", 123456789L); // 12345.6789
+            Group g2 = factory.newGroup();
+            g2.add("amount", -50000L); // -5.0000
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            DoubleBlock block = (DoubleBlock) page.getBlock(0);
+            assertEquals(12345.6789, block.getDouble(0), 0.0001);
+            assertEquals(-5.0, block.getDouble(1), 0.0001);
+        }
+    }
+
+    public void testReadDecimalFixedLenColumn() throws Exception {
+        // DECIMAL(10, 2) backed by FIXED_LEN_BYTE_ARRAY(8)
+        int fixedLen = 8;
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(fixedLen)
+            .as(LogicalTypeAnnotation.decimalType(2, 10))
+            .named("total")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("total", Binary.fromConstantByteArray(toFixedLenDecimal(1234567, fixedLen))); // 12345.67
+            Group g2 = factory.newGroup();
+            g2.add("total", Binary.fromConstantByteArray(toFixedLenDecimal(-100, fixedLen))); // -1.00
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            DoubleBlock block = (DoubleBlock) page.getBlock(0);
+            assertEquals(12345.67, block.getDouble(0), 0.01);
+            assertEquals(-1.00, block.getDouble(1), 0.01);
+        }
+    }
+
+    public void testReadDecimalBinaryColumn() throws Exception {
+        // DECIMAL(10, 2) backed by BINARY
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.decimalType(2, 10))
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("value", Binary.fromConstantByteArray(BigInteger.valueOf(9999).toByteArray())); // 99.99
+            return List.of(g1);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            DoubleBlock block = (DoubleBlock) page.getBlock(0);
+            assertEquals(99.99, block.getDouble(0), 0.01);
+        }
+    }
+
+    // --- TIMESTAMP MICROS/NANOS tests ---
+
+    public void testReadTimestampMicrosColumn() throws Exception {
+        // TIMESTAMP(MICROS, adjustedToUTC=true)
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test_schema");
+
+        long epochMillis = 946728000000L; // 2000-01-01T12:00:00Z
+        long epochMicros = epochMillis * 1000;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("ts", epochMicros);
+            return List.of(g1);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(epochMillis, block.getLong(0));
+        }
+    }
+
+    public void testReadTimestampNanosColumn() throws Exception {
+        // TIMESTAMP(NANOS, adjustedToUTC=true)
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .named("ts")
+            .named("test_schema");
+
+        long epochMillis = 946728000000L; // 2000-01-01T12:00:00Z
+        long epochNanos = epochMillis * 1_000_000;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("ts", epochNanos);
+            return List.of(g1);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(epochMillis, block.getLong(0));
+        }
+    }
+
+    public void testReadTimestampMillisColumn() throws Exception {
+        // TIMESTAMP(MILLIS, adjustedToUTC=true) — existing behavior, verifying it still works
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .named("test_schema");
+
+        long epochMillis = 946728000000L;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("ts", epochMillis);
+            return List.of(g1);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(epochMillis, block.getLong(0));
+        }
+    }
+
+    // --- INT96 timestamp tests ---
+
+    public void testReadInt96TimestampColumn() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT96).named("ts").named("test_schema");
+
+        // 2000-01-01T12:00:00Z → Julian day 2451545, nanos = 12h = 43_200_000_000_000
+        int julianDay = 2_451_545;
+        long nanosOfDay = 43_200_000_000_000L;
+        long expectedMillis = 946728000000L;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("ts", new NanoTime(julianDay, nanosOfDay));
+            return List.of(g1);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertEquals(expectedMillis, block.getLong(0));
+        }
+    }
+
+    // --- FLOAT16 tests ---
+
+    public void testReadFloat16Column() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(2)
+            .as(LogicalTypeAnnotation.float16Type())
+            .named("val")
+            .named("test_schema");
+
+        float value1 = 3.14f;
+        float value2 = -1.0f;
+        float value3 = 0.0f;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("val", Binary.fromConstantByteArray(toFloat16Bytes(value1)));
+            Group g2 = factory.newGroup();
+            g2.add("val", Binary.fromConstantByteArray(toFloat16Bytes(value2)));
+            Group g3 = factory.newGroup();
+            g3.add("val", Binary.fromConstantByteArray(toFloat16Bytes(value3)));
+            return List.of(g1, g2, g3);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            DoubleBlock block = (DoubleBlock) page.getBlock(0);
+            assertEquals(Float.float16ToFloat(Float.floatToFloat16(value1)), block.getDouble(0), 0.01);
+            assertEquals(Float.float16ToFloat(Float.floatToFloat16(value2)), block.getDouble(1), 0.001);
+            assertEquals(0.0, block.getDouble(2), 0.001);
+        }
+    }
+
+    // --- UUID tests ---
+
+    public void testReadUuidColumn() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(16)
+            .as(LogicalTypeAnnotation.uuidType())
+            .named("id")
+            .named("test_schema");
+
+        UUID uuid1 = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID uuid2 = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("id", Binary.fromConstantByteArray(toUuidBytes(uuid1)));
+            Group g2 = factory.newGroup();
+            g2.add("id", Binary.fromConstantByteArray(toUuidBytes(uuid2)));
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            assertEquals(uuid1.toString(), block.getBytesRef(0, new BytesRef()).utf8ToString());
+            assertEquals(uuid2.toString(), block.getBytesRef(1, new BytesRef()).utf8ToString());
+        }
+    }
+
+    // --- LIST tests ---
+
+    public void testReadListOfIntegersColumn() throws Exception {
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("numbers");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            // Row 0: [1, 2, 3]
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("numbers");
+            list1.addGroup("list").append("element", 1);
+            list1.addGroup("list").append("element", 2);
+            list1.addGroup("list").append("element", 3);
+
+            // Row 1: [10]
+            Group g2 = factory.newGroup();
+            Group list2 = g2.addGroup("numbers");
+            list2.addGroup("list").append("element", 10);
+
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.INTEGER, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+
+            IntBlock block = (IntBlock) page.getBlock(0);
+            // Row 0: [1, 2, 3]
+            assertEquals(3, block.getValueCount(0));
+            int start0 = block.getFirstValueIndex(0);
+            assertEquals(1, block.getInt(start0));
+            assertEquals(2, block.getInt(start0 + 1));
+            assertEquals(3, block.getInt(start0 + 2));
+
+            // Row 1: [10]
+            assertEquals(1, block.getValueCount(1));
+            assertEquals(10, block.getInt(block.getFirstValueIndex(1)));
+        }
+    }
+
+    public void testReadListOfStringsColumn() throws Exception {
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("tags");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("tags");
+            list1.addGroup("list").append("element", "red");
+            list1.addGroup("list").append("element", "blue");
+
+            Group g2 = factory.newGroup();
+            Group list2 = g2.addGroup("tags");
+            list2.addGroup("list").append("element", "green");
+
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            // Row 0: ["red", "blue"]
+            assertEquals(2, block.getValueCount(0));
+            int start0 = block.getFirstValueIndex(0);
+            assertEquals(new BytesRef("red"), block.getBytesRef(start0, new BytesRef()));
+            assertEquals(new BytesRef("blue"), block.getBytesRef(start0 + 1, new BytesRef()));
+
+            // Row 1: ["green"]
+            assertEquals(1, block.getValueCount(1));
+            assertEquals(new BytesRef("green"), block.getBytesRef(block.getFirstValueIndex(1), new BytesRef()));
+        }
+    }
+
+    public void testReadListWithNullList() throws Exception {
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT64).named("values");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            // Row 0: [100, 200]
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("values");
+            list1.addGroup("list").append("element", 100L);
+            list1.addGroup("list").append("element", 200L);
+
+            // Row 1: null (no addGroup call)
+            Group g2 = factory.newGroup();
+
+            // Row 2: [300]
+            Group g3 = factory.newGroup();
+            Group list3 = g3.addGroup("values");
+            list3.addGroup("list").append("element", 300L);
+
+            return List.of(g1, g2, g3);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+
+            LongBlock block = (LongBlock) page.getBlock(0);
+            // Row 0: [100, 200]
+            assertFalse(block.isNull(0));
+            assertEquals(2, block.getValueCount(0));
+            int start0 = block.getFirstValueIndex(0);
+            assertEquals(100L, block.getLong(start0));
+            assertEquals(200L, block.getLong(start0 + 1));
+
+            // Row 1: null
+            assertTrue(block.isNull(1));
+
+            // Row 2: [300]
+            assertFalse(block.isNull(2));
+            assertEquals(1, block.getValueCount(2));
+            assertEquals(300L, block.getLong(block.getFirstValueIndex(2)));
+        }
+    }
+
+    // --- UUID formatting unit test ---
+
+    public void testFormatUuid() {
+        UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        byte[] bytes = toUuidBytes(uuid);
+        String formatted = ParquetFormatReader.formatUuid(bytes);
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", formatted);
+    }
+
     public void testMetadataReturnsCorrectSourceType() throws Exception {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
 
@@ -689,6 +1164,32 @@ public class ParquetFormatReaderTests extends ESTestCase {
             }
         }
         assertEquals("Reading all ranges should produce the same total as a full read", totalRowsDirect, totalRowsFromRanges);
+    }
+
+    // --- Test helpers ---
+
+    private static byte[] toFloat16Bytes(float value) {
+        short float16 = Float.floatToFloat16(value);
+        byte[] bytes = new byte[2];
+        bytes[0] = (byte) (float16 & 0xFF);
+        bytes[1] = (byte) ((float16 >> 8) & 0xFF);
+        return bytes;
+    }
+
+    private static byte[] toUuidBytes(UUID uuid) {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        buf.putLong(uuid.getMostSignificantBits());
+        buf.putLong(uuid.getLeastSignificantBits());
+        return buf.array();
+    }
+
+    private static byte[] toFixedLenDecimal(long unscaledValue, int fixedLen) {
+        byte[] unscaledBytes = BigInteger.valueOf(unscaledValue).toByteArray();
+        byte[] padded = new byte[fixedLen];
+        byte fill = unscaledValue < 0 ? (byte) 0xFF : (byte) 0x00;
+        java.util.Arrays.fill(padded, fill);
+        System.arraycopy(unscaledBytes, 0, padded, fixedLen - unscaledBytes.length, unscaledBytes.length);
+        return padded;
     }
 
     @FunctionalInterface


### PR DESCRIPTION
The Parquet format reader silently produced wrong data, partial results,
or nulls for several Parquet type combinations. This fixes the MVP set
of type-mapping gaps: DECIMAL values no longer lose their scale factor,
MICROS/NANOS timestamps are correctly converted to milliseconds, legacy
INT96 timestamps are decoded from Julian day encoding, FLOAT16 and UUID
columns produce proper DOUBLE and formatted-string values respectively,
and LIST-of-primitives columns are read into multi-valued ESQL blocks.

Developed with AI-assisted tooling