### PR TITLE
Avoid OOME in SearchResponse.toString()

### DIFF
--- a/docs/changelog/144266.yaml
+++ b/docs/changelog/144266.yaml
@@ -1,0 +1,6 @@
+pr: 144266
+summary: Avoid OOME in SearchResponse.toString()
+area: Search
+type: bug
+issues:
+  - 143694

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -12,7 +12,6 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.OriginalIndices;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.DelayableWriteable;
@@ -473,7 +472,22 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
     @Override
     public String toString() {
-        return hasReferences() == false ? "SearchResponse[released]" : Strings.toString(this);
+        if (hasReferences() == false) {
+            return "SearchResponse[released]";
+        }
+        return "SearchResponse{totalShards="
+            + totalShards
+            + ", successfulShards="
+            + successfulShards
+            + ", skippedShards="
+            + skippedShards
+            + ", tookInMillis="
+            + tookInMillis
+            + ", hits="
+            + (hits == null ? "null" : hits.getTotalHits())
+            + ", scrollId="
+            + (scrollId != null ? "[present]" : "null")
+            + "}";
     }
 
     /**


### PR DESCRIPTION
## What

`SearchResponse.toString()` calls `Strings.toString(this)` which serializes the entire response as JSON into a `ByteArrayOutputStream`. For large responses this blows past the 2GiB array limit and throws an `OutOfMemoryError` that takes down the node.

The call path is `OutboundHandler.sendMessage()` -> log warning -> string concat triggers `SearchResponse.toString()` -> `Strings.toString(ChunkedToXContent)` -> boom.

## Fix

Replaced the full JSON serialization with a lightweight summary string that includes shard counts, took time, and total hits. This gives enough diagnostic info for logging without materializing the entire response.

The `Strings.toString(ChunkedToXContent)` overload is already `@Deprecated` with a TODO to remove it — this PR removes one of its callers.

Closes #143694