### PR TITLE
Fix SearchHits ref leak in AsyncSearchTaskTests. testCompletionTimeoutAndSuppressPartialResults

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -297,12 +297,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasources.GlobDiscoveryLocalTests
   method: testRecursiveDoubleStarAllFiles
   issue: https://github.com/elastic/elasticsearch/issues/142576
-- class: org.elasticsearch.xpack.search.AsyncSearchTaskTests
-  methods:
-  - testFatalFailureDuringFetch
-  - testWithFetchFailures
-  - testAddCompletionListenerScheduleErrorWaitForInitListener
-  issue: https://github.com/elastic/elasticsearch/issues/142626
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/suggested_type}
   issue: https://github.com/elastic/elasticsearch/issues/142525
@@ -315,9 +309,6 @@ tests:
 - class: org.elasticsearch.xpack.core.termsenum.TermsEnumTests
   method: testTermsEnumIPRandomized
   issue: https://github.com/elastic/elasticsearch/issues/142811
-- class: org.elasticsearch.xpack.search.AsyncSearchTaskTests
-  method: testWithFailure
-  issue: https://github.com/elastic/elasticsearch/issues/142821
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/142079

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -336,34 +336,41 @@ public class AsyncSearchTaskTests extends ESTestCase {
 
             // Ensure that once we have the final aggregations and hits, we do send a full response to the listeners, regardless of
             // partialResultsSuppressed flag.
-            ActionListener.respondAndRelease(
-                (AsyncSearchTask.Listener) task.getProgressListener(),
-                SearchResponseUtils.response(
-                    new SearchHits(new SearchHit[1], new TotalHits(10, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), 1)
-                )
-                    .aggregations(
-                        InternalAggregations.from(
-                            Collections.singletonList(
-                                new StringTerms(
-                                    "name",
-                                    BucketOrder.key(true),
-                                    BucketOrder.key(true),
-                                    1,
-                                    1,
-                                    Collections.emptyMap(),
-                                    DocValueFormat.RAW,
-                                    1,
-                                    false,
-                                    1,
-                                    Collections.emptyList(),
-                                    0L
+            SearchHits hits = new SearchHits(
+                new SearchHit[] { new SearchHit(0) },
+                new TotalHits(10, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+                1
+            );
+            try {
+                ActionListener.respondAndRelease(
+                    (AsyncSearchTask.Listener) task.getProgressListener(),
+                    SearchResponseUtils.response(hits)
+                        .aggregations(
+                            InternalAggregations.from(
+                                Collections.singletonList(
+                                    new StringTerms(
+                                        "name",
+                                        BucketOrder.key(true),
+                                        BucketOrder.key(true),
+                                        1,
+                                        1,
+                                        Collections.emptyMap(),
+                                        DocValueFormat.RAW,
+                                        1,
+                                        false,
+                                        1,
+                                        Collections.emptyList(),
+                                        0L
+                                    )
                                 )
                             )
                         )
-                    )
-                    .shards(totalShards, totalShards, numSkippedShards)
-                    .build()
-            );
+                        .shards(totalShards, totalShards, numSkippedShards)
+                        .build()
+                );
+            } finally {
+                hits.decRef();
+            }
             assertCompletionListeners(task, totalShards, totalShards, numSkippedShards, 0, false, false, randomBoolean());
         }
     }


### PR DESCRIPTION
`ActionListener.respondAndRelease` releases the` SearchResponse` it receives, but it does not release the caller’s original `SearchHits` reference. Updated the code to release the local `SearchHits` ref after building `SearchResponse`, in a finally block.

Solves #142626 #142821