### PR TITLE
Consolidate calls to finalFlags in CLI launcher

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmErgonomics.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmErgonomics.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.node.NodeRoleSettings;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,13 +36,13 @@ final class JvmErgonomics {
     /**
      * Chooses additional JVM options for Elasticsearch.
      *
-     * @param userDefinedJvmOptions A list of JVM options that have been defined by the user.
+     * @param finalJvmOptions the final JVM options as determined by the JVM
+     * @param heapSize the effective max heap size in bytes
+     * @param nodeSettings the node settings
      * @return A list of additional JVM options to set.
      */
-    static List<String> choose(final List<String> userDefinedJvmOptions, Settings nodeSettings) throws InterruptedException, IOException {
+    static List<String> choose(final Map<String, JvmOption> finalJvmOptions, long heapSize, Settings nodeSettings) {
         final List<String> ergonomicChoices = new ArrayList<>();
-        final Map<String, JvmOption> finalJvmOptions = JvmOption.findFinalOptions(userDefinedJvmOptions);
-        final long heapSize = JvmOption.extractMaxHeapSize(finalJvmOptions);
         final long maxDirectMemorySize = JvmOption.extractMaxDirectMemorySize(finalJvmOptions);
         if (maxDirectMemorySize == 0) {
             ergonomicChoices.add("-XX:MaxDirectMemorySize=" + (long) (DIRECT_MEMORY_TO_HEAP_FACTOR * heapSize));

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
@@ -143,8 +143,18 @@ public final class JvmOptionsParser {
 
         final List<String> substitutedJvmOptions = substitutePlaceholders(jvmOptions, Collections.unmodifiableMap(substitutions));
         final SystemMemoryInfo memoryInfo = new OverridableSystemMemoryInfo(substitutedJvmOptions, new DefaultSystemMemoryInfo());
-        substitutedJvmOptions.addAll(machineDependentHeap.determineHeapSettings(args.nodeSettings(), memoryInfo, substitutedJvmOptions));
-        final List<String> ergonomicJvmOptions = JvmErgonomics.choose(substitutedJvmOptions, args.nodeSettings());
+        final Map<String, JvmOption> parsedJvmOptions = JvmOption.findFinalOptions(substitutedJvmOptions);
+        final List<String> heapSettings = machineDependentHeap.determineHeapSettings(
+            args.nodeSettings(),
+            memoryInfo,
+            parsedJvmOptions,
+            substitutedJvmOptions
+        );
+        substitutedJvmOptions.addAll(heapSettings);
+        final long effectiveHeapSize = heapSettings.isEmpty()
+            ? JvmOption.extractMaxHeapSize(parsedJvmOptions)
+            : parseHeapSizeFromOptions(heapSettings);
+        final List<String> ergonomicJvmOptions = JvmErgonomics.choose(parsedJvmOptions, effectiveHeapSize, args.nodeSettings());
         final List<String> systemJvmOptions = SystemJvmOptions.systemJvmOptions(args.nodeSettings(), cliSysprops);
 
         final List<String> apmOptions = APMJvmOptions.apmJvmOptions(args.nodeSettings(), args.secrets(), args.logsDir(), tmpDir);
@@ -353,6 +363,23 @@ public final class JvmOptionsParser {
                 invalidLineConsumer.accept(lineNumber, line);
             }
         }
+    }
+
+    /**
+     * Parses the max heap size in bytes from heap options produced by {@link MachineDependentHeap}.
+     * Expects the format {@code -Xmx<N>m}.
+     */
+    static long parseHeapSizeFromOptions(List<String> heapSettings) {
+        for (String option : heapSettings) {
+            if (option.startsWith("-Xmx")) {
+                String value = option.substring(4);
+                if (value.endsWith("m") == false) {
+                    throw new IllegalStateException("Expected heap option in megabytes: " + option);
+                }
+                return Long.parseLong(value.substring(0, value.length() - 1)) * 1024 * 1024;
+            }
+        }
+        throw new IllegalStateException("Heap settings did not contain -Xmx option: " + heapSettings);
     }
 
 }

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.node.NodeRoleSettings;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,22 +47,21 @@ public class MachineDependentHeap {
      * Calculate heap options.
      *
      * @param nodeSettings the settings for the node
-     * @param userDefinedJvmOptions JVM arguments provided by the user
+     * @param finalJvmOptions the final JVM options as determined by the JVM
+     * @param userDefinedJvmOptions JVM arguments provided by the user, used for feature flag detection
      * @return final heap options, or an empty collection if user provided heap options are to be used
-     * @throws IOException if unable to load elasticsearch.yml
      */
     public final List<String> determineHeapSettings(
         Settings nodeSettings,
         SystemMemoryInfo systemMemoryInfo,
+        Map<String, JvmOption> finalJvmOptions,
         List<String> userDefinedJvmOptions
-    ) throws IOException, InterruptedException {
+    ) {
         if (userDefinedJvmOptions.contains("-Des.new_ml_memory_computation_feature_flag_enabled=true")
             || NEW_ML_MEMORY_COMPUTATION_FEATURE_FLAG.isEnabled()) {
             useNewMlMemoryComputation = true;
         }
 
-        // TODO: this could be more efficient, to only parse final options once
-        final Map<String, JvmOption> finalJvmOptions = JvmOption.findFinalOptions(userDefinedJvmOptions);
         if (isMaxHeapSpecified(finalJvmOptions) || isMinHeapSpecified(finalJvmOptions) || isInitialHeapSpecified(finalJvmOptions)) {
             // User has explicitly set memory settings so we use those
             return Collections.emptyList();

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmErgonomicsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmErgonomicsTests.java
@@ -112,41 +112,61 @@ public class JvmErgonomicsTests extends ESTestCase {
     }
 
     public void testG1GOptionsForSmallHeap() throws Exception {
-        List<String> jvmErgonomics = JvmErgonomics.choose(Arrays.asList("-Xms6g", "-Xmx6g", "-XX:+UseG1GC"), Settings.EMPTY);
+        long heapSize = 6L << 30;
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
+        List<String> jvmErgonomics = JvmErgonomics.choose(opts, heapSize, Settings.EMPTY);
         assertThat(jvmErgonomics, hasItem("-XX:G1HeapRegionSize=4m"));
         assertThat(jvmErgonomics, hasItem("-XX:InitiatingHeapOccupancyPercent=30"));
         assertThat(jvmErgonomics, hasItem("-XX:G1ReservePercent=15"));
     }
 
     public void testG1GOptionsForSmallHeapWhenTuningSet() throws Exception {
-        List<String> jvmErgonomics = JvmErgonomics.choose(
-            Arrays.asList("-Xms6g", "-Xmx6g", "-XX:+UseG1GC", "-XX:G1HeapRegionSize=4m", "-XX:InitiatingHeapOccupancyPercent=45"),
-            Settings.EMPTY
+        long heapSize = 6L << 30;
+        Map<String, JvmOption> opts = buildG1Options(
+            heapSize,
+            Map.of(
+                "G1HeapRegionSize",
+                new JvmOption("4194304", "command line"),
+                "InitiatingHeapOccupancyPercent",
+                new JvmOption("45", "command line")
+            )
         );
+        List<String> jvmErgonomics = JvmErgonomics.choose(opts, heapSize, Settings.EMPTY);
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:InitiatingHeapOccupancyPercent="))));
         assertThat(jvmErgonomics, hasItem("-XX:G1ReservePercent=15"));
     }
 
     public void testG1GOptionsForLargeHeap() throws Exception {
-        List<String> jvmErgonomics = JvmErgonomics.choose(Arrays.asList("-Xms8g", "-Xmx8g", "-XX:+UseG1GC"), Settings.EMPTY);
+        long heapSize = 8L << 30;
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
+        List<String> jvmErgonomics = JvmErgonomics.choose(opts, heapSize, Settings.EMPTY);
         assertThat(jvmErgonomics, hasItem("-XX:InitiatingHeapOccupancyPercent=30"));
         assertThat(jvmErgonomics, hasItem("-XX:G1ReservePercent=25"));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
     }
 
     public void testG1GOptionsForSmallHeapWhenOtherGCSet() throws Exception {
-        List<String> jvmErgonomics = JvmErgonomics.choose(Arrays.asList("-Xms6g", "-Xmx6g", "-XX:+UseParallelGC"), Settings.EMPTY);
+        long heapSize = 6L << 30;
+        Map<String, JvmOption> opts = buildFinalOptions(heapSize, false, Map.of());
+        List<String> jvmErgonomics = JvmErgonomics.choose(opts, heapSize, Settings.EMPTY);
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:InitiatingHeapOccupancyPercent="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1ReservePercent="))));
     }
 
     public void testG1GOptionsForLargeHeapWhenTuningSet() throws Exception {
-        List<String> jvmErgonomics = JvmErgonomics.choose(
-            Arrays.asList("-Xms8g", "-Xmx8g", "-XX:+UseG1GC", "-XX:InitiatingHeapOccupancyPercent=60", "-XX:G1ReservePercent=10"),
-            Settings.EMPTY
+        long heapSize = 8L << 30;
+        Map<String, JvmOption> opts = buildG1Options(
+            heapSize,
+            Map.of(
+                "InitiatingHeapOccupancyPercent",
+                new JvmOption("60", "command line"),
+                "G1ReservePercent",
+                new JvmOption("10", "command line")
+            )
         );
+        List<String> jvmErgonomics = JvmErgonomics.choose(opts, heapSize, Settings.EMPTY);
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:InitiatingHeapOccupancyPercent="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1ReservePercent="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
@@ -158,34 +178,38 @@ public class JvmErgonomicsTests extends ESTestCase {
     }
 
     public void testMaxDirectMemorySizeChoice() throws Exception {
-        final Map<String, String> heapMaxDirectMemorySize = Map.of(
+        final Map<String, Long> heapSizes = Map.of(
             "64M",
-            Long.toString((64L << 20) / 2),
+            64L << 20,
             "512M",
-            Long.toString((512L << 20) / 2),
+            512L << 20,
             "1024M",
-            Long.toString((1024L << 20) / 2),
+            1024L << 20,
             "1G",
-            Long.toString((1L << 30) / 2),
+            1L << 30,
             "2048M",
-            Long.toString((2048L << 20) / 2),
+            2048L << 20,
             "2G",
-            Long.toString((2L << 30) / 2),
+            2L << 30,
             "8G",
-            Long.toString((8L << 30) / 2)
+            8L << 30
         );
-        final String heapSize = randomFrom(heapMaxDirectMemorySize.keySet().toArray(String[]::new));
+        final String heapLabel = randomFrom(heapSizes.keySet().toArray(String[]::new));
+        final long heapSize = heapSizes.get(heapLabel);
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
         assertThat(
-            JvmErgonomics.choose(Arrays.asList("-Xms" + heapSize, "-Xmx" + heapSize), Settings.EMPTY),
-            hasItem("-XX:MaxDirectMemorySize=" + heapMaxDirectMemorySize.get(heapSize))
+            JvmErgonomics.choose(opts, heapSize, Settings.EMPTY),
+            hasItem("-XX:MaxDirectMemorySize=" + (long) (heapSize * JvmErgonomics.DIRECT_MEMORY_TO_HEAP_FACTOR))
         );
     }
 
     public void testMaxDirectMemorySizeChoiceWhenSet() throws Exception {
-        assertThat(
-            JvmErgonomics.choose(Arrays.asList("-Xms1g", "-Xmx1g", "-XX:MaxDirectMemorySize=1g"), Settings.EMPTY),
-            everyItem(not(startsWith("-XX:MaxDirectMemorySize=")))
+        long heapSize = 1L << 30;
+        Map<String, JvmOption> opts = buildG1Options(
+            heapSize,
+            Map.of("MaxDirectMemorySize", new JvmOption(Long.toString(1L << 30), "command line"))
         );
+        assertThat(JvmErgonomics.choose(opts, heapSize, Settings.EMPTY), everyItem(not(startsWith("-XX:MaxDirectMemorySize="))));
     }
 
     public void testConcGCThreadsNotSetBasedOnProcessors() throws Exception {
@@ -197,7 +221,12 @@ public class JvmErgonomicsTests extends ESTestCase {
             IntStream.range(1, maxProcessors + 1).filter(i -> i < 4 || i > 5).forEach(possibleProcessors::add);
             nodeSettingsBuilder.put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), randomFrom(possibleProcessors));
         }
-        assertThat(JvmErgonomics.choose(List.of(), nodeSettingsBuilder.build()), everyItem(not(startsWith("-XX:ConcGCThreads="))));
+        long defaultHeapSize = 1L << 30;
+        Map<String, JvmOption> opts = buildG1Options(defaultHeapSize, Map.of());
+        assertThat(
+            JvmErgonomics.choose(opts, defaultHeapSize, nodeSettingsBuilder.build()),
+            everyItem(not(startsWith("-XX:ConcGCThreads=")))
+        );
     }
 
     public void testConcGCThreadsNotSetBasedOnRoles() throws Exception {
@@ -208,8 +237,12 @@ public class JvmErgonomicsTests extends ESTestCase {
             possibleRoles.remove(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE);
             nodeSettingsBuilder.put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), randomFrom(possibleRoles).roleName());
         }
-        assertThat(JvmErgonomics.choose(List.of(), nodeSettingsBuilder.build()), everyItem(not(startsWith("-XX:ConcGCThreads="))));
-
+        long defaultHeapSize = 1L << 30;
+        Map<String, JvmOption> opts = buildG1Options(defaultHeapSize, Map.of());
+        assertThat(
+            JvmErgonomics.choose(opts, defaultHeapSize, nodeSettingsBuilder.build()),
+            everyItem(not(startsWith("-XX:ConcGCThreads=")))
+        );
     }
 
     public void testConcGCThreadsSet() throws Exception {
@@ -217,14 +250,18 @@ public class JvmErgonomicsTests extends ESTestCase {
             .put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), between(4, 5))
             .put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.SEARCH_ROLE.roleName())
             .build();
-        assertThat(JvmErgonomics.choose(List.of(), nodeSettings), hasItem("-XX:ConcGCThreads=2"));
+        long defaultHeapSize = 1L << 30;
+        Map<String, JvmOption> opts = buildG1Options(defaultHeapSize, Map.of());
+        assertThat(JvmErgonomics.choose(opts, defaultHeapSize, nodeSettings), hasItem("-XX:ConcGCThreads=2"));
     }
 
     public void testMinimumNewSizeNotSetBasedOnHeap() throws Exception {
         Settings nodeSettings = Settings.builder()
             .put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.SEARCH_ROLE.roleName())
             .build();
-        List<String> chosen = JvmErgonomics.choose(List.of("-Xmx" + between(5, 31) + "g"), nodeSettings);
+        long heapSize = (long) between(5, 31) << 30;
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
+        List<String> chosen = JvmErgonomics.choose(opts, heapSize, nodeSettings);
         assertThat(chosen, everyItem(not(is("-XX:+UnlockExperimentalVMOptions"))));
         assertThat(chosen, everyItem(not(startsWith("-XX:G1NewSizePercent="))));
     }
@@ -241,7 +278,9 @@ public class JvmErgonomicsTests extends ESTestCase {
                 .put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), randomFrom(possibleRoles).roleName())
                 .build();
         }
-        List<String> chosen = JvmErgonomics.choose(List.of("-Xmx" + between(1, 4) + "g"), nodeSettings);
+        long heapSize = (long) between(1, 4) << 30;
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
+        List<String> chosen = JvmErgonomics.choose(opts, heapSize, nodeSettings);
         assertThat(chosen, everyItem(not(is("-XX:+UnlockExperimentalVMOptions"))));
         assertThat(chosen, everyItem(not(startsWith("-XX:G1NewSizePercent="))));
     }
@@ -250,7 +289,9 @@ public class JvmErgonomicsTests extends ESTestCase {
         Settings nodeSettings = Settings.builder()
             .put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.SEARCH_ROLE.roleName())
             .build();
-        List<String> chosen = JvmErgonomics.choose(List.of("-Xmx" + between(1, 4) + "g"), nodeSettings);
+        long heapSize = (long) between(1, 4) << 30;
+        Map<String, JvmOption> opts = buildG1Options(heapSize, Map.of());
+        List<String> chosen = JvmErgonomics.choose(opts, heapSize, nodeSettings);
         assertThat(chosen, hasItem("-XX:+UnlockExperimentalVMOptions"));
         assertThat(chosen, hasItem("-XX:G1NewSizePercent=10"));
     }
@@ -295,6 +336,28 @@ public class JvmErgonomicsTests extends ESTestCase {
             expectThrows(IllegalStateException.class, () -> new JvmOption("OptionName", null)).getMessage(),
             allOf(containsString("could not determine the origin of JVM option [OptionName]"), containsString("unsupported"))
         );
+    }
+
+    /**
+     * Builds a final JVM options map simulating G1GC being enabled with the given heap size.
+     */
+    private static Map<String, JvmOption> buildG1Options(long heapSize, Map<String, JvmOption> overrides) {
+        return buildFinalOptions(heapSize, true, overrides);
+    }
+
+    /**
+     * Builds a final JVM options map with the given settings.
+     */
+    private static Map<String, JvmOption> buildFinalOptions(long heapSize, boolean g1gc, Map<String, JvmOption> overrides) {
+        Map<String, JvmOption> options = new HashMap<>();
+        options.put("MaxHeapSize", new JvmOption(Long.toString(heapSize), "command line"));
+        options.put("MaxDirectMemorySize", new JvmOption("0", "default"));
+        options.put("UseG1GC", new JvmOption(g1gc ? "true" : "false", g1gc ? "default" : "command line"));
+        options.put("G1HeapRegionSize", new JvmOption("0", "default"));
+        options.put("InitiatingHeapOccupancyPercent", new JvmOption("45", "default"));
+        options.put("G1ReservePercent", new JvmOption("10", "default"));
+        options.putAll(overrides);
+        return options;
     }
 
 }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/MachineDependentHeapTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/MachineDependentHeapTests.java
@@ -16,26 +16,36 @@ import org.hamcrest.Matcher;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 
-// TODO: rework these tests to mock jvm option finder so they can run with security manager, no forking needed
 public class MachineDependentHeapTests extends ESTestCase {
 
     public void testDefaultHeapSize() throws Exception {
         MachineDependentHeap heap = new MachineDependentHeap();
-        List<String> options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInGigabytes(8), Collections.emptyList());
+        List<String> options = heap.determineHeapSettings(
+            Settings.EMPTY,
+            systemMemoryInGigabytes(8),
+            noHeapSpecifiedOptions(),
+            Collections.emptyList()
+        );
         assertThat(options, containsInAnyOrder("-Xmx4096m", "-Xms4096m"));
     }
 
     public void testUserPassedHeapArgs() throws Exception {
         var systemMemoryInfo = systemMemoryInGigabytes(8);
         MachineDependentHeap heap = new MachineDependentHeap();
-        List<String> options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, List.of("-Xmx4g"));
+        List<String> options = heap.determineHeapSettings(
+            Settings.EMPTY,
+            systemMemoryInfo,
+            maxHeapSpecifiedOptions(),
+            Collections.emptyList()
+        );
         assertThat(options, empty());
 
-        options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, List.of("-Xms4g"));
+        options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, minHeapSpecifiedOptions(), Collections.emptyList());
         assertThat(options, empty());
     }
 
@@ -44,10 +54,15 @@ public class MachineDependentHeapTests extends ESTestCase {
     public void testOddUserPassedHeapArgs() throws Exception {
         var systemMemoryInfo = systemMemoryInGigabytes(8);
         MachineDependentHeap heap = new MachineDependentHeap();
-        List<String> options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, List.of("-Xmx409m"));
+        List<String> options = heap.determineHeapSettings(
+            Settings.EMPTY,
+            systemMemoryInfo,
+            maxHeapSpecifiedOptions(),
+            Collections.emptyList()
+        );
         assertThat(options, empty());
 
-        options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, List.of("-Xms409m"));
+        options = heap.determineHeapSettings(Settings.EMPTY, systemMemoryInfo, minHeapSpecifiedOptions(), Collections.emptyList());
         assertThat(options, empty());
     }
 
@@ -94,8 +109,46 @@ public class MachineDependentHeapTests extends ESTestCase {
         SystemMemoryInfo systemMemoryInfo = systemMemoryInGigabytes(memoryInGigabytes);
         MachineDependentHeap machineDependentHeap = new MachineDependentHeap();
         Settings nodeSettings = Settings.builder().putList("node.roles", roles).build();
-        List<String> heapOptions = machineDependentHeap.determineHeapSettings(nodeSettings, systemMemoryInfo, Collections.emptyList());
+        List<String> heapOptions = machineDependentHeap.determineHeapSettings(
+            nodeSettings,
+            systemMemoryInfo,
+            noHeapSpecifiedOptions(),
+            Collections.emptyList()
+        );
         assertThat(heapOptions, optionsMatcher);
+    }
+
+    private static Map<String, JvmOption> noHeapSpecifiedOptions() {
+        return Map.of(
+            "MaxHeapSize",
+            new JvmOption("0", "default"),
+            "MinHeapSize",
+            new JvmOption("0", "default"),
+            "InitialHeapSize",
+            new JvmOption("0", "default")
+        );
+    }
+
+    private static Map<String, JvmOption> maxHeapSpecifiedOptions() {
+        return Map.of(
+            "MaxHeapSize",
+            new JvmOption("4294967296", "command line"),
+            "MinHeapSize",
+            new JvmOption("0", "default"),
+            "InitialHeapSize",
+            new JvmOption("0", "default")
+        );
+    }
+
+    private static Map<String, JvmOption> minHeapSpecifiedOptions() {
+        return Map.of(
+            "MaxHeapSize",
+            new JvmOption("0", "default"),
+            "MinHeapSize",
+            new JvmOption("4294967296", "command line"),
+            "InitialHeapSize",
+            new JvmOption("0", "default")
+        );
     }
 
     private static SystemMemoryInfo systemMemoryInGigabytes(double gigabytes) {


### PR DESCRIPTION
This updates our sever-cli launcher so that we call `JvmOption.finalFlags()` only once. This method forks a JVM, so it's a bit costly, also, when debugging Elasticsearch, the multiple calls can cause a race condition with the attached debugger not restarting quickly enough between calls. Removing the reduntant calls alleviates this problem as well.