### PR TITLE
Fix CsvIT to check test capabilities

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql;
 
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -46,10 +47,12 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.analytics.mapper.EncodedTDigest;
 import org.elasticsearch.xpack.core.analytics.mapper.TDigestParser;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.action.ResponseValueUtils;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
+import org.junit.AssumptionViolatedException;
 import org.supercsv.io.CsvListReader;
 import org.supercsv.prefs.CsvPreference;
 
@@ -76,6 +79,7 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.test.ESTestCase.assertThat;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.reader;
 import static org.elasticsearch.xpack.esql.SpecReader.shouldSkipLine;
 import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeToUnsignedLong;
@@ -85,6 +89,9 @@ import static org.elasticsearch.xpack.esql.core.util.NumericUtils.asLongUnsigned
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToAggregateMetricDoubleLiteral;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.in;
+import static org.junit.Assume.assumeFalse;
 
 public final class CsvTestUtils {
     private static final int MAX_WIDTH = 80;
@@ -123,6 +130,49 @@ public final class CsvTestUtils {
             return false;
         }
         return true;
+    }
+
+    public static void checkTestCapabilities(
+        EsqlCapabilities allCapabilities,
+        EsqlCapabilities enabledCapabilities,
+        List<String> requiredCapabilities,
+        Logger logger
+    ) {
+        if (Build.current().isSnapshot()) {
+            assertThat(
+                "Capability is not included in the enabled list capabilities on a snapshot build. Spelling mistake?",
+                requiredCapabilities,
+                everyItem(in(allCapabilities.capabilities()))
+            );
+            assumeTrueLogging(
+                "Capability not supported in this build",
+                enabledCapabilities.capabilities().containsAll(requiredCapabilities),
+                logger
+            );
+        } else {
+            for (EsqlCapabilities.Cap c : EsqlCapabilities.Cap.values()) {
+                if (false == c.isEnabled()) {
+                    assumeFalseLogging(
+                        c.capabilityName() + " is not supported in non-snapshot releases",
+                        requiredCapabilities.contains(c.capabilityName()),
+                        logger
+                    );
+                }
+            }
+        }
+    }
+
+    public static void assumeTrueLogging(String message, boolean condition, Logger logger) {
+        assumeFalseLogging(message, condition == false, logger);
+    }
+
+    public static void assumeFalseLogging(String message, boolean condition, Logger logger) {
+        try {
+            assumeFalse(message, condition);
+        } catch (AssumptionViolatedException ave) {
+            logger.info("skipping test: " + ave.getMessage());
+            throw ave;
+        }
     }
 
     private static final Pattern INSTRUCTION_PATTERN = Pattern.compile("\\[(.*?)]");

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -101,6 +101,7 @@ import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.loadCsvSpecValues;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.CSV_DATASET;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.INFERENCE_CONFIGS;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.classpathResources;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.greaterThan;
@@ -116,6 +117,8 @@ import static org.hamcrest.Matchers.hasSize;
 public class CsvIT extends ESTestCase {
 
     private static final Logger logger = LogManager.getLogger(CsvIT.class);
+    private static final EsqlCapabilities ENABLED_CAPS = EsqlCapabilities.capabilities(TEST_FUNCTION_REGISTRY, false);
+    private static final EsqlCapabilities ALL_CAPS = EsqlCapabilities.capabilities(TEST_FUNCTION_REGISTRY, true);
 
     private static InternalTestCluster cluster;
     private static String currentGroupName = null;
@@ -218,6 +221,7 @@ public class CsvIT extends ESTestCase {
             "CSV tests cannot handle EXTERNAL sources (requires QA integration tests)",
             testCase.query.trim().toUpperCase(java.util.Locale.ROOT).startsWith("EXTERNAL")
         );
+        checkTestCapabilities();
 
         currentGroupName = groupName;
         // verify no prior failures
@@ -258,6 +262,10 @@ public class CsvIT extends ESTestCase {
             t.setStackTrace(prependSpec(t.getStackTrace()));
             throw t;
         }
+    }
+
+    private void checkTestCapabilities() {
+        CsvTestUtils.checkTestCapabilities(ALL_CAPS, ENABLED_CAPS, testCase.requiredCapabilities, logger);
     }
 
     private StackTraceElement[] prependSpec(StackTraceElement[] original) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -140,7 +139,6 @@ import org.elasticsearch.xpack.esql.view.InMemoryViewService;
 import org.elasticsearch.xpack.esql.view.PutViewAction;
 import org.elasticsearch.xpack.esql.view.ViewResolver;
 import org.junit.After;
-import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -185,10 +183,8 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.queryClusterSettings;
 import static org.elasticsearch.xpack.esql.action.EsqlExecutionInfoTests.createEsqlExecutionInfo;
 import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -428,26 +424,7 @@ public class CsvTests extends ESTestCase {
                     && Set.of("Exact count with where on single-valued data", "Exact total single-valued field count").contains(testName)
             );
 
-            if (Build.current().isSnapshot()) {
-                assertThat(
-                    "Capability is not included in the enabled list capabilities on a snapshot build. Spelling mistake?",
-                    testCase.requiredCapabilities,
-                    everyItem(in(ALL_CAPS.capabilities()))
-                );
-                assumeTrueLogging(
-                    "Capability not supported in this build",
-                    ENABLED_CAPS.capabilities().containsAll(testCase.requiredCapabilities)
-                );
-            } else {
-                for (EsqlCapabilities.Cap c : EsqlCapabilities.Cap.values()) {
-                    if (false == c.isEnabled()) {
-                        assumeFalseLogging(
-                            c.capabilityName() + " is not supported in non-snapshot releases",
-                            testCase.requiredCapabilities.contains(c.capabilityName())
-                        );
-                    }
-                }
-            }
+            checkTestCapabilities();
 
             doTest();
         } catch (Throwable th) {
@@ -455,17 +432,16 @@ public class CsvTests extends ESTestCase {
         }
     }
 
+    private void checkTestCapabilities() {
+        CsvTestUtils.checkTestCapabilities(ALL_CAPS, ENABLED_CAPS, testCase.requiredCapabilities, LOGGER);
+    }
+
     private static void assumeTrueLogging(String message, boolean condition) {
-        assumeFalseLogging(message, condition == false);
+        CsvTestUtils.assumeTrueLogging(message, condition, LOGGER);
     }
 
     private static void assumeFalseLogging(String message, boolean condition) {
-        try {
-            assumeFalse(message, condition);
-        } catch (AssumptionViolatedException ave) {
-            LOGGER.info("skipping test: " + ave.getMessage());
-            throw ave;
-        }
+        CsvTestUtils.assumeFalseLogging(message, condition, LOGGER);
     }
 
     @Override


### PR DESCRIPTION
So it turns out that CsvIT does not check test capabilities at all. The main consequence is in release tests, where all SNAPSHOT-only features result in test failure.