### PR TITLE
[9.2] Require isExpectedNoOp tests to return boolean (#144131)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/EntitlementTest.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/EntitlementTest.java
@@ -60,9 +60,10 @@ public @interface EntitlementTest {
     boolean isExpectedDefaultNull() default false;
 
     /**
-     * When a denied entitlement strategy silently returns early (no-op) for a void method
-     * instead of throwing, set this to {@code true}. The test infrastructure will accept
-     * a successful response as valid denial behavior.
+     * When a denied entitlement strategy silently returns early (no-op) instead of throwing,
+     * set this to {@code true}. The test method must return {@code boolean} indicating whether
+     * the call actually changed state ({@code true}) or was effectively a no-op ({@code false}).
+     * The test infrastructure asserts the state changed when allowed and did not change when denied.
      * Mutually exclusive with {@link #expectedDefaultIfDenied()} and {@link #isExpectedDefaultNull()}.
      */
     boolean isExpectedNoOp() default false;

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -143,8 +143,8 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                     "Entitlement test method [" + method + "] must have a return type when a default value is expected"
                 );
             }
-            if (isExpectedNoOp && method.getReturnType() != void.class) {
-                throw new AssertionError("Entitlement test method [" + method + "] must be void when isExpectedNoOp is set");
+            if (isExpectedNoOp && method.getReturnType() != boolean.class) {
+                throw new AssertionError("Entitlement test method [" + method + "] must return boolean when isExpectedNoOp is set");
             }
             final CheckedFunction<Environment, Object, Exception> call = createFunctionForMethod(method);
             CheckedFunction<Environment, Object, Exception> action = env -> {
@@ -299,7 +299,7 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                     response.addHeader("isExpectedDefaultNull", "true");
                 }
                 if (checkAction.isExpectedNoOp()) {
-                    response.addHeader("isExpectedNoOp", "true");
+                    response.addHeader("noOpChanged", result.toString());
                 }
             } catch (Exception e) {
                 var statusCode = checkAction.expectedExceptionIfDenied.isInstance(e)

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
@@ -75,12 +75,19 @@ public abstract class AbstractEntitlementsIT extends ESRestTestCase {
         if (expectAllowed) {
             Response result = executeCheck();
             assertThat(result.getStatusLine().getStatusCode(), equalTo(200));
+            String noOpChanged = result.getHeader("noOpChanged");
+            if (noOpChanged != null) {
+                assertTrue("Action [" + actionName + "] expected state to change when allowed but it did not", "true".equals(noOpChanged));
+            }
         } else {
             try {
                 Response result = executeCheck();
                 assertThat(result.getStatusLine().getStatusCode(), equalTo(200));
-                if ("true".equals(result.getHeader("isExpectedNoOp"))) {
-                    // void method with elseReturnEarly — silent success is expected
+                if (result.getHeader("noOpChanged") != null) {
+                    assertFalse(
+                        "Action [" + actionName + "] expected no-op when denied but state changed",
+                        "true".equals(result.getHeader("noOpChanged"))
+                    );
                 } else if ("true".equals(result.getHeader("isExpectedDefaultNull"))) {
                     assertTrue(
                         "Action [" + actionName + "] expected null default but got a non-null result",


### PR DESCRIPTION
Backport of #144131 to 9.2.