### PR TITLE
[Transform] Expose ProjectId

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.transform.Transform;
@@ -62,18 +63,31 @@ public class TransformContext {
     private final AtomicLong currentCheckpoint;
 
     private final Instant from;
+    private final ProjectId projectId;
 
     public TransformContext(TransformTaskState taskState, String stateReason, long currentCheckpoint, Listener taskListener) {
         this(taskState, stateReason, currentCheckpoint, null, taskListener);
     }
 
     public TransformContext(TransformTaskState taskState, String stateReason, long currentCheckpoint, Instant from, Listener taskListener) {
+        this(taskState, stateReason, currentCheckpoint, from, taskListener, ProjectId.DEFAULT);
+    }
+
+    public TransformContext(
+        TransformTaskState taskState,
+        String stateReason,
+        long currentCheckpoint,
+        Instant from,
+        Listener taskListener,
+        ProjectId projectId
+    ) {
         this.taskState = new AtomicReference<>(taskState);
         this.stateReason = new AtomicReference<>(stateReason);
         this.currentCheckpoint = new AtomicLong(currentCheckpoint);
         this.from = from;
         this.taskListener = taskListener;
         this.failureCount = new AtomicInteger(0);
+        this.projectId = projectId;
     }
 
     TransformTaskState getTaskState() {
@@ -122,6 +136,10 @@ public class TransformContext {
 
     Instant from() {
         return from;
+    }
+
+    ProjectId projectId() {
+        return projectId;
     }
 
     long incrementAndGetCheckpoint() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -15,6 +15,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Predicates;
@@ -124,7 +125,14 @@ public class TransformTask extends AllocatedPersistentTask
         this.initialIndexerState = initialState;
         this.initialPosition = initialPosition;
 
-        this.context = new TransformContext(initialTaskState, initialReason, initialCheckpoint, transform.from(), this);
+        this.context = new TransformContext(
+            initialTaskState,
+            initialReason,
+            initialCheckpoint,
+            transform.from(),
+            this,
+            ProjectId.ofNullable(getProjectId(), ProjectId.DEFAULT)
+        );
         if (state != null) {
             this.context.setAuthState(state.getAuthState());
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformContextTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformContextTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationState;
@@ -179,5 +180,16 @@ public class TransformContextTests extends ESTestCase {
         Instant from = Instant.ofEpochMilli(randomLongBetween(0, 1_000_000_000_000L));
         TransformContext context = new TransformContext(TransformTaskState.STARTED, null, 0, from, listener);
         assertThat(context.from(), is(equalTo(from)));
+    }
+
+    public void testProjectIdDefaultsToDefault() {
+        var context = new TransformContext(TransformTaskState.STARTED, null, 0, listener);
+        assertThat(context.projectId(), is(equalTo(ProjectId.DEFAULT)));
+    }
+
+    public void testProjectIdExplicit() {
+        ProjectId projectId = ProjectId.fromId("myproject123");
+        var context = new TransformContext(TransformTaskState.STARTED, null, 0, null, listener, projectId);
+        assertThat(context.projectId(), is(equalTo(projectId)));
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -815,6 +816,41 @@ public class TransformTaskTests extends ESTestCase {
 
         verify(indexer, indexerVerificationMode).maybeTriggerAsyncJob(anyLong());
         verifyNoInteractions(auditor, threadPool);
+    }
+
+    public void testContextProjectIdDefaultsToDefaultWhenNoHeader() {
+        var transformTask = new TransformTask(
+            42,
+            "some_type",
+            "some_action",
+            TaskId.EMPTY_TASK_ID,
+            createTransformTaskParams("transform-1"),
+            null,
+            new TransformScheduler(Clock.systemUTC(), mock(ThreadPool.class), Settings.EMPTY, TimeValue.ZERO),
+            MockTransformAuditor.createMockAuditor(),
+            mock(ThreadPool.class),
+            Collections.emptyMap(),
+            mockTransformNode()
+        );
+        assertThat(transformTask.getContext().projectId(), is(equalTo(ProjectId.DEFAULT)));
+    }
+
+    public void testContextProjectIdReadsFromHeader() {
+        var projectId = ProjectId.fromId("myproject123");
+        var transformTask = new TransformTask(
+            42,
+            "some_type",
+            "some_action",
+            TaskId.EMPTY_TASK_ID,
+            createTransformTaskParams("transform-1"),
+            null,
+            new TransformScheduler(Clock.systemUTC(), mock(ThreadPool.class), Settings.EMPTY, TimeValue.ZERO),
+            MockTransformAuditor.createMockAuditor(),
+            mock(ThreadPool.class),
+            Collections.singletonMap(Task.X_ELASTIC_PROJECT_ID_HTTP_HEADER, projectId.id()),
+            mockTransformNode()
+        );
+        assertThat(transformTask.getContext().projectId(), is(equalTo(projectId)));
     }
 
     private static TransformTaskParams createTransformTaskParams(String transformId) {


### PR DESCRIPTION
Sets the ProjectId in TransformContext so it can be shared with ClientTransformIndexer and its subclasses.