### PR TITLE
Fix `ConcurrentSnapshotsIT#testBackToBackQueuedDeletes`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -255,9 +255,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.snapshots.ConcurrentSnapshotsIT
-  method: testBackToBackQueuedDeletes
-  issue: https://github.com/elastic/elasticsearch/issues/143387
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/143407

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1012,7 +1012,12 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testBackToBackQueuedDeletes() throws Exception {
-        final String masterName = internalCluster().startMasterOnlyNode();
+        final String masterName = internalCluster().startMasterOnlyNode(
+            Settings.builder()
+                // we block a snapshot thread, and SnapshotDeletionStartBatcher requires one, so we must have >=2 of them
+                .put("thread_pool.snapshot.max", 2)
+                .build()
+        );
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");


### PR DESCRIPTION
This test fails if it only has a single snapshot thread and that thread
gets blocked on the repository before the second snapshot has been
enqueued: since #141998 landed, enqueuing batches of deletes requires a
snapshot thread. This commit fixes the problem by adding a second
snapshot thread.

Closes #143387