### PR TITLE
Stabilize simplified linear and rrf retriever tests

### DIFF
--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/20_linear_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/20_linear_retriever_simplified.yml
@@ -293,12 +293,13 @@ setup:
 
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "3" }
   - lte: { hits.hits.0._score: 2.0 }
-  - match: { hits.hits.1._id: "2" }
   - lte: { hits.hits.1._score: 2.0 }
-  - match: { hits.hits.2._id: "1" }
   - lte: { hits.hits.2._score: 2.0 }
+  # Document ordering is non-deterministic when scores are equal
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
 
 ---
 "Lexical match per-field boosting using the simplified format":
@@ -601,6 +602,7 @@ setup:
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       headers:
         Content-Type: application/json
@@ -614,24 +616,25 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "2" }
   - lte: { hits.hits.0._score: 2.0 }
-  - match: { hits.hits.1._id: "3" }
   - lte: { hits.hits.1._score: 2.0 }
-  - match: { hits.hits.2._id: "1" }
   - lte: { hits.hits.2._score: 2.0 }
-  - match: { hits.hits.3._id: "6" }
   - lte: { hits.hits.3._score: 2.0 }
-  - match: { hits.hits.4._id: "4" }
   - lte: { hits.hits.4._score: 2.0 }
-  - match: { hits.hits.5._id: "5" }
   - lte: { hits.hits.5._score: 2.0 }
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }
 
 ---
 "Queries multiple indices with a list of fields":
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       headers:
         Content-Type: application/json
@@ -646,24 +649,34 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "3" }
   - lte: { hits.hits.0._score: 2.0 }
-  - match: { hits.hits.1._id: "2" }
   - lte: { hits.hits.1._score: 2.0 }
-  - match: { hits.hits.2._id: "1" }
   - lte: { hits.hits.2._score: 2.0 }
-  - match: { hits.hits.3._id: "6" }
   - lte: { hits.hits.3._score: 2.0 }
-  - match: { hits.hits.4._id: "4" }
   - lte: { hits.hits.4._score: 2.0 }
-  - match: { hits.hits.5._id: "5" }
   - lte: { hits.hits.5._score: 2.0 }
+  # Top 3 results are docs 1, 2, 3 (from test-index) in any order
+  - match: { hits.hits.0._index: "test-index" }
+  - match: { hits.hits.1._index: "test-index" }
+  - match: { hits.hits.2._index: "test-index" }
+  # Bottom 3 results are docs 4, 5, 6 (from test-another-index) in any order
+  - match: { hits.hits.3._index: "test-another-index" }
+  - match: { hits.hits.4._index: "test-another-index" }
+  - match: { hits.hits.5._index: "test-another-index" }
+  # Verify all expected docs are present
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }
 
 ---
 "Queries multiple indices with a list of fields with weights":
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       headers:
         Content-Type: application/json
@@ -678,24 +691,34 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "6" }
+  # Top 3 results are docs 4, 5, 6 (from test-another-index) with scores >= 11.0
   - gte: { hits.hits.0._score: 11.0 }
-  - match: { hits.hits.1._id: "4" }
   - gte: { hits.hits.1._score: 11.0 }
-  - match: { hits.hits.2._id: "5" }
   - gte: { hits.hits.2._score: 11.0 }
-  - match: { hits.hits.3._id: "3" }
+  - match: { hits.hits.0._index: "test-another-index" }
+  - match: { hits.hits.1._index: "test-another-index" }
+  - match: { hits.hits.2._index: "test-another-index" }
+  # Bottom 3 results are docs 1, 2, 3 (from test-index) with scores <= 11.0
   - lte: { hits.hits.3._score: 11.0 }
-  - match: { hits.hits.4._id: "2" }
   - lte: { hits.hits.4._score: 11.0 }
-  - match: { hits.hits.5._id: "1" }
   - lte: { hits.hits.5._score: 11.0 }
+  - match: { hits.hits.3._index: "test-index" }
+  - match: { hits.hits.4._index: "test-index" }
+  - match: { hits.hits.5._index: "test-index" }
+  # Verify all expected docs are present
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }
 
 ---
 "Conflicting boosts for inference fields in default_field":
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       catch: bad_request
       search:
@@ -712,6 +735,7 @@ setup:
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       headers:
         Content-Type: application/json
@@ -737,6 +761,7 @@ setup:
   - requires:
       cluster_features: [ "linear_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified linear retriever"
+
   - do:
       headers:
         Content-Type: application/json
@@ -751,15 +776,24 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "6" }
+  # Top 3 results are docs 4, 5, 6 (from test-another-index) with scores >= 11.0
   - gte: { hits.hits.0._score: 11.0 }
-  - match: { hits.hits.1._id: "4" }
   - gte: { hits.hits.1._score: 11.0 }
-  - match: { hits.hits.2._id: "5" }
   - gte: { hits.hits.2._score: 11.0 }
-  - match: { hits.hits.3._id: "9" }
+  - match: { hits.hits.0._index: "test-another-index" }
+  - match: { hits.hits.1._index: "test-another-index" }
+  - match: { hits.hits.2._index: "test-another-index" }
+  # Bottom 3 results are docs 7, 8, 9 (from test-index-with-default-field) with scores <= 11.0
   - lte: { hits.hits.3._score: 11.0 }
-  - match: { hits.hits.4._id: "8" }
   - lte: { hits.hits.4._score: 11.0 }
-  - match: { hits.hits.5._id: "7" }
   - lte: { hits.hits.5._score: 11.0 }
+  - match: { hits.hits.3._index: "test-index-with-default-field" }
+  - match: { hits.hits.4._index: "test-index-with-default-field" }
+  - match: { hits.hits.5._index: "test-index-with-default-field" }
+  # Verify all expected docs are present
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }
+  - contains: { hits.hits: { _id: "7" } }
+  - contains: { hits.hits: { _id: "8" } }
+  - contains: { hits.hits: { _id: "9" } }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/20_linear_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/20_linear_retriever_simplified.yml
@@ -296,7 +296,8 @@ setup:
   - lte: { hits.hits.0._score: 2.0 }
   - lte: { hits.hits.1._score: 2.0 }
   - lte: { hits.hits.2._score: 2.0 }
-  # Document ordering is non-deterministic when scores are equal
+  # Document ordering is non-deterministic because all results are equally good lexical matches and a mock inference
+  # service that generates fake embeddings is used for semantic matches
   - contains: { hits.hits: { _id: "1" } }
   - contains: { hits.hits: { _id: "2" } }
   - contains: { hits.hits: { _id: "3" } }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
@@ -213,9 +213,11 @@ setup:
 
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.2._id: "3" }
+  # Document ordering is non-deterministic because all results are equally good lexical matches and a mock inference
+  # service that generates fake embeddings is used for semantic matches
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
 
 ---
 "Lexical match per-field boosting using the simplified format":
@@ -341,9 +343,11 @@ setup:
 
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "3" }
-  - match: { hits.hits.2._id: "1" }
+  # Document ordering is non-deterministic because a mock inference service that generates fake embeddings is used for
+  # semantic matches
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
 
 ---
 "Can query keyword fields":
@@ -568,6 +572,7 @@ setup:
   - requires:
       cluster_features: [ "rrf_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified RRF retriever"
+
   - do:
       search:
         index: test-index,test-another-index
@@ -578,18 +583,21 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "4" }
-  - match: { hits.hits.1._id: "6" }
-  - match: { hits.hits.2._id: "1" }
-  - match: { hits.hits.3._id: "2" }
-  - match: { hits.hits.4._id: "3" }
-  - match: { hits.hits.5._id: "5" }
+  # Document ordering is non-deterministic because all results are equally good lexical matches and a mock inference
+  # service that generates fake embeddings is used for semantic matches
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }
 
 ---
 "Queries multiple indices with a list of fields":
   - requires:
       cluster_features: [ "rrf_retriever.multi_index_simplified_format_support" ]
       reason: "Support for querying multiple indices in simplified RRF retriever"
+
   - do:
       search:
         index: test-index,test-another-index
@@ -601,9 +609,18 @@ setup:
 
   - match: { hits.total.value: 6 }
   - length: { hits.hits: 6 }
-  - match: { hits.hits.0._id: "1" }
-  - match: { hits.hits.1._id: "2" }
-  - match: { hits.hits.2._id: "3" }
-  - match: { hits.hits.3._id: "6" }
-  - match: { hits.hits.4._id: "4" }
-  - match: { hits.hits.5._id: "5" }
+  # Top 3 results are docs 1, 2, 3 (from test-index) in any order
+  - match: { hits.hits.0._index: "test-index" }
+  - match: { hits.hits.1._index: "test-index" }
+  - match: { hits.hits.2._index: "test-index" }
+  # Bottom 3 results are docs 4, 5, 6 (from test-another-index) in any order
+  - match: { hits.hits.3._index: "test-another-index" }
+  - match: { hits.hits.4._index: "test-another-index" }
+  - match: { hits.hits.5._index: "test-another-index" }
+  # Verify all expected docs are present
+  - contains: { hits.hits: { _id: "1" } }
+  - contains: { hits.hits: { _id: "2" } }
+  - contains: { hits.hits: { _id: "3" } }
+  - contains: { hits.hits: { _id: "4" } }
+  - contains: { hits.hits: { _id: "5" } }
+  - contains: { hits.hits: { _id: "6" } }


### PR DESCRIPTION
Some of the simplified `linear` and `rrf` retriever tests check for exact result orders that can be unstable. For example, in some of these tests, all docs are equally relevant and therefore have nearly identical scores. Small changes to other parts of the codebase can change the result order, making these tests hard to maintain.

This PR updates the appropriate simplified `linear` and `rrf` retriever YAML tests to not check for exact result ordering. This should make them easier to maintain, while still preserving their value as functional tests.