### PR TITLE
Unmute InferenceRestIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,18 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/138012
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144159
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144160
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144161
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testInferDeploysDefaultRerank
-  issue: https://github.com/elastic/elasticsearch/issues/144162
 - class: org.elasticsearch.upgrades.MappingSupplementaryCharacterRollingUpgradeIT
   method: testMappingWithSupplementaryCharacterFieldName {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/144163


### PR DESCRIPTION
Unmute these tests, ML reverts the breaking change in https://github.com/elastic/ml-cpp/pull/2995

Fixes #144159
Fixes #144160
Fixes #144161
Fixes #144162