### PR TITLE
restore dropped allowPartialSearchResults configuration

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -158,6 +158,7 @@ public class Querier {
             options = IndicesOptions.builder(options).crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true)).build();
         }
         final OpenPointInTimeRequest openPitRequest = new OpenPointInTimeRequest(search.indices()).indicesOptions(options)
+            .allowPartialSearchResults(cfg.allowPartialSearchResults())
             .keepAlive(cfg.pageTimeout());
         if (cfg.crossProject() && cfg.projectRouting() != null) {
             openPitRequest.projectRouting(cfg.projectRouting());


### PR DESCRIPTION
This got mistakenly dropped in one of my merges/rebases in https://github.com/elastic/elasticsearch/pull/143488