### PR TITLE
Clarify index not found error when project pattern is used

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
+++ b/server/src/main/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidator.java
@@ -120,7 +120,11 @@ public class CrossProjectIndexResolutionValidator {
             // TODO consider sorting during index re-writing, to avoid sorting here
             var remoteExpressions = localResolvedIndices.remoteExpressions().stream().sorted().toList();
             ResolvedIndexExpression.LocalExpressions localExpressions = localResolvedIndices.localExpressions();
-            ElasticsearchException localException = checkResolutionFailure(localExpressions, originalExpression, indicesOptions);
+            ElasticsearchException localException = checkResolutionFailure(
+                localExpressions,
+                asOriginExpression(originalExpression),
+                indicesOptions
+            );
 
             if (isQualifiedExpression) {
                 if (localException != null) {
@@ -366,6 +370,14 @@ public class CrossProjectIndexResolutionValidator {
             .orElse(null);
     }
 
+    private static String asOriginExpression(String originalExpression) {
+        var split = RemoteClusterAware.splitIndexName(originalExpression);
+        if (split[0] == null || split[0].indexOf('*') == -1) {
+            return originalExpression;
+        }
+        return RemoteClusterAware.buildRemoteIndexName("_origin", split[1]);
+    }
+
     private static ElasticsearchException checkResolutionFailure(
         ResolvedIndexExpression.LocalExpressions localExpressions,
         String expression,
@@ -382,7 +394,6 @@ public class CrossProjectIndexResolutionValidator {
             } else if (result == CONCRETE_RESOURCE_UNAUTHORIZED) {
                 assert localExpressions.exception() != null
                     : "ResolvedIndexExpression should have exception set when concrete index is unauthorized";
-
                 return localExpressions.exception();
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
@@ -1620,6 +1620,83 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
         assertThat(e.getMessage(), equalTo("no such index [P1:logs]"));
     }
 
+    public void testWildcardClusterAliasConcreteIndex() {
+
+        // local index not found with cluster alias pattern
+        var localNotFound = CrossProjectIndexResolutionValidator.validate(
+            getStrictIgnoreUnavailable(),
+            null,
+            new ResolvedIndexExpressions(
+                List.of(
+                    new ResolvedIndexExpression(
+                        "*:logs",
+                        new ResolvedIndexExpression.LocalExpressions(
+                            Set.of("logs"),
+                            ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE,
+                            null
+                        ),
+                        Set.of("linked-1:logs")
+                    )
+                )
+            ),
+            Map.of(
+                "linked-1",
+                new ResolvedIndexExpressions(
+                    List.of(
+                        new ResolvedIndexExpression(
+                            "logs",
+                            new ResolvedIndexExpression.LocalExpressions(
+                                Set.of("logs"),
+                                ResolvedIndexExpression.LocalIndexResolutionResult.SUCCESS,
+                                null
+                            ),
+                            Set.of()
+                        )
+                    )
+                )
+            )
+        );
+        assertNotNull(localNotFound);
+        assertThat(localNotFound.getMessage(), equalTo("no such index [_origin:logs]"));
+
+        // remote index not found with cluster alias pattern
+        var remoteNotFound = CrossProjectIndexResolutionValidator.validate(
+            getStrictIgnoreUnavailable(),
+            null,
+            new ResolvedIndexExpressions(
+                List.of(
+                    new ResolvedIndexExpression(
+                        "*:logs",
+                        new ResolvedIndexExpression.LocalExpressions(
+                            Set.of("logs"),
+                            ResolvedIndexExpression.LocalIndexResolutionResult.SUCCESS,
+                            null
+                        ),
+                        Set.of("linked-1:logs")
+                    )
+                )
+            ),
+            Map.of(
+                "linked-1",
+                new ResolvedIndexExpressions(
+                    List.of(
+                        new ResolvedIndexExpression(
+                            "logs",
+                            new ResolvedIndexExpression.LocalExpressions(
+                                Set.of("logs"),
+                                ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE,
+                                null
+                            ),
+                            Set.of()
+                        )
+                    )
+                )
+            )
+        );
+        assertNotNull(remoteNotFound);
+        assertThat(remoteNotFound.getMessage(), equalTo("no such index [linked-1:logs]"));
+    }
+
     private IndicesOptions getStrictAllowNoIndices() {
         return getIndicesOptions(true, false);
     }

--- a/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/crossproject/CrossProjectIndexResolutionValidatorTests.java
@@ -1327,7 +1327,7 @@ public class CrossProjectIndexResolutionValidatorTests extends ESTestCase {
 
         var e = CrossProjectIndexResolutionValidator.validate(getStrictIgnoreUnavailable(), null, local, remote);
         assertThat(e, is(notNullValue()));
-        assertThat(e.getMessage(), equalTo("no such index [" + originalExpression + "]"));
+        assertThat(e.getMessage(), equalTo("no such index [" + originalExpression.replace("*:", "_origin:") + "]"));
         assertThat(e.getSuppressed(), emptyArray());
     }
 


### PR DESCRIPTION
Today when resolving `*:logs` in CPS env we require `logs` index to be found on all projects.
If project is not found on remote we fail with `no such index [my_linked_project:logs]` that explicitly states name of the project where the index is not found. However when the index is not found in local/origin project we fail with a generic `no such index [*:logs]` that is harder to reason about.
This change updates the local failure to `no such index [_origin:logs]` so it is easier to pin the issue to the local/origin project.
