### PR TITLE
Preserve executable permissions for native binaries in Docker images

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
@@ -60,8 +60,8 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
     mv config/log4j2.properties config/log4j2.file.properties && \\
     mv config/log4j2.docker.properties config/log4j2.properties && \\
     find . -type d -exec chmod 0555 {} + && \\
-    find . -type f -exec chmod 0444 {} + && \\
-    chmod 0555 bin/* jdk/bin/* jdk/lib/jspawnhelper modules/x-pack-ml/platform/linux-*/bin/* && \\
+    find . -type f -perm /111 -exec chmod 0555 {} + && \\
+    find . -type f ! -perm /111 -exec chmod 0444 {} + && \\
     chmod 0775 bin config config/jvm.options.d data logs plugins && \\
     find config -type f -exec chmod 0664 {} +
 

--- a/distribution/docker/src/docker/dockerfiles/default/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/default/Dockerfile
@@ -52,10 +52,9 @@ RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1 && \\
     find . -type d -exec chmod 0555 {} + && \\
 # keep default elasticsearch log4j config
     mv config/log4j2.properties config/log4j2.file.properties && \\
-# Reset permissions on all files
-    find . -type f -exec chmod 0444 {} + && \\
-# Make CLI tools executable
-    chmod 0555 bin/* jdk/bin/* jdk/lib/jspawnhelper modules/x-pack-ml/platform/linux-*/bin/* && \\
+# Reset permissions on all files, preserving the execute bit from the archive
+    find . -type f -perm /111 -exec chmod 0555 {} + && \\
+    find . -type f ! -perm /111 -exec chmod 0444 {} + && \\
 # Make some directories writable. `bin` must be writable because
 # plugins can install their own CLI utilities.
     chmod 0775 bin config config/jvm.options.d data logs plugins && \\

--- a/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
@@ -60,8 +60,8 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
     mv config/log4j2.properties config/log4j2.file.properties && \\
     mv config/log4j2.docker.properties config/log4j2.properties && \\
     find . -type d -exec chmod 0555 {} + && \\
-    find . -type f -exec chmod 0444 {} + && \\
-    chmod 0555 bin/* jdk/bin/* jdk/lib/jspawnhelper modules/x-pack-ml/platform/linux-*/bin/* && \\
+    find . -type f -perm /111 -exec chmod 0555 {} + && \\
+    find . -type f ! -perm /111 -exec chmod 0444 {} + && \\
     chmod 0775 bin config config/jvm.options.d data logs plugins && \\
     find config -type f -exec chmod 0664 {} +
 

--- a/distribution/docker/src/docker/dockerfiles/wolfi/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/wolfi/Dockerfile
@@ -68,8 +68,8 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
     mv config/log4j2.properties config/log4j2.file.properties && \\
     mv config/log4j2.docker.properties config/log4j2.properties && \\
     find . -type d -exec chmod 0555 {} + && \\
-    find . -type f -exec chmod 0444 {} + && \\
-    chmod 0555 bin/* jdk/bin/* jdk/lib/jspawnhelper modules/x-pack-ml/platform/linux-*/bin/* && \\
+    find . -type f -perm /111 -exec chmod 0555 {} + && \\
+    find . -type f ! -perm /111 -exec chmod 0444 {} + && \\
     chmod 0775 bin config config/jvm.options.d data logs plugins && \\
     find config -type f -exec chmod 0664 {} +
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -978,7 +978,7 @@ public class DockerTests extends PackagingTestCase {
      */
     public void test130JavaHasCorrectOwnership() {
         final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
-        assertThat(infos, hasSize(2));
+        assertThat(infos, hasSize(1));
 
         for (ProcessInfo info : infos) {
             assertThat("Incorrect UID", info.uid(), equalTo(1000));
@@ -1005,6 +1005,20 @@ public class DockerTests extends PackagingTestCase {
 
         assertThat("Incorrect GID", info.gid(), equalTo(0));
         assertThat("Incorrect group", info.group(), equalTo("root"));
+    }
+
+    /**
+     * Check that the native server-launcher is used instead of the Java fallback. When the native
+     * launcher is executable, the bin/elasticsearch script execs it directly and the launcher forks
+     * a single JVM for the ES server. The Java fallback path would instead produce two java
+     * processes (the launcher JVM and the server JVM).
+     */
+    public void test132NativeServerLauncherIsUsed() {
+        final List<ProcessInfo> launcherProcesses = ProcessInfo.getProcessInfo(sh, "server-launcher");
+        assertThat("Expected native server-launcher process to be running", launcherProcesses, hasSize(1));
+
+        final List<ProcessInfo> javaProcesses = ProcessInfo.getProcessInfo(sh, "java");
+        assertThat("Expected exactly one java process, indicating the native server-launcher is in use", javaProcesses, hasSize(1));
     }
 
     /**


### PR DESCRIPTION
## Summary

- The Docker image build resets all file permissions to `0444` and then selectively restores `0555` on a hardcoded list of paths. The native `server-launcher` binary (and the serverless equivalent) was not in that list, so it lost its execute bit and the startup script fell back to the Java launcher.
- Replace the blanket chmod + hardcoded restore with two `find` commands that key off the archive's existing execute bit, so any file the build system marks executable is preserved automatically. Applied to all four Dockerfile variants (default, wolfi, ironbank, cloud_ess_fips).
- Add a Docker packaging test (`test132`) that verifies the native `server-launcher` process is running and only one JVM is present.

## Test plan

- [ ] Docker packaging tests pass (`test130`, `test131`, `test132`)
- [ ] Verify native `server-launcher` binary is executable inside built Docker image
- [ ] Verify only a single `java` process is running after container startup


Made with [Cursor](https://cursor.com)