### PR TITLE
Clean up unused variables in MetadataCreateIndexServiceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -693,42 +693,28 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         return DiscoveryNodeUtils.builder(nodeId).roles(Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE)).build();
     }
 
-    public void testValidateIndexName() throws Exception {
+    public void testValidateIndexName() {
         withTemporaryClusterService(((clusterService, threadPool) -> {
-            MetadataCreateIndexService checkerService = new MetadataCreateIndexService(
-                Settings.EMPTY,
-                clusterService,
-                null,
-                null,
-                createTestShardLimitService(randomIntBetween(1, 1000), clusterService),
-                null,
-                null,
-                threadPool,
-                null,
-                EmptySystemIndices.INSTANCE,
-                false,
-                new IndexSettingProviders(Set.of())
-            );
-            validateIndexName(checkerService, "index?name", "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+            validateIndexName("index?name", "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
 
-            validateIndexName(checkerService, "index#name", "must not contain '#'");
+            validateIndexName("index#name", "must not contain '#'");
 
-            validateIndexName(checkerService, "_indexname", "must not start with '_', '-', or '+'");
-            validateIndexName(checkerService, "-indexname", "must not start with '_', '-', or '+'");
-            validateIndexName(checkerService, "+indexname", "must not start with '_', '-', or '+'");
+            validateIndexName("_indexname", "must not start with '_', '-', or '+'");
+            validateIndexName("-indexname", "must not start with '_', '-', or '+'");
+            validateIndexName("+indexname", "must not start with '_', '-', or '+'");
 
-            validateIndexName(checkerService, "INDEXNAME", "must be lowercase");
+            validateIndexName("INDEXNAME", "must be lowercase");
 
-            validateIndexName(checkerService, "..", "must not be '.' or '..'");
+            validateIndexName("..", "must not be '.' or '..'");
 
-            validateIndexName(checkerService, "foo:bar", "must not contain ':'");
+            validateIndexName("foo:bar", "must not contain ':'");
 
-            validateIndexName(checkerService, "", "must not be empty");
-            validateIndexName(checkerService, null, "must not be empty");
+            validateIndexName("", "must not be empty");
+            validateIndexName(null, "must not be empty");
         }));
     }
 
-    private static void validateIndexName(MetadataCreateIndexService metadataCreateIndexService, String indexName, String errorMessage) {
+    private static void validateIndexName(String indexName, String errorMessage) {
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         InvalidIndexNameException e = expectThrows(
             InvalidIndexNameException.class,
@@ -1817,7 +1803,6 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
     public void testCreateClusterBlocksTransformerForIndexCreation() {
         boolean isStateless = randomBoolean();
         boolean useRefreshBlock = randomBoolean();
-        var minTransportVersion = TransportVersionUtils.randomCompatibleVersion();
 
         var applier = MetadataCreateIndexService.createClusterBlocksTransformerForIndexCreation(
             Settings.builder()


### PR DESCRIPTION
Small unused variables cleanup
Follows: https://github.com/elastic/elasticsearch/pull/85370 which made `MetadataCreateIndexService::validateIndexName` static + removing one other unused field.

Note: This is being pulled out of #144074 per discussion https://github.com/elastic/elasticsearch/pull/144074#pullrequestreview-3977649544