### PR TITLE
Entitlements: fix missing mrjar rule updates for Java 20/21

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main20/java/org/elasticsearch/entitlement/qa/test/VersionSpecificNioFileSystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main20/java/org/elasticsearch/entitlement/qa/test/VersionSpecificNioFileSystemActions.java
@@ -16,15 +16,15 @@ import java.nio.file.attribute.BasicFileAttributes;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
 class VersionSpecificNioFileSystemActions {
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void checkReadAttributesIfExists() throws IOException {
         var fs = FileSystems.getDefault().provider();
         fs.readAttributesIfExists(FileCheckActions.readFile(), BasicFileAttributes.class);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void checkExists() {
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "false", expectedDefaultType = boolean.class)
+    static boolean checkExists() {
         var fs = FileSystems.getDefault().provider();
-        fs.exists(FileCheckActions.readFile());
+        return fs.exists(FileCheckActions.readFile());
     }
 }

--- a/libs/entitlement/src/main20/java/org/elasticsearch/entitlement/config/Java20Instrumentation.java
+++ b/libs/entitlement/src/main20/java/org/elasticsearch/entitlement/config/Java20Instrumentation.java
@@ -20,6 +20,7 @@ import org.elasticsearch.entitlement.rules.Policies;
 import org.elasticsearch.entitlement.rules.TypeToken;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
 
+import java.io.IOException;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.SegmentScope;
@@ -143,13 +144,13 @@ public class Java20Instrumentation implements InstrumentationConfig {
                 TypeToken.of(Path.class),
                 new TypeToken<Class<? extends BasicFileAttributes>>() {},
                 TypeToken.of(LinkOption[].class)
-            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrowNotEntitled();
+            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrow(IOException::new);
         });
 
         builder.on(FileSystems.getDefault().provider().getClass(), rule -> {
             rule.calling(FileSystemProvider::exists, Path.class, LinkOption[].class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseReturn(false);
         });
     }
 }

--- a/libs/entitlement/src/main21/java/org/elasticsearch/entitlement/config/Java21Instrumentation.java
+++ b/libs/entitlement/src/main21/java/org/elasticsearch/entitlement/config/Java21Instrumentation.java
@@ -21,6 +21,7 @@ import org.elasticsearch.entitlement.rules.Policies;
 import org.elasticsearch.entitlement.rules.TypeToken;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
 
+import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
@@ -107,13 +108,13 @@ public class Java21Instrumentation implements InstrumentationConfig {
                 TypeToken.of(Path.class),
                 new TypeToken<Class<? extends BasicFileAttributes>>() {},
                 TypeToken.of(LinkOption[].class)
-            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrowNotEntitled();
+            ).enforce((provider, path) -> Policies.fileRead(path)).elseThrow(IOException::new);
         });
 
         builder.on(FileSystems.getDefault().provider().getClass(), rule -> {
             rule.calling(FileSystemProvider::exists, Path.class, LinkOption[].class)
                 .enforce((provider, path) -> Policies.fileRead(path))
-                .elseThrowNotEntitled();
+                .elseReturn(false);
         });
     }
 }


### PR DESCRIPTION
Fixes a couple rules that were missed during backport due to mrjar differences in 8.19.