### PR TITLE
ESQL: Skip missing test checker on release builds

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,9 +399,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testApmIntegration {withOTel=true}
   issue: https://github.com/elastic/elasticsearch/issues/144072
-- class: org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistryTests
-  method: testRegisteredFunctionHaveTests
-  issue: https://github.com/elastic/elasticsearch/issues/144076
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/138012

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.test.ESTestCase;
@@ -240,6 +241,10 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
     }
 
     public void testRegisteredFunctionHaveTests() {
+        assumeTrue("""
+            Some functions are missing when outside of snapshot and we really
+            only care about the superset of all functions. Just skip this test
+            on release builds.""", Build.current().isSnapshot());
         EsqlFunctionRegistry registry = new EsqlFunctionRegistry().snapshotRegistry();
         Set<String> errors = new TreeSet<>();
         for (FunctionDefinition def : registry.listFunctions()) {


### PR DESCRIPTION
On release builds we get a smaller list of functions which makes the "missing test" checker angry. Some functions look fixed. But they aren't fixed. We could ignore this sort of failure in a complex way, but it isn't worth it. We just skip the test on release builds. It still does it's job - telling us about missing tests.

Closes #144076
Relates #144086
