### PR TITLE
ESQL: DS: Align schema generation across formats

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -24,10 +24,9 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 import org.elasticsearch.xpack.esql.datasources.CloseableIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -491,8 +490,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             String trimmedType = parts[1].trim();
             String typeName = trimmedType.toUpperCase(Locale.ROOT);
             DataType dataType = parseDataType(typeName);
-            EsField field = new EsField(name, dataType, Map.of(), true, EsField.TimeSeriesFieldType.NONE);
-            attributes.add(new FieldAttribute(Source.EMPTY, name, field));
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, name, dataType));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrer.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrer.java
@@ -9,17 +9,15 @@ package org.elasticsearch.xpack.esql.datasource.csv;
 
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Infers column types from CSV data by sampling rows when headers lack explicit type annotations.
@@ -94,8 +92,7 @@ public class CsvSchemaInferrer {
         for (int col = 0; col < numCols; col++) {
             String name = columnNames[col].trim();
             DataType type = seenValue[col] ? TYPE_CANDIDATES[candidateIdx[col]] : DataType.KEYWORD;
-            EsField field = new EsField(name, type, Map.of(), true, EsField.TimeSeriesFieldType.NONE);
-            attributes.add(new FieldAttribute(Source.EMPTY, name, field));
+            attributes.add(new ReferenceAttribute(Source.EMPTY, null, name, type));
         }
         return attributes;
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
@@ -14,11 +14,10 @@ import com.fasterxml.jackson.core.JsonToken;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -166,16 +165,7 @@ public class NdJsonSchemaInferrer {
     }
 
     public static Attribute attribute(String name, DataType type, boolean nullable) {
-        return new FieldAttribute(
-            Source.EMPTY,
-            null,
-            null,
-            name,
-            new EsField(name, type, Map.of(), false, null),
-            nullable ? Nullability.TRUE : Nullability.UNKNOWN,
-            null,
-            false
-        );
+        return new ReferenceAttribute(Source.EMPTY, null, name, type, nullable ? Nullability.TRUE : Nullability.UNKNOWN, null, false);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -304,7 +304,27 @@ public class ExternalSourceResolver {
         return config;
     }
 
+    /**
+     * Validates that datasource plugins export ReferenceAttribute only.
+     * Called when receiving schema from any plugin (FormatReader, TableCatalog, Connector).
+     */
+    private static void validateSchemaUsesOnlyReferenceAttributes(List<Attribute> schema) {
+        for (Attribute attr : schema) {
+            if (attr instanceof ReferenceAttribute == false) {
+                throw new IllegalArgumentException(
+                    "Datasource schema must contain only ReferenceAttribute, but found "
+                        + attr.getClass().getSimpleName()
+                        + " for column ["
+                        + attr.name()
+                        + "]"
+                );
+            }
+        }
+    }
+
     private ExternalSourceMetadata wrapAsExternalSourceMetadata(SourceMetadata metadata, Map<String, Object> queryConfig) {
+        validateSchemaUsesOnlyReferenceAttributes(metadata.schema());
+
         if (metadata instanceof ExternalSourceMetadata extMetadata) {
             if (extMetadata.config() != null && extMetadata.config().isEmpty() == false) {
                 return extMetadata;
@@ -331,7 +351,7 @@ public class ExternalSourceResolver {
             }
 
             @Override
-            public java.util.List<org.elasticsearch.xpack.esql.core.expression.Attribute> schema() {
+            public java.util.List<Attribute> schema() {
                 return metadata.schema();
             }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 /**
@@ -411,6 +412,24 @@ public class ExternalSourceResolverTests extends ESTestCase {
         assertTrue(schema.get(3).synthetic());
     }
 
+    public void testSchemaWithFieldAttributeFailsValidation() throws Exception {
+        List<Attribute> schemaWithFieldAttr = List.of(
+            new FieldAttribute(Source.EMPTY, "a", new EsField("a", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+        );
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/file.parquet", schemaWithFieldAttr);
+
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put("s3://bucket/data/", List.of(entry("s3://bucket/data/file.parquet", 100)));
+
+        Exception e = expectThrows(
+            Exception.class,
+            () -> resolveMultiplePaths(List.of("s3://bucket/data/file.parquet"), schemasByPath, listingsByPrefix)
+        );
+        assertThat(e.getCause().getMessage(), containsString("ReferenceAttribute"));
+        assertThat(e.getCause().getMessage(), containsString("FieldAttribute"));
+    }
+
     private ExternalSourceMetadata createStubMetadata(String location, List<Attribute> schema) {
         return new ExternalSourceMetadata() {
             @Override
@@ -451,7 +470,7 @@ public class ExternalSourceResolverTests extends ESTestCase {
     // ===== Helpers =====
 
     private static Attribute attr(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+        return new ReferenceAttribute(Source.EMPTY, null, name, type);
     }
 
     private static StorageEntry entry(String path, long length) {


### PR DESCRIPTION
This aligns CSV and NDJSON plugins to generate schemes containing `ReferenceAttributes`, instead of `FieldAttributes`. The latter are for ES indices (and trigger some operators look for shards in the source).
We might subsequently want to evolve this, have a dedicated external attribute.