### PR TITLE
Deprecate CsvTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -261,7 +261,10 @@ public class CsvTests extends ESTestCase {
     public static List<Object[]> readScriptSpec() throws Exception {
         List<URL> urls = classpathResources("/*.csv-spec");
         assertThat("Not enough specs found " + urls, urls, hasSize(greaterThan(0)));
-        return SpecReader.readScriptSpec(urls, specParser());
+        // CsvTests infrastructure is being replaced by org.elasticsearch.xpack.esql.CsvIT, please consider using it instead.
+        // This one will be eventually removed but for now it is limited to only a single test case.
+        // in order to save build pipeline test execution time while allowing running select specs locally.
+        return SpecReader.readScriptSpec(urls, specParser()).subList(0, 1);
     }
 
     @Before


### PR DESCRIPTION
This change deprecates CsvTests in favor of CsvIT.
It does not remote older infra yet, but limits its execution during build pipeline to save on build time.