### PR TITLE
ESQL: Speed up remote Parquet reads

### DIFF
--- a/docs/changelog/144454.yaml
+++ b/docs/changelog/144454.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144454
+summary: Speed up remote Parquet reads
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -53,6 +53,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,8 @@ import java.util.OptionalLong;
 public class ParquetFormatReader implements RangeAwareFormatReader {
 
     private final BlockFactory blockFactory;
+
+    static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
 
     public ParquetFormatReader(BlockFactory blockFactory) {
         this.blockFactory = blockFactory;
@@ -256,8 +259,50 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             for (BlockMetaData block : rowGroups) {
                 ranges.add(new long[] { block.getStartingPos(), block.getTotalByteSize() });
             }
-            return ranges;
+            List<long[]> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
+            return coalesced.size() <= 1 ? List.of() : coalesced;
         }
+    }
+
+    static List<long[]> coalesceRowGroupRanges(List<long[]> rowGroupRanges, long targetBytes) {
+        if (rowGroupRanges == null || rowGroupRanges.size() <= 1) {
+            return List.of();
+        }
+        if (targetBytes <= 0) {
+            return List.copyOf(rowGroupRanges);
+        }
+
+        List<long[]> sorted = new ArrayList<>(rowGroupRanges);
+        sorted.sort(Comparator.comparingLong(a -> a[0]));
+
+        List<long[]> out = new ArrayList<>();
+        long groupStart = -1;
+        long groupEnd = -1;
+
+        for (long[] range : sorted) {
+            long start = range[0];
+            long length = range[1];
+            long end = start + length;
+
+            if (groupStart < 0) {
+                groupStart = start;
+                groupEnd = end;
+            } else {
+                groupEnd = Math.max(groupEnd, end);
+            }
+
+            if (groupEnd - groupStart >= targetBytes) {
+                out.add(new long[] { groupStart, groupEnd - groupStart });
+                groupStart = -1;
+                groupEnd = -1;
+            }
+        }
+
+        if (groupStart >= 0) {
+            out.add(new long[] { groupStart, groupEnd - groupStart });
+        }
+
+        return out;
     }
 
     /**
@@ -281,7 +326,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         FileMetaData fileMetaData = reader.getFileMetaData();
         MessageType parquetSchema = fileMetaData.getSchema();
-        List<Attribute> attributes = convertParquetSchemaToAttributes(parquetSchema);
+        // The framework passes planning-time resolved attributes for this query (AsyncExternalSourceOperatorFactory).
+        // Reuse them to avoid redundant schema conversion work per split. We still read Parquet metadata to drive row groups.
+        final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
+            ? resolvedAttributes
+            : convertParquetSchemaToAttributes(parquetSchema);
 
         List<Attribute> projectedAttributes;
         if (projectedColumns == null || projectedColumns.isEmpty()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -260,7 +260,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 ranges.add(new long[] { block.getStartingPos(), block.getTotalByteSize() });
             }
             List<long[]> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
-            return coalesced.size() <= 1 ? List.of() : coalesced;
+            // If the whole file fits into a single macro-split target, keep row-group split granularity
+            // (i.e. return the original ranges) to preserve parallelism.
+            return coalesced.size() < 2 ? ranges : coalesced;
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -11,7 +11,10 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Adapter that wraps a StorageObject to implement Parquet's InputFile interface.
@@ -19,13 +22,27 @@ import java.io.InputStream;
  *
  * <p>Key features:
  * <ul>
- *   <li>Converts StorageObject's range-based reads to Parquet's seekable stream interface</li>
- *   <li>Supports efficient random access for columnar format reading</li>
- *   <li>No Hadoop dependencies - uses pure Java InputStream</li>
+ *   <li>Uses <strong>only</strong> range reads ({@code newStream(position, length)}) — never full-object GET</li>
+ *   <li>Sliding window cache (default 4MB) to amortize seeks and avoid {@code InputStream.skip}</li>
+ *   <li>Optimized for remote storage (S3, HTTP) where full GET and skip-download are expensive</li>
+ *   <li>No Hadoop dependencies — uses pure Java InputStream</li>
  * </ul>
  */
 public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputFile {
     private final StorageObject storageObject;
+    private final long length;
+    private final FooterCacheKey footerCacheKey;
+
+    /** Default window size (4MB) for the sliding range cache. Capped so total budget stays ≤16MB per reader. */
+    static final int DEFAULT_WINDOW_SIZE = 4 * 1024 * 1024;
+
+    /** Footer cache budget across the JVM (8MB). */
+    static final int FOOTER_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+
+    /** Max single footer entry (2MB). Prevents caching unusually large footers. */
+    static final int FOOTER_CACHE_MAX_ENTRY_BYTES = 2 * 1024 * 1024;
+
+    private static final FooterCache FOOTER_CACHE = new FooterCache(FOOTER_CACHE_MAX_BYTES, FOOTER_CACHE_MAX_ENTRY_BYTES);
 
     /**
      * Creates an adapter for the given StorageObject.
@@ -37,36 +54,67 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             throw new IllegalArgumentException("storageObject cannot be null");
         }
         this.storageObject = storageObject;
+        try {
+            this.length = storageObject.length();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read storage object length for [" + storageObject.path() + "]", e);
+        }
+        this.footerCacheKey = buildFooterCacheKey(storageObject, this.length);
     }
 
     @Override
     public long getLength() throws IOException {
-        return storageObject.length();
+        return length;
     }
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-        return new StorageObjectSeekableInputStream(storageObject);
+        return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, DEFAULT_WINDOW_SIZE);
+    }
+
+    static void clearFooterCacheForTests() {
+        FOOTER_CACHE.clear();
+    }
+
+    private static FooterCacheKey buildFooterCacheKey(StorageObject storageObject, long length) {
+        Instant lastModified;
+        try {
+            lastModified = storageObject.lastModified();
+        } catch (IOException e) {
+            lastModified = null;
+        }
+        Long lastModifiedMillis = lastModified == null ? null : lastModified.toEpochMilli();
+        return new FooterCacheKey(storageObject.path().toString(), length, lastModifiedMillis);
     }
 
     /**
-     * SeekableInputStream backed by StorageObject's range-based InputStream API.
-     * All reads (byte-array and ByteBuffer) go through a single cached InputStream
-     * that is reopened on seek.
+     * SeekableInputStream that uses only range reads and a sliding window cache.
+     * Never calls {@link StorageObject#newStream()} (full GET) or {@link java.io.InputStream#skip(long)}.
+     * On seek: if the target position is within the current window, only the cursor is updated;
+     * otherwise a new range is fetched via {@code newStream(position, windowSize)}.
      */
-    private static class StorageObjectSeekableInputStream extends SeekableInputStream {
+    private static class RangeFirstSeekableInputStream extends SeekableInputStream {
         private final StorageObject storageObject;
-        private InputStream currentStream;
-        private long position;
-        private long streamStartPosition;
+        private final FooterCacheKey footerCacheKey;
         private final long length;
+        private final int windowSize;
+        private final byte[] window;
 
-        StorageObjectSeekableInputStream(StorageObject storageObject) throws IOException {
+        private long windowStart;
+        private int windowLength;
+        private long position;
+        private boolean closed;
+
+        RangeFirstSeekableInputStream(StorageObject storageObject, FooterCacheKey footerCacheKey, long length, int windowSize) {
             this.storageObject = storageObject;
-            this.length = storageObject.length();
+            this.footerCacheKey = footerCacheKey;
+            this.length = length;
+            this.windowSize = windowSize;
+            this.window = new byte[windowSize];
+            this.windowStart = -1;
+            this.windowLength = 0;
             this.position = 0;
-            this.streamStartPosition = 0;
-            this.currentStream = storageObject.newStream();
+            this.closed = false;
         }
 
         @Override
@@ -76,6 +124,9 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
         @Override
         public void seek(long newPos) throws IOException {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
             if (newPos < 0) {
                 throw new IOException("Cannot seek to negative position: " + newPos);
             }
@@ -83,43 +134,69 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 throw new IOException("Cannot seek beyond end of file: " + newPos + " > " + length);
             }
 
-            if (newPos >= streamStartPosition && newPos >= position) {
-                long skipAmount = newPos - position;
-                if (skipAmount > 0) {
-                    long skipped = currentStream.skip(skipAmount);
-                    if (skipped != skipAmount) {
-                        reopenStreamAt(newPos);
-                    } else {
-                        position = newPos;
-                    }
-                }
+            position = newPos;
+
+            if (position >= windowStart && position < windowStart + windowLength) {
                 return;
             }
 
-            reopenStreamAt(newPos);
+            fetchWindowAt(position);
         }
 
-        private void reopenStreamAt(long newPos) throws IOException {
-            InputStream old = currentStream;
-            currentStream = null;
-            try {
-                long remainingBytes = length - newPos;
-                currentStream = storageObject.newStream(newPos, remainingBytes);
-                streamStartPosition = newPos;
-                position = newPos;
-            } finally {
-                if (old != null) {
-                    old.close();
-                }
+        private void fetchWindowAt(long pos) throws IOException {
+            long remaining = length - pos;
+            long toRead = Math.min(windowSize, remaining);
+            if (toRead <= 0) {
+                windowStart = pos;
+                windowLength = 0;
+                return;
             }
+
+            FooterCacheEntry cached = FOOTER_CACHE.get(footerCacheKey);
+            if (cached != null && cached.covers(pos, (int) toRead)) {
+                int from = (int) (pos - cached.startOffset());
+                System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
+                windowStart = pos;
+                windowLength = (int) toRead;
+                return;
+            }
+
+            windowStart = pos;
+            windowLength = 0;
+            ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
+            int bytesRead = storageObject.readBytes(pos, target);
+            windowLength = bytesRead < 0 ? 0 : bytesRead;
+
+            if (windowLength > 0 && windowStart + windowLength == length) {
+                FOOTER_CACHE.putTailIfEligible(footerCacheKey, windowStart, window, windowLength);
+            }
+        }
+
+        private void ensureWindow() throws IOException {
+            if (position >= length) {
+                return;
+            }
+            if (position >= windowStart && position < windowStart + windowLength) {
+                return;
+            }
+            fetchWindowAt(position);
         }
 
         @Override
         public int read() throws IOException {
-            int b = currentStream.read();
-            if (b >= 0) {
-                position++;
+            if (closed) {
+                throw new IOException("Stream is closed");
             }
+            if (position >= length) {
+                return -1;
+            }
+            ensureWindow();
+            if (position >= windowStart + windowLength) {
+                return -1;
+            }
+            int offset = (int) (position - windowStart);
+            int b = window[offset] & 0xFF;
+            position++;
             return b;
         }
 
@@ -130,31 +207,54 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            int bytesRead = currentStream.read(b, off, len);
-            if (bytesRead > 0) {
-                position += bytesRead;
+            if (closed) {
+                throw new IOException("Stream is closed");
             }
-            return bytesRead;
+            if (position >= length) {
+                return -1;
+            }
+            if (len <= 0) {
+                return 0;
+            }
+            ensureWindow();
+            int availableInWindow = windowLength - (int) (position - windowStart);
+            if (availableInWindow <= 0) {
+                return -1;
+            }
+            int toRead = Math.min(len, availableInWindow);
+            int offset = (int) (position - windowStart);
+            System.arraycopy(window, offset, b, off, toRead);
+            position += toRead;
+            return toRead;
         }
 
         @Override
         public long skip(long n) throws IOException {
-            long skipped = currentStream.skip(n);
-            position += skipped;
+            if (n <= 0) {
+                return 0;
+            }
+            long newPos = Math.min(position + n, length);
+            long skipped = newPos - position;
+            seek(newPos);
             return skipped;
         }
 
         @Override
         public int available() throws IOException {
-            return currentStream.available();
+            if (closed || position >= length) {
+                return 0;
+            }
+            if (position >= windowStart && position < windowStart + windowLength) {
+                return windowLength - (int) (position - windowStart);
+            }
+            return 0;
         }
 
         @Override
         public void close() throws IOException {
-            if (currentStream != null) {
-                currentStream.close();
-                currentStream = null;
-            }
+            closed = true;
+            windowStart = -1;
+            windowLength = 0;
         }
 
         @Override
@@ -217,6 +317,65 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 readFully(transfer, 0, toRead);
                 buf.put(transfer, 0, toRead);
             }
+        }
+    }
+
+    private record FooterCacheKey(String path, long length, Long lastModifiedMillis) {}
+
+    private record FooterCacheEntry(long startOffset, byte[] bytes) {
+        boolean covers(long position, int length) {
+            if (length <= 0) {
+                return true;
+            }
+            long start = startOffset;
+            long endExclusive = startOffset + bytes.length;
+            long requestedEnd = position + length;
+            return position >= start && requestedEnd <= endExclusive;
+        }
+    }
+
+    private static class FooterCache {
+        private final int maxBytes;
+        private final int maxEntryBytes;
+        private final LinkedHashMap<FooterCacheKey, FooterCacheEntry> map = new LinkedHashMap<>(16, 0.75f, true);
+        private int totalBytes;
+
+        FooterCache(int maxBytes, int maxEntryBytes) {
+            this.maxBytes = maxBytes;
+            this.maxEntryBytes = maxEntryBytes;
+        }
+
+        synchronized FooterCacheEntry get(FooterCacheKey key) {
+            return map.get(key);
+        }
+
+        synchronized void putTailIfEligible(FooterCacheKey key, long startOffset, byte[] buffer, int length) {
+            if (length <= 0 || length > maxEntryBytes) {
+                return;
+            }
+            byte[] bytes = new byte[length];
+            System.arraycopy(buffer, 0, bytes, 0, length);
+
+            FooterCacheEntry previous = map.put(key, new FooterCacheEntry(startOffset, bytes));
+            if (previous != null) {
+                totalBytes -= previous.bytes().length;
+            }
+            totalBytes += bytes.length;
+            evictIfNeeded();
+        }
+
+        private void evictIfNeeded() {
+            while (totalBytes > maxBytes && map.isEmpty() == false) {
+                Map.Entry<FooterCacheKey, FooterCacheEntry> eldest = map.entrySet().iterator().next();
+                FooterCacheEntry removed = eldest.getValue();
+                map.remove(eldest.getKey());
+                totalBytes -= removed.bytes().length;
+            }
+        }
+
+        synchronized void clear() {
+            map.clear();
+            totalBytes = 0;
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
@@ -71,4 +71,3 @@ public class ParquetSplitCoalescingTests extends ESTestCase {
         }
     }
 }
-

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParquetSplitCoalescingTests extends ESTestCase {
+
+    public void testCoalesceProducesFewerRangesAndPreservesCoverage() {
+        List<long[]> ranges = new ArrayList<>();
+        ranges.add(new long[] { 0, 10 });
+        ranges.add(new long[] { 10, 10 });
+        ranges.add(new long[] { 20, 10 });
+        ranges.add(new long[] { 30, 10 });
+        ranges.add(new long[] { 40, 10 });
+
+        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
+        assertTrue(coalesced.size() < ranges.size());
+
+        for (long[] original : ranges) {
+            long start = original[0];
+            assertTrue("Missing coverage for start=" + start, isCoveredByAny(coalesced, start));
+        }
+
+        assertSortedNonOverlapping(coalesced);
+    }
+
+    public void testCoalesceWithLargeTargetProducesSingleRange() {
+        List<long[]> ranges = List.of(new long[] { 0, 10 }, new long[] { 10, 10 }, new long[] { 20, 10 });
+        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 1024 * 1024);
+        assertEquals(1, coalesced.size());
+        assertEquals(0, coalesced.get(0)[0]);
+        assertEquals(30, coalesced.get(0)[1]);
+        assertSortedNonOverlapping(coalesced);
+    }
+
+    public void testCoalesceWithNonPositiveTargetReturnsOriginal() {
+        List<long[]> ranges = List.of(new long[] { 20, 10 }, new long[] { 0, 10 }, new long[] { 10, 10 });
+        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 0);
+        assertEquals(ranges.size(), coalesced.size());
+        for (int i = 0; i < ranges.size(); i++) {
+            assertArrayEquals(ranges.get(i), coalesced.get(i));
+        }
+    }
+
+    private static boolean isCoveredByAny(List<long[]> coalesced, long start) {
+        for (long[] group : coalesced) {
+            long groupStart = group[0];
+            long groupEnd = groupStart + group[1];
+            if (start >= groupStart && start < groupEnd) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void assertSortedNonOverlapping(List<long[]> ranges) {
+        long lastEnd = Long.MIN_VALUE;
+        for (long[] r : ranges) {
+            assertTrue("length must be > 0", r[1] > 0);
+            assertTrue("ranges must be sorted and non-overlapping", r[0] >= lastEnd);
+            lastEnd = r[0] + r[1];
+        }
+    }
+}
+

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -50,7 +50,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamRead() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -64,7 +64,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamReadArray() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -79,7 +79,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamSeekForward() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -137,7 +137,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamReadFully() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -151,7 +151,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamReadFullyWithOffset() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -364,7 +364,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
     public void testSeekableInputStreamSkip() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        StorageObject storageObject = createStorageObject(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
 
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
@@ -374,6 +374,231 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             assertEquals(3, stream.getPos());
             assertEquals(4, stream.read());
         }
+    }
+
+    /**
+     * Verifies that the adapter never calls {@link StorageObject#newStream()} (full GET).
+     * A stub that throws on newStream() is used; all operations succeed via newStream(pos, len) only.
+     */
+    public void testNoFullGetUsesOnlyRangeReads() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        StorageObject rangeOnlyStorageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported; use range reads only");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyStorageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            assertEquals(0, stream.getPos());
+            assertEquals(1, stream.read());
+            assertEquals(2, stream.read());
+            stream.seek(5);
+            assertEquals(6, stream.read());
+            stream.seek(0);
+            byte[] buf = new byte[5];
+            stream.readFully(buf);
+            assertArrayEquals(new byte[] { 1, 2, 3, 4, 5 }, buf);
+        }
+    }
+
+    /**
+     * Verifies that repeated reads within the same window do not trigger additional range requests.
+     * The sliding window should serve multiple reads from the same cached range.
+     */
+    public void testSeekWindowBehaviorReusesCachedRange() throws IOException {
+        byte[] data = new byte[1024];
+        randomBytes(data);
+        final int[] rangeReadCount = { 0 };
+        StorageObject countingStorageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount[0]++;
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.read();
+            stream.read();
+            stream.read();
+            stream.seek(0);
+            stream.read();
+            stream.seek(10);
+            stream.read();
+        }
+
+        assertTrue("Expected few range reads (window reuse); got " + rangeReadCount[0], rangeReadCount[0] <= 2);
+    }
+
+    public void testFooterCacheServesTailReadsWithoutExtraRangeRequest() throws IOException {
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        byte[] data = new byte[1024 * 1024];
+        randomBytes(data);
+        final int[] rangeReadCount = { 0 };
+        Instant lastModified = Instant.ofEpochMilli(123);
+
+        StorageObject countingStorageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount[0]++;
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return lastModified;
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject);
+        long tailStart = data.length - 1024;
+
+        byte[] first = new byte[1024];
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(tailStart);
+            stream.readFully(first);
+        }
+        assertEquals(1, rangeReadCount[0]);
+
+        byte[] second = new byte[1024];
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(tailStart);
+            stream.readFully(second);
+        }
+        assertEquals(1, rangeReadCount[0]);
+        assertArrayEquals(first, second);
+    }
+
+    public void testReadFullyCrossesWindowBoundaries() throws IOException {
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        int size = ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 123;
+        byte[] data = new byte[size];
+        randomBytes(data);
+        final int[] rangeReadCount = { 0 };
+
+        StorageObject rangeOnlyCounting = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount[0]++;
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.ofEpochMilli(0);
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyCounting);
+        byte[] read = new byte[size];
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.readFully(read);
+        }
+        assertArrayEquals(data, read);
+        assertEquals(2, rangeReadCount[0]);
     }
 
     private void randomBytes(byte[] data) {


### PR DESCRIPTION
Remote Parquet reads are sensitive to full-object GETs and small, repeated range
requests during seeking and footer parsing.

Use a range-first seekable adapter backed by StorageObject.readBytes with a small
sliding window, cache tail/footer bytes in a bounded JVM-wide LRU, and coalesce
row-group ranges into macro-splits to reduce split fragmentation. Also reuse the
planning-time resolved attributes for per-split reads.

Developed with AI-assisted tooling