### PR TITLE
Disable Feature Flags in Snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/FeatureFlag.java
+++ b/server/src/main/java/org/elasticsearch/common/util/FeatureFlag.java
@@ -71,12 +71,7 @@ public class FeatureFlag {
         final String propertyName = "es." + name + "_feature_flag_" + suffix;
         if (build.isSnapshot()) {
             enabled = parseSystemProperty(getSystemProperty, propertyName, true);
-            if (enabled == false) {
-                throw new IllegalArgumentException(
-                    "Feature flag " + name + " (via system property '" + propertyName + "') cannot be disabled in snapshot builds"
-                );
-            }
-            logger.info("The current build is a snapshot, feature flag [{}] is enabled", name);
+            logger.info("The current build is a snapshot, feature flag [{}] is {}", name, enabled ? "enabled" : "disabled");
         } else {
             enabled = parseSystemProperty(getSystemProperty, propertyName, false);
             logger.debug("The current build is a not snapshot, feature flag [{}] is {}", name, enabled ? "enabled" : "disabled");

--- a/server/src/test/java/org/elasticsearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/FeatureFlagTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.test.VersionUtils;
 import java.time.Instant;
 import java.util.Properties;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class FeatureFlagTests extends ESTestCase {
@@ -59,10 +58,10 @@ public class FeatureFlagTests extends ESTestCase {
         assertThat(flag.isEnabled(), is(true));
     }
 
-    public void testSetFeatureFlagCannotBeDisabledInSnapshotBuild() {
+    public void testSetFeatureFlagExplicitlyDisabledInSnapshotBuild() {
         final Properties properties = setProperty("es.test_feature_flag_enabled", "false");
-        final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> newFeatureFlag(properties, true));
-        assertThat(ex.getMessage(), containsString("cannot be disabled in snapshot builds"));
+        final FeatureFlag flag = newFeatureFlag(properties, true);
+        assertThat(flag.isEnabled(), is(false));
     }
 
     private static FeatureFlag newFeatureFlag(Properties properties, boolean isSnapshot) {


### PR DESCRIPTION
Allows tests and snapshots to disable feature flags.