### PR TITLE
Remove escaped dots because subobjects are enabled

### DIFF
--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
@@ -114,64 +114,64 @@ setup:
   - match:  { hits.hits.0._source._doc_count: 1 }
   - match:  { hits.hits.0._source.@timestamp: 2021-04-28T18:00:00.000Z }
   # Dimensions
-  - match:  { hits.hits.0._source.k8s\.pod\.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
+  - match:  { hits.hits.0._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
   - match:  { hits.hits.0._source.metricset: pod }
   # Metrics
-  - match:  { hits.hits.0._source.k8s\.pod\.multi-counter: 7 }
-  - match:  { hits.hits.0._source.k8s\.pod\.scaled-counter: 7.0 }
-  - match:  { hits.hits.0._source.k8s\.pod\.multi-gauge.min: 100 }
-  - match:  { hits.hits.0._source.k8s\.pod\.multi-gauge.max: 102 }
-  - match:  { hits.hits.0._source.k8s\.pod\.multi-gauge.sum: 607 }
-  - match:  { hits.hits.0._source.k8s\.pod\.multi-gauge.value_count: 6 }
-  - match: { hits.hits.0._source.k8s\.pod\.scaled-gauge.min: 100.0 }
-  - match: { hits.hits.0._source.k8s\.pod\.scaled-gauge.max: 101.0 }
-  - match: { hits.hits.0._source.k8s\.pod\.scaled-gauge.sum: 201.0 }
-  - match: { hits.hits.0._source.k8s\.pod\.scaled-gauge.value_count: 2 }
-  - match:  { hits.hits.0._source.k8s\.pod\.network\.tx.min: 1434521831 }
-  - match:  { hits.hits.0._source.k8s\.pod\.network\.tx.max: 1434577921 }
-  - match:  { hits.hits.0._source.k8s\.pod\.network\.tx.value_count: 2 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-counter: 7 }
+  - match:  { hits.hits.0._source.k8s.pod.scaled-counter: 7.0 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.min: 100 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.max: 102 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.sum: 607 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.value_count: 6 }
+  - match: { hits.hits.0._source.k8s.pod.scaled-gauge.min: 100.0 }
+  - match: { hits.hits.0._source.k8s.pod.scaled-gauge.max: 101.0 }
+  - match: { hits.hits.0._source.k8s.pod.scaled-gauge.sum: 201.0 }
+  - match: { hits.hits.0._source.k8s.pod.scaled-gauge.value_count: 2 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.min: 1434521831 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.max: 1434577921 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.value_count: 2 }
   # Labels
-  - match:  { hits.hits.0._source.k8s\.pod\.ip: "10.10.55.56" }
-  - match:  { hits.hits.0._source.k8s\.pod\.created_at: "2021-04-28T19:43:00.000Z" }
-  - match:  { hits.hits.0._source.k8s\.pod\.number_of_containers: 1 }
-  - match:  { hits.hits.0._source.k8s\.pod\.tags: ["backend", "test", "us-west2"] }
-  - match:  { hits.hits.0._source.k8s\.pod\.values: [1, 1, 2] }
-  - is_false: hits.hits.0._source.k8s\.pod\.running
+  - match:  { hits.hits.0._source.k8s.pod.ip: "10.10.55.56" }
+  - match:  { hits.hits.0._source.k8s.pod.created_at: "2021-04-28T19:43:00.000Z" }
+  - match:  { hits.hits.0._source.k8s.pod.number_of_containers: 1 }
+  - match:  { hits.hits.0._source.k8s.pod.tags: ["backend", "test", "us-west2"] }
+  - match:  { hits.hits.0._source.k8s.pod.values: [1, 1, 2] }
+  - is_false: hits.hits.0._source.k8s.pod.running
 
   # Doc with counter resets
   - is_false: hits.hits.1._source._doc_count
   - match: { hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z }
   # Dimensions
-  - match: { hits.hits.1._source.k8s\.pod\.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
+  - match: { hits.hits.1._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
   - match: { hits.hits.1._source.metricset: pod }
   # Metrics
-  - match: { hits.hits.1._source.k8s\.pod\.multi-counter: 0 }
-  - match: { hits.hits.1._source.k8s\.pod\.scaled-counter: 0.0 }
+  - match: { hits.hits.1._source.k8s.pod.multi-counter: 0 }
+  - match: { hits.hits.1._source.k8s.pod.scaled-counter: 0.0 }
   # Only dimensions and counters that have been reset are in this doc
-  - is_false: hits.hits.1._source.k8s\.pod\.multi-gauge
+  - is_false: hits.hits.1._source.k8s.pod.multi-gauge
 
   # Next downsampled doc
   - match:  { hits.hits.2._source._doc_count: 1 }
   - match:  { hits.hits.2._source.@timestamp: 2021-04-28T19:00:00.000Z }
   # Dimensions
-  - match:  { hits.hits.2._source.k8s\.pod\.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
+  - match:  { hits.hits.2._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
   - match:  { hits.hits.2._source.metricset: pod }
   # Metrics
-  - match:  { hits.hits.2._source.k8s\.pod\.multi-counter: 1000 }
-  - match:  { hits.hits.2._source.k8s\.pod\.scaled-counter: 1000.0 }
-  - match:  { hits.hits.2._source.k8s\.pod\.multi-gauge.min: 95 }
+  - match:  { hits.hits.2._source.k8s.pod.multi-counter: 1000 }
+  - match:  { hits.hits.2._source.k8s.pod.scaled-counter: 1000.0 }
+  - match:  { hits.hits.2._source.k8s.pod.multi-gauge.min: 95 }
 
   # Doc with counter resets
   - is_false: hits.hits.3._source._doc_count
   - match: { hits.hits.3._source.@timestamp: 2021-04-28T19:51:03.142Z }
   # Dimensions
-  - match: { hits.hits.3._source.k8s\.pod\.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
+  - match: { hits.hits.3._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
   - match: { hits.hits.3._source.metricset: pod }
   # Metrics
-  - match: { hits.hits.3._source.k8s\.pod\.multi-counter: 76 }
+  - match: { hits.hits.3._source.k8s.pod.multi-counter: 76 }
   # Only dimensions and counters that have been reset are in this doc
-  - is_false: hits.hits.3._source.k8s\.pod\.scaled-counter
-  - is_false: hits.hits.3._source.k8s\.pod\.multi-gauge
+  - is_false: hits.hits.3._source.k8s.pod.scaled-counter
+  - is_false: hits.hits.3._source.k8s.pod.multi-gauge
 
   # Assert downsample index settings
   - do:


### PR DESCRIPTION
This yaml test was escaping the dots like other tests but that is wrong. The mapping of this index does not have `subobjects: false` meaning the results are returned nested and in order for the test to match them properly we need to remove the `/`.
