### PR TITLE
[8.19] Update FileSystemProvider entitlement rules (#142909)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFileSystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFileSystemActions.java
@@ -35,44 +35,42 @@ class NioFileSystemActions {
         new DummyImplementations.DummyFileSystemProvider();
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void checkNewFileSystemFromUri() throws IOException {
         try (var fs = FileSystems.getDefault().provider().newFileSystem(URI.create("/dummy/path"), Map.of())) {}
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void checkNewFileSystemFromPath() {
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
+    static void checkNewFileSystemFromPath() throws IOException {
         var fs = FileSystems.getDefault().provider();
-        try (var newFs = fs.newFileSystem(Path.of("/dummy/path"), Map.of())) {} catch (IOException e) {
-            // When entitled, we expect to throw IOException, as the path is not valid - we don't really want to create a FS
-        }
+        try (var newFs = fs.newFileSystem(Path.of("/dummy/path"), Map.of())) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewInputStream() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var is = fs.newInputStream(FileCheckActions.readFile())) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewOutputStream() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var os = fs.newOutputStream(FileCheckActions.readWriteFile())) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewFileChannelRead() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var fc = fs.newFileChannel(FileCheckActions.readFile(), Set.of(StandardOpenOption.READ))) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewFileChannelWrite() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var fc = fs.newFileChannel(FileCheckActions.readWriteFile(), Set.of(StandardOpenOption.WRITE))) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewAsynchronousFileChannel() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (
@@ -84,26 +82,26 @@ class NioFileSystemActions {
         ) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewByteChannel() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var bc = fs.newByteChannel(FileCheckActions.readWriteFile(), Set.of(StandardOpenOption.WRITE))) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkNewDirectoryStream() throws IOException {
         var fs = FileSystems.getDefault().provider();
         try (var bc = fs.newDirectoryStream(FileCheckActions.readDir(), entry -> false)) {}
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkCreateDirectory() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var directory = EntitledActions.createTempDirectoryForWrite();
         fs.createDirectory(directory.resolve("subdir"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkCreateSymbolicLink() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var directory = EntitledActions.createTempDirectoryForWrite();
@@ -114,7 +112,7 @@ class NioFileSystemActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkCreateLink() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var directory = EntitledActions.createTempDirectoryForWrite();
@@ -125,35 +123,35 @@ class NioFileSystemActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkDelete() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var file = EntitledActions.createTempFileForWrite();
         fs.delete(file);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkDeleteIfExists() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var file = EntitledActions.createTempFileForWrite();
         fs.deleteIfExists(file);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkReadSymbolicLink() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var link = EntitledActions.createTempSymbolicLink();
         fs.readSymbolicLink(link);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkCopy() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var directory = EntitledActions.createTempDirectoryForWrite();
         fs.copy(FileCheckActions.readFile(), directory.resolve("copied"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkMove() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var directory = EntitledActions.createTempDirectoryForWrite();
@@ -161,50 +159,50 @@ class NioFileSystemActions {
         fs.move(file, directory.resolve("moved"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkIsSameFile() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.isSameFile(FileCheckActions.readWriteFile(), FileCheckActions.readFile());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkIsHidden() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.isHidden(FileCheckActions.readFile());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkGetFileStore() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var file = EntitledActions.createTempFileForRead();
         var store = fs.getFileStore(file);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkCheckAccess() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.checkAccess(FileCheckActions.readFile());
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void checkGetFileAttributeView() {
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedDefaultNull = true)
+    static FileOwnerAttributeView checkGetFileAttributeView() {
         var fs = FileSystems.getDefault().provider();
-        fs.getFileAttributeView(FileCheckActions.readFile(), FileOwnerAttributeView.class);
+        return fs.getFileAttributeView(FileCheckActions.readFile(), FileOwnerAttributeView.class);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkReadAttributesWithClass() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.readAttributes(FileCheckActions.readFile(), BasicFileAttributes.class);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkReadAttributesWithString() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.readAttributes(FileCheckActions.readFile(), "*");
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkSetAttribute() throws IOException {
         var fs = FileSystems.getDefault().provider();
         var file = EntitledActions.createTempFileForWrite();

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileSystemProviderInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileSystemProviderInstrumentation.java
@@ -14,6 +14,7 @@ import org.elasticsearch.entitlement.rules.Policies;
 import org.elasticsearch.entitlement.rules.TypeToken;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.AccessMode;
 import java.nio.file.CopyOption;
@@ -40,94 +41,94 @@ public class FileSystemProviderInstrumentation implements InstrumentationConfig 
         builder.on(FileSystems.getDefault().provider().getClass(), rule -> {
             rule.calling(FileSystemProvider::newFileSystem, TypeToken.of(URI.class), new TypeToken<Map<String, ?>>() {})
                 .enforce(Policies::changeJvmGlobalState)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::newFileSystem, TypeToken.of(Path.class), new TypeToken<Map<String, ?>>() {})
                 .enforce(Policies::changeJvmGlobalState)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::newInputStream, Path.class, OpenOption[].class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::newOutputStream, Path.class, OpenOption[].class)
                 .enforce((provider, path) -> Policies.fileWrite(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(
                 FileSystemProvider::newFileChannel,
                 TypeToken.of(Path.class),
                 new TypeToken<Set<OpenOption>>() {},
                 TypeToken.of(FileAttribute[].class)
-            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrowNotEntitled();
+            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrow(IOException::new);
             rule.calling(
                 FileSystemProvider::newAsynchronousFileChannel,
                 TypeToken.of(Path.class),
                 new TypeToken<Set<OpenOption>>() {},
                 TypeToken.of(ExecutorService.class),
                 TypeToken.of(FileAttribute[].class)
-            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrowNotEntitled();
+            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrow(IOException::new);
             rule.calling(
                 FileSystemProvider::newByteChannel,
                 TypeToken.of(Path.class),
                 new TypeToken<Set<? extends OpenOption>>() {},
                 TypeToken.of(FileAttribute[].class)
-            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrowNotEntitled();
+            ).enforce((provider, path, options) -> Policies.fileReadOrWrite(path, options)).elseThrow(IOException::new);
             rule.calling(
                 FileSystemProvider::newDirectoryStream,
                 TypeToken.of(Path.class),
                 new TypeToken<DirectoryStream.Filter<? super Path>>() {}
-            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrowNotEntitled();
+            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::createDirectory, Path.class, FileAttribute[].class)
                 .enforce((provider, path) -> Policies.fileWrite(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::createSymbolicLink, Path.class, Path.class, FileAttribute[].class)
                 .enforce((provider, link, target) -> Policies.fileWrite(link).and(Policies.fileRead(target)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::createLink, Path.class, Path.class)
                 .enforce((provider, link, target) -> Policies.fileWrite(link).and(Policies.fileRead(target)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::delete, Path.class)
                 .enforce((provider, path) -> Policies.fileWrite(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::deleteIfExists, Path.class)
                 .enforce((provider, path) -> Policies.fileWrite(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::readSymbolicLink, Path.class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::copy, Path.class, Path.class, CopyOption[].class)
                 .enforce((provider, source, target) -> Policies.fileRead(source).and(Policies.fileWrite(target)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::move, Path.class, Path.class, CopyOption[].class)
                 .enforce((provider, source, target) -> Policies.fileRead(source).and(Policies.fileWrite(target)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::isSameFile, Path.class, Path.class)
                 .enforce((provider, path, path2) -> Policies.fileRead(path).and(Policies.fileRead(path2)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::isHidden, Path.class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(FileSystemProvider::getFileStore, Path.class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::checkAccess, Path.class, AccessMode[].class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(
                 FileSystemProvider::getFileAttributeView,
                 TypeToken.of(Path.class),
                 new TypeToken<Class<FileAttributeView>>() {},
                 TypeToken.of(LinkOption[].class)
-            ).enforce(Policies::getFileAttributeView).elseThrowNotEntitled();
+            ).enforce(Policies::getFileAttributeView).elseReturn(null);
             rule.calling(
                 FileSystemProvider::readAttributes,
                 TypeToken.of(Path.class),
                 new TypeToken<Class<BasicFileAttributes>>() {},
                 TypeToken.of(LinkOption[].class)
-            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrowNotEntitled();
+            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrow(IOException::new);
             rule.calling(FileSystemProvider::readAttributes, Path.class, String.class, LinkOption[].class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileSystemProvider::setAttribute, Path.class, String.class, Object.class, LinkOption[].class)
                 .enforce((provider, path) -> Policies.fileWrite(path))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
     }
 }


### PR DESCRIPTION
Backport of #142909 to 8.19.

Resolves conflicts due to:
- Unnamed lambda parameters (`_`) not available in 8.19's JDK
- `FileSystemProvider::readAttributesIfExists` and `FileSystemProvider::exists` not present in 8.19's JDK