### PR TITLE
Fix NPE in fieldExtractPhysicalOperation when sourceAttribute is null

### DIFF
--- a/docs/changelog/144427.yaml
+++ b/docs/changelog/144427.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144427
+summary: Improve error message for object mapping conflicts in ESQL
+type: enhancement

--- a/docs/changelog/144472.yaml
+++ b/docs/changelog/144472.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144472
+summary: Fix flaky DecayTests due to invalid randomized inputs
+type: bug

--- a/docs/changelog/144479.yaml
+++ b/docs/changelog/144479.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144470
+summary: Fix NullPointerException in ESQL field extraction when source attribute is null
+type: bug

--- a/docs/changelog/144479.yaml
+++ b/docs/changelog/144479.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
-pr: 144470
+pr: 144479
 summary: Fix NullPointerException in ESQL field extraction when source attribute is null
 type: bug

--- a/docs/changelog/144565.yaml
+++ b/docs/changelog/144565.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
-pr: 144479
+pr: 144565
 summary: Fix NullPointerException in ESQL field extraction when source attribute is null
 type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -125,6 +125,36 @@ public class InvalidMappedField extends EsField {
     }
 
     private static String makeErrorMessage(Map<String, Set<String>> typesToIndices, boolean includeInsistKeyword) {
+        boolean hasObject = typesToIndices.keySet().stream()
+            .anyMatch(t -> t.equals(DataType.OBJECT.typeName()));
+
+        if (hasObject) {
+            StringBuilder message = new StringBuilder();
+            message.append("Field has incompatible mappings: ");
+
+            boolean first = true;
+            for (Map.Entry<String, Set<String>> e : typesToIndices.entrySet()) {
+                if (first) {
+                    first = false;
+                } else {
+                    message.append(", ");
+                }
+                message.append("[");
+                message.append(e.getKey());
+                message.append("] in ");
+                if (e.getValue().size() <= 3) {
+                    message.append(e.getValue());
+                } else {
+                    message.append(e.getValue().stream().sorted().limit(3).collect(Collectors.toList()));
+                    message.append(" and [").append(e.getValue().size() - 3).append("] other ");
+                    message.append(e.getValue().size() == 4 ? "index" : "indices");
+                }
+            }
+
+            message.append(". Casting cannot resolve this conflict because [object] fields cannot be cast to scalar types.");
+
+            return message.toString();
+        }
         StringBuilder errorMessage = new StringBuilder();
         var isInsistKeywordOnlyKeyword = includeInsistKeyword && typesToIndices.containsKey(DataType.KEYWORD.typeName()) == false;
         errorMessage.append("mapped as [");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -185,7 +185,19 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
     ) {
         Layout.Builder layout = source.layout.builder();
         var sourceAttr = fieldExtractExec.sourceAttribute();
-        int docChannel = source.layout.get(sourceAttr.id()).channel();
+
+        if (sourceAttr == null) {
+            throw new IllegalStateException("sourceAttribute is null during field extraction (likely non-TSDB index in CCS)");
+        }
+
+        var layoutEntry = source.layout.get(sourceAttr.id());
+        if (layoutEntry == null) {
+            throw new IllegalStateException(
+                "Attribute [" + sourceAttr.name() + "] not found in layout during field extraction"
+            );
+        }
+
+        int docChannel = layoutEntry.channel();
         for (Attribute attr : fieldExtractExec.attributesToExtract()) {
             layout.append(attr);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3937,4 +3937,64 @@ public class VerifierTests extends ESTestCase {
     protected List<String> filteredWarnings() {
         return withDefaultLimitWarning(super.filteredWarnings());
     }
+
+    public void testObjectMappingConflictWithCast() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "object", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("cannot be cast"));
+    }
+
+    public void testObjectMappingConflictWithoutCast() {
+        var typesToIndices = Map.of(
+            "object", Set.of("test1"),
+            "keyword", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("incompatible mappings"));
+    }
+
+    public void testNonObjectConflictKeepsOriginalMessage() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "long", Set.of("test2")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        // Should NOT contain your new explanation
+        assertFalse(message.contains("cannot be cast"));
+
+        // Should still contain original style
+        assertTrue(message.contains("incompatible types"));
+    }
+
+    public void testMultipleTypesIncludingObject() {
+        var typesToIndices = Map.of(
+            "keyword", Set.of("test1"),
+            "object", Set.of("test2"),
+            "long", Set.of("test3")
+        );
+
+        var field = new InvalidMappedField("foo", typesToIndices);
+
+        String message = field.errorMessage();
+
+        assertTrue(message.contains("object"));
+        assertTrue(message.contains("cannot be cast"));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
@@ -638,9 +638,9 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         return List.of(new TestCaseSupplier(List.of(DataType.INTEGER, DataType.INTEGER, DataType.INTEGER, DataType.SOURCE), () -> {
             int randomValue = randomInt();
             int randomOrigin = randomInt();
-            int randomScale = randomInt();
-            int randomOffset = randomInt();
-            double randomDecay = randomDouble();
+            int randomScale = randomIntBetween(1, Integer.MAX_VALUE);
+            int randomOffset = randomIntBetween(0, Integer.MAX_VALUE);
+            double randomDecay = randomDoubleBetween(0.0, 1.0, true);
             String randomType = getRandomType();
 
             double scoreScriptNumericResult = intDecayWithScoreScript(
@@ -712,9 +712,9 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         return List.of(new TestCaseSupplier(List.of(DataType.LONG, DataType.LONG, DataType.LONG, DataType.SOURCE), () -> {
             long randomValue = randomLong();
             long randomOrigin = randomLong();
-            long randomScale = randomLong();
-            long randomOffset = randomLong();
-            double randomDecay = randomDouble();
+            long randomScale = randomLongBetween(1, Long.MAX_VALUE);
+            long randomOffset = randomLongBetween(0, Long.MAX_VALUE);
+            double randomDecay = randomDoubleBetween(0.0, 1.0, true);
             String randomType = randomFrom("linear", "gauss", "exp");
 
             double scoreScriptNumericResult = longDecayWithScoreScript(
@@ -780,11 +780,11 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
 
     private static List<TestCaseSupplier> doubleRandomTestCases() {
         return List.of(new TestCaseSupplier(List.of(DataType.DOUBLE, DataType.DOUBLE, DataType.DOUBLE, DataType.SOURCE), () -> {
-            double randomValue = randomLong();
-            double randomOrigin = randomLong();
-            double randomScale = randomLong();
-            double randomOffset = randomLong();
-            double randomDecay = randomDouble();
+            double randomValue = randomDouble();
+            double randomOrigin = randomDouble();
+            double randomScale = randomDoubleBetween(0.0001, Double.MAX_VALUE, true);
+            double randomOffset = randomDoubleBetween(0.0, Double.MAX_VALUE, true);
+            double randomDecay = randomDoubleBetween(0.0, 1.0, true);
             String randomType = randomFrom("linear", "gauss", "exp");
 
             double scoreScriptNumericResult = doubleDecayWithScoreScript(
@@ -882,7 +882,7 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
             GeoPoint randomOrigin = randomGeoPoint();
             String randomScale = randomDistance();
             String randomOffset = randomDistance();
-            double randomDecay = randomDouble();
+            double randomDecay = randomDoubleBetween(0.0, 1.0, true);
             String randomType = randomDecayType();
 
             double scoreScriptNumericResult = geoPointDecayWithScoreScript(
@@ -1061,7 +1061,7 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
             long randomOffsetMillis = randomNonNegativeLong() % (30L * 24 * 60 * 60 * 1000);
             Duration randomScale = Duration.ofMillis(randomScaleMillis);
             Duration randomOffset = Duration.ofMillis(randomOffsetMillis);
-            double randomDecay = randomDouble();
+            double randomDecay = randomDoubleBetween(0.0, 1.0, true);
             String randomType = randomFrom("linear", "gauss", "exp");
 
             double scoreScriptNumericResult = datetimeDecayWithScoreScript(
@@ -1148,7 +1148,7 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
                 Duration randomScale = Duration.ofMillis(randomScaleMillis);
                 Duration randomOffset = Duration.ofMillis(randomOffsetMillis);
 
-                double randomDecay = randomDouble();
+                double randomDecay = randomDoubleBetween(0.0, 1.0, true);
                 String randomType = randomFrom("linear", "gauss", "exp");
 
                 double scoreScriptNumericResult = dateNanosDecayWithScoreScript(


### PR DESCRIPTION
Fixes a NullPointerException in EsPhysicalOperationProviders#fieldExtractPhysicalOperation
when sourceAttribute is null (e.g. CCS queries involving non-TSDB indices).

Adds validation to prevent dereferencing a null attribute and provides a clearer error.

Relates to #144479