### PR TITLE
Support GA versions in EarlyAccessCatalogJdkToolchainResolver

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -70,6 +70,7 @@ import javax.inject.Inject;
 
 import static org.elasticsearch.gradle.internal.conventions.GUtils.elvis;
 import static org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin.VERSIONS_EXT;
+import static org.elasticsearch.gradle.internal.toolchain.EarlyAccessCatalogJdkToolchainResolver.RECENT_JDK_RELEASES_CATALOG_URL;
 import static org.elasticsearch.gradle.internal.toolchain.EarlyAccessCatalogJdkToolchainResolver.findLatestPreReleaseBuild;
 import static org.elasticsearch.gradle.internal.toolchain.EarlyAccessCatalogJdkToolchainResolver.findPreReleaseBuild;
 
@@ -434,7 +435,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private RuntimeJava resolvePreReleaseRuntimeJavaHome(String runtimeJavaProperty, String bundledJdkMajorVersion) {
         var major = JavaLanguageVersion.of(Integer.parseInt(runtimeJavaProperty.substring(0, runtimeJavaProperty.length() - 4)));
         Integer buildNumber = Integer.getInteger("runtime.java.build");
-        var jdkbuild = buildNumber == null ? findLatestPreReleaseBuild(major) : findPreReleaseBuild(major, buildNumber);
+        var jdkbuild = (buildNumber == null ? findLatestPreReleaseBuild(major) : findPreReleaseBuild(major, buildNumber)).orElseThrow(
+            () -> new IllegalStateException("No pre-release JDK build found for Java " + major + " in " + RECENT_JDK_RELEASES_CATALOG_URL)
+        );
         String preReleaseType = jdkbuild.type();
         String prVersionString = String.format("%d-%s+%d", major.asInt(), preReleaseType, jdkbuild.buildNumber());
         NamedDomainObjectContainer<Jdk> container = (NamedDomainObjectContainer<Jdk>) project.getExtensions().getByName("jdks");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolver.java
@@ -55,7 +55,7 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
 
     @FunctionalInterface
     interface EarlyAccessJdkBuildResolver {
-        PreReleaseJdkBuild findLatestEABuild(JavaLanguageVersion languageVersion);
+        Optional<PreReleaseJdkBuild> findLatestEABuild(JavaLanguageVersion languageVersion);
     }
 
     // allow overriding for testing
@@ -64,24 +64,26 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
     public record PreReleaseJdkBuild(JavaLanguageVersion languageVersion, int buildNumber, String type) implements JdkBuild {
         @Override
         public String url(String os, String arch, String extension) {
-            // example:
+            // examples:
             // https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26-ea+6/openjdk-26-ea+6_linux-aarch64_bin.tar.gz
+            // https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26-rc+30/openjdk-26_linux-x64_bin.tar.gz
+            // https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_linux-x64_bin.tar.gz
 
-            // RCs don't attach a special suffix to the artifact name
-            String releaseTypeSuffix = type.equals("ea") ? "-" + type + "+" + buildNumber : "";
+            // EA builds include the type+build in both folder and artifact name
+            // RC builds include type+build in folder only
+            // GA builds use just the version for both folder and artifact
+            String folderSuffix = type.equals("ga") ? "" : "-" + type + "+" + buildNumber;
+            String artifactSuffix = type.equals("ea") ? "-" + type + "+" + buildNumber : "";
             return "https://builds.es-jdk-archive.com/jdks/openjdk/"
                 + languageVersion.asInt()
                 + "/"
                 + "openjdk-"
                 + languageVersion.asInt()
-                + "-"
-                + type
-                + "+"
-                + buildNumber
+                + folderSuffix
                 + "/"
                 + "openjdk-"
                 + languageVersion.asInt()
-                + releaseTypeSuffix
+                + artifactSuffix
                 + "_"
                 + os
                 + "-"
@@ -132,7 +134,7 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
         }
 
         JavaLanguageVersion languageVersion = javaToolchainSpec.getLanguageVersion().get();
-        return Optional.of(earlyAccessJdkBuildResolver.findLatestEABuild(languageVersion));
+        return earlyAccessJdkBuildResolver.findLatestEABuild(languageVersion);
     }
 
     static List<PreReleaseJdkBuild> findRecentPreReleaseBuild(JavaLanguageVersion languageVersion) {
@@ -142,7 +144,10 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = mapper.readTree(is);
                 ObjectNode majors = (ObjectNode) node.get("majors");
-                ObjectNode perVersion = (ObjectNode) majors.get("" + languageVersion.asInt());
+                JsonNode perVersion = majors.get("" + languageVersion.asInt());
+                if (perVersion == null) {
+                    return List.of();
+                }
                 ArrayNode buildsNode = (ArrayNode) perVersion.get("builds");
                 List<JsonNode> buildsList = new ArrayList<>();
                 buildsNode.forEach(buildsList::add);
@@ -164,15 +169,14 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
         }
     }
 
-    public static PreReleaseJdkBuild findPreReleaseBuild(JavaLanguageVersion languageVersion, int buildNumber) {
+    public static Optional<PreReleaseJdkBuild> findPreReleaseBuild(JavaLanguageVersion languageVersion, int buildNumber) {
         return findRecentPreReleaseBuild(languageVersion).stream()
             .filter(preReleaseJdkBuild -> preReleaseJdkBuild.buildNumber == buildNumber)
-            .max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber))
-            .get();
+            .max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber));
     }
 
-    public static PreReleaseJdkBuild findLatestPreReleaseBuild(JavaLanguageVersion languageVersion) {
-        return findRecentPreReleaseBuild(languageVersion).stream().max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber)).get();
+    public static Optional<PreReleaseJdkBuild> findLatestPreReleaseBuild(JavaLanguageVersion languageVersion) {
+        return findRecentPreReleaseBuild(languageVersion).stream().max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber));
     }
 
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolver.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -62,6 +63,13 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
     EarlyAccessJdkBuildResolver earlyAccessJdkBuildResolver = (languageVersion) -> findLatestPreReleaseBuild(languageVersion);
 
     public record PreReleaseJdkBuild(JavaLanguageVersion languageVersion, int buildNumber, String type) implements JdkBuild {
+
+        private static final Map<String, Integer> TYPE_RANK = Map.of("ea", 0, "rc", 1, "ga", 2);
+
+        int typeRank() {
+            return TYPE_RANK.getOrDefault(type, -1);
+        }
+
         @Override
         public String url(String os, String arch, String extension) {
             // examples:
@@ -169,14 +177,17 @@ public abstract class EarlyAccessCatalogJdkToolchainResolver extends AbstractCus
         }
     }
 
+    private static final Comparator<PreReleaseJdkBuild> BUILD_COMPARATOR = Comparator.comparingInt(PreReleaseJdkBuild::buildNumber)
+        .thenComparingInt(PreReleaseJdkBuild::typeRank);
+
     public static Optional<PreReleaseJdkBuild> findPreReleaseBuild(JavaLanguageVersion languageVersion, int buildNumber) {
         return findRecentPreReleaseBuild(languageVersion).stream()
             .filter(preReleaseJdkBuild -> preReleaseJdkBuild.buildNumber == buildNumber)
-            .max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber));
+            .max(BUILD_COMPARATOR);
     }
 
     public static Optional<PreReleaseJdkBuild> findLatestPreReleaseBuild(JavaLanguageVersion languageVersion) {
-        return findRecentPreReleaseBuild(languageVersion).stream().max(Comparator.comparingInt(PreReleaseJdkBuild::buildNumber));
+        return findRecentPreReleaseBuild(languageVersion).stream().max(BUILD_COMPARATOR);
     }
 
 }

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolverSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolverSpec.groovy
@@ -29,7 +29,7 @@ class EarlyAccessCatalogJdkToolchainResolverSpec extends AbstractToolchainResolv
             }
         }
         resolver.earlyAccessJdkBuildResolver = (JavaLanguageVersion version) -> {
-            new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(version, 30, 'ea')
+            Optional.of(new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(version, 30, 'ea'))
         }
         return resolver
     }
@@ -43,7 +43,7 @@ class EarlyAccessCatalogJdkToolchainResolverSpec extends AbstractToolchainResolv
             }
         }
         resolver.earlyAccessJdkBuildResolver = (JavaLanguageVersion version) -> {
-            new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(version, 30, 'rc')
+            Optional.of(new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(version, 30, 'rc'))
         }
         when:
         Optional<JavaToolchainDownload> download = resolver.resolve(request(JavaLanguageVersion.of(langVersion), vendor, platform(os, arch)))
@@ -67,6 +67,32 @@ class EarlyAccessCatalogJdkToolchainResolverSpec extends AbstractToolchainResolv
         ]
     }
 
+    def "resolves ga versions #os #arch #vendor jdk #langVersion"() {
+        given:
+        def resolver = new EarlyAccessCatalogJdkToolchainResolver() {
+            @Override
+            BuildServiceParameters.None getParameters() {
+                return null
+            }
+        }
+        resolver.earlyAccessJdkBuildResolver = (JavaLanguageVersion version) -> {
+            Optional.of(new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(version, 35, 'ga'))
+        }
+        when:
+        Optional<JavaToolchainDownload> download = resolver.resolve(request(JavaLanguageVersion.of(langVersion), vendor, platform(os, arch)))
+
+        then:
+        download.get().uri == URI.create(expectedUrl)
+        where:
+
+        [langVersion, vendor, os, arch, expectedUrl] << [
+            [26, anyVendor(), LINUX, X86_64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_linux-x64_bin.tar.gz"],
+            [26, anyVendor(), LINUX, AARCH64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_linux-aarch64_bin.tar.gz"],
+            [26, anyVendor(), MAC_OS, X86_64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_macos-x64_bin.tar.gz"],
+            [26, anyVendor(), MAC_OS, AARCH64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_macos-aarch64_bin.tar.gz"],
+            [26, anyVendor(), WINDOWS, X86_64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26/openjdk-26_windows-x64_bin.zip"]
+        ]
+    }
 
     @Override
     def supportedRequests() {
@@ -83,6 +109,24 @@ class EarlyAccessCatalogJdkToolchainResolverSpec extends AbstractToolchainResolv
             [26, anyVendor(), MAC_OS, AARCH64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26-ea+30/openjdk-26-ea+30_macos-aarch64_bin.tar.gz"],
             [26, anyVendor(), WINDOWS, X86_64, "https://builds.es-jdk-archive.com/jdks/openjdk/26/openjdk-26-ea+30/openjdk-26-ea+30_windows-x64_bin.zip"]
         ]
+    }
+
+    def "returns empty when version is not in catalog"() {
+        given:
+        def resolver = new EarlyAccessCatalogJdkToolchainResolver() {
+            @Override
+            BuildServiceParameters.None getParameters() {
+                return null
+            }
+        }
+        resolver.earlyAccessJdkBuildResolver = (JavaLanguageVersion version) -> {
+            Optional.empty()
+        }
+        when:
+        Optional<JavaToolchainDownload> download = resolver.resolve(request(JavaLanguageVersion.of(26), anyVendor(), platform(LINUX, X86_64)))
+
+        then:
+        download.isEmpty()
     }
 
     @Override

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolverSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/EarlyAccessCatalogJdkToolchainResolverSpec.groovy
@@ -111,6 +111,24 @@ class EarlyAccessCatalogJdkToolchainResolverSpec extends AbstractToolchainResolv
         ]
     }
 
+    def "prefers ga over rc over ea when build numbers are the same"() {
+        given:
+        def rcBuild = new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(JavaLanguageVersion.of(26), 35, 'rc')
+        def gaBuild = new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(JavaLanguageVersion.of(26), 35, 'ga')
+        def eaBuild = new EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild(JavaLanguageVersion.of(26), 35, 'ea')
+
+        when:
+        def builds = [rcBuild, gaBuild, eaBuild]
+        def best = builds.stream().max(
+            Comparator.comparingInt(EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild::buildNumber)
+                .thenComparingInt(EarlyAccessCatalogJdkToolchainResolver.PreReleaseJdkBuild::typeRank)
+        )
+
+        then:
+        best.isPresent()
+        best.get().type() == 'ga'
+    }
+
     def "returns empty when version is not in catalog"() {
         given:
         def resolver = new EarlyAccessCatalogJdkToolchainResolver() {


### PR DESCRIPTION
This is to make the JDK26 available, since it is not yet reachable through the Adoptium API.
Also, gracefully fallback to the next Toolchain resolver if the JDK version is not available in the EarlyAccessCatalog.
