### PR TITLE
[9.3] fix: content parser returns null on keywords fields encoded with SMILE

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -277,7 +277,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public final XContentString optimizedTextOrNull() throws IOException {
-        if (currentToken() == Token.VALUE_NULL) {
+        if (currentToken() == Token.VALUE_NULL || currentToken() == Token.VALUE_EMBEDDED_OBJECT) {
             return null;
         }
         return optimizedText();

--- a/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.common.xcontent.smile;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.BaseXContentTestCase;
 import org.elasticsearch.xcontent.XContentGenerator;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.smile.SmileXContent;
 
@@ -33,6 +35,29 @@ public class SmileXContentTests extends BaseXContentTestCase {
     public void testAllowsDuplicates() throws Exception {
         try (XContentParser xParser = createParser(builder().startObject().endObject())) {
             expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
+    }
+
+    /**
+     * Binary SMILE values (VALUE_EMBEDDED_OBJECT tokens) have no text representation.
+     * {@code optimizedTextOrNull()} must return {@code null} for them, not {@code Text}
+     * object with null internals, to avoid a NullPointerException when callers access the
+     * string content (e.g. via {@code stringLength()}).
+     */
+    public void testOptimizedTextOrNullReturnNullForBinaryValue() throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (XContentGenerator generator = SmileXContent.smileXContent.createGenerator(os)) {
+            generator.writeStartObject();
+            generator.writeBinaryField("field", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+            generator.writeEndObject();
+        }
+        try (XContentParser parser = createParser(SmileXContent.smileXContent, new BytesArray(os.toByteArray()))) {
+            assertSame(Token.START_OBJECT, parser.nextToken());
+            assertSame(Token.FIELD_NAME, parser.nextToken());
+            assertSame(Token.VALUE_EMBEDDED_OBJECT, parser.nextToken());
+            // Binary SMILE values have no text representation; optimizedTextOrNull() must return null,
+            // not new Text(null), which would NPE when stringLength() is called on it.
+            assertNull(parser.optimizedTextOrNull());
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
@@ -45,8 +46,11 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentGenerator;
+import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.Matchers;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -1230,5 +1234,31 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     @Override
     protected List<SortShortcutSupport> getSortShortcutSupport() {
         return List.of(new SortShortcutSupport(this::minimalMapping, this::writeField, true));
+    }
+
+    /**
+     * Parsing a keyword field that contains a SMILE binary value (VALUE_EMBEDDED_OBJECT token)
+     * must not throw a NullPointerException. Binary values have no text representation and should
+     * be treated as null by the parser, so the field must be skipped rather than indexed.
+     *
+     * Regression test for when {@code KeywordFieldMapper.parseCreateField}
+     * calls {@code optimizedTextOrNull()}, which for binary SMILE tokens returned {@code new Text(null)}
+     * instead of {@code null}.
+     */
+    public void testParseSmileBinaryValueInKeywordField() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (XContentGenerator generator = XContentType.SMILE.xContent().createGenerator(os)) {
+            generator.writeStartObject();
+            generator.writeBinaryField("field", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+            generator.writeEndObject();
+        }
+
+        SourceToParse source = new SourceToParse("1", new BytesArray(os.toByteArray()), XContentType.SMILE);
+
+        // Binary values have no text representation; the keyword field must be skipped without NPE.
+        ParsedDocument doc = mapper.parse(source);
+        assertThat(doc.rootDoc().getFields("field"), empty());
     }
 }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/143766 to 9.3