### PR TITLE
Enable multimodal inputs for all chat completion integrations

### DIFF
--- a/docs/changelog/144509.yaml
+++ b/docs/changelog/144509.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 144509
+summary: Enable multimodal inputs for all chat completion integrations
+type: enhancement

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
@@ -56,7 +56,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwUnsupportedEmbeddingOperation;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwUnsupportedMultimodalUnifiedCompletionOperation;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwUnsupportedReasoningUnifiedCompletionOperation;
 
 public abstract class SenderService<M extends Model> implements InferenceService {
@@ -201,18 +200,11 @@ public abstract class SenderService<M extends Model> implements InferenceService
         ActionListener<InferenceServiceResults> listener
     ) {
         SubscribableListener.newForked(this::init).<InferenceServiceResults>andThen((completionInferListener) -> {
-            if (supportsMultimodalCompletions() == false && request.containsMultimodalContent()) {
-                throwUnsupportedMultimodalUnifiedCompletionOperation(name());
-            }
             if (supportsChatCompletionReasoning() == false && request.containsChatCompletionReasoning()) {
                 throwUnsupportedReasoningUnifiedCompletionOperation(name());
             }
             doUnifiedCompletionInfer(model, new UnifiedChatInput(request, true), timeout, completionInferListener);
         }).addListener(listener);
-    }
-
-    protected boolean supportsMultimodalCompletions() {
-        return false;
     }
 
     protected boolean supportsChatCompletionReasoning() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceUtils.java
@@ -998,10 +998,6 @@ public final class ServiceUtils {
         throwUnsupportedTaskOperation(serviceName, "unified completion");
     }
 
-    public static void throwUnsupportedMultimodalUnifiedCompletionOperation(String serviceName) {
-        throwUnsupportedTaskOperation(serviceName, "unified completion with non-text inputs");
-    }
-
     public static void throwUnsupportedReasoningUnifiedCompletionOperation(String serviceName) {
         throwUnsupportedTaskOperation(serviceName, "unified completion with reasoning inputs");
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -208,11 +208,6 @@ public class ElasticInferenceService extends SenderService<ElasticInferenceServi
     }
 
     @Override
-    protected boolean supportsMultimodalCompletions() {
-        return true;
-    }
-
-    @Override
     protected boolean supportsChatCompletionReasoning() {
         return true;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerService.java
@@ -53,7 +53,6 @@ import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_P
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.invalidModelTypeForUpdateModelWithEmbeddingDetails;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwUnsupportedEmbeddingOperation;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwUnsupportedMultimodalUnifiedCompletionOperation;
 
 public class SageMakerService implements InferenceService, RerankingInferenceService {
     public static final String NAME = "amazon_sagemaker";
@@ -243,10 +242,6 @@ public class SageMakerService implements InferenceService, RerankingInferenceSer
         if (model instanceof SageMakerModel == false) {
             listener.onFailure(createInvalidModelException(model));
             return;
-        }
-
-        if (request.containsMultimodalContent()) {
-            throwUnsupportedMultimodalUnifiedCompletionOperation(NAME);
         }
 
         try {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
@@ -299,35 +299,38 @@ public class SenderServiceTests extends ESTestCase {
         }
     }
 
-    public void testMultimodalChatCompletionNotSupportedByDefault() throws IOException {
+    public void testMultimodalChatCompletionSupportedByDefault() throws IOException {
         var sender = createMockSender();
 
         var factory = mock(HttpRequestSender.Factory.class);
         when(factory.createSender()).thenReturn(sender);
 
-        try (var service = new TestSenderService(factory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
-            PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-            var request = new UnifiedCompletionRequest(
-                List.of(
-                    new Message(
-                        new ContentObjects(List.of(randomContentObjectText(), randomContentObjectImage(), randomContentObjectFile())),
-                        "user",
-                        null,
-                        null
-                    )
-                ),
-                null,
-                null,
-                null,
-                null,
-                null,
+        List<Message> messages = List.of(
+            new Message(
+                new ContentObjects(List.of(randomContentObjectText(), randomContentObjectImage(), randomContentObjectFile())),
+                "user",
                 null,
                 null
-            );
+            )
+        );
+        var service = new TestSenderService(factory, createWithEmptySettings(threadPool), mockClusterServiceEmpty()) {
+            @Override
+            protected void doUnifiedCompletionInfer(
+                Model model,
+                UnifiedChatInput inputs,
+                TimeValue timeout,
+                ActionListener<InferenceServiceResults> listener
+            ) {
+                assertThat(inputs.getRequest().messages(), is(messages));
+                listener.onResponse(mock(InferenceServiceResults.class));
+            }
+        };
+        try (service) {
+            PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+            var request = new UnifiedCompletionRequest(messages, null, null, null, null, null, null, null);
             service.unifiedCompletionInfer(mock(Model.class), request, TIMEOUT, listener);
 
-            var exception = assertThrows(UnsupportedOperationException.class, () -> listener.actionGet(TIMEOUT));
-            assertThat(exception.getMessage(), is("The test service service does not support unified completion with non-text inputs"));
+            listener.actionGet(TIMEOUT);
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointWith
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -28,10 +27,7 @@ import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.inference.UnparsedModel;
-import org.elasticsearch.inference.completion.ContentObjects;
-import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings;
@@ -62,9 +58,6 @@ import static org.elasticsearch.action.ActionListener.assertOnce;
 import static org.elasticsearch.action.support.ActionTestUtils.assertNoFailureListener;
 import static org.elasticsearch.action.support.ActionTestUtils.assertNoSuccessListener;
 import static org.elasticsearch.core.TimeValue.THIRTY_SECONDS;
-import static org.elasticsearch.xpack.core.inference.action.UnifiedCompletionRequestTests.randomContentObjectFile;
-import static org.elasticsearch.xpack.core.inference.action.UnifiedCompletionRequestTests.randomContentObjectImage;
-import static org.elasticsearch.xpack.core.inference.action.UnifiedCompletionRequestTests.randomContentObjectText;
 import static org.elasticsearch.xpack.core.inference.action.UnifiedCompletionRequestTests.randomTextInputOnlyUnifiedCompletionRequest;
 import static org.elasticsearch.xpack.core.inference.action.UnifiedCompletionRequestTests.randomUnifiedCompletionRequest;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterService;
@@ -402,35 +395,6 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
         );
         verify(client, only()).invokeStream(any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
-    }
-
-    public void testUnifiedInferDoesNotSupportMultimodalContent() {
-        var model = mockModel();
-
-        var request = new UnifiedCompletionRequest(
-            List.of(
-                new Message(
-                    new ContentObjects(List.of(randomContentObjectText(), randomContentObjectImage(), randomContentObjectFile())),
-                    "user",
-                    null,
-                    null
-                )
-            ),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-
-        PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-        var exception = assertThrows(
-            UnsupportedOperationException.class,
-            () -> sageMakerService.unifiedCompletionInfer(model, request, THIRTY_SECONDS, listener)
-        );
-        assertThat(exception.getMessage(), is("The amazon_sagemaker service does not support unified completion with non-text inputs"));
     }
 
     public void testUnifiedInferError() {


### PR DESCRIPTION
This commit removes the check for whether an inference API integration supports multimodal chat completion inputs in
SenderService.unifiedCompletionInfer(), which allows any integration which supports the chat completion task type to accept multimodal inputs. If a user sends a request containing multimodal inputs to a model that doesn't support them, the request will fail with an error from the provider.