### PR TITLE
[9.2] Update network entitlement rules (#142910)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -648,7 +648,7 @@ class FileCheckActions {
         new FileImageInputStream(file.toFile()).close();
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void javaXmlFileRequest() throws Exception {
         // java.xml is part of the jdk, but not a system module. this checks it can't access files
         var saxParser = SAXParserFactory.newInstance().newSAXParser();

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
@@ -56,22 +56,25 @@ import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAcce
 @SuppressWarnings({ "unused" /* called via reflection */, "deprecation" })
 class NetworkAccessCheckActions {
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void serverSocketAccept() throws IOException {
         try (ServerSocket socket = new DummyImplementations.DummyBoundServerSocket()) {
             try {
                 socket.accept();
             } catch (IOException e) {
+                // Any other IOException (including entitlement denials) should propagate.
                 // Our dummy socket cannot accept connections unless we tell the JDK how to create a socket for it.
                 // But Socket.setSocketImplFactory(); is one of the methods we always forbid, so we cannot use it.
                 // Still, we can check accept is called (allowed/denied), we don't care if it fails later for this
                 // known reason.
-                assert e.getMessage().contains("client socket implementation factory not set");
+                if (e.getMessage() == null || e.getMessage().contains("client socket implementation factory not set") == false) {
+                    throw e;
+                }
             }
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void serverSocketBind() throws IOException {
         try (ServerSocket socket = new DummyImplementations.DummyServerSocket()) {
             socket.bind(null);
@@ -85,14 +88,14 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketBind() throws IOException {
         try (Socket socket = new DummyImplementations.DummySocket()) {
             socket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketConnect() throws IOException {
         try (Socket socket = new DummyImplementations.DummySocket()) {
             socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
@@ -110,21 +113,21 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void serverSocketChannelBind() throws IOException {
         try (var serverSocketChannel = ServerSocketChannel.open()) {
             serverSocketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void serverSocketChannelBindWithBacklog() throws IOException {
         try (var serverSocketChannel = ServerSocketChannel.open()) {
             serverSocketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 50);
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void serverSocketChannelAccept() throws IOException {
         try (var serverSocketChannel = ServerSocketChannel.open()) {
             serverSocketChannel.configureBlocking(false);
@@ -137,14 +140,14 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void asynchronousServerSocketChannelBind() throws IOException {
         try (var serverSocketChannel = AsynchronousServerSocketChannel.open()) {
             serverSocketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void asynchronousServerSocketChannelBindWithBacklog() throws IOException {
         try (var serverSocketChannel = AsynchronousServerSocketChannel.open()) {
             serverSocketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 50);
@@ -184,14 +187,14 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketChannelBind() throws IOException {
         try (var socketChannel = SocketChannel.open()) {
             socketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketChannelConnect() throws IOException {
         try (var socketChannel = SocketChannel.open()) {
             try {
@@ -203,12 +206,12 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketChannelOpenProtocol() throws IOException {
         SocketChannel.open(StandardProtocolFamily.INET).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void socketChannelOpenAddress() throws IOException {
         try {
             SocketChannel.open(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)).close();
@@ -217,7 +220,7 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void asynchronousSocketChannelBind() throws IOException {
         try (var socketChannel = AsynchronousSocketChannel.open()) {
             socketChannel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
@@ -253,14 +256,14 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void datagramChannelBind() throws IOException {
         try (var channel = DatagramChannel.open()) {
             channel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void datagramChannelConnect() throws IOException {
         try (var channel = DatagramChannel.open()) {
             channel.configureBlocking(false);
@@ -273,7 +276,7 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void datagramChannelSend() throws IOException {
         try (var channel = DatagramChannel.open()) {
             channel.configureBlocking(false);
@@ -281,7 +284,7 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void datagramChannelReceive() throws IOException {
         try (var channel = DatagramChannel.open()) {
             channel.configureBlocking(false);
@@ -320,14 +323,26 @@ class NetworkAccessCheckActions {
         });
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void setDefaultResponseCache() {
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedNoOp = true)
+    static boolean setDefaultResponseCache() {
+        var original = ResponseCache.getDefault();
         ResponseCache.setDefault(null);
+        boolean changed = ResponseCache.getDefault() != original;
+        if (changed) {
+            ResponseCache.setDefault(original);
+        }
+        return changed;
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void setDefaultProxySelector() {
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedNoOp = true)
+    static boolean setDefaultProxySelector() {
+        var original = ProxySelector.getDefault();
         ProxySelector.setDefault(null);
+        boolean changed = ProxySelector.getDefault() != original;
+        if (changed) {
+            ProxySelector.setDefault(original);
+        }
+        return changed;
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedNoOp = true)
@@ -372,22 +387,28 @@ class NetworkAccessCheckActions {
         return connection.getSSLSocketFactory() != original;
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void datagramSocket$$setDatagramSocketImplFactory() throws IOException {
         DatagramSocket.setDatagramSocketImplFactory(() -> { throw new IllegalStateException(); });
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void httpURLConnection$$setFollowRedirects() {
-        HttpURLConnection.setFollowRedirects(HttpURLConnection.getFollowRedirects());
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedNoOp = true)
+    static boolean httpURLConnection$$setFollowRedirects() {
+        boolean original = HttpURLConnection.getFollowRedirects();
+        HttpURLConnection.setFollowRedirects(original == false);
+        boolean changed = HttpURLConnection.getFollowRedirects() != original;
+        if (changed) {
+            HttpURLConnection.setFollowRedirects(original);
+        }
+        return changed;
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void serverSocket$$setSocketFactory() throws IOException {
         ServerSocket.setSocketFactory(() -> { throw new IllegalStateException(); });
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void socket$$setSocketImplFactory() throws IOException {
         Socket.setSocketImplFactory(() -> { throw new IllegalStateException(); });
     }
@@ -397,9 +418,15 @@ class NetworkAccessCheckActions {
         URL.setURLStreamHandlerFactory(__ -> { throw new IllegalStateException(); });
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void urlConnection$$setFileNameMap() {
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, isExpectedNoOp = true)
+    static boolean urlConnection$$setFileNameMap() {
+        var original = URLConnection.getFileNameMap();
         URLConnection.setFileNameMap(__ -> { throw new IllegalStateException(); });
+        boolean changed = URLConnection.getFileNameMap() != original;
+        if (changed) {
+            URLConnection.setFileNameMap(original);
+        }
+        return changed;
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
@@ -414,7 +441,7 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = SocketException.class)
     static void connectDatagramSocket() throws SocketException {
         try (var socket = new DummyImplementations.DummyDatagramSocket()) {
             socket.connect(new InetSocketAddress(1234));
@@ -422,6 +449,13 @@ class NetworkAccessCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
+    static void connectDatagramSocketInetAddress() throws IOException {
+        try (var socket = new DummyImplementations.DummyDatagramSocket()) {
+            socket.connect(InetAddress.getByAddress(new byte[] { (byte) 230, 0, 0, 1 }), 1234);
+        }
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void joinGroupDatagramSocket() throws IOException {
         try (var socket = new DummyImplementations.DummyDatagramSocket()) {
             socket.joinGroup(
@@ -431,7 +465,7 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void leaveGroupDatagramSocket() throws IOException {
         try (var socket = new DummyImplementations.DummyDatagramSocket()) {
             socket.leaveGroup(
@@ -441,21 +475,21 @@ class NetworkAccessCheckActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sendDatagramSocket() throws IOException {
         try (var socket = new DummyImplementations.DummyDatagramSocket()) {
             socket.send(new DatagramPacket(new byte[] { 0 }, 1, InetAddress.getLocalHost(), 1234));
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void receiveDatagramSocket() throws IOException {
         try (var socket = new DummyImplementations.DummyDatagramSocket()) {
             socket.receive(new DatagramPacket(new byte[1], 1, InetAddress.getLocalHost(), 1234));
         }
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void javaXmlNetworkRequest() throws Exception {
         // java.xml is part of the jdk, but not a system module. this checks it can't access the network
         var saxParser = SAXParserFactory.newInstance().newSAXParser();

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
@@ -17,6 +17,7 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
 import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.spi.SelectorProvider;
@@ -89,7 +90,7 @@ class NioChannelsActions {
         jdk.nio.Channels.readWriteSelectableChannel(new FileDescriptor(), new DummyImplementations.DummySelectableChannelCloser()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = ClosedChannelException.class)
     static void selectableChannelRegisterConnect() throws IOException {
         try (var selectableChannel = new DummyImplementations.DummySelectableChannel(SelectorProvider.provider())) {
             selectableChannel.configureBlocking(false);
@@ -97,7 +98,7 @@ class NioChannelsActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = ClosedChannelException.class)
     static void selectableChannelRegisterAccept() throws IOException {
         try (var selectableChannel = new DummyImplementations.DummySelectableChannel(SelectorProvider.provider())) {
             selectableChannel.configureBlocking(false);

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/URLConnectionFileActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/URLConnectionFileActions.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.entitlement.qa.test;
 
-import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
 
 import java.io.IOException;
@@ -20,216 +20,223 @@ import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAcce
 
 class URLConnectionFileActions {
 
-    private static void withJdkFileConnection(CheckedConsumer<URLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJdkFileConnection(CheckedFunction<URLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createFileURLConnection();
         // Be sure we got the connection implementation we want
         assert conn.getClass().getSimpleName().equals("FileURLConnection");
-        try {
-            connectionConsumer.accept(conn);
-        } catch (IOException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to perform some operation
-        }
+        return connectionFunction.apply(conn);
     }
 
-    private static void withJarConnection(CheckedConsumer<JarURLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJarConnection(CheckedFunction<JarURLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createJarURLConnection();
         // Be sure we got the connection implementation we want
         assert JarURLConnection.class.isAssignableFrom(conn.getClass());
-        connectionConsumer.accept((JarURLConnection) conn);
+        return connectionFunction.apply((JarURLConnection) conn);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunFileURLConnectionConnect() throws Exception {
-        withJdkFileConnection(URLConnection::connect);
+        callJdkFileConnection(conn -> {
+            conn.connect();
+            return null;
+        });
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFields() throws Exception {
-        withJdkFileConnection(URLConnection::getHeaderFields);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "{}", expectedDefaultType = java.util.Map.class)
+    static java.util.Map<String, java.util.List<String>> sunFileURLConnectionGetHeaderFields() throws Exception {
+        return callJdkFileConnection(URLConnection::getHeaderFields);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFieldWithName() throws Exception {
-        withJdkFileConnection(urlConnection -> urlConnection.getHeaderField("date"));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunFileURLConnectionGetHeaderFieldWithName() throws Exception {
+        return callJdkFileConnection(urlConnection -> urlConnection.getHeaderField("date"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFieldWithIndex() throws Exception {
-        withJdkFileConnection(urlConnection -> urlConnection.getHeaderField(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunFileURLConnectionGetHeaderFieldWithIndex() throws Exception {
+        return callJdkFileConnection(urlConnection -> urlConnection.getHeaderField(0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetContentLength() throws Exception {
-        withJdkFileConnection(URLConnection::getContentLength);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = int.class)
+    static int sunFileURLConnectionGetContentLength() throws Exception {
+        return callJdkFileConnection(URLConnection::getContentLength);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetContentLengthLong() throws Exception {
-        withJdkFileConnection(URLConnection::getContentLengthLong);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = long.class)
+    static long sunFileURLConnectionGetContentLengthLong() throws Exception {
+        return callJdkFileConnection(URLConnection::getContentLengthLong);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFieldKey() throws Exception {
-        withJdkFileConnection(urlConnection -> urlConnection.getHeaderFieldKey(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunFileURLConnectionGetHeaderFieldKey() throws Exception {
+        return callJdkFileConnection(urlConnection -> urlConnection.getHeaderFieldKey(0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetLastModified() throws Exception {
-        withJdkFileConnection(URLConnection::getLastModified);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunFileURLConnectionGetLastModified() throws Exception {
+        return callJdkFileConnection(URLConnection::getLastModified);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunFileURLConnectionGetInputStream() throws Exception {
-        withJdkFileConnection(URLConnection::getInputStream);
+        callJdkFileConnection(URLConnection::getInputStream);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetContentType() throws Exception {
-        withJdkFileConnection(URLConnection::getContentType);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunFileURLConnectionGetContentType() throws Exception {
+        return callJdkFileConnection(URLConnection::getContentType);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetContentEncoding() throws Exception {
-        withJdkFileConnection(URLConnection::getContentEncoding);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunFileURLConnectionGetContentEncoding() throws Exception {
+        return callJdkFileConnection(URLConnection::getContentEncoding);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetExpiration() throws Exception {
-        withJdkFileConnection(URLConnection::getExpiration);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunFileURLConnectionGetExpiration() throws Exception {
+        return callJdkFileConnection(URLConnection::getExpiration);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetDate() throws Exception {
-        withJdkFileConnection(URLConnection::getDate);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunFileURLConnectionGetDate() throws Exception {
+        return callJdkFileConnection(URLConnection::getDate);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFieldInt() throws Exception {
-        withJdkFileConnection(conn -> conn.getHeaderFieldInt("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = int.class)
+    static int sunFileURLConnectionGetHeaderFieldInt() throws Exception {
+        return callJdkFileConnection(conn -> conn.getHeaderFieldInt("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFileURLConnectionGetHeaderFieldLong() throws Exception {
-        withJdkFileConnection(conn -> conn.getHeaderFieldLong("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunFileURLConnectionGetHeaderFieldLong() throws Exception {
+        return callJdkFileConnection(conn -> conn.getHeaderFieldLong("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunFileURLConnectionGetContent() throws Exception {
-        withJdkFileConnection(URLConnection::getContent);
+        callJdkFileConnection(URLConnection::getContent);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunFileURLConnectionGetContentWithClasses() throws Exception {
-        withJdkFileConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
+        callJdkFileConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void netJarURLConnectionGetManifest() throws Exception {
-        withJarConnection(JarURLConnection::getManifest);
+        callJarConnection(JarURLConnection::getManifest);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void netJarURLConnectionGetJarEntry() throws Exception {
-        withJarConnection(JarURLConnection::getJarEntry);
+        callJarConnection(JarURLConnection::getJarEntry);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void netJarURLConnectionGetAttributes() throws Exception {
-        withJarConnection(JarURLConnection::getAttributes);
+        callJarConnection(JarURLConnection::getAttributes);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void netJarURLConnectionGetMainAttributes() throws Exception {
-        withJarConnection(JarURLConnection::getMainAttributes);
+        callJarConnection(JarURLConnection::getMainAttributes);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void netJarURLConnectionGetCertificates() throws Exception {
-        withJarConnection(JarURLConnection::getCertificates);
+        callJarConnection(JarURLConnection::getCertificates);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetJarFile() throws Exception {
-        withJarConnection(JarURLConnection::getJarFile);
+        // Use a lambda instead of a method reference to avoid exposing JarFile as a type parameter,
+        // which would trigger a forbiddenApis violation.
+        callJarConnection(conn -> {
+            conn.getJarFile();
+            return null;
+        });
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetJarEntry() throws Exception {
-        withJarConnection(JarURLConnection::getJarEntry);
+        callJarConnection(JarURLConnection::getJarEntry);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionConnect() throws Exception {
-        withJarConnection(JarURLConnection::connect);
+        callJarConnection(conn -> {
+            conn.connect();
+            return null;
+        });
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetInputStream() throws Exception {
-        withJarConnection(JarURLConnection::getInputStream);
+        callJarConnection(JarURLConnection::getInputStream);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetContentLength() throws Exception {
-        withJarConnection(JarURLConnection::getContentLength);
+        callJarConnection(JarURLConnection::getContentLength);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetContentLengthLong() throws Exception {
-        withJarConnection(JarURLConnection::getContentLengthLong);
+        callJarConnection(JarURLConnection::getContentLengthLong);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetContent() throws Exception {
-        withJarConnection(JarURLConnection::getContent);
+        callJarConnection(JarURLConnection::getContent);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetContentType() throws Exception {
-        withJarConnection(JarURLConnection::getContentType);
+        callJarConnection(JarURLConnection::getContentType);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void sunJarURLConnectionGetHeaderFieldWithName() throws Exception {
-        withJarConnection(conn -> conn.getHeaderField("field"));
+        callJarConnection(conn -> conn.getHeaderField("field"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetContentEncoding() throws Exception {
-        withJarConnection(URLConnection::getContentEncoding);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String netJarURLConnectionGetContentEncoding() throws Exception {
+        return callJarConnection(URLConnection::getContentEncoding);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetExpiration() throws Exception {
-        withJarConnection(URLConnection::getExpiration);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long netJarURLConnectionGetExpiration() throws Exception {
+        return callJarConnection(URLConnection::getExpiration);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetDate() throws Exception {
-        withJarConnection(URLConnection::getDate);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long netJarURLConnectionGetDate() throws Exception {
+        return callJarConnection(URLConnection::getDate);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetLastModified() throws Exception {
-        withJarConnection(URLConnection::getLastModified);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long netJarURLConnectionGetLastModified() throws Exception {
+        return callJarConnection(URLConnection::getLastModified);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetHeaderFieldInt() throws Exception {
-        withJarConnection(conn -> conn.getHeaderFieldInt("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = int.class)
+    static int netJarURLConnectionGetHeaderFieldInt() throws Exception {
+        return callJarConnection(conn -> conn.getHeaderFieldInt("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetHeaderFieldLong() throws Exception {
-        withJarConnection(conn -> conn.getHeaderFieldLong("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long netJarURLConnectionGetHeaderFieldLong() throws Exception {
+        return callJarConnection(conn -> conn.getHeaderFieldLong("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void netJarURLConnectionGetHeaderFieldDate() throws Exception {
-        withJarConnection(conn -> conn.getHeaderFieldDate("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long netJarURLConnectionGetHeaderFieldDate() throws Exception {
+        return callJarConnection(conn -> conn.getHeaderFieldDate("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void netJarURLConnectionGetContent() throws Exception {
-        withJarConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
+        callJarConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
     }
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/URLConnectionNetworkActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/URLConnectionNetworkActions.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.entitlement.qa.test;
 
-import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
 
@@ -42,9 +42,17 @@ class URLConnectionNetworkActions {
         }
     }
 
-    private static void withPlainNetworkConnection(CheckedConsumer<HttpURLConnection, Exception> connectionConsumer) throws Exception {
-        // Create a HttpURLConnection with minimal overrides to test calling directly into URLConnection methods as much as possible
-        var conn = new HttpURLConnection(HTTP_URL) {
+    private static boolean isCausedByNotEntitledException(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t.getClass().getName().equals("org.elasticsearch.entitlement.bridge.NotEntitledException")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static HttpURLConnection createPlainNetworkConnection() {
+        return new HttpURLConnection(HTTP_URL) {
             @Override
             public void connect() {}
 
@@ -58,68 +66,84 @@ class URLConnectionNetworkActions {
 
             @Override
             public InputStream getInputStream() throws IOException {
-                // Mock an attempt to call connect
                 throw new ConnectException();
             }
         };
+    }
 
+    private static <R> R callPlainNetworkConnection(CheckedFunction<HttpURLConnection, R, Exception> connectionFunction) throws Exception {
         try {
-            connectionConsumer.accept(conn);
-        } catch (java.net.ConnectException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to connect
+            return connectionFunction.apply(createPlainNetworkConnection());
+        } catch (IOException e) {
+            if (isCausedByNotEntitledException(e)) {
+                throw e;
+            }
+            return null;
         }
     }
 
-    private static void withJdkHttpConnection(CheckedConsumer<HttpURLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJdkHttpConnection(CheckedFunction<HttpURLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createHttpURLConnection();
         // Be sure we got the connection implementation we want
         assert HttpURLConnection.class.isAssignableFrom(conn.getClass());
         try {
-            connectionConsumer.accept((HttpURLConnection) conn);
-        } catch (java.net.ConnectException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to connect
+            return connectionFunction.apply((HttpURLConnection) conn);
+        } catch (IOException e) {
+            if (isCausedByNotEntitledException(e)) {
+                throw e;
+            }
+            return null;
         }
     }
 
-    private static void withJdkHttpsConnection(CheckedConsumer<HttpsURLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJdkHttpsConnection(CheckedFunction<HttpsURLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createHttpsURLConnection();
         // Be sure we got the connection implementation we want
         assert HttpsURLConnection.class.isAssignableFrom(conn.getClass());
         try {
-            connectionConsumer.accept((HttpsURLConnection) conn);
-        } catch (java.net.ConnectException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to connect
+            return connectionFunction.apply((HttpsURLConnection) conn);
+        } catch (IOException e) {
+            if (isCausedByNotEntitledException(e)) {
+                throw e;
+            }
+            return null;
         }
     }
 
-    private static void withJdkFtpConnection(CheckedConsumer<URLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJdkFtpConnection(CheckedFunction<URLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createFtpURLConnection();
         // Be sure we got the connection implementation we want
         assert conn.getClass().getSimpleName().equals("FtpURLConnection");
         try {
-            connectionConsumer.accept(conn);
-        } catch (java.net.ConnectException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to connect
+            return connectionFunction.apply(conn);
+        } catch (IOException e) {
+            if (isCausedByNotEntitledException(e)) {
+                throw e;
+            }
+            return null;
         }
     }
 
-    private static void withJdkMailToConnection(CheckedConsumer<URLConnection, Exception> connectionConsumer) throws Exception {
+    private static <R> R callJdkMailToConnection(CheckedFunction<URLConnection, R, Exception> connectionFunction) throws Exception {
         var conn = EntitledActions.createMailToURLConnection();
         // Be sure we got the connection implementation we want
         assert conn.getClass().getSimpleName().equals("MailToURLConnection");
         try {
-            connectionConsumer.accept(conn);
+            return connectionFunction.apply(conn);
         } catch (IOException e) {
-            // It's OK, it means we passed entitlement checks, and we tried to perform some IO
+            if (isCausedByNotEntitledException(e)) {
+                throw e;
+            }
+            return null;
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void urlOpenConnection() throws Exception {
         URI.create("http://127.0.0.1:12345/").toURL().openConnection();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     @SuppressForbidden(reason = "just testing, not a real connection")
     static void urlOpenConnectionWithProxy() throws URISyntaxException, IOException {
         var url = new URI("http://localhost").toURL();
@@ -127,7 +151,7 @@ class URLConnectionNetworkActions {
         assert urlConnection != null;
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void urlOpenStream() throws Exception {
         try {
             URI.create("http://127.0.0.1:12345/").toURL().openStream().close();
@@ -136,7 +160,7 @@ class URLConnectionNetworkActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void urlGetContent() throws Exception {
         try {
             URI.create("http://127.0.0.1:12345/").toURL().getContent();
@@ -145,7 +169,7 @@ class URLConnectionNetworkActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void urlGetContentWithClasses() throws Exception {
         try {
             URI.create("http://127.0.0.1:12345/").toURL().getContent(new Class<?>[] { String.class });
@@ -154,300 +178,312 @@ class URLConnectionNetworkActions {
         }
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetContentLength() throws Exception {
-        withPlainNetworkConnection(URLConnection::getContentLength);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = int.class)
+    static int baseUrlConnectionGetContentLength() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getContentLength);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetContentLength() throws Exception {
-        withJdkHttpConnection(URLConnection::getContentLength);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = int.class)
+    static int sunHttpConnectionGetContentLength() throws Exception {
+        return callJdkHttpConnection(URLConnection::getContentLength);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetContentType() throws Exception {
-        withPlainNetworkConnection(URLConnection::getContentType);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String baseUrlConnectionGetContentType() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getContentType);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetContentType() throws Exception {
-        withJdkHttpConnection(URLConnection::getContentType);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpConnectionGetContentType() throws Exception {
+        return callJdkHttpConnection(URLConnection::getContentType);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetContentEncoding() throws Exception {
-        withPlainNetworkConnection(URLConnection::getContentEncoding);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String baseUrlConnectionGetContentEncoding() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getContentEncoding);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetContentEncoding() throws Exception {
-        withJdkHttpConnection(URLConnection::getContentEncoding);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpConnectionGetContentEncoding() throws Exception {
+        return callJdkHttpConnection(URLConnection::getContentEncoding);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetExpiration() throws Exception {
-        withPlainNetworkConnection(URLConnection::getExpiration);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long baseUrlConnectionGetExpiration() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getExpiration);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetExpiration() throws Exception {
-        withJdkHttpConnection(URLConnection::getExpiration);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpConnectionGetExpiration() throws Exception {
+        return callJdkHttpConnection(URLConnection::getExpiration);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetDate() throws Exception {
-        withPlainNetworkConnection(URLConnection::getDate);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long baseUrlConnectionGetDate() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getDate);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetDate() throws Exception {
-        withJdkHttpConnection(URLConnection::getDate);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpConnectionGetDate() throws Exception {
+        return callJdkHttpConnection(URLConnection::getDate);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetLastModified() throws Exception {
-        withPlainNetworkConnection(URLConnection::getLastModified);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long baseUrlConnectionGetLastModified() throws Exception {
+        return callPlainNetworkConnection(URLConnection::getLastModified);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetLastModified() throws Exception {
-        withJdkHttpConnection(URLConnection::getLastModified);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpConnectionGetLastModified() throws Exception {
+        return callJdkHttpConnection(URLConnection::getLastModified);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetHeaderFieldInt() throws Exception {
-        withPlainNetworkConnection(conn -> conn.getHeaderFieldInt("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = int.class)
+    static int baseUrlConnectionGetHeaderFieldInt() throws Exception {
+        return callPlainNetworkConnection(conn -> conn.getHeaderFieldInt("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetHeaderFieldInt() throws Exception {
-        withJdkHttpConnection(conn -> conn.getHeaderFieldInt("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = int.class)
+    static int sunHttpConnectionGetHeaderFieldInt() throws Exception {
+        return callJdkHttpConnection(conn -> conn.getHeaderFieldInt("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseUrlConnectionGetHeaderFieldLong() throws Exception {
-        withPlainNetworkConnection(conn -> conn.getHeaderFieldLong("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long baseUrlConnectionGetHeaderFieldLong() throws Exception {
+        return callPlainNetworkConnection(conn -> conn.getHeaderFieldLong("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpConnectionGetHeaderFieldLong() throws Exception {
-        withJdkHttpConnection(conn -> conn.getHeaderFieldLong("field", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpConnectionGetHeaderFieldLong() throws Exception {
+        return callJdkHttpConnection(conn -> conn.getHeaderFieldLong("field", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void baseUrlConnectionGetContent() throws Exception {
-        withPlainNetworkConnection(URLConnection::getContent);
+        callPlainNetworkConnection(URLConnection::getContent);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpConnectionGetContent() throws Exception {
-        withJdkHttpConnection(URLConnection::getContent);
+        callJdkHttpConnection(URLConnection::getContent);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void baseUrlConnectionGetContentWithClasses() throws Exception {
-        withPlainNetworkConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
+        callPlainNetworkConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpConnectionGetContentWithClasses() throws Exception {
-        withJdkHttpConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
+        callJdkHttpConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunFtpURLConnectionConnect() throws Exception {
-        withJdkFtpConnection(URLConnection::connect);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFtpURLConnectionGetInputStream() throws Exception {
-        withJdkFtpConnection(URLConnection::getInputStream);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunFtpURLConnectionGetOutputStream() throws Exception {
-        withJdkFtpConnection(URLConnection::getOutputStream);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseHttpURLConnectionGetResponseCode() throws Exception {
-        withPlainNetworkConnection(HttpURLConnection::getResponseCode);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseHttpURLConnectionGetResponseMessage() throws Exception {
-        withPlainNetworkConnection(HttpURLConnection::getResponseMessage);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void baseHttpURLConnectionGetHeaderFieldDate() throws Exception {
-        withPlainNetworkConnection(conn -> conn.getHeaderFieldDate("date", 0));
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionConnect() throws Exception {
-        withJdkHttpConnection(HttpURLConnection::connect);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetOutputStream() throws Exception {
-        withJdkHttpConnection(httpURLConnection -> {
-            httpURLConnection.setDoOutput(true);
-            httpURLConnection.getOutputStream();
+        callJdkFtpConnection(conn -> {
+            conn.connect();
+            return null;
         });
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void sunFtpURLConnectionGetInputStream() throws Exception {
+        callJdkFtpConnection(URLConnection::getInputStream);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void sunFtpURLConnectionGetOutputStream() throws Exception {
+        callJdkFtpConnection(URLConnection::getOutputStream);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void baseHttpURLConnectionGetResponseCode() throws Exception {
+        callPlainNetworkConnection(HttpURLConnection::getResponseCode);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void baseHttpURLConnectionGetResponseMessage() throws Exception {
+        callPlainNetworkConnection(HttpURLConnection::getResponseMessage);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long baseHttpURLConnectionGetHeaderFieldDate() throws Exception {
+        return callPlainNetworkConnection(conn -> conn.getHeaderFieldDate("date", 0));
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void sunHttpURLConnectionConnect() throws Exception {
+        callJdkHttpConnection(conn -> {
+            conn.connect();
+            return null;
+        });
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void sunHttpURLConnectionGetOutputStream() throws Exception {
+        callJdkHttpConnection(conn -> {
+            conn.setDoOutput(true);
+            return conn.getOutputStream();
+        });
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpURLConnectionGetInputStream() throws Exception {
-        withJdkHttpConnection(HttpURLConnection::getInputStream);
+        callJdkHttpConnection(HttpURLConnection::getInputStream);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetErrorStream() throws Exception {
-        withJdkHttpConnection(HttpURLConnection::getErrorStream);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static InputStream sunHttpURLConnectionGetErrorStream() throws Exception {
+        return callJdkHttpConnection(HttpURLConnection::getErrorStream);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetHeaderFieldWithName() throws Exception {
-        withJdkHttpConnection(conn -> conn.getHeaderField("date"));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpURLConnectionGetHeaderFieldWithName() throws Exception {
+        return callJdkHttpConnection(conn -> conn.getHeaderField("date"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetHeaderFields() throws Exception {
-        withJdkHttpConnection(HttpURLConnection::getHeaderFields);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "{}", expectedDefaultType = java.util.Map.class)
+    static java.util.Map<String, java.util.List<String>> sunHttpURLConnectionGetHeaderFields() throws Exception {
+        return callJdkHttpConnection(HttpURLConnection::getHeaderFields);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetHeaderFieldWithIndex() throws Exception {
-        withJdkHttpConnection(conn -> conn.getHeaderField(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpURLConnectionGetHeaderFieldWithIndex() throws Exception {
+        return callJdkHttpConnection(conn -> conn.getHeaderField(0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpURLConnectionGetHeaderFieldKey() throws Exception {
-        withJdkHttpConnection(conn -> conn.getHeaderFieldKey(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpURLConnectionGetHeaderFieldKey() throws Exception {
+        return callJdkHttpConnection(conn -> conn.getHeaderFieldKey(0));
     }
 
     // https
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplConnect() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::connect);
-    }
-
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetOutputStream() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> {
-            httpsURLConnection.setDoOutput(true);
-            httpsURLConnection.getOutputStream();
+        callJdkHttpsConnection(conn -> {
+            conn.connect();
+            return null;
         });
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
+    static void sunHttpsURLConnectionImplGetOutputStream() throws Exception {
+        callJdkHttpsConnection(conn -> {
+            conn.setDoOutput(true);
+            return conn.getOutputStream();
+        });
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplGetInputStream() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getInputStream);
+        callJdkHttpsConnection(HttpsURLConnection::getInputStream);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetErrorStream() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getErrorStream);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static InputStream sunHttpsURLConnectionImplGetErrorStream() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getErrorStream);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldWithName() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderField("date"));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpsURLConnectionImplGetHeaderFieldWithName() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderField("date"));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFields() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getHeaderFields);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "{}", expectedDefaultType = java.util.Map.class)
+    static java.util.Map<String, java.util.List<String>> sunHttpsURLConnectionImplGetHeaderFields() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getHeaderFields);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldWithIndex() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderField(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpsURLConnectionImplGetHeaderFieldWithIndex() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderField(0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldKey() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldKey(0));
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpsURLConnectionImplGetHeaderFieldKey() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldKey(0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplGetResponseCode() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getResponseCode);
+        callJdkHttpsConnection(HttpsURLConnection::getResponseCode);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplGetResponseMessage() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getResponseMessage);
+        callJdkHttpsConnection(HttpsURLConnection::getResponseMessage);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetContentLength() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getContentLength);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = int.class)
+    static int sunHttpsURLConnectionImplGetContentLength() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getContentLength);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImpl$getContentLengthLong() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getContentLengthLong);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImpl$getContentLengthLong() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getContentLengthLong);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetContentType() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getContentType);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpsURLConnectionImplGetContentType() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getContentType);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetContentEncoding() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getContentEncoding);
+    @EntitlementTest(expectedAccess = PLUGINS, isExpectedDefaultNull = true)
+    static String sunHttpsURLConnectionImplGetContentEncoding() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getContentEncoding);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetExpiration() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getExpiration);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImplGetExpiration() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getExpiration);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetDate() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getDate);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImplGetDate() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getDate);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetLastModified() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getLastModified);
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImplGetLastModified() throws Exception {
+        return callJdkHttpsConnection(HttpsURLConnection::getLastModified);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldInt() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldInt("content-length", -1));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = int.class)
+    static int sunHttpsURLConnectionImplGetHeaderFieldInt() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldInt("content-length", -1));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldLong() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldLong("content-length", -1));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "-1", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImplGetHeaderFieldLong() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldLong("content-length", -1));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void sunHttpsURLConnectionImplGetHeaderFieldDate() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldDate("date", 0));
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)
+    static long sunHttpsURLConnectionImplGetHeaderFieldDate() throws Exception {
+        return callJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getHeaderFieldDate("date", 0));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplGetContent() throws Exception {
-        withJdkHttpsConnection(HttpsURLConnection::getContent);
+        callJdkHttpsConnection(HttpsURLConnection::getContent);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunHttpsURLConnectionImplGetContentWithClasses() throws Exception {
-        withJdkHttpsConnection(httpsURLConnection -> httpsURLConnection.getContent(new Class<?>[] { String.class }));
+        callJdkHttpsConnection(conn -> conn.getContent(new Class<?>[] { String.class }));
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunMailToURLConnectionConnect() throws Exception {
-        withJdkMailToConnection(URLConnection::connect);
+        callJdkMailToConnection(conn -> {
+            conn.connect();
+            return null;
+        });
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void sunMailToURLConnectionGetOutputStream() throws Exception {
-        withJdkMailToConnection(URLConnection::getOutputStream);
+        callJdkMailToConnection(URLConnection::getOutputStream);
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
@@ -21,6 +21,7 @@ import org.elasticsearch.entitlement.rules.TypeToken;
 import org.elasticsearch.entitlement.rules.function.CheckMethod;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
 
+import java.io.IOException;
 import java.net.Authenticator;
 import java.net.ContentHandlerFactory;
 import java.net.CookieHandler;
@@ -40,6 +41,7 @@ import java.net.ResponseCache;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.SocketImplFactory;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -54,6 +56,7 @@ import java.net.spi.URLStreamHandlerProvider;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.CompletionHandler;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
@@ -64,6 +67,7 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.AbstractSelectableChannel;
 import java.nio.channels.spi.AsynchronousChannelProvider;
 import java.nio.channels.spi.SelectorProvider;
+import java.util.Collections;
 
 public class NetworkInstrumentation implements InstrumentationConfig {
     @Override
@@ -73,25 +77,25 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(ProxySelector.class, rule -> {
             rule.callingVoidStatic(ProxySelector::setDefault, ProxySelector.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseReturnEarly();
         });
 
         builder.on(ResponseCache.class, rule -> {
             rule.callingVoidStatic(ResponseCache::setDefault, ResponseCache.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseReturnEarly();
         });
 
         builder.on(Authenticator.class, rule -> {
             rule.callingVoidStatic(Authenticator::setDefault, Authenticator.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseReturnEarly();
         });
 
         builder.on(CookieHandler.class, rule -> {
             rule.callingVoidStatic(CookieHandler::setDefault, CookieHandler.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseReturnEarly();
         });
 
         builder.on(URL.class, rule -> {
@@ -104,55 +108,57 @@ public class NetworkInstrumentation implements InstrumentationConfig {
             rule.callingVoidStatic(URL::setURLStreamHandlerFactory, URLStreamHandlerFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrowNotEntitled();
-            rule.calling(URL::openConnection).enforce(Policies::entitlementForUrl).elseThrowNotEntitled();
+            rule.calling(URL::openConnection).enforce(Policies::entitlementForUrl).elseThrow(IOException::new);
             rule.calling(URL::openConnection, Proxy.class).enforce((url, proxy) -> {
                 if (proxy.type() != Proxy.Type.DIRECT) {
                     return Policies.outboundNetworkAccess().and(Policies.entitlementForUrl(url));
                 }
                 return Policies.entitlementForUrl(url);
-            }).elseThrowNotEntitled();
-            rule.calling(URL::openStream).enforce(Policies::entitlementForUrl).elseThrowNotEntitled();
-            rule.calling(URL::getContent).enforce(Policies::entitlementForUrl).elseThrowNotEntitled();
-            rule.calling(URL::getContent, Class[].class).enforce(Policies::entitlementForUrl).elseThrowNotEntitled();
+            }).elseThrow(IOException::new);
+            rule.calling(URL::openStream).enforce(Policies::entitlementForUrl).elseThrow(IOException::new);
+            rule.calling(URL::getContent).enforce(Policies::entitlementForUrl).elseThrow(IOException::new);
+            rule.calling(URL::getContent, Class[].class).enforce(Policies::entitlementForUrl).elseThrow(IOException::new);
         });
 
         builder.on(URLConnection.class, rule -> {
-            rule.callingVoid(URLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(URLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
             rule.callingVoidStatic(URLConnection::setContentHandlerFactory, ContentHandlerFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrowNotEntitled();
             rule.callingVoidStatic(URLConnection::setFileNameMap, FileNameMap.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
-            rule.calling(URLConnection::getContentLength).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getContentLengthLong).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getContentType).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getContentEncoding).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getExpiration).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getDate).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getLastModified).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
+                .elseReturnEarly();
+            rule.calling(URLConnection::getContentLength).enforce(Policies::entitlementForUrlConnection).elseReturn(-1);
+            rule.calling(URLConnection::getContentLengthLong).enforce(Policies::entitlementForUrlConnection).elseReturn(-1L);
+            rule.calling(URLConnection::getContentType).enforce(Policies::entitlementForUrlConnection).elseReturn(null);
+            rule.calling(URLConnection::getContentEncoding).enforce(Policies::entitlementForUrlConnection).elseReturn(null);
+            rule.calling(URLConnection::getExpiration).enforce(Policies::entitlementForUrlConnection).elseReturn(0L);
+            rule.calling(URLConnection::getDate).enforce(Policies::entitlementForUrlConnection).elseReturn(0L);
+            rule.calling(URLConnection::getLastModified).enforce(Policies::entitlementForUrlConnection).elseReturn(0L);
             rule.calling(URLConnection::getHeaderFieldInt, String.class, Integer.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
+                .elseReturnArg(1);
             rule.calling(URLConnection::getHeaderFieldLong, String.class, Long.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
+                .elseReturnArg(1);
             rule.calling(URLConnection::getHeaderFieldDate, String.class, Long.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
-            rule.calling(URLConnection::getContent).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(URLConnection::getContent, Class[].class).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
+                .elseReturnArg(1);
+            rule.calling(URLConnection::getContent).enforce(Policies::entitlementForUrlConnection).elseThrow(IOException::new);
+            rule.calling(URLConnection::getContent, Class[].class)
+                .enforce(Policies::entitlementForUrlConnection)
+                .elseThrow(IOException::new);
         });
 
         builder.on(HttpURLConnection.class, rule -> {
             rule.callingVoidStatic(HttpURLConnection::setFollowRedirects, Boolean.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
-            rule.calling(HttpURLConnection::getResponseCode).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpURLConnection::getResponseMessage).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+                .elseReturnEarly();
+            rule.calling(HttpURLConnection::getResponseCode).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpURLConnection::getResponseMessage).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
             rule.calling(HttpURLConnection::getHeaderFieldDate, String.class, Long.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturnArg(1);
         });
 
         builder.on(Socket.class, rule -> {
@@ -182,12 +188,12 @@ public class NetworkInstrumentation implements InstrumentationConfig {
                 .elseThrowNotEntitled();
             rule.callingVoidStatic(Socket::setSocketImplFactory, SocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
-            rule.callingVoid(Socket::bind, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingVoid(Socket::connect, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingVoid(Socket::bind, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.callingVoid(Socket::connect, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
             rule.callingVoid(Socket::connect, SocketAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(ServerSocket.class, rule -> {
@@ -201,12 +207,12 @@ public class NetworkInstrumentation implements InstrumentationConfig {
                 .elseThrowNotEntitled();
             rule.callingVoidStatic(ServerSocket::setSocketFactory, SocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
-            rule.callingVoid(ServerSocket::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingVoid(ServerSocket::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
             rule.callingVoid(ServerSocket::bind, SocketAddress.class, Integer.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.calling(ServerSocket::accept).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.calling(ServerSocket::accept).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
         });
 
         builder.on(URLClassLoader.class, rule -> {
@@ -267,83 +273,107 @@ public class NetworkInstrumentation implements InstrumentationConfig {
             rule.callingStatic(DatagramSocket::new, SocketAddress.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
             rule.callingVoidStatic(DatagramSocket::setDatagramSocketImplFactory, DatagramSocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
-            rule.callingVoid(DatagramSocket::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingVoid(DatagramSocket::bind, SocketAddress.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
             rule.callingVoid(DatagramSocket::connect, InetAddress.class, Integer.class)
                 .enforce(Policies::allNetworkAccess)
                 .elseThrowNotEntitled();
-            rule.callingVoid(DatagramSocket::connect, SocketAddress.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
-            rule.callingVoid(DatagramSocket::receive, DatagramPacket.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(DatagramSocket::connect, SocketAddress.class)
+                .enforce(Policies::allNetworkAccess)
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
+            rule.callingVoid(DatagramSocket::receive, DatagramPacket.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(IOException::new);
             rule.callingVoid(DatagramSocket::send, DatagramPacket.class)
                 .enforce(
                     (socket, packet) -> packet.getAddress().isMulticastAddress()
                         ? Policies.allNetworkAccess()
                         : Policies.outboundNetworkAccess()
                 )
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(DatagramSocket::joinGroup, SocketAddress.class, NetworkInterface.class)
                 .enforce(Policies::allNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(DatagramSocket::leaveGroup, SocketAddress.class, NetworkInterface.class)
                 .enforce(Policies::allNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(MulticastSocket.class, rule -> {
-            rule.callingVoid(MulticastSocket::joinGroup, InetAddress.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(MulticastSocket::joinGroup, InetAddress.class).enforce(Policies::allNetworkAccess).elseThrow(IOException::new);
             rule.callingVoid(MulticastSocket::joinGroup, SocketAddress.class, NetworkInterface.class)
                 .enforce(Policies::allNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.callingVoid(MulticastSocket::leaveGroup, InetAddress.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingVoid(MulticastSocket::leaveGroup, InetAddress.class)
+                .enforce(Policies::allNetworkAccess)
+                .elseThrow(IOException::new);
             rule.callingVoid(MulticastSocket::leaveGroup, SocketAddress.class, NetworkInterface.class)
                 .enforce(Policies::allNetworkAccess)
                 .elseThrowNotEntitled();
         });
 
         builder.on(SocketChannel.class, rule -> {
-            rule.callingStatic(SocketChannel::open, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(SocketChannel::open, ProtocolFamily.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(SocketChannel::open).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingVoid(SocketChannel::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(SocketChannel::open, SocketAddress.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
+            rule.callingStatic(SocketChannel::open, ProtocolFamily.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
+            rule.callingStatic(SocketChannel::open).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.callingVoid(SocketChannel::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
         });
 
         builder.on("sun.nio.ch.SocketChannelImpl", SocketChannel.class, rule -> {
-            rule.callingVoid(SocketChannel::bind, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingVoid(SocketChannel::connect, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(SocketChannel::bind, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.callingVoid(SocketChannel::connect, SocketAddress.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on(ServerSocketChannel.class, rule -> {
-            rule.callingVoid(ServerSocketChannel::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(ServerSocketChannel::bind, SocketAddress.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on("sun.nio.ch.ServerSocketChannelImpl", ServerSocketChannel.class, rule -> {
             rule.callingVoid(ServerSocketChannel::bind, SocketAddress.class, Integer.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.calling(ServerSocketChannel::accept).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.calling(ServerSocketChannel::accept).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
         });
 
         builder.on(DatagramChannel.class, rule -> {
-            rule.callingVoid(DatagramChannel::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(DatagramChannel::bind, SocketAddress.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on("sun.nio.ch.DatagramChannelImpl", DatagramChannel.class, rule -> {
-            rule.callingVoid(DatagramChannel::bind, SocketAddress.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingVoid(DatagramChannel::connect, SocketAddress.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(DatagramChannel::bind, SocketAddress.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(IOException::new);
+            rule.callingVoid(DatagramChannel::connect, SocketAddress.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
             rule.callingVoid(DatagramChannel::send, ByteBuffer.class, SocketAddress.class).enforce((_, _, target) -> {
                 if (target instanceof InetSocketAddress isa && isa.getAddress().isMulticastAddress()) {
                     return Policies.allNetworkAccess();
                 } else {
                     return Policies.outboundNetworkAccess();
                 }
-            }).elseThrowNotEntitled();
-            rule.callingVoid(DatagramChannel::receive, ByteBuffer.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            }).elseThrow(IOException::new);
+            rule.callingVoid(DatagramChannel::receive, ByteBuffer.class)
+                .enforce(Policies::inboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on(AsynchronousServerSocketChannel.class, rule -> {
             rule.callingVoid(AsynchronousServerSocketChannel::bind, SocketAddress.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on("sun.nio.ch.AsynchronousSocketChannelImpl", AsynchronousSocketChannel.class, rule -> {
@@ -358,13 +388,13 @@ public class NetworkInstrumentation implements InstrumentationConfig {
             ).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
             rule.callingVoid(AsynchronousSocketChannel::bind, SocketAddress.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on("sun.nio.ch.AsynchronousServerSocketChannelImpl", AsynchronousServerSocketChannel.class, rule -> {
             rule.callingVoid(AsynchronousServerSocketChannel::bind, SocketAddress.class, Integer.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(AsynchronousServerSocketChannel::accept).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
             rule.callingVoid(
                 AsynchronousServerSocketChannel::accept,
@@ -376,7 +406,7 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(AsynchronousSocketChannel.class, rule -> {
             rule.callingVoid(AsynchronousSocketChannel::bind, SocketAddress.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(
@@ -396,7 +426,11 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(SelectableChannel.class, rule -> {
             rule.calling(SelectableChannel::register, Selector.class, Integer.class)
                 .enforce(() -> Policies.outboundNetworkAccess().and(Policies.inboundNetworkAccess()))
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new ClosedChannelException();
+                    ex.initCause(e);
+                    return ex;
+                });
         });
 
         builder.on(AsynchronousChannelProvider.class, rule -> {
@@ -406,22 +440,24 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(sun.net.www.URLConnection.class, rule -> {
             rule.calling(sun.net.www.URLConnection::getHeaderField, String.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
+                .elseReturn(null);
             rule.calling(sun.net.www.URLConnection::getHeaderField, Integer.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
-            rule.calling(sun.net.www.URLConnection::getHeaderFields).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
+                .elseReturn(null);
+            rule.calling(sun.net.www.URLConnection::getHeaderFields)
+                .enforce(Policies::entitlementForUrlConnection)
+                .elseReturn(Collections.emptyMap());
             rule.calling(sun.net.www.URLConnection::getHeaderFieldKey, Integer.class)
                 .enforce(Policies::entitlementForUrlConnection)
-                .elseThrowNotEntitled();
-            rule.calling(sun.net.www.URLConnection::getContentType).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
-            rule.calling(sun.net.www.URLConnection::getContentLength).enforce(Policies::entitlementForUrlConnection).elseThrowNotEntitled();
+                .elseReturn(null);
+            rule.calling(sun.net.www.URLConnection::getContentType).enforce(Policies::entitlementForUrlConnection).elseReturn(null);
+            rule.calling(sun.net.www.URLConnection::getContentLength).enforce(Policies::entitlementForUrlConnection).elseReturn(-1);
         });
 
         builder.on(FtpURLConnection.class, rule -> {
-            rule.callingVoid(FtpURLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(FtpURLConnection::getInputStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(FtpURLConnection::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(FtpURLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(FtpURLConnection::getInputStream).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(FtpURLConnection::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
         });
 
         builder.on(sun.net.www.protocol.http.HttpURLConnection.class, rule -> {
@@ -431,80 +467,82 @@ public class NetworkInstrumentation implements InstrumentationConfig {
             // .elseThrowNotEntitled()
             rule.callingVoid(sun.net.www.protocol.http.HttpURLConnection::connect)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getInputStream)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getOutputStream)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getErrorStream)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturn(null);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getHeaderField, String.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturn(null);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getHeaderFields)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturn(Collections.emptyMap());
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getHeaderField, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturn(null);
             rule.calling(sun.net.www.protocol.http.HttpURLConnection::getHeaderFieldKey, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturn(null);
         });
 
         builder.on(HttpsURLConnectionImpl.class, rule -> {
-            rule.callingVoid(HttpsURLConnectionImpl::connect).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getInputStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getErrorStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getHeaderField, String.class)
-                .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getHeaderField, Integer.class)
-                .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+            rule.callingVoid(HttpsURLConnectionImpl::connect).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getInputStream).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getErrorStream).enforce(Policies::outboundNetworkAccess).elseReturn(null);
+            rule.calling(HttpsURLConnectionImpl::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getHeaderField, String.class).enforce(Policies::outboundNetworkAccess).elseReturn(null);
+            rule.calling(HttpsURLConnectionImpl::getHeaderField, Integer.class).enforce(Policies::outboundNetworkAccess).elseReturn(null);
             rule.calling(HttpsURLConnectionImpl::getHeaderFieldKey, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getHeaderFields).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getResponseCode).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getResponseMessage).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContentLength).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContentLengthLong).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContentType).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContentEncoding).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getDate).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getExpiration).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getLastModified).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+                .elseReturn(null);
+            rule.calling(HttpsURLConnectionImpl::getHeaderFields)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseReturn(Collections.emptyMap());
+            rule.calling(HttpsURLConnectionImpl::getResponseCode).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getResponseMessage).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getContentLength).enforce(Policies::outboundNetworkAccess).elseReturn(-1);
+            rule.calling(HttpsURLConnectionImpl::getContentLengthLong).enforce(Policies::outboundNetworkAccess).elseReturn(-1L);
+            rule.calling(HttpsURLConnectionImpl::getContentType).enforce(Policies::outboundNetworkAccess).elseReturn(null);
+            rule.calling(HttpsURLConnectionImpl::getContentEncoding).enforce(Policies::outboundNetworkAccess).elseReturn(null);
+            rule.calling(HttpsURLConnectionImpl::getDate).enforce(Policies::outboundNetworkAccess).elseReturn(0L);
+            rule.calling(HttpsURLConnectionImpl::getExpiration).enforce(Policies::outboundNetworkAccess).elseReturn(0L);
+            rule.calling(HttpsURLConnectionImpl::getLastModified).enforce(Policies::outboundNetworkAccess).elseReturn(0L);
             rule.calling(HttpsURLConnectionImpl::getHeaderFieldDate, String.class, Long.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturnArg(1);
             rule.calling(HttpsURLConnectionImpl::getHeaderFieldInt, String.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseReturnArg(1);
             rule.calling(HttpsURLConnectionImpl::getHeaderFieldLong, String.class, Long.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContent).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(HttpsURLConnectionImpl::getContent, Class[].class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+                .elseReturnArg(1);
+            rule.calling(HttpsURLConnectionImpl::getContent).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(HttpsURLConnectionImpl::getContent, Class[].class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on(AbstractDelegateHttpsURLConnection.class, rule -> {
-            rule.callingVoid(AbstractDelegateHttpsURLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(AbstractDelegateHttpsURLConnection::connect)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
         });
 
         builder.on(MailToURLConnection.class, rule -> {
-            rule.callingVoid(MailToURLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.calling(MailToURLConnection::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingVoid(MailToURLConnection::connect).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
+            rule.calling(MailToURLConnection::getOutputStream).enforce(Policies::outboundNetworkAccess).elseThrow(IOException::new);
         });
 
         builder.on("jdk.internal.net.http.HttpClientImpl", HttpClient.class, rule -> {
             rule.calling(HttpClient::send, TypeToken.of(HttpRequest.class), new TypeToken<HttpResponse.BodyHandler<?>>() {})
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(HttpClient::sendAsync, TypeToken.of(HttpRequest.class), new TypeToken<HttpResponse.BodyHandler<?>>() {})
                 .enforce(Policies::outboundNetworkAccess)
                 .elseThrowNotEntitled();
@@ -519,7 +557,7 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(HttpClientFacade.class, rule -> {
             rule.calling(HttpClientFacade::send, TypeToken.of(HttpRequest.class), new TypeToken<HttpResponse.BodyHandler<?>>() {})
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.calling(HttpClientFacade::sendAsync, TypeToken.of(HttpRequest.class), new TypeToken<HttpResponse.BodyHandler<?>>() {})
                 .enforce(Policies::outboundNetworkAccess)
                 .elseThrowNotEntitled();
@@ -542,7 +580,11 @@ public class NetworkInstrumentation implements InstrumentationConfig {
                 }
 
                 return check;
-            }).elseThrowNotEntitled();
+            }).elseThrow(e -> {
+                var ex = new ClosedChannelException();
+                ex.initCause(e);
+                return ex;
+            });
             rule.calling(AbstractSelectableChannel::register, Selector.class, Integer.class).enforce((_, _, ops) -> {
                 CheckMethod check = Policies.empty();
                 if ((ops & SelectionKey.OP_CONNECT) != 0) {
@@ -553,7 +595,11 @@ public class NetworkInstrumentation implements InstrumentationConfig {
                 }
 
                 return check;
-            }).elseThrowNotEntitled();
+            }).elseThrow(e -> {
+                var ex = new ClosedChannelException();
+                ex.initCause(e);
+                return ex;
+            });
         });
 
     }


### PR DESCRIPTION
Backport of #142910 to 9.2.

Resolved one conflict in `NetworkAccessCheckActions.java` — added `connectDatagramSocketInetAddress` test method that was missing on 9.2.