### PR TITLE
Ignore QueryDSL filters on view fragments

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1206,6 +1206,10 @@ public class EsqlCapabilities {
          */
         VIEWS_CRUD_AS_INDEX_ACTIONS(VIEWS_WITH_NO_BRANCHING.isEnabled()),
         /**
+         * Request-level QueryDSL filter is not pushed down to source indexes inside view definitions.
+         */
+        VIEWS_SKIP_REQUEST_FILTER(VIEWS_WITH_NO_BRANCHING.isEnabled()),
+        /**
          * Views with branching (requires subqueries/FORK).
          */
         VIEWS_WITH_BRANCHING(VIEWS_WITH_NO_BRANCHING.isEnabled() && SUBQUERY_IN_FROM_COMMAND.isEnabled()),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -108,6 +108,16 @@ public class EsRelation extends LeafPlan {
         return indexMode;
     }
 
+    /**
+     * Returns true when this relation targets an index that appears inside a view definition.
+     * Derived from the {@link Source#viewName()} which is set during view resolution parsing.
+     * Used to prevent the request-level QueryDSL filter from being pushed down to these indexes,
+     * since the filter should logically apply to the view output, not to the underlying source indexes.
+     */
+    public boolean fromView() {
+        return source().viewName() != null;
+    }
+
     public Map<String, List<String>> originalIndices() {
         return originalIndices;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -318,6 +318,9 @@ public class PlannerUtils {
 
     public static PhysicalPlan integrateEsFilterIntoFragment(PhysicalPlan plan, @Nullable QueryBuilder esFilter) {
         return esFilter == null ? plan : plan.transformUp(FragmentExec.class, f -> {
+            if (fragmentContainsOnlyViewRelations(f)) {
+                return f;
+            }
             var fragmentFilter = f.esFilter();
             // TODO: have an ESFilter and push down to EsQueryExec / EsSource
             // This is an ugly hack to push the filter parameter to Lucene
@@ -326,6 +329,19 @@ public class PlannerUtils {
             LOGGER.debug("Fold filter {} to EsQueryExec", filter);
             return f.withFilter(filter);
         });
+    }
+
+    /**
+     * Returns true when every {@link EsRelation} leaf in the fragment originates from within a view
+     * definition. In that case the request-level QueryDSL filter must not be applied, because it
+     * should logically target the view output columns rather than the underlying source indexes.
+     * The view-origin is detected via {@link EsRelation#fromView()}, which checks whether the
+     * {@link org.elasticsearch.xpack.esql.core.tree.Source} was tagged with a view name during
+     * view resolution parsing.
+     */
+    private static boolean fragmentContainsOnlyViewRelations(FragmentExec f) {
+        var relations = f.fragment().collect(EsRelation.class::isInstance);
+        return relations.isEmpty() == false && relations.stream().allMatch(p -> ((EsRelation) p).fromView());
     }
 
     public static PhysicalPlan localPlan(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -386,7 +386,7 @@ public class ViewResolver {
         List<UnresolvedRelation> unresolvedRelations = new ArrayList<>();
         List<LogicalPlan> otherPlans = new ArrayList<>();
         for (ViewPlan lp : subqueries) {
-            if (lp.plan instanceof UnresolvedRelation urp && urp.indexMode() == IndexMode.STANDARD) {
+            if (lp.name == null && lp.plan instanceof UnresolvedRelation urp && urp.indexMode() == IndexMode.STANDARD) {
                 unresolvedRelations.add(urp);
             } else {
                 otherPlans.add(new Subquery(ur.source(), lp.plan, lp.name));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/PlannerUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/PlannerUtilsTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class PlannerUtilsTests extends ESTestCase {
+
+    private static final EsField INT_FIELD = new EsField("val", DataType.INTEGER, Map.of(), true, EsField.TimeSeriesFieldType.NONE);
+    private static final Attribute ATTR = new FieldAttribute(Source.EMPTY, null, null, "val", INT_FIELD);
+    private static final Source VIEW_SOURCE = new Source(1, 0, "FROM idx").withViewName("my_view");
+
+    /**
+     * The request-level QueryDSL filter must not be attached to a FragmentExec
+     * whose logical plan contains only EsRelation nodes from within a view definition.
+     */
+    public void testRequestFilterNotAppliedToViewFragments() {
+        EsRelation viewRelation = new EsRelation(
+            VIEW_SOURCE,
+            "view_idx",
+            IndexMode.STANDARD,
+            Map.of(),
+            Map.of(),
+            Map.of("view_idx", IndexMode.STANDARD),
+            List.of(ATTR)
+        );
+        assertTrue("EsRelation with view source should report fromView=true", viewRelation.fromView());
+
+        FragmentExec fragment = new FragmentExec(viewRelation);
+        PhysicalPlan result = PlannerUtils.integrateEsFilterIntoFragment(fragment, new TermQueryBuilder("val", 42));
+
+        assertThat(result, instanceOf(FragmentExec.class));
+        FragmentExec resultFragment = (FragmentExec) result;
+        assertNull("Request filter should not be attached to view-sourced fragment", resultFragment.esFilter());
+    }
+
+    /**
+     * The request-level QueryDSL filter must be attached to a FragmentExec
+     * whose logical plan contains regular (non-view) EsRelation nodes.
+     */
+    public void testRequestFilterAppliedToRegularFragments() {
+        EsRelation regularRelation = new EsRelation(
+            Source.EMPTY,
+            "regular_idx",
+            IndexMode.STANDARD,
+            Map.of(),
+            Map.of(),
+            Map.of("regular_idx", IndexMode.STANDARD),
+            List.of(ATTR)
+        );
+        assertFalse("EsRelation without view source should report fromView=false", regularRelation.fromView());
+
+        FragmentExec fragment = new FragmentExec(regularRelation);
+        PhysicalPlan result = PlannerUtils.integrateEsFilterIntoFragment(fragment, new TermQueryBuilder("val", 42));
+
+        assertThat(result, instanceOf(FragmentExec.class));
+        FragmentExec resultFragment = (FragmentExec) result;
+        assertNotNull("Request filter should be attached to regular fragment", resultFragment.esFilter());
+    }
+
+    /**
+     * {@link EsRelation#fromView()} derives its answer from the Source's viewName.
+     */
+    public void testFromViewDerivedFromSourceViewName() {
+        EsRelation withView = new EsRelation(VIEW_SOURCE, "idx", IndexMode.STANDARD, Map.of(), Map.of(), Map.of(), List.of());
+        assertTrue(withView.fromView());
+
+        EsRelation withoutView = new EsRelation(Source.EMPTY, "idx", IndexMode.STANDARD, Map.of(), Map.of(), Map.of(), List.of());
+        assertFalse(withoutView.fromView());
+    }
+
+    /**
+     * When no filter is provided, the fragment is returned unchanged regardless of view status.
+     */
+    public void testNullFilterPassesThrough() {
+        EsRelation viewRelation = new EsRelation(
+            VIEW_SOURCE,
+            "view_idx",
+            IndexMode.STANDARD,
+            Map.of(),
+            Map.of(),
+            Map.of("view_idx", IndexMode.STANDARD),
+            List.of(ATTR)
+        );
+        FragmentExec fragment = new FragmentExec(viewRelation);
+        PhysicalPlan result = PlannerUtils.integrateEsFilterIntoFragment(fragment, null);
+        assertSame("Null filter should return same plan", fragment, result);
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/201_view_filter.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/201_view_filter.yml
@@ -1,0 +1,141 @@
+---
+setup:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          capabilities: [views_skip_request_filter]
+        - method: GET
+          path: /_query/view
+          capabilities: [view_index_abstraction]
+      test_runner_features: capabilities
+      reason: "Request-level QueryDSL filter must not be pushed down into view source indexes"
+
+  - do:
+      indices.create:
+        index: direct_idx
+        body:
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              value:
+                type: integer
+
+  - do:
+      indices.create:
+        index: view_idx
+        body:
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              value:
+                type: integer
+
+  - do:
+      bulk:
+        index: "direct_idx"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-01-01T00:00:00Z", "value": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-01T00:00:00Z", "value": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2024-03-01T00:00:00Z", "value": 3 }
+
+  - do:
+      bulk:
+        index: "view_idx"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-01-01T00:00:00Z", "value": 10 }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-01T00:00:00Z", "value": 20 }
+          - { "index": { } }
+          - { "@timestamp": "2024-03-01T00:00:00Z", "value": 30 }
+
+  - do:
+      esql.put_view:
+        name: my_view
+        body:
+          query: 'FROM view_idx'
+
+---
+"filter applies to direct index":
+  - do:
+      esql.query:
+        body:
+          query: 'FROM direct_idx | SORT value | KEEP value | LIMIT 10'
+          filter:
+            range:
+              "@timestamp":
+                gte: "2024-02-01T00:00:00Z"
+
+  - match: { columns.0.name: "value" }
+  - length: { values: 2 }
+  - match: { values.0: [2] }
+  - match: { values.1: [3] }
+
+---
+"filter does not apply to view":
+  - do:
+      esql.query:
+        body:
+          query: 'FROM my_view | SORT value | KEEP value | LIMIT 10'
+          filter:
+            range:
+              "@timestamp":
+                gte: "2024-02-01T00:00:00Z"
+
+  - match: { columns.0.name: "value" }
+  - length: { values: 3 }
+  - match: { values.0: [10] }
+  - match: { values.1: [20] }
+  - match: { values.2: [30] }
+
+---
+"filter applies to direct index but not to view":
+  - do:
+      esql.query:
+        body:
+          query: 'FROM direct_idx, my_view | SORT value | KEEP value | LIMIT 10'
+          filter:
+            range:
+              "@timestamp":
+                gte: "2024-02-01T00:00:00Z"
+
+  - match: { columns.0.name: "value" }
+  - length: { values: 5 }
+  - match: { values.0: [2] }
+  - match: { values.1: [3] }
+  - match: { values.2: [10] }
+  - match: { values.3: [20] }
+  - match: { values.4: [30] }
+
+---
+"same index direct and via view - filter applies only to direct access":
+  - do:
+      esql.put_view:
+        name: direct_view
+        body:
+          query: 'FROM direct_idx'
+
+  - do:
+      esql.query:
+        body:
+          query: 'FROM direct_idx, direct_view | SORT value | KEEP value | LIMIT 10'
+          filter:
+            range:
+              "@timestamp":
+                gte: "2024-02-01T00:00:00Z"
+
+  - match: { columns.0.name: "value" }
+  - length: { values: 5 }
+  - match: { values.0: [1] }
+  - match: { values.1: [2] }
+  - match: { values.2: [2] }
+  - match: { values.3: [3] }
+  - match: { values.4: [3] }


### PR DESCRIPTION
Since EsRelation contains a Source that knows it is from a view, it is possible to block the attachment of QueryDSL filters to FragmentExec nodes that contain EsRelations from views only. The goal here is to move the behaviour of QueryDSL filters on views to be closer to the long term goal of applying to the output of the view, not the source indexes.
