### PR TITLE
update pipeline setting for version bump

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -440,6 +440,7 @@ spec:
       name: elasticsearch-version-bump
     spec:
       pipeline_file: ".buildkite/pipelines/version-bump-pipeline.yml"
+      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
       repository: elastic/elasticsearch


### PR DESCRIPTION
Hi Team, 

This is a follow up to an existing PR: https://github.com/elastic/elasticsearch/pull/142992

By default `skip_intermediate_builds` is true. In an event that there are parallel version bumps, it would cancel the queued builds in the version bump pipeline. 

This PR disables intermediate builds.
