### PR TITLE
Don't run backport checks on feature branches

### DIFF
--- a/.buildkite/pipelines/pull-request/validate-index-version-backport.yml
+++ b/.buildkite/pipelines/pull-request/validate-index-version-backport.yml
@@ -1,5 +1,4 @@
-config:
-  skip-target-branches: "main"
 steps:
   - label: validate-index-version-backport
+    if: build.pull_request.base_branch =~ /^(\d+\.\d+|\d+\.x)$$/
     command: .buildkite/scripts/validate-index-version-backport.sh

--- a/.buildkite/pipelines/pull-request/validate-transport-version-backport.yml
+++ b/.buildkite/pipelines/pull-request/validate-transport-version-backport.yml
@@ -1,5 +1,4 @@
-config:
-  skip-target-branches: "main"
 steps:
   - label: validate-transport-version-backport
+    if: build.pull_request.base_branch =~ /^(\d+\.\d+|\d+\.x)$$/
     command: .buildkite/scripts/validate-transport-version-backport.sh


### PR DESCRIPTION
We should only validate "backport" version continuity when our pull request is targeting a backport branch. PRs again feature branches should be ignore here.