### PR TITLE
ES|QL: Implement to_tdigest for the exponential_histogram type

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/types/to_tdigest.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/to_tdigest.md
@@ -4,6 +4,7 @@
 
 | field | result |
 | --- | --- |
+| exponential_histogram {applies_to}`stack: preview 9.4.0` | tdigest |
 | histogram | tdigest |
 | tdigest | tdigest |
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/to_tdigest.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/to_tdigest.json
@@ -8,6 +8,18 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "exponential_histogram",
+          "optional" : false,
+          "description" : "The histogram value to be converted"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "tdigest"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "histogram",
           "optional" : false,
           "description" : "The histogram value to be converted"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/mapper/EncodedTDigest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/mapper/EncodedTDigest.java
@@ -203,17 +203,27 @@ public final class EncodedTDigest implements TDigestReadView {
         return Collections.unmodifiableList(decoded);
     }
 
-    private static void encodeCentroidsFromIterator(CentroidIterator centroids, StreamOutput out) throws IOException {
+    /**
+     * Encodes the given centroids into the given output. Also compute the sum of all counts and returns it.
+     *
+     * @param centroids the centroids to encode
+     * @param out the output to encode into
+     * @return the sum of all counts in the centroids
+     */
+    public static long encodeCentroidsFromIterator(CentroidIterator centroids, StreamOutput out) throws IOException {
+        long totalCount = 0;
         while (centroids.next()) {
             long count = centroids.currentCount();
             if (count < 0) {
                 throw new IllegalArgumentException("Centroid count cannot be negative: " + count);
             }
+            totalCount += count;
             if (count > 0) {
                 out.writeVLong(count);
                 out.writeDouble(centroids.currentMean());
             }
         }
+        return totalCount;
     }
 
     private void resetCachedStats() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BreakingTDigestHolder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BreakingTDigestHolder.java
@@ -65,6 +65,17 @@ public class BreakingTDigestHolder implements Releasable, Accountable {
         holder.reset(encodedDigestBuffer.bytesRefView(), min, max, sum, tdigest.size());
     }
 
+    public void set(EncodedTDigest.CentroidIterator centroids, double sum, double min, double max) {
+        encodedDigestBuffer.clear();
+        long totalCount;
+        try {
+            totalCount = EncodedTDigest.encodeCentroidsFromIterator(centroids, encodedDigestBuffer);
+        } catch (IOException e) {
+            throw new IllegalStateException("Centroid encoding threw exception", e);
+        }
+        holder.reset(encodedDigestBuffer.bytesRefView(), min, max, sum, totalCount);
+    }
+
     public void set(TDigestHolder tdigest) {
         encodedDigestBuffer.clear();
         BytesRef bytesToCopy = tdigest.getEncodedDigest();

--- a/x-pack/plugin/esql/compute/test/build.gradle
+++ b/x-pack/plugin/esql/compute/test/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'elasticsearch.build'
 dependencies {
   api project(':test:framework')
   api project(xpackModule('esql:compute'))
+  api project(xpackModule('core'))
   // Use esql-core to see SpatialCoordinateTypes. That's in core because
   // Literal is in core. There's a bit of a chain here. We'd prefer not
   // do this, but such is life. For now.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
@@ -12,6 +12,47 @@ FROM tdigest_standard_index
 2025-01-01T00:00:00Z | hand-rolled-empty | "{""centroids"":[], ""counts"":[]}"
 ;
 
+// -------------------------------------------------------------------------------
+
+to_tdigest from exponential histogram
+required_capability: to_tdigest_from_exponential_histogram
+
+FROM exp_histo_sample
+ | WHERE instance == "dummy-full"
+ | STATS min = MIN(to_tdigest(responseTime)),
+         max = MAX(to_tdigest(responseTime)),
+         p10 = PERCENTILE(to_tdigest(responseTime), 10),
+         p50 = PERCENTILE(to_tdigest(responseTime), 50),
+         p90 = PERCENTILE(to_tdigest(responseTime), 90),
+         sum = SUM(to_tdigest(responseTime)),
+         cnt = COUNT(to_tdigest(responseTime))
+;
+
+min:double | max:double | p10:double | p50:double | p90:double | sum:double | cnt:long
+-100.0     | 50.0       | -100..-90  | -30..-20    | 35..40    | -3775.0    | 151
+;
+
+// -------------------------------------------------------------------------------
+
+timeseries to_tdigest from exponential histogram
+required_capability: to_tdigest_from_exponential_histogram
+required_capability: ts_command_v0
+
+TS exp_histo_sample
+ | WHERE instance == "dummy-full"
+ | STATS min = MIN(to_tdigest(responseTime)),
+         max = MAX(to_tdigest(responseTime)),
+         p10 = PERCENTILE(to_tdigest(responseTime), 10),
+         p50 = PERCENTILE(to_tdigest(responseTime), 50),
+         p90 = PERCENTILE(to_tdigest(responseTime), 90),
+         sum = SUM(to_tdigest(responseTime)),
+         cnt = COUNT(to_tdigest(responseTime))
+;
+
+min:double | max:double | p10:double | p50:double | p90:double | sum:double | cnt:long
+-100.0     | 50.0       | -100..-90  | -30..-20    | 35..40    | -3775.0    | 151
+;
+
 
 allAggsUngrouped
 required_capability: tdigest_time_series_metric

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromExponentialHistogramEvaluator.java
@@ -1,0 +1,135 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import java.util.function.Function;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BreakingTDigestHolder;
+import org.elasticsearch.compute.data.ExponentialHistogramBlock;
+import org.elasticsearch.compute.data.ExponentialHistogramScratch;
+import org.elasticsearch.compute.data.TDigestBlock;
+import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link ToTDigest}.
+ * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
+ */
+public final class ToTDigestFromExponentialHistogramEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ToTDigestFromExponentialHistogramEvaluator.class);
+
+  private final ExpressionEvaluator in;
+
+  private final BreakingTDigestHolder scratch;
+
+  public ToTDigestFromExponentialHistogramEvaluator(Source source, ExpressionEvaluator in,
+      BreakingTDigestHolder scratch, DriverContext driverContext) {
+    super(driverContext, source);
+    this.in = in;
+    this.scratch = scratch;
+  }
+
+  @Override
+  public ExpressionEvaluator next() {
+    return in;
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    throw new UnsupportedOperationException("vectors are unsupported for this evaluator");
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    ExponentialHistogramBlock block = (ExponentialHistogramBlock) b;
+    int positionCount = block.getPositionCount();
+    try (TDigestBlock.Builder builder = driverContext.blockFactory().newTDigestBlockBuilder(positionCount)) {
+      ExponentialHistogramScratch scratchPad = new ExponentialHistogramScratch();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          try {
+            TDigestHolder value = evalValue(block, i, scratchPad);
+            if (positionOpened == false && valueCount > 1) {
+              builder.beginPositionEntry();
+              positionOpened = true;
+            }
+            builder.appendTDigest(value);
+            valuesAppended = true;
+          } catch (IllegalArgumentException  e) {
+            registerException(e);
+          }
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private TDigestHolder evalValue(ExponentialHistogramBlock container, int index,
+      ExponentialHistogramScratch scratchPad) {
+    ExponentialHistogram value = container.getExponentialHistogram(index, scratchPad);
+    return ToTDigest.fromExponentialHistogram(value, this.scratch);
+  }
+
+  @Override
+  public String toString() {
+    return "ToTDigestFromExponentialHistogramEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in, scratch);
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += in.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory in;
+
+    private final Function<DriverContext, BreakingTDigestHolder> scratch;
+
+    public Factory(Source source, ExpressionEvaluator.Factory in,
+        Function<DriverContext, BreakingTDigestHolder> scratch) {
+      this.source = source;
+      this.in = in;
+      this.scratch = scratch;
+    }
+
+    @Override
+    public ToTDigestFromExponentialHistogramEvaluator get(DriverContext context) {
+      return new ToTDigestFromExponentialHistogramEvaluator(source, in.get(context), scratch.apply(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToTDigestFromExponentialHistogramEvaluator[" + "in=" + in + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestFromExponentialHistogramEvaluator.java
@@ -4,7 +4,6 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
-import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
 import java.util.function.Function;
@@ -63,17 +62,13 @@ public final class ToTDigestFromExponentialHistogramEvaluator extends AbstractCo
         boolean positionOpened = false;
         boolean valuesAppended = false;
         for (int i = start; i < end; i++) {
-          try {
-            TDigestHolder value = evalValue(block, i, scratchPad);
-            if (positionOpened == false && valueCount > 1) {
-              builder.beginPositionEntry();
-              positionOpened = true;
-            }
-            builder.appendTDigest(value);
-            valuesAppended = true;
-          } catch (IllegalArgumentException  e) {
-            registerException(e);
+          TDigestHolder value = evalValue(block, i, scratchPad);
+          if (positionOpened == false && valueCount > 1) {
+            builder.beginPositionEntry();
+            positionOpened = true;
           }
+          builder.appendTDigest(value);
+          valuesAppended = true;
         }
         if (valuesAppended == false) {
           builder.appendNull();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2154,6 +2154,11 @@ public class EsqlCapabilities {
         TO_EXPONENTIAL_HISTOGRAM,
 
         /**
+         * Support for converting {@code exponential_histogram} fields via {@code TO_TDIGEST}.
+         */
+        TO_TDIGEST_FROM_EXPONENTIAL_HISTOGRAM,
+
+        /**
          * Support for {@code MEDIAN} aggregation on {@code tdigest} type fields.
          */
         TDIGEST_MEDIAN,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
@@ -13,8 +13,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.data.BreakingTDigestHolder;
 import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.xpack.core.analytics.mapper.EncodedTDigest;
+import org.elasticsearch.xpack.core.analytics.mapper.ExponentialHistogramToTDigestConverter;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -44,6 +47,14 @@ public class ToTDigest extends AbstractConvertFunction {
         Map.entry(
             DataType.HISTOGRAM,
             (source, in) -> new ToTDigestFromHistogramEvaluator.Factory(source, in, dc -> new EncodedTDigest(), dc -> new TDigestHolder())
+        ),
+        Map.entry(
+            DataType.EXPONENTIAL_HISTOGRAM,
+            (source, in) -> new ToTDigestFromExponentialHistogramEvaluator.Factory(
+                source,
+                in,
+                dc -> BreakingTDigestHolder.create(dc.breaker())
+            )
         )
     );
 
@@ -56,7 +67,11 @@ public class ToTDigest extends AbstractConvertFunction {
     )
     public ToTDigest(
         Source source,
-        @Param(name = "field", type = { "histogram", "tdigest" }, description = "The histogram value to be converted") Expression field
+        @Param(
+            name = "field",
+            type = { "histogram", "tdigest", "exponential_histogram" },
+            description = "The histogram value to be converted"
+        ) Expression field
     ) {
         super(source, field);
     }
@@ -121,6 +136,21 @@ public class ToTDigest extends AbstractConvertFunction {
         }
         scratch.reset(in, min, max, sum, totalCount);
         return scratch;
+    }
+
+    @ConvertEvaluator(extraName = "FromExponentialHistogram", warnExceptions = { IllegalArgumentException.class })
+    static TDigestHolder fromExponentialHistogram(
+        ExponentialHistogram in,
+        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BreakingTDigestHolder scratch
+    ) {
+        EncodedTDigest.CentroidIterator convertedCentroids = ExponentialHistogramToTDigestConverter.convert(
+            in.negativeBuckets(),
+            in.zeroBucket(),
+            in.positiveBuckets()
+        );
+        double sum = in.valueCount() > 0 ? in.sum() : Double.NaN;
+        scratch.set(convertedCentroids, sum, in.min(), in.max());
+        return scratch.accessor();
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
@@ -138,7 +138,7 @@ public class ToTDigest extends AbstractConvertFunction {
         return scratch;
     }
 
-    @ConvertEvaluator(extraName = "FromExponentialHistogram", warnExceptions = { IllegalArgumentException.class })
+    @ConvertEvaluator(extraName = "FromExponentialHistogram")
     static TDigestHolder fromExponentialHistogram(
         ExponentialHistogram in,
         @Fixed(includeInToString = false, scope = THREAD_LOCAL) BreakingTDigestHolder scratch

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestErrorTests.java
@@ -32,6 +32,6 @@ public class ToTDigestErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
-        return equalTo(typeErrorMessage(false, validPerPosition, signature, (v, p) -> "histogram or tdigest"));
+        return equalTo(typeErrorMessage(false, validPerPosition, signature, (v, p) -> "exponential_histogram or histogram or tdigest"));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestTests.java
@@ -14,17 +14,23 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.xpack.core.analytics.mapper.EncodedTDigest;
+import org.elasticsearch.xpack.core.analytics.mapper.ExponentialHistogramToTDigestConverter;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import static org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier.appliesTo;
 
 public class ToTDigestTests extends AbstractScalarFunctionTestCase {
 
@@ -35,6 +41,7 @@ public class ToTDigestTests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
+        FunctionAppliesTo expHistogramAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.4.0", "", true);
 
         TestCaseSupplier.forUnaryHistogram(
             suppliers,
@@ -52,6 +59,22 @@ public class ToTDigestTests extends AbstractScalarFunctionTestCase {
             h -> h,
             List.of()
         );
+
+        List<TestCaseSupplier> expHistogramSuppliers = new ArrayList<>();
+        TestCaseSupplier.forUnaryExponentialHistogram(
+            expHistogramSuppliers,
+            "ToTDigestFromExponentialHistogramEvaluator[in=Attribute[channel=0]]",
+            DataType.TDIGEST,
+            ToTDigestTests::fromExponentialHistogram,
+            List.of()
+        );
+        suppliers.addAll(
+            TestCaseSupplier.mapTestCases(
+                expHistogramSuppliers,
+                tc -> tc.withData(tc.getData().stream().map(td -> td.withAppliesTo(expHistogramAppliesTo)).toList())
+            )
+        );
+
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
 
@@ -95,5 +118,32 @@ public class ToTDigestTests extends AbstractScalarFunctionTestCase {
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage());
         }
+    }
+
+    static TDigestHolder fromExponentialHistogram(ExponentialHistogram in) {
+        EncodedTDigest.CentroidIterator convertedCentroids = ExponentialHistogramToTDigestConverter.convert(
+            in.negativeBuckets(),
+            in.zeroBucket(),
+            in.positiveBuckets()
+        );
+        List<Double> means = new ArrayList<>();
+        List<Long> counts = new ArrayList<>();
+        while (convertedCentroids.next()) {
+            means.add(convertedCentroids.currentMean());
+            counts.add(convertedCentroids.currentCount());
+        }
+        BytesRef encoded = EncodedTDigest.encodeCentroids(means, counts);
+
+        TDigestHolder expected = new TDigestHolder();
+        double min = Double.NaN;
+        double max = Double.NaN;
+        double sum = Double.NaN;
+        if (in.valueCount() > 0) {
+            min = in.min();
+            max = in.max();
+            sum = in.sum();
+        }
+        expected.reset(encoded, min, max, sum, in.valueCount());
+        return expected;
     }
 }


### PR DESCRIPTION
Part of #140973. Allows the conversion from `exponential_histogram` to `tdigest` in ES|QL, using the very same algorithm that we use for `coerce` on the field mappers.