### PR TITLE
Handle empty cluster state when collecting data in WriteLoadConstraintMonitor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitor.java
@@ -263,6 +263,9 @@ public class WriteLoadConstraintMonitor {
 
     private Collection<LongWithAttributes> getHotspottingNodeFlags() {
         final ClusterState state = clusterStateSupplier.get();
+        if (state == null) {
+            return List.of();
+        }
         final Map<NodeIdName, Long> hotspotNodeStartTimesView = hotspotNodeStartTimes;
 
         List<LongWithAttributes> nodeHotspotStatus = new ArrayList<>(state.nodes().size());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitorTests.java
@@ -327,6 +327,24 @@ public class WriteLoadConstraintMonitorTests extends ESTestCase {
         assertMetricsCollected(recordingMeterRegistry, List.of(), Map.of(), flagCounts);
     }
 
+    public void testCollectBeforeClusterStateHasFinishedInitializing() {
+
+        TestState testState = createTestStateWithNumberOfNodesAndHotSpots(10, 1, 1, 0);
+
+        final RecordingMeterRegistry recordingMeterRegistry = new RecordingMeterRegistry();
+        final WriteLoadConstraintMonitor writeLoadConstraintMonitor = new WriteLoadConstraintMonitor(
+            new WriteLoadConstraintSettings(testState.clusterSettings),
+            testState.currentTimeSupplier,
+            () -> null, // clusterStateSupplier returns null before the state is fully initialized in the ClusterService
+            testState.mockRerouteService,
+            recordingMeterRegistry
+        );
+
+        recordingMeterRegistry.getRecorder().collect();
+        // Collect returns empty values, but does not error out
+        assertMetricsCollected(recordingMeterRegistry, List.of(), Map.of(), Map.of());
+    }
+
     public void testZeroHotspotCount() {
         // test a zero count is issued when there has been an onNewInfo call
         TestState testState = createTestStateWithNumberOfNodesAndHotSpots(10, 1, 1, 0);


### PR DESCRIPTION
Metrics can be collected before the ClusterState is fully available, so we need to 
guard against NullPointerExceptions when registering metric callbacks.  If the 
cluster state is not ready yet, then we return an empty list when collecting per-node 
hotspot data.

Fixes https://elasticco.atlassian.net/browse/ES-14444