### PR TITLE
[9.3] Support interface types in entitlement rule definitions (#144447)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.util.TypeUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -220,29 +221,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
             .collect(Collectors.toSet());
     }
 
-    private static final java.util.Map<Class<?>, Class<?>> PRIMITIVE_TO_BOXED = java.util.Map.of(
-        boolean.class,
-        Boolean.class,
-        int.class,
-        Integer.class,
-        long.class,
-        Long.class,
-        double.class,
-        Double.class,
-        float.class,
-        Float.class,
-        short.class,
-        Short.class,
-        byte.class,
-        Byte.class,
-        char.class,
-        Character.class
-    );
-
-    private static Class<?> boxed(Class<?> type) {
-        return PRIMITIVE_TO_BOXED.getOrDefault(type, type);
-    }
-
     private static final String NOT_ENTITLED_EXCEPTION_NAME = "org.elasticsearch.entitlement.bridge.NotEntitledException";
 
     private static boolean hasCause(Throwable e, String className) {
@@ -292,7 +270,7 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                     response.addHeader("expectedDefaultIfDenied", checkAction.expectedDefaultIfDenied()[0]);
                 }
                 if (checkAction.expectedDefaultType() != void.class) {
-                    Class<?> expectedType = boxed(checkAction.expectedDefaultType());
+                    Class<?> expectedType = TypeUtils.toBoxed(checkAction.expectedDefaultType());
                     response.addHeader("defaultTypeMatch", String.valueOf(result != null && expectedType.isInstance(result)));
                 }
                 if (checkAction.isExpectedDefaultNull()) {

--- a/libs/entitlement/src/main/java/module-info.java
+++ b/libs/entitlement/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.elasticsearch.entitlement {
     exports org.elasticsearch.entitlement.runtime.policy.entitlements to org.elasticsearch.server;
     exports org.elasticsearch.entitlement.rules;
     exports org.elasticsearch.entitlement.rules.function;
+    exports org.elasticsearch.entitlement.util;
 
     uses org.elasticsearch.entitlement.instrumentation.InstrumentationService;
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/ClassMethodBuilder.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/ClassMethodBuilder.java
@@ -18,6 +18,7 @@ import org.elasticsearch.entitlement.rules.function.Call3;
 import org.elasticsearch.entitlement.rules.function.Call4;
 import org.elasticsearch.entitlement.rules.function.Call5;
 import org.elasticsearch.entitlement.rules.function.Call6;
+import org.elasticsearch.entitlement.rules.function.VarargCallAdapter;
 import org.elasticsearch.entitlement.rules.function.VoidCall0;
 import org.elasticsearch.entitlement.rules.function.VoidCall1;
 import org.elasticsearch.entitlement.rules.function.VoidCall2;
@@ -26,10 +27,14 @@ import org.elasticsearch.entitlement.rules.function.VoidCall4;
 import org.elasticsearch.entitlement.rules.function.VoidCall5;
 import org.elasticsearch.entitlement.rules.function.VoidCall6;
 import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
+import org.elasticsearch.entitlement.util.TypeUtils;
 
 import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Builder for selecting and configuring methods to be instrumented with entitlement checks.
@@ -1079,30 +1084,90 @@ public class ClassMethodBuilder<T> {
     @SuppressForbidden(reason = "relies on reflection")
     private static MethodKey resolveMethodReference(Class<?> clazz, Object ref, Class<?>... args) {
         try {
-            Method writeReplace = ref.getClass().getDeclaredMethod("writeReplace");
-            writeReplace.setAccessible(true);
-
-            SerializedLambda serialized = (SerializedLambda) writeReplace.invoke(ref);
-            String className = serialized.getImplClass();
-            String methodName = serialized.getImplMethodName();
-
-            assertImplementationClass(clazz, className);
-
-            return new MethodKey(
-                resolveDeclaringClass(clazz, methodName, args).getTypeName().replace(".", "/"),
-                methodName,
-                Arrays.stream(args).map(ClassMethodBuilder::getParameterTypeName).toList()
-            );
+            return resolveMethodReferenceViaSerializedLambda(clazz, ref, args);
         } catch (Exception e) {
+            if (clazz.isInterface()) {
+                try {
+                    return resolveMethodReferenceViaProxy(clazz, ref, args);
+                } catch (Exception proxyException) {
+                    proxyException.addSuppressed(e);
+                    throw new RuntimeException(
+                        "Error occurred when inspecting class: "
+                            + clazz.getName()
+                            + "; SerializedLambda resolution failed and proxy fallback failed",
+                        proxyException
+                    );
+                }
+            }
             throw new RuntimeException("Error occurred when inspecting class: " + clazz.getName(), e);
         }
     }
 
-    private static String getParameterTypeName(Class<?> clazz) {
-        if (clazz.isArray()) {
-            return clazz.getComponentType().getName() + "[]";
+    @SuppressForbidden(reason = "relies on reflection")
+    private static MethodKey resolveMethodReferenceViaSerializedLambda(Class<?> clazz, Object ref, Class<?>... args) throws Exception {
+        Method writeReplace = ref.getClass().getDeclaredMethod("writeReplace");
+        writeReplace.setAccessible(true);
+
+        SerializedLambda serialized = (SerializedLambda) writeReplace.invoke(ref);
+        String className = serialized.getImplClass();
+        String methodName = serialized.getImplMethodName();
+
+        assertImplementationClass(clazz, className);
+
+        return new MethodKey(
+            resolveDeclaringClass(clazz, methodName, args).getTypeName().replace(".", "/"),
+            methodName,
+            Arrays.stream(args).map(TypeUtils::getParameterTypeName).toList()
+        );
+    }
+
+    /**
+     * Resolves a method reference for an interface type by invoking the lambda with a recording proxy.
+     * The proxy records which method was invoked; we then build a MethodKey from that Method.
+     * Only used when SerializedLambda resolution fails (e.g. interface method refs pointing at synthetic classes).
+     */
+    @SuppressForbidden(reason = "relies on reflection")
+    private static MethodKey resolveMethodReferenceViaProxy(Class<?> clazz, Object ref, Class<?>... args) throws Exception {
+        var holder = new Object() {
+            Method recordedMethod;
+        };
+        InvocationHandler handler = (proxy, method, methodArgs) -> {
+            holder.recordedMethod = method;
+            return TypeUtils.defaultValueFor(method.getReturnType());
+        };
+        Object proxy = Proxy.newProxyInstance(clazz.getClassLoader(), new Class<?>[] { clazz }, handler);
+
+        Object[] callArgs = new Object[1 + args.length];
+        callArgs[0] = proxy;
+        for (int i = 0; i < args.length; i++) {
+            callArgs[1 + i] = TypeUtils.defaultValueFor(args[i]);
         }
-        return clazz.getName();
+
+        if (ref instanceof VarargCallAdapter<?> adapter) {
+            adapter.asVarargCall().call(callArgs);
+        } else {
+            Class<?>[] paramTypes = new Class<?>[1 + args.length];
+            paramTypes[0] = clazz;
+            System.arraycopy(args, 0, paramTypes, 1, args.length);
+            Method callMethod = ref.getClass().getMethod("call", paramTypes);
+            callMethod.invoke(ref, callArgs);
+        }
+
+        if (holder.recordedMethod == null) {
+            throw new IllegalStateException(
+                "Proxy fallback only supports instance method references; no method was invoked on the proxy for "
+                    + clazz.getName()
+                    + ". If this is a static method reference, resolution must use SerializedLambda."
+            );
+        }
+        return methodKeyFromMethod(holder.recordedMethod);
+    }
+
+    private static MethodKey methodKeyFromMethod(Method method) {
+        String className = method.getDeclaringClass().getName().replace(".", "/");
+        String methodName = method.getName();
+        List<String> parameterTypes = Arrays.stream(method.getParameterTypes()).map(TypeUtils::getParameterTypeName).toList();
+        return new MethodKey(className, methodName, parameterTypes);
     }
 
     private static void assertImplementationClass(Class<?> clazz, String implClassName) throws ClassNotFoundException {
@@ -1120,7 +1185,7 @@ public class ClassMethodBuilder<T> {
             return clazz;
         }
 
-        Class<?>[] resolvedArgs = Arrays.stream(args).map(ClassMethodBuilder::toPrimitiveIfBoxed).toArray(Class[]::new);
+        Class<?>[] resolvedArgs = Arrays.stream(args).map(TypeUtils::toPrimitive).toArray(Class[]::new);
         Class<?> current = clazz;
         while (current != null) {
             try {
@@ -1132,37 +1197,6 @@ public class ClassMethodBuilder<T> {
         }
 
         throw new NoSuchMethodException("Method " + methodName + " not found on class hierarchy of " + clazz.getName());
-    }
-
-    private static Class<?> toPrimitiveIfBoxed(Class<?> type) {
-        if (type == Boolean.class) {
-            return boolean.class;
-        }
-        if (type == Byte.class) {
-            return byte.class;
-        }
-        if (type == Short.class) {
-            return short.class;
-        }
-        if (type == Character.class) {
-            return char.class;
-        }
-        if (type == Integer.class) {
-            return int.class;
-        }
-        if (type == Long.class) {
-            return long.class;
-        }
-        if (type == Float.class) {
-            return float.class;
-        }
-        if (type == Double.class) {
-            return double.class;
-        }
-        if (type == Void.class) {
-            return void.class;
-        }
-        return type;
     }
 
     private MethodKey getConstructorMethodKey(Class<?>... args) {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/util/TypeUtils.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/util/TypeUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.util;
+
+import java.util.Map;
+
+/**
+ * Utilities for mapping between primitive and boxed types and for obtaining default values.
+ * Used when resolving method references and building instrumentation metadata.
+ */
+public final class TypeUtils {
+
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_BOXED = Map.of(
+        boolean.class,
+        Boolean.class,
+        byte.class,
+        Byte.class,
+        short.class,
+        Short.class,
+        char.class,
+        Character.class,
+        int.class,
+        Integer.class,
+        long.class,
+        Long.class,
+        float.class,
+        Float.class,
+        double.class,
+        Double.class,
+        void.class,
+        Void.class
+    );
+
+    private static final Map<Class<?>, Class<?>> BOXED_TO_PRIMITIVE = Map.of(
+        Boolean.class,
+        boolean.class,
+        Byte.class,
+        byte.class,
+        Short.class,
+        short.class,
+        Character.class,
+        char.class,
+        Integer.class,
+        int.class,
+        Long.class,
+        long.class,
+        Float.class,
+        float.class,
+        Double.class,
+        double.class,
+        Void.class,
+        void.class
+    );
+
+    private TypeUtils() {}
+
+    /**
+     * Returns the primitive type corresponding to the given type, or the type itself if it is not a boxed primitive.
+     */
+    public static Class<?> toPrimitive(Class<?> type) {
+        return BOXED_TO_PRIMITIVE.getOrDefault(type, type);
+    }
+
+    /**
+     * Returns the boxed type corresponding to the given type, or the type itself if it is not a primitive.
+     */
+    public static Class<?> toBoxed(Class<?> type) {
+        return PRIMITIVE_TO_BOXED.getOrDefault(type, type);
+    }
+
+    /**
+     * Returns a default value for the given type (e.g. 0 for int, false for boolean, null for reference types).
+     */
+    public static Object defaultValueFor(Class<?> type) {
+        if (type == void.class || type == Void.class) {
+            return null;
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return false;
+        }
+        if (type == byte.class || type == Byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class || type == Short.class) {
+            return (short) 0;
+        }
+        if (type == char.class || type == Character.class) {
+            return (char) 0;
+        }
+        if (type == int.class || type == Integer.class) {
+            return 0;
+        }
+        if (type == long.class || type == Long.class) {
+            return 0L;
+        }
+        if (type == float.class || type == Float.class) {
+            return 0f;
+        }
+        if (type == double.class || type == Double.class) {
+            return 0d;
+        }
+        return null;
+    }
+
+    /**
+     * Returns a string suitable for use as a parameter type in instrumentation keys (e.g. method descriptors).
+     * Uses {@link Class#getName()} and appends "[]" for array component types.
+     */
+    public static String getParameterTypeName(Class<?> clazz) {
+        if (clazz.isArray()) {
+            return clazz.getComponentType().getName() + "[]";
+        }
+        return clazz.getName();
+    }
+}

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/DslTestTypes.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/DslTestTypes.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.rules;
+
+/**
+ * Dummy types for testing the EntitlementRulesBuilder DSL. Do not use real JDK types
+ * in DSL tests so behaviour is stable across implementations and JDK versions.
+ */
+public final class DslTestTypes {
+
+    private DslTestTypes() {}
+
+    /** Concrete class: instance/static/void methods and constructors. */
+    public static class Concrete {
+        public Concrete() {}
+
+        public Concrete(String arg) {}
+
+        public boolean noArg() {
+            return true;
+        }
+
+        public String withArg(String a) {
+            return a;
+        }
+
+        public int withInt(int x) {
+            return x;
+        }
+
+        public void voidNoArg() {}
+
+        public void voidWithArg(String a) {}
+
+        public static boolean staticNoArg() {
+            return true;
+        }
+
+        public static String staticWithArg(int i) {
+            return String.valueOf(i);
+        }
+
+        public static void staticVoidNoArg() {}
+
+        public static void staticVoidWithArg(String a) {}
+
+        public void overloaded(int i) {}
+
+        public void overloaded(String s) {}
+
+        public String withArray(byte[] bytes) {
+            return bytes == null ? null : String.valueOf(bytes.length);
+        }
+    }
+
+    /** Abstract class for testing SerializedLambda resolution on abstract types. */
+    public abstract static class Abstract {
+        public abstract boolean abstractMethod();
+
+        public abstract String abstractWithArg(String a);
+    }
+
+    /** Concrete subclass of Abstract so we can use method references (e.g. AbstractSub::abstractMethod). */
+    public static class AbstractSub extends Abstract {
+        @Override
+        public boolean abstractMethod() {
+            return true;
+        }
+
+        @Override
+        public String abstractWithArg(String a) {
+            return a;
+        }
+    }
+
+    /** Interface for testing proxy-based method reference resolution. */
+    public interface TargetInterface {
+        int noArg();
+
+        String withArg(String a);
+    }
+
+    /** Second dummy type for "multiple classes" tests. */
+    public static class OtherDummy {
+        public String noArg() {
+            return "other";
+        }
+    }
+
+    /** Dummy with generic-style method for TypeToken tests. */
+    public static class DummyWithGeneric {
+        public static Object takeOne(int i) {
+            return i;
+        }
+
+        public static String takeOneStatic(int i) {
+            return String.valueOf(i);
+        }
+    }
+}

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/EntitlementRulesBuilderTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/EntitlementRulesBuilderTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.rules;
+
+import org.elasticsearch.entitlement.instrumentation.MethodKey;
+import org.elasticsearch.entitlement.runtime.registry.InstrumentationRegistryImpl;
+import org.elasticsearch.entitlement.runtime.registry.InternalInstrumentationRegistry;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.entitlement.rules.DslTestTypes.AbstractSub;
+import static org.elasticsearch.entitlement.rules.DslTestTypes.Concrete;
+import static org.elasticsearch.entitlement.rules.DslTestTypes.DummyWithGeneric;
+import static org.elasticsearch.entitlement.rules.DslTestTypes.OtherDummy;
+import static org.elasticsearch.entitlement.rules.DslTestTypes.TargetInterface;
+
+/**
+ * Unit tests for the EntitlementRulesBuilder DSL. Asserts that rules registered via the DSL
+ * appear in the registry with the correct MethodKeys. No bytecode instrumentation.
+ */
+public class EntitlementRulesBuilderTests extends ESTestCase {
+
+    private static final String CONCRETE_INTERNAL = "org/elasticsearch/entitlement/rules/DslTestTypes$Concrete";
+    private static final String ABSTRACT_SUB_INTERNAL = "org/elasticsearch/entitlement/rules/DslTestTypes$AbstractSub";
+    private static final String TARGET_IFACE_INTERNAL = "org/elasticsearch/entitlement/rules/DslTestTypes$TargetInterface";
+    private static final String OTHER_DUMMY_INTERNAL = "org/elasticsearch/entitlement/rules/DslTestTypes$OtherDummy";
+    private static final String DUMMY_WITH_GENERIC_INTERNAL = "org/elasticsearch/entitlement/rules/DslTestTypes$DummyWithGeneric";
+
+    private InternalInstrumentationRegistry newRegistry() {
+        return new InstrumentationRegistryImpl(null);
+    }
+
+    private EntitlementRulesBuilder newBuilder(InternalInstrumentationRegistry registry) {
+        return new EntitlementRulesBuilder(registry);
+    }
+
+    private void assertHasRule(InternalInstrumentationRegistry registry, MethodKey expectedKey) {
+        assertTrue(
+            "Expected registry to contain " + expectedKey + " but had: " + registry.getInstrumentedMethods().keySet(),
+            registry.getInstrumentedMethods().containsKey(expectedKey)
+        );
+    }
+
+    private Map<MethodKey, ?> methods(InternalInstrumentationRegistry registry) {
+        return registry.getInstrumentedMethods();
+    }
+
+    public void testOnConcreteClassInstanceMethod() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).calling(Concrete::noArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "noArg", List.of()));
+    }
+
+    public void testOnConcreteClassInstanceMethodWithParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .calling(Concrete::withArg, String.class)
+            .enforce((a, b) -> Policies.empty())
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "withArg", List.of("java.lang.String")));
+    }
+
+    public void testOnInterfaceInstanceMethod() {
+        var registry = newRegistry();
+        newBuilder(registry).on(TargetInterface.class).calling(TargetInterface::noArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(TARGET_IFACE_INTERNAL, "noArg", List.of()));
+    }
+
+    public void testOnInterfaceInstanceMethodWithParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(TargetInterface.class)
+            .calling(TargetInterface::withArg, String.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(TARGET_IFACE_INTERNAL, "withArg", List.of("java.lang.String")));
+    }
+
+    public void testOnAbstractClassInstanceMethod() {
+        var registry = newRegistry();
+        newBuilder(registry).on(AbstractSub.class).calling(AbstractSub::abstractMethod).enforce(Policies::empty).elseThrowNotEntitled();
+        // Method is implemented (declared) in AbstractSub, so declaring class is AbstractSub
+        assertHasRule(registry, new MethodKey(ABSTRACT_SUB_INTERNAL, "abstractMethod", List.of()));
+    }
+
+    public void testStaticMethodWithReturn() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).callingStatic(Concrete::staticNoArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "staticNoArg", List.of()));
+    }
+
+    public void testStaticMethodWithParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .callingStatic(Concrete::staticWithArg, Integer.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "staticWithArg", List.of("java.lang.Integer")));
+    }
+
+    public void testStaticVoidMethod() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .callingVoidStatic(Concrete::staticVoidNoArg)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "staticVoidNoArg", List.of()));
+    }
+
+    public void testStaticVoidMethodWithParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .callingVoidStatic(Concrete::staticVoidWithArg, String.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "staticVoidWithArg", List.of("java.lang.String")));
+    }
+
+    public void testInstanceVoidMethod() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).callingVoid(Concrete::voidNoArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "voidNoArg", List.of()));
+    }
+
+    public void testInstanceVoidMethodWithParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .callingVoid(Concrete::voidWithArg, String.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "voidWithArg", List.of("java.lang.String")));
+    }
+
+    public void testProtectedCtorNoArg() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).protectedCtor().enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "<init>", List.of()));
+    }
+
+    public void testProtectedCtorWithArg() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).protectedCtor(String.class).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "<init>", List.of("java.lang.String")));
+    }
+
+    public void testTypeTokenParameter() {
+        var registry = newRegistry();
+        newBuilder(registry).on(DummyWithGeneric.class)
+            .callingStatic(DummyWithGeneric::takeOne, TypeToken.of(Integer.class))
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(DUMMY_WITH_GENERIC_INTERNAL, "takeOne", List.of("java.lang.Integer")));
+    }
+
+    public void testOnClassName() {
+        var registry = newRegistry();
+        var className = Concrete.class.getName();
+        newBuilder(registry).on(className, Concrete.class).calling(Concrete::noArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "noArg", List.of()));
+    }
+
+    public void testOnClassWithConsumer() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class, b -> b.calling(Concrete::noArg).enforce(Policies::empty).elseThrowNotEntitled());
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "noArg", List.of()));
+    }
+
+    public void testOnMultipleClasses() {
+        var registry = newRegistry();
+        var builder = newBuilder(registry);
+        builder.on(Concrete.class).calling(Concrete::noArg).enforce(Policies::empty).elseThrowNotEntitled();
+        builder.on(OtherDummy.class).calling(OtherDummy::noArg).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "noArg", List.of()));
+        assertHasRule(registry, new MethodKey(OTHER_DUMMY_INTERNAL, "noArg", List.of()));
+        assertEquals(2, methods(registry).size());
+    }
+
+    public void testMultipleRulesSameClass() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .calling(Concrete::noArg)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled()
+            .calling(Concrete::withArg, String.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "noArg", List.of()));
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "withArg", List.of("java.lang.String")));
+        assertEquals(2, methods(registry).size());
+    }
+
+    public void testOverloadedMethodDifferentKeys() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class)
+            .callingVoid(Concrete::overloaded, Integer.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled()
+            .callingVoid(Concrete::overloaded, String.class)
+            .enforce(Policies::empty)
+            .elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "overloaded", List.of("java.lang.Integer")));
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "overloaded", List.of("java.lang.String")));
+        assertEquals(2, methods(registry).size());
+    }
+
+    public void testPrimitiveParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).calling(Concrete::withInt, Integer.class).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "withInt", List.of("java.lang.Integer")));
+    }
+
+    public void testArrayParam() {
+        var registry = newRegistry();
+        newBuilder(registry).on(Concrete.class).calling(Concrete::withArray, byte[].class).enforce(Policies::empty).elseThrowNotEntitled();
+        assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "withArray", List.of("byte[]")));
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Support interface types in entitlement rule definitions (#144447)