### PR TITLE
Remove max_tokens parameter from reasoning and update validation logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/completion/Reasoning.java
+++ b/server/src/main/java/org/elasticsearch/inference/completion/Reasoning.java
@@ -26,17 +26,14 @@ import java.util.Locale;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.EFFORT_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.ENABLED_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.EXCLUDE_FIELD;
-import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MAX_TOKENS_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.SUMMARY_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.getUnrecognizedTypeException;
-import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.validateNonNegativeLong;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * This class represents the reasoning configuration for a completion request.
  * It encapsulates various parameters that control the reasoning process.
  * @param effort The {@link ReasoningEffort} level to apply. This is an optional parameter.
- * @param maxTokens The maximum number of tokens to use for reasoning. This is an optional parameter.
  * @param summary The {@link ReasoningSummary} level to provide. This is an optional parameter.
  * @param exclude Whether to exclude reasoning from the response. This is an optional parameter.
  * @param enabled Whether to enable reasoning. This is an optional parameter.
@@ -45,7 +42,6 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  */
 public record Reasoning(
     @Nullable ReasoningEffort effort,
-    @Nullable Long maxTokens,
     @Nullable ReasoningSummary summary,
     @Nullable Boolean exclude,
     @Nullable Boolean enabled
@@ -56,31 +52,21 @@ public record Reasoning(
     public static final ConstructingObjectParser<Reasoning, Void> PARSER = new ConstructingObjectParser<>(
         Reasoning.class.getSimpleName(),
         args -> {
-            // Extract the fields from the parsed arguments, handling nullability and type conversion as needed
             final var effort = args[0] == null ? null : ReasoningEffort.fromString((String) args[0]);
-            final var maxTokens = (Long) args[1];
-            final var summary = args[2] == null ? null : ReasoningSummary.fromString((String) args[2]);
-            final var exclude = (Boolean) args[3];
-            final var enabled = (Boolean) args[4];
+            final var summary = args[1] == null ? null : ReasoningSummary.fromString((String) args[1]);
+            final var exclude = (Boolean) args[2];
+            final var enabled = (Boolean) args[3];
 
-            // Validate the effort, maxTokens, and enabled fields according to the defined rules
-            validateFields(effort, maxTokens, enabled);
+            validateFields(effort, enabled);
 
-            // If validation passes, construct and return the Reasoning object
-            return new Reasoning(effort, maxTokens, summary, exclude, enabled);
+            return new Reasoning(effort, summary, exclude, enabled);
         }
     );
 
     static {
-        /*
-         * The reasoning configuration requires at least one of [effort, max_tokens, enabled] to be provided.
-         * [effort] and [max_tokens] cannot be specified together as they represent different ways to configure reasoning.
-         */
-        PARSER.declareRequiredFieldSet(EFFORT_FIELD, MAX_TOKENS_FIELD, ENABLED_FIELD);
-        PARSER.declareExclusiveFieldSet(EFFORT_FIELD, MAX_TOKENS_FIELD);
+        PARSER.declareRequiredFieldSet(EFFORT_FIELD, ENABLED_FIELD);
 
         PARSER.declareString(optionalConstructorArg(), new ParseField(EFFORT_FIELD));
-        PARSER.declareLong(optionalConstructorArg(), new ParseField(MAX_TOKENS_FIELD));
         PARSER.declareString(optionalConstructorArg(), new ParseField(SUMMARY_FIELD));
         PARSER.declareBoolean(optionalConstructorArg(), new ParseField(EXCLUDE_FIELD));
         PARSER.declareBoolean(optionalConstructorArg(), new ParseField(ENABLED_FIELD));
@@ -90,27 +76,20 @@ public record Reasoning(
      * Method to validate the reasoning configuration.
      * It ensures that:
      * <ul>
-     *     <li>If [effort] and [max_tokens] are null and [enabled] is false, an exception is thrown.</li>
-     *     <li>[max_tokens] must be greater than or equal to 0. If [max_tokens] is negative, an exception is thrown.</li>
+     *     <li>If [effort] is null and [enabled] is false, an exception is thrown.</li>
      * </ul>
      * @param effort The reasoning effort level to validate.
-     * @param maxTokens The maximum number of tokens for reasoning to validate.
      * @param enabled `enabled` field to validate.
      */
-    private static void validateFields(@Nullable ReasoningEffort effort, @Nullable Long maxTokens, @Nullable Boolean enabled) {
-        if (Boolean.FALSE.equals(enabled) && effort == null && maxTokens == null) {
-            throw new ElasticsearchStatusException(
-                "When [enabled] is false, either [effort] or [max_tokens] must be specified.",
-                RestStatus.BAD_REQUEST
-            );
+    private static void validateFields(@Nullable ReasoningEffort effort, @Nullable Boolean enabled) {
+        if (Boolean.FALSE.equals(enabled) && effort == null) {
+            throw new ElasticsearchStatusException("When [enabled] is false, [effort] must be specified.", RestStatus.BAD_REQUEST);
         }
-        validateNonNegativeLong(maxTokens, MAX_TOKENS_FIELD);
     }
 
     public Reasoning(StreamInput in) throws IOException {
         this(
             in.readOptionalEnum(ReasoningEffort.class),
-            in.readOptionalVLong(),
             in.readOptionalEnum(ReasoningSummary.class),
             in.readOptionalBoolean(),
             in.readOptionalBoolean()
@@ -120,7 +99,6 @@ public record Reasoning(
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalEnum(effort);
-        out.writeOptionalVLong(maxTokens);
         out.writeOptionalEnum(summary);
         out.writeOptionalBoolean(exclude);
         out.writeOptionalBoolean(enabled);
@@ -131,9 +109,6 @@ public record Reasoning(
         builder.startObject();
         if (effort != null) {
             builder.field(EFFORT_FIELD, effort);
-        }
-        if (maxTokens != null) {
-            builder.field(MAX_TOKENS_FIELD, maxTokens);
         }
         if (summary != null) {
             builder.field(SUMMARY_FIELD, summary);

--- a/server/src/test/java/org/elasticsearch/inference/completion/ReasoningTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/completion/ReasoningTests.java
@@ -29,7 +29,6 @@ import static org.elasticsearch.inference.completion.Reasoning.ReasoningSummary;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.EFFORT_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.ENABLED_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.EXCLUDE_FIELD;
-import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MAX_TOKENS_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.SUMMARY_FIELD;
 import static org.hamcrest.Matchers.is;
 
@@ -47,7 +46,7 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
 
         try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
             var reasoning = Reasoning.PARSER.apply(parser, null);
-            var expected = new Reasoning(ReasoningEffort.MEDIUM, null, ReasoningSummary.DETAILED, false, false);
+            var expected = new Reasoning(ReasoningEffort.MEDIUM, ReasoningSummary.DETAILED, false, false);
 
             assertThat(reasoning, is(expected));
         }
@@ -62,22 +61,7 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
 
         try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
             var reasoning = Reasoning.PARSER.apply(parser, null);
-            var expected = new Reasoning(ReasoningEffort.MEDIUM, null, null, null, null);
-
-            assertThat(reasoning, is(expected));
-        }
-    }
-
-    public void testParsingReasoning_OnlyMaxTokens() throws IOException {
-        String reasoningJson = """
-            {
-                "max_tokens": 25
-            }
-            """;
-
-        try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
-            var reasoning = Reasoning.PARSER.apply(parser, null);
-            var expected = new Reasoning(null, 25L, null, null, null);
+            var expected = new Reasoning(ReasoningEffort.MEDIUM, null, null, null);
 
             assertThat(reasoning, is(expected));
         }
@@ -92,23 +76,9 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
 
         try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
             var reasoning = Reasoning.PARSER.apply(parser, null);
-            var expected = new Reasoning(null, null, null, null, true);
+            var expected = new Reasoning(null, null, null, true);
 
             assertThat(reasoning, is(expected));
-        }
-    }
-
-    public void testParsingReasoning_BothEffortAndMaxTokens_ThrowsException() throws IOException {
-        String reasoningJson = """
-            {
-                "effort": "medium",
-                "max_tokens": 25
-            }
-            """;
-
-        try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
-            var exception = assertThrows(IllegalArgumentException.class, () -> Reasoning.PARSER.apply(parser, null));
-            assertThat(exception.getMessage(), is("The following fields are not allowed together: [effort, max_tokens] "));
         }
     }
 
@@ -125,7 +95,7 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
                 exception,
                 ElasticsearchStatusException.class
             );
-            assertThat(rootCause.getMessage(), is("When [enabled] is false, either [effort] or [max_tokens] must be specified."));
+            assertThat(rootCause.getMessage(), is("When [enabled] is false, [effort] must be specified."));
             assertThat(rootCause.status(), is(RestStatus.BAD_REQUEST));
         }
     }
@@ -135,7 +105,7 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
 
         try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
             var exception = assertThrows(IllegalArgumentException.class, () -> Reasoning.PARSER.apply(parser, null));
-            assertThat(exception.getMessage(), is("Required one of fields [effort, max_tokens, enabled], but none were specified."));
+            assertThat(exception.getMessage(), is("Required one of fields [effort, enabled], but none were specified."));
         }
     }
 
@@ -182,24 +152,6 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
         }
     }
 
-    public void testParsingReasoning_MaxTokensLessThanZero_ThrowsException() throws IOException {
-        String reasoningJson = """
-            {
-                "max_tokens": -1
-            }
-            """;
-
-        try (var parser = createParser(JsonXContent.jsonXContent, reasoningJson)) {
-            var exception = assertThrows(XContentParseException.class, () -> Reasoning.PARSER.apply(parser, null));
-            ElasticsearchStatusException rootCause = (ElasticsearchStatusException) ExceptionsHelper.unwrap(
-                exception,
-                ElasticsearchStatusException.class
-            );
-            assertThat(rootCause.getMessage(), is("Field [max_tokens] must be non-negative, but was [-1]"));
-            assertThat(rootCause.status(), is(RestStatus.BAD_REQUEST));
-        }
-    }
-
     public void testParsingReasoning_UnknownField_ThrowsException() throws IOException {
         String reasoningJson = """
             {
@@ -238,19 +190,17 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
     @Override
     protected Reasoning mutateInstance(Reasoning instance) throws IOException {
         ReasoningEffort effort = instance.effort();
-        Long maxTokens = instance.maxTokens();
         ReasoningSummary summary = instance.summary();
         Boolean exclude = instance.exclude();
         Boolean enabled = instance.enabled();
 
         // Build eligible fields for mutation following the validation rules of Reasoning class.
         // This prevents mutation of fields that would lead to an invalid Reasoning instance.
-        var eligibleFields = buildEligibleFields(effort, maxTokens);
+        var eligibleFields = buildEligibleFields(effort);
 
         // Randomly select one eligible field to mutate.
         switch (randomFrom(eligibleFields)) {
             case EFFORT_FIELD -> effort = randomValueOtherThan(effort, () -> randomFrom(ReasoningEffort.values()));
-            case MAX_TOKENS_FIELD -> maxTokens = randomValueOtherThan(maxTokens, ESTestCase::randomNonNegativeLong);
             case SUMMARY_FIELD -> summary = randomValueOtherThan(
                 summary,
                 () -> randomBoolean() ? randomFrom(ReasoningSummary.values()) : null
@@ -260,11 +210,11 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
             default -> throw new AssertionError("Illegal mutation branch");
         }
         // Return new Reasoning instance. Business rules are enforced by eligible field selection.
-        return new Reasoning(effort, maxTokens, summary, exclude, enabled);
+        return new Reasoning(effort, summary, exclude, enabled);
     }
 
-    private static Set<String> buildEligibleFields(ReasoningEffort effort, Long maxTokens) {
-        var eligibleFields = new HashSet<String>(5);
+    private static Set<String> buildEligibleFields(ReasoningEffort effort) {
+        var eligibleFields = new HashSet<String>(4);
         // Summary and exclude are always eligible for mutation
         eligibleFields.add(SUMMARY_FIELD);
         eligibleFields.add(EXCLUDE_FIELD);
@@ -272,12 +222,8 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
         if (effort != null) {
             eligibleFields.add(EFFORT_FIELD);
         }
-        // Only mutate maxTokens if present
-        if (maxTokens != null) {
-            eligibleFields.add(MAX_TOKENS_FIELD);
-        }
-        // Only mutate enabled if effort or maxTokens is present
-        if (effort != null || maxTokens != null) {
+        // Only mutate enabled if effort is present
+        if (effort != null) {
             eligibleFields.add(ENABLED_FIELD);
         }
         return eligibleFields;
@@ -285,20 +231,13 @@ public class ReasoningTests extends AbstractBWCSerializationTestCase<Reasoning> 
 
     public static Reasoning randomReasoning() {
         var effort = randomBoolean() ? randomFrom(ReasoningEffort.values()) : null;
-        var maxTokens = (effort == null && randomBoolean()) ? randomNonNegativeLong() : null;
         Boolean enabled;
-        if (effort == null && maxTokens == null) {
+        if (effort == null) {
             enabled = true;
         } else {
             enabled = randomOptionalBoolean();
         }
-        return new Reasoning(
-            effort,
-            maxTokens,
-            randomBoolean() ? randomFrom(ReasoningSummary.values()) : null,
-            randomOptionalBoolean(),
-            enabled
-        );
+        return new Reasoning(effort, randomBoolean() ? randomFrom(ReasoningSummary.values()) : null, randomOptionalBoolean(), enabled);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
@@ -213,7 +213,7 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
                     )
                 ),
                 0.2F,
-                new Reasoning(Reasoning.ReasoningEffort.MEDIUM, null, Reasoning.ReasoningSummary.DETAILED, false, false)
+                new Reasoning(Reasoning.ReasoningEffort.MEDIUM, Reasoning.ReasoningSummary.DETAILED, false, false)
             );
 
             assertThat(request, is(expected));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1152,7 +1152,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 null,
                 null,
                 null,
-                new Reasoning(Reasoning.ReasoningEffort.MEDIUM, null, Reasoning.ReasoningSummary.DETAILED, false, false)
+                new Reasoning(Reasoning.ReasoningEffort.MEDIUM, Reasoning.ReasoningSummary.DETAILED, false, false)
             );
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();


### PR DESCRIPTION
This PR follows up on https://github.com/elastic/elasticsearch/pull/143242

Its main purpose is to remove the max_tokens field from the reasoning object in UnifiedCompletionRequest. We are removing this field to avoid continuing support for a soon-to-be-deprecated parameter, which would otherwise add unnecessary maintenance burden going forward.

- [X] - Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] - Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [X] - If submitting code, have you built your formula locally prior to submission with `gradle check`?
- [X] - If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [X] - If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [X] - If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.