### PR TITLE
Fix flaky MappingSupplementaryCharacterRollingUpgradeIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -294,15 +294,6 @@ tests:
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteBlobWithRetries
   issue: https://github.com/elastic/elasticsearch/issues/144025
-- class: org.elasticsearch.upgrades.MappingSupplementaryCharacterRollingUpgradeIT
-  method: testMappingWithSupplementaryCharacterFieldName {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/144163
-- class: org.elasticsearch.upgrades.MappingSupplementaryCharacterRollingUpgradeIT
-  method: testMappingWithSupplementaryCharacterFieldName {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/144164
-- class: org.elasticsearch.upgrades.MappingSupplementaryCharacterRollingUpgradeIT
-  method: testMappingWithSupplementaryCharacterFieldName {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/144165
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testJvmMetrics {withOTel=true}
   issue: https://github.com/elastic/elasticsearch/issues/144166

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MappingSupplementaryCharacterRollingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MappingSupplementaryCharacterRollingUpgradeIT.java
@@ -102,7 +102,7 @@ public class MappingSupplementaryCharacterRollingUpgradeIT extends AbstractRolli
             .startObject()
             .startObject("settings")
             .field("number_of_shards", 1)
-            .field("number_of_replicas", 1)
+            .field("number_of_replicas", 0)
             .endObject()
             .startObject("mappings")
             .startObject("properties")


### PR DESCRIPTION
Use number_of_replicas=0 to avoid shard allocation flakiness during rolling upgrades. The test validates mapping serialization, not replication.

Closes #144164
Closes #144165
Closes #144163
