### PR TITLE
Consistent rerouteBehavior parameter position

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -423,7 +423,6 @@ public class MetadataRolloverService {
                 projectState.cluster(),
                 createIndexClusterStateRequest,
                 silent,
-                RerouteBehavior.SKIP_REROUTE,
                 (builder, indexMetadata) -> {
                     downgradeBrokenTsdbBackingIndices(dataStream, builder);
                     builder.put(
@@ -435,6 +434,7 @@ public class MetadataRolloverService {
                         )
                     );
                 },
+                RerouteBehavior.SKIP_REROUTE,
                 rerouteCompletionIsNotRequired()
             );
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -464,8 +464,8 @@ public class MetadataCreateDataStreamService {
                 currentState,
                 createIndexRequest,
                 false,
-                RerouteBehavior.SKIP_REROUTE,
                 metadataTransformer,
+                RerouteBehavior.SKIP_REROUTE,
                 AllocationActionListener.rerouteCompletionIsNotRequired()
             );
         } catch (ResourceAlreadyExistsException e) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -484,8 +484,8 @@ public class MetadataCreateIndexService {
         ClusterState currentState,
         CreateIndexClusterStateUpdateRequest request,
         boolean silent,
-        RerouteBehavior rerouteBehavior,
         BiConsumer<ProjectMetadata.Builder, IndexMetadata> metadataTransformer,
+        RerouteBehavior rerouteBehavior,
         ActionListener<Void> rerouteListener
     ) throws Exception {
 
@@ -626,7 +626,7 @@ public class MetadataCreateIndexService {
         RerouteBehavior rerouteBehavior,
         ActionListener<Void> rerouteListener
     ) throws Exception {
-        return applyCreateIndexRequest(currentState, request, silent, rerouteBehavior, null, rerouteListener);
+        return applyCreateIndexRequest(currentState, request, silent, null, rerouteBehavior, rerouteListener);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -386,7 +386,7 @@ public class TransportRolloverActionTests extends ESTestCase {
         when(mockCreateIndexService.applyCreateIndexRequest(any(), any(), anyBoolean(), any(RerouteBehavior.class), any())).thenReturn(
             stateBefore
         );
-        when(mockCreateIndexService.applyCreateIndexRequest(any(), any(), anyBoolean(), any(RerouteBehavior.class), any(), any()))
+        when(mockCreateIndexService.applyCreateIndexRequest(any(), any(), anyBoolean(), any(), any(RerouteBehavior.class), any()))
             .thenReturn(stateBefore);
         when(mdIndexAliasesService.applyAliasActions(any(), any())).thenReturn(stateBefore);
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -660,8 +660,8 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
                 any(ClusterState.class),
                 any(CreateIndexClusterStateUpdateRequest.class),
                 anyBoolean(),
-                any(RerouteBehavior.class),
                 any(),
+                any(RerouteBehavior.class),
                 any()
             )
         ).thenAnswer(objectAnswer);

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -1017,8 +1017,8 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                     createIndexClusterStateUpdateRequest,
                     true,
                     // Copy index metadata from source index to downsample index
-                    RerouteBehavior.PERFORM_REROUTE,
                     (builder, indexMetadata) -> builder.put(copyIndexMetadata(sourceIndexMetadata, indexMetadata, indexScopedSettings)),
+                    RerouteBehavior.PERFORM_REROUTE,
                     delegate.reroute()
                 );
             }


### PR DESCRIPTION
Follows: https://github.com/elastic/elasticsearch/pull/144140. Moves rerouteBehavior adjacent to rerouteListener across all `applyCreateIndexRequest` overloads, so the two related parameters always appear together. This is a style nit really. But it feels much more readable that way.

Note: This is being pulled out of https://github.com/elastic/elasticsearch/pull/144074 per discussion https://github.com/elastic/elasticsearch/pull/144074#pullrequestreview-3977649544
