### PR TITLE
Assert SystemIndexDescriptor is not used for a data stream

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -229,6 +229,8 @@ public class MetadataCreateDataStreamService {
         assert (isSystemDataStreamName && systemDataStreamDescriptor != null)
             || (isSystemDataStreamName == false && systemDataStreamDescriptor == null)
             : "dataStream [" + request.name + "] is system but no system descriptor was provided!";
+        assert metadataCreateIndexService.getSystemIndices().findMatchingDescriptor(dataStreamName) == null
+            : "dataStream [" + dataStreamName + "] matches a SystemIndexDescriptor but should use a SystemDataStreamDescriptor instead";
 
         Objects.requireNonNull(metadataCreateIndexService);
         Objects.requireNonNull(currentState);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemDataStreamDescriptor.Type;
+import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.SystemIndices.Feature;
 import org.elasticsearch.test.ESTestCase;
@@ -566,9 +567,49 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         );
     }
 
+    public void testCreateDataStreamMatchingSystemIndexDescriptorFails() throws Exception {
+        final String dataStreamName = ".my-system-idx";
+        SystemIndices systemIndices = new SystemIndices(
+            List.of(
+                new Feature(
+                    "testFeature",
+                    "a test feature with an index descriptor matching a data stream name",
+                    List.of(SystemIndexDescriptorUtils.createUnmanaged(".my-system-idx*", "test"))
+                )
+            )
+        );
+        MetadataCreateIndexService metadataCreateIndexService = getMetadataCreateIndexService(systemIndices);
+        ComposableIndexTemplate template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(dataStreamName + "*"))
+            .dataStreamTemplate(new DataStreamTemplate())
+            .build();
+        final var projectId = randomProjectIdOrDefault();
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .putProjectMetadata(ProjectMetadata.builder(projectId).put("template", template).build())
+            .build();
+        CreateDataStreamClusterStateUpdateRequest req = new CreateDataStreamClusterStateUpdateRequest(projectId, dataStreamName);
+        AssertionError e = expectThrows(
+            AssertionError.class,
+            () -> MetadataCreateDataStreamService.createDataStream(
+                metadataCreateIndexService,
+                Settings.EMPTY,
+                cs,
+                randomBoolean(),
+                req,
+                ActionListener.noop(),
+                false
+            )
+        );
+        assertThat(e.getMessage(), containsString("matches a SystemIndexDescriptor"));
+    }
+
     private static MetadataCreateIndexService getMetadataCreateIndexService() throws Exception {
+        return getMetadataCreateIndexService(getSystemIndices());
+    }
+
+    private static MetadataCreateIndexService getMetadataCreateIndexService(SystemIndices systemIndices) throws Exception {
         MetadataCreateIndexService s = mock(MetadataCreateIndexService.class);
-        when(s.getSystemIndices()).thenReturn(getSystemIndices());
+        when(s.getSystemIndices()).thenReturn(systemIndices);
         Answer<Object> objectAnswer = mockInvocation -> {
             ClusterState currentState = (ClusterState) mockInvocation.getArguments()[0];
             CreateIndexClusterStateUpdateRequest request = (CreateIndexClusterStateUpdateRequest) mockInvocation.getArguments()[1];
@@ -583,7 +624,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
                                 .build()
                         )
                         .putMapping(generateMapping("@timestamp"))
-                        .system(getSystemIndices().isSystemName(request.index()))
+                        .system(systemIndices.isSystemName(request.index()))
                         .numberOfShards(1)
                         .numberOfReplicas(1)
                         .build(),


### PR DESCRIPTION
## Summary

- Adds an assertion in `MetadataCreateDataStreamService.createDataStream()` that fires when a data stream name matches a `SystemIndexDescriptor` pattern, indicating a `SystemDataStreamDescriptor` should be used instead.
- Adds a unit test verifying the assertion catches the misconfiguration.

Closes #144049

## Test plan

- [x] New test `testCreateDataStreamMatchingSystemIndexDescriptorFails` passes
- [x] All existing `MetadataCreateDataStreamServiceTests` continue to pass

Made with [Cursor](https://cursor.com)