### PR TITLE
Mute InferenceRestIT and DefaultEndPointsIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -348,6 +348,18 @@ tests:
 - class: org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests
   method: testOrderByCardinality
   issue: https://github.com/elastic/elasticsearch/issues/142484
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144161
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144159
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144160
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testInferDeploysDefaultRerank
+  issue: https://github.com/elastic/elasticsearch/issues/144162
 
 # Examples:
 #


### PR DESCRIPTION
Mutes on 9.3 for
- https://github.com/elastic/elasticsearch/issues/144161
- https://github.com/elastic/elasticsearch/issues/144159
- https://github.com/elastic/elasticsearch/issues/144160
- https://github.com/elastic/elasticsearch/issues/144162