### PR TITLE
Improve quantile interpolation stability for exponential histograms

### DIFF
--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
@@ -70,7 +70,8 @@ public class ExponentialHistogramQuantile {
         if (lowerRank == upperRank) {
             result = values.valueAtRank();
         } else {
-            result = values.valueAtPreviousRank() * (1 - upperFactor) + values.valueAtRank() * upperFactor;
+            double delta = values.valueAtRank() - values.valueAtPreviousRank();
+            result = values.valueAtPreviousRank() + delta * upperFactor;
         }
         return removeNegativeZero(result);
     }

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/QuantileAccuracyTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/QuantileAccuracyTests.java
@@ -296,7 +296,6 @@ public class QuantileAccuracyTests extends ExponentialHistogramTestCase {
             }
             double exactValue = values[lowerRank] * (1 - upperFactor) + values[upperRank] * upperFactor;
 
-
             // Skip comparison if exact value is close to zero to avoid false-positives due to numerical imprecision
             if (Math.abs(exactValue) < 1e-100) {
                 continue;

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/QuantileAccuracyTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/QuantileAccuracyTests.java
@@ -42,6 +42,7 @@ import static org.elasticsearch.exponentialhistogram.ExponentialHistogram.MIN_IN
 import static org.elasticsearch.exponentialhistogram.ExponentialScaleUtils.computeIndex;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
@@ -275,12 +276,18 @@ public class QuantileAccuracyTests extends ExponentialHistogramTestCase {
         double maxError = 0;
         double allowedError = getMaximumRelativeError(values, bucketCount);
 
+        double lastQuantile = Double.NEGATIVE_INFINITY;
         // Compare histogram quantiles with exact quantiles
         for (double q : QUANTILES_TO_TEST) {
             double percentileRank = q * (values.length - 1);
             int lowerRank = (int) Math.floor(percentileRank);
             int upperRank = (int) Math.ceil(percentileRank);
             double upperFactor = percentileRank - lowerRank;
+
+            double histoValue = ExponentialHistogramQuantile.getQuantile(histogram, q);
+            // values should be monotonically increasing
+            assertThat(histoValue, greaterThanOrEqualTo(lastQuantile));
+            lastQuantile = histoValue;
 
             if (values[lowerRank] < 0 && values[upperRank] > 0) {
                 // the percentile lies directly between a sign change and we interpolate linearly in-between
@@ -289,7 +296,6 @@ public class QuantileAccuracyTests extends ExponentialHistogramTestCase {
             }
             double exactValue = values[lowerRank] * (1 - upperFactor) + values[upperRank] * upperFactor;
 
-            double histoValue = ExponentialHistogramQuantile.getQuantile(histogram, q);
 
             // Skip comparison if exact value is close to zero to avoid false-positives due to numerical imprecision
             if (Math.abs(exactValue) < 1e-100) {


### PR DESCRIPTION
Fixes #144569.

The exponential histogram quantile algorithm interpolates linearly between percentiles falling on fractional ranks.
E.g. if a percentile corresponds to the value at rank `42.3`, we linearly interpolate between the values at rank `42` and `43`.

This interpolation was implemented in a way, that it could break percentile monotonicity (higher percentile => higher or equal result value) due to floating point errors.

This PR fixes this problem by changing the code how the interpolation is performed and it adds an assertion for monotonicity to `QuantileAccuracyTests` which easily reproduced the error on almost every randomized run. 