### PR TITLE
Document how ES|QL uses the circuit breaker

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
@@ -142,6 +142,24 @@ This circuit breaker can be configured using the following settings:
 
 
 
+## ES|QL circuit breaker [circuit-breakers-page-esql]
+
+{{esql}} executes queries by building blocks of data (columns, aggregations, and other pipeline structures) in memory. When processing large datasets or running queries with high-cardinality aggregations, the memory used by these structures can grow significantly and potentially exceed the available JVM heap, which could cause an `OutOfMemoryError` and bring down the node.
+
+To prevent this, {{esql}} uses the [request circuit breaker](#request-circuit-breaker), which limits memory allocation during query execution. There is no dedicated {{esql}} circuit breaker; {{esql}} shares the request breaker with other per-request operations such as aggregations. When the breaker is triggered, an `org.elasticsearch.common.breaker.CircuitBreakingException` is thrown and a descriptive error message including `circuit_breaking_exception` is returned to the user.
+
+The request breaker settings (`indices.breaker.request.limit`, `indices.breaker.request.overhead`, and `indices.breaker.request.type`) are documented in the [Request circuit breaker](#request-circuit-breaker) section.
+
+{{esql}} also supports the following block factory settings that tune how memory is reserved per execution driver:
+
+`esql.block_factory.local_breaker.over_reserved`
+:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The number of bytes to over-reserve from the request breaker per driver to reduce the frequency of atomic operations. Defaults to `8kb`.
+
+`esql.block_factory.local_breaker.max_over_reserved`
+:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The maximum number of bytes that can be over-reserved across all drivers. Defaults to `512kb`.
+
+
+
 ### {{ml-cap}} circuit breaker [circuit-breakers-page-model-inference]
 
 `breaker.model_inference.limit`

--- a/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
@@ -150,14 +150,6 @@ To prevent this, {{esql}} uses the [request circuit breaker](#request-circuit-br
 
 The request breaker settings (`indices.breaker.request.limit`, `indices.breaker.request.overhead`, and `indices.breaker.request.type`) are documented in the [Request circuit breaker](#request-circuit-breaker) section.
 
-{{esql}} also supports the following block factory settings that tune how memory is reserved per execution driver:
-
-`esql.block_factory.local_breaker.over_reserved`
-:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The number of bytes to over-reserve from the request breaker per driver to reduce the frequency of atomic operations. Defaults to `8kb`.
-
-`esql.block_factory.local_breaker.max_over_reserved`
-:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The maximum number of bytes that can be over-reserved across all drivers. Defaults to `512kb`.
-
 
 
 ### {{ml-cap}} circuit breaker [circuit-breakers-page-model-inference]

--- a/docs/reference/query-languages/esql.md
+++ b/docs/reference/query-languages/esql.md
@@ -50,3 +50,8 @@ You can interact with {{esql}} in two ways:
 - **Interactive interfaces**: Work with {{esql}} through Elastic user interfaces including Kibana Discover, Dashboards, Dev Tools, and analysis tools in Elastic Security and Observability.
   - Refer to [Using {{esql}} in {{kib}}](docs-content://explore-analyze/query-filter/languages/esql-kibana.md).
 
+
+## ES|QL circuit breaker settings [esql-circuit-breaker]
+
+The relevant circuit breaker settings can be found in the [Circuit Breakers page](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#circuit-breakers-page-esql).
+

--- a/docs/reference/query-languages/esql/esql-troubleshooting.md
+++ b/docs/reference/query-languages/esql/esql-troubleshooting.md
@@ -11,3 +11,4 @@ This section provides some useful resource for troubleshooting {{esql}} issues:
 
 - [Query log](esql-query-log.md): Learn how to log {{esql}} queries
 - [Task management API](esql-task-management.md): Learn how to diagnose issues like long-running queries.
+- [Circuit breaker settings](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#circuit-breakers-page-esql): Learn how {{esql}} uses the circuit breaker and how to configure it. For circuit breaker errors, see [Circuit breaker errors](docs-content://troubleshoot/elasticsearch/circuit-breaker-errors.md).


### PR DESCRIPTION
Add ES|QL circuit breaker documentation mirroring the EQL section in the circuit breaker docs.

## Changes
- Add `circuit-breakers-page-esql` section to circuit-breaker-settings.md describing how ES|QL uses the request circuit breaker and the block factory settings
- Add `esql-circuit-breaker` section to esql.md linking to the circuit breaker settings
- Add circuit breaker troubleshooting link to esql-troubleshooting.md

Closes #112861

Made with [Cursor](https://cursor.com)