### PR TITLE
Improve error message for object mapping conflicts in ESQL

### DIFF
--- a/docs/changelog/144427.yaml
+++ b/docs/changelog/144427.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144427
+summary: Improve error message for object mapping conflicts in ESQL
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -124,6 +124,36 @@ public class InvalidMappedField extends EsField {
     }
 
     private static String makeErrorMessage(Map<String, Set<String>> typesToIndices, boolean includeInsistKeyword) {
+        boolean hasObject = typesToIndices.keySet().stream()
+            .anyMatch(t -> t.equals(DataType.OBJECT.typeName()));
+
+        if (hasObject) {
+            StringBuilder message = new StringBuilder();
+            message.append("Field has incompatible mappings: ");
+
+            boolean first = true;
+            for (Map.Entry<String, Set<String>> e : typesToIndices.entrySet()) {
+                if (first) {
+                    first = false;
+                } else {
+                    message.append(", ");
+                }
+                message.append("[");
+                message.append(e.getKey());
+                message.append("] in ");
+                if (e.getValue().size() <= 3) {
+                    message.append(e.getValue());
+                } else {
+                    message.append(e.getValue().stream().sorted().limit(3).collect(Collectors.toList()));
+                    message.append(" and [").append(e.getValue().size() - 3).append("] other ");
+                    message.append(e.getValue().size() == 4 ? "index" : "indices");
+                }
+            }
+
+            message.append(". Casting cannot resolve this conflict because [object] fields cannot be cast to scalar types.");
+
+            return message.toString();
+        }
         StringBuilder errorMessage = new StringBuilder();
         var isInsistKeywordOnlyKeyword = includeInsistKeyword && typesToIndices.containsKey(DataType.KEYWORD.typeName()) == false;
         errorMessage.append("mapped as [");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3822,4 +3822,64 @@ public class VerifierTests extends ESTestCase {
     protected List<String> filteredWarnings() {
         return withDefaultLimitWarning(super.filteredWarnings());
     }
+
+    public void testObjectMappingConflictWithCast() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "object", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("cannot be cast"));
+    }
+
+    public void testObjectMappingConflictWithoutCast() {
+        var typesToIndices = Map.of(
+            "object", Set.of("test1"),
+            "keyword", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("incompatible mappings"));
+    }
+
+    public void testNonObjectConflictKeepsOriginalMessage() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "long", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        // Should NOT contain your new explanation
+        assertFalse(message.contains("cannot be cast"));
+
+        // Should still contain original style
+        assertTrue(message.contains("incompatible types"));
+    }
+
+    public void testMultipleTypesIncludingObject() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "object", Set.of("test2"),
+            "long", Set.of("test3")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("cannot be cast"));
+    }
 }


### PR DESCRIPTION
## Problem

When resolving mapping conflicts across indices, ESQL returns a generic ambiguity error even when casting is explicitly attempted.

Example:
FROM test1, test2 | EVAL foo = foo::keyword

If `foo` is mapped as `keyword` in one index and `object` in another, the error message is:

"Cannot use field [foo] due to ambiguities being mapped as incompatible types..."

This is misleading because:
- Casting is explicitly attempted
- `object` fields are not scalar values
- The conflict cannot be resolved via casting

## Solution

Improve the error message when one of the conflicting types is `object` to clarify that:
- The mappings are incompatible
- Casting cannot resolve the conflict
- `object` fields cannot be cast to scalar types

## Testing

- Added unit tests covering object mapping conflicts
- Verified existing behavior remains unchanged for non-object conflicts

Relates to #144400