### PR TITLE
ESQL: Add node-level S3 settings for external datasources

### DIFF
--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
@@ -7,20 +7,37 @@
 
 package org.elasticsearch.xpack.esql.datasource.s3;
 
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * Data source plugin providing S3 storage support for ESQL.
  * Supports s3://, s3a://, and s3n:// URI schemes.
+ * <p>
+ * When no credentials are provided via the EXTERNAL WITH clause, falls back to
+ * {@code esql.s3.*} node settings (access_key, secret_key, endpoint, region).
  */
 public class S3DataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    private static final String ESQL_S3_PREFIX = "esql.s3.";
+
+    static final Setting<String> ACCESS_KEY_SETTING = Setting.simpleString(ESQL_S3_PREFIX + "access_key", Setting.Property.NodeScope);
+    static final Setting<String> SECRET_KEY_SETTING = Setting.simpleString(ESQL_S3_PREFIX + "secret_key", Setting.Property.NodeScope);
+    static final Setting<String> ENDPOINT_SETTING = Setting.simpleString(ESQL_S3_PREFIX + "endpoint", Setting.Property.NodeScope);
+    static final Setting<String> REGION_SETTING = Setting.simpleString(ESQL_S3_PREFIX + "region", Setting.Property.NodeScope);
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(ACCESS_KEY_SETTING, SECRET_KEY_SETTING, ENDPOINT_SETTING, REGION_SETTING);
+    }
 
     @Override
     public Set<String> supportedSchemes() {
@@ -31,24 +48,50 @@ public class S3DataSourcePlugin extends Plugin implements DataSourcePlugin {
     public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
         StorageProviderFactory s3Factory = new StorageProviderFactory() {
             @Override
-            public StorageProvider create(Settings settings) {
-                return new S3StorageProvider(null);
+            public StorageProvider create(Settings nodeSettings) {
+                return new S3StorageProvider(configFromNodeSettings(nodeSettings));
             }
 
             @Override
-            public StorageProvider create(Settings settings, Map<String, Object> config) {
+            public StorageProvider create(Settings nodeSettings, Map<String, Object> config) {
                 if (config == null || config.isEmpty()) {
-                    return create(settings);
+                    return create(nodeSettings);
                 }
+                String accessKey = (String) config.get("access_key");
+                String secretKey = (String) config.get("secret_key");
+                String endpoint = (String) config.get("endpoint");
+                String region = (String) config.get("region");
+
+                if (accessKey == null && secretKey == null && endpoint == null && region == null) {
+                    return create(nodeSettings);
+                }
+
+                S3Configuration fallback = configFromNodeSettings(nodeSettings);
                 S3Configuration s3Config = S3Configuration.fromFields(
-                    (String) config.get("access_key"),
-                    (String) config.get("secret_key"),
-                    (String) config.get("endpoint"),
-                    (String) config.get("region")
+                    accessKey != null ? accessKey : (fallback != null ? fallback.accessKey() : null),
+                    secretKey != null ? secretKey : (fallback != null ? fallback.secretKey() : null),
+                    endpoint != null ? endpoint : (fallback != null ? fallback.endpoint() : null),
+                    region != null ? region : (fallback != null ? fallback.region() : null)
                 );
                 return new S3StorageProvider(s3Config);
             }
         };
         return Map.of("s3", s3Factory, "s3a", s3Factory, "s3n", s3Factory);
+    }
+
+    private static S3Configuration configFromNodeSettings(Settings settings) {
+        if (settings == null) {
+            return null;
+        }
+        String accessKey = ACCESS_KEY_SETTING.get(settings);
+        String secretKey = SECRET_KEY_SETTING.get(settings);
+        String endpoint = ENDPOINT_SETTING.get(settings);
+        String region = REGION_SETTING.get(settings);
+        return S3Configuration.fromFields(
+            accessKey.isEmpty() == false ? accessKey : null,
+            secretKey.isEmpty() == false ? secretKey : null,
+            endpoint.isEmpty() == false ? endpoint : null,
+            region.isEmpty() == false ? region : null
+        );
     }
 }

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePluginTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class S3DataSourcePluginTests extends ESTestCase {
+
+    private final S3DataSourcePlugin plugin = new S3DataSourcePlugin();
+
+    public void testSupportedSchemes() {
+        assertTrue(plugin.supportedSchemes().contains("s3"));
+        assertTrue(plugin.supportedSchemes().contains("s3a"));
+        assertTrue(plugin.supportedSchemes().contains("s3n"));
+    }
+
+    public void testNodeSettingsRegistered() {
+        var settingsList = plugin.getSettings();
+        assertEquals(4, settingsList.size());
+        assertTrue(settingsList.contains(S3DataSourcePlugin.ACCESS_KEY_SETTING));
+        assertTrue(settingsList.contains(S3DataSourcePlugin.SECRET_KEY_SETTING));
+        assertTrue(settingsList.contains(S3DataSourcePlugin.ENDPOINT_SETTING));
+        assertTrue(settingsList.contains(S3DataSourcePlugin.REGION_SETTING));
+    }
+
+    public void testCreateWithNoConfig() throws IOException {
+        StorageProviderFactory factory = plugin.storageProviders(Settings.EMPTY).get("s3");
+        try (StorageProvider provider = factory.create(Settings.EMPTY)) {
+            assertNotNull(provider);
+        }
+    }
+
+    public void testCreateWithNodeSettings() throws IOException {
+        Settings nodeSettings = Settings.builder()
+            .put("esql.s3.access_key", "node-key")
+            .put("esql.s3.secret_key", "node-secret")
+            .put("esql.s3.endpoint", "http://localhost:9000")
+            .put("esql.s3.region", "us-east-1")
+            .build();
+        StorageProviderFactory factory = plugin.storageProviders(nodeSettings).get("s3");
+        try (StorageProvider provider = factory.create(nodeSettings)) {
+            assertNotNull(provider);
+        }
+    }
+
+    public void testCreateWithPerQueryConfigOverridesNodeSettings() throws IOException {
+        Settings nodeSettings = Settings.builder()
+            .put("esql.s3.access_key", "node-key")
+            .put("esql.s3.secret_key", "node-secret")
+            .put("esql.s3.endpoint", "http://node-endpoint:9000")
+            .put("esql.s3.region", "us-west-2")
+            .build();
+        Map<String, Object> queryConfig = Map.of("access_key", "query-key", "secret_key", "query-secret");
+
+        StorageProviderFactory factory = plugin.storageProviders(nodeSettings).get("s3");
+        try (StorageProvider provider = factory.create(nodeSettings, queryConfig)) {
+            assertNotNull(provider);
+        }
+    }
+
+    public void testCreateWithEmptyConfigFallsBackToNodeSettings() throws IOException {
+        Settings nodeSettings = Settings.builder().put("esql.s3.access_key", "node-key").put("esql.s3.secret_key", "node-secret").build();
+        StorageProviderFactory factory = plugin.storageProviders(nodeSettings).get("s3");
+        try (StorageProvider providerEmpty = factory.create(nodeSettings, Map.of())) {
+            assertNotNull(providerEmpty);
+        }
+        try (StorageProvider providerNull = factory.create(nodeSettings, null)) {
+            assertNotNull(providerNull);
+        }
+    }
+
+    public void testAllSchemesReturnSameFactory() {
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        assertSame(providers.get("s3"), providers.get("s3a"));
+        assertSame(providers.get("s3"), providers.get("s3n"));
+    }
+}


### PR DESCRIPTION
Allow S3 credentials (access_key, secret_key, endpoint, region) to be
configured as node-level settings under the `esql.s3.*` prefix. When an
EXTERNAL query omits the WITH clause, the plugin falls back to these
settings instead of requiring per-query credentials. Per-query config
still takes precedence for any field that is explicitly provided.

This enables deployment scenarios where S3 access is pre-configured at
the cluster level (e.g. via `elasticsearch.yml`), eliminating the need
for users to pass credentials in every query.

Developed with AI-assisted tooling