### PR TITLE
Fix "reset anomaly detection API" crashing when only colliding indices exist

### DIFF
--- a/docs/changelog/144545.yaml
+++ b/docs/changelog/144545.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues:
+ - 144544
+pr: 144545
+summary: Fix "reset anomaly detection API" crashing when only colliding indices exist
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -601,6 +601,10 @@ public final class MlIndexAndAlias {
             return i.equals(index) || (has6DigitSuffix(i) && i.length() == baseIndexName.length() + FIRST_INDEX_SIX_DIGIT_SUFFIX.length());
         }).toArray(String[]::new);
 
+        if (filtered.length == 0) {
+            return index;
+        }
+
         return MlIndexAndAlias.latestIndex(filtered);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -507,6 +507,22 @@ public class MlIndexAndAliasTests extends ESTestCase {
         assertEquals(".ml-anomalies-custom-foo-notthisone-000002", latest);
     }
 
+    public void testLatestIndexMatchingBaseName_OnlyCollidingIndicesExist() {
+        Metadata.Builder metadata = Metadata.builder();
+        metadata.put(createSharedResultsIndex(".ml-anomalies-custom-foobar", IndexVersion.current(), List.of("job1")));
+        metadata.put(createSharedResultsIndex(".ml-anomalies-custom-foobaz", IndexVersion.current(), List.of("job2")));
+        ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
+        csBuilder.metadata(metadata);
+        var state = csBuilder.build();
+
+        var latest = MlIndexAndAlias.latestIndexMatchingBaseName(
+            ".ml-anomalies-custom-foo",
+            TestIndexNameExpressionResolver.newInstance(),
+            state
+        );
+        assertEquals(".ml-anomalies-custom-foo", latest);
+    }
+
     public void testBuildIndexAliasesRequest() {
         var anomaliesIndex = ".ml-anomalies-sharedindex";
         var newIndex = anomaliesIndex + "-000001";


### PR DESCRIPTION
The PR fixes a `NoSuchElementException` in the ML “reset anomaly detection job” API when the cluster only has indices whose names collide with (but do not exactly match) the target results index base name. 

fixes #144544