### PR TITLE
ES|QL: Fix MagnitudeSerializationTests release tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -436,15 +436,6 @@ tests:
   method: testMMRLimitedInput
   issue: https://github.com/elastic/elasticsearch/issues/144077
 - class: org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/144078
-- class: org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests
-  method: testSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/144079
-- class: org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests
-  method: testConcurrentSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/144080
-- class: org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests
   method: testConcurrentEquals
   issue: https://github.com/elastic/elasticsearch/issues/144081
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -435,9 +435,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
   method: testMMRLimitedInput
   issue: https://github.com/elastic/elasticsearch/issues/144077
-- class: org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests
-  method: testConcurrentEquals
-  issue: https://github.com/elastic/elasticsearch/issues/144081
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/MagnitudeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/MagnitudeSerializationTests.java
@@ -7,11 +7,19 @@
 
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+import org.junit.Before;
 
 public class MagnitudeSerializationTests extends AbstractUnaryScalarSerializationTests<Magnitude> {
+
+    @Before
+    public void checkCapability() {
+        assumeTrue("v_magnitude available in snapshot", EsqlCapabilities.Cap.MAGNITUDE_SCALAR_VECTOR_FUNCTION.isEnabled());
+    }
+
     @Override
     protected Magnitude create(Source source, Expression child) {
         return new Magnitude(source, child);


### PR DESCRIPTION
related https://github.com/elastic/elasticsearch/issues/144086

close https://github.com/elastic/elasticsearch/issues/144078
close https://github.com/elastic/elasticsearch/issues/144079
close https://github.com/elastic/elasticsearch/issues/144080
close https://github.com/elastic/elasticsearch/issues/144081

tested with:

```
./gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeSerializationTests.*"  -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dlicense.key=x-pack/license-tools/src/test/resources/public.key
```