### PR TITLE
Pass --continue to Gradle in Java EA pipelines

### DIFF
--- a/.buildkite/pipelines/periodic-java-ea.template.yml
+++ b/.buildkite/pipelines/periodic-java-ea.template.yml
@@ -1,5 +1,6 @@
 env:
   JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
+  EXTRA_GRADLE_ARGS: "--continue"
 
 steps:
   - group: bwc

--- a/.buildkite/pipelines/periodic-java-ea.yml
+++ b/.buildkite/pipelines/periodic-java-ea.yml
@@ -1,6 +1,7 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-java-ea.template.yml
 env:
   JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
+  EXTRA_GRADLE_ARGS: "--continue"
 
 steps:
   - group: bwc

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -49,4 +49,4 @@ if [[ -n "${TESTS_SEED:-}" ]]; then
   echo "Using test seed: $TESTS_SEED"
 fi
 
-$GRADLEW -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM "$@"
+$GRADLEW -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"


### PR DESCRIPTION
## Summary

- Adds `EXTRA_GRADLE_ARGS` env var support to `.ci/scripts/run-gradle.sh` so pipelines can inject additional Gradle flags without editing individual step commands.
- Sets `EXTRA_GRADLE_ARGS: "--continue"` in the periodic Java EA pipeline template so all Gradle invocations continue past failures, matching the behavior already present in `periodic.template.yml`.

## Test plan

- [ ] Verify the periodic Java EA pipeline passes `--continue` to Gradle by inspecting build scan output from the next scheduled run.

Made with [Cursor](https://cursor.com)