### PR TITLE
test(mmr_retriever): use explicit hnsw index type for deterministic results

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
@@ -394,7 +394,7 @@ teardown:
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._source.textbody: "first text" }
   - match: { hits.hits.1._source.textbody: "third text" }
-  - match: { hits.hits.2._source.textbody: "fifth text" }
+  - match: { hits.hits.2._source.textbody: "fourth text" }
 
 ---
 "Test MMR diversification with arbitrary shards":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
@@ -23,6 +23,8 @@ setup:
               textvector:
                 type: dense_vector
                 dims: 4
+                index_options:
+                  type: hnsw
 
   - do:
       indices.create:
@@ -39,6 +41,8 @@ setup:
               textvector:
                 type: dense_vector
                 dims: 4
+                index_options:
+                  type: hnsw
 
   - do:
       indices.create:
@@ -207,7 +211,7 @@ teardown:
   - match: { hits.hits.6._source.textbody: "ninth text" }
   - match: { hits.hits.7._source.textbody: "seventh text" }
   - match: { hits.hits.8._source.textbody: "eighth text" }
-  - match: { hits.hits.9._source.textbody: "fourth text" }
+  - match: { hits.hits.9._source.textbody: "fifth text" }
 
   - do:
       search:
@@ -300,7 +304,7 @@ teardown:
   - match: { hits.hits.6._source.textbody: "ninth text" }
   - match: { hits.hits.7._source.textbody: "seventh text" }
   - match: { hits.hits.8._source.textbody: "eighth text" }
-  - match: { hits.hits.9._source.textbody: "fourth text" }
+  - match: { hits.hits.9._source.textbody: "fifth text" }
 
   - do:
       search:
@@ -348,7 +352,7 @@ teardown:
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._source.textbody: "seventh text" }
   - match: { hits.hits.1._source.textbody: "eighth text" }
-  - match: { hits.hits.2._source.textbody: "fourth text" }
+  - match: { hits.hits.2._source.textbody: "fifth text" }
 
 ---
 "Test MMR result diversification byte vector type":
@@ -390,7 +394,7 @@ teardown:
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._source.textbody: "first text" }
   - match: { hits.hits.1._source.textbody: "third text" }
-  - match: { hits.hits.2._source.textbody: "fourth text" }
+  - match: { hits.hits.2._source.textbody: "fifth text" }
 
 ---
 "Test MMR diversification with arbitrary shards":
@@ -464,9 +468,9 @@ teardown:
 
   - match: { hits.total.value: 10 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._source.textbody: "second text other" }
-  - match: { hits.hits.1._source.textbody: "third text other" }
-  - match: { hits.hits.2._source.textbody: "third text duplicate other" }
+  - match: { hits.hits.0._source.textbody: "second text" }
+  - match: { hits.hits.1._source.textbody: "third text" }
+  - match: { hits.hits.2._source.textbody: "third text duplicate" }
 
 ---
 "Test MMR result diversification with default size should return results":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
@@ -502,7 +502,7 @@ teardown:
   - match: { hits.hits.6._source.textbody: "ninth text" }
   - match: { hits.hits.7._source.textbody: "seventh text" }
   - match: { hits.hits.8._source.textbody: "eighth text" }
-  - match: { hits.hits.9._source.textbody: "fourth text" }
+  - match: { hits.hits.9._source.textbody: "fifth text" }
 
 ---
 "Test MMR result diversification rank_window_size restricts top docs":


### PR DESCRIPTION

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->

Essentially a backport of [Fix flaky MMR diversification YAML tests](https://github.com/elastic/elasticsearch/pull/143706) to 9.3

Fixes https://github.com/elastic/elasticsearch/issues/142671

Without `hnsw`, the default int8_hnsw index type quantizes float32 vectors to
int8 and in combination with the very small vector dimensions (4) can cause non-deterministic results. 


