### PR TITLE
Unmute tests with closed tracking issues

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -285,27 +285,12 @@ tests:
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteBlobWithRetries
   issue: https://github.com/elastic/elasticsearch/issues/144025
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
-  method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
-  issue: https://github.com/elastic/elasticsearch/issues/138012
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testJvmMetrics {withOTel=true}
   issue: https://github.com/elastic/elasticsearch/issues/144166
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testJvmMetrics {withOTel=false}
   issue: https://github.com/elastic/elasticsearch/issues/144167
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {csv-spec:approximation.Approximate stats by on large multi-valued data}
-  issue: https://github.com/elastic/elasticsearch/issues/144169
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:approximation.Approximate stats by with zero variance}
-  issue: https://github.com/elastic/elasticsearch/issues/144240
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:approximation.Approximate stats by with zero variance}
-  issue: https://github.com/elastic/elasticsearch/issues/144246
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
-  method: testEndpointGetsUpdated_GivenFingerprintChanges_FromNull
-  issue: https://github.com/elastic/elasticsearch/issues/144249
 - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
   method: testAuthenticateShouldNotFallThroughInCaseOfFailure
   issue: https://github.com/elastic/elasticsearch/issues/144262
@@ -333,9 +318,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:approximation.Approximate stats by on large single-valued data}
   issue: https://github.com/elastic/elasticsearch/issues/144382
-- class: org.elasticsearch.action.bulk.TransportBulkActionTests
-  method: testProhibitAppendWritesInBackingIndicesSkippedForSeqNoDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/144392
 - class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
   method: testOpenAiEmbeddings {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/144440


### PR DESCRIPTION
## Summary

Remove 6 muted-tests.yml entries on `main` where the corresponding GitHub tracking issue has been closed, meaning the underlying test failure has been resolved.

### Removed entries

| Issue | Test | Closed by |
|---|---|---|
| [#138012](https://github.com/elastic/elasticsearch/issues/138012) | `AuthorizationTaskExecutorIT.testCreatesChatCompletion_AndThenCreatesTextEmbedding` | [#144312](https://github.com/elastic/elasticsearch/pull/144312) |
| [#144169](https://github.com/elastic/elasticsearch/issues/144169) | `CsvTests` csv-spec `approximation.Approximate stats by on large multi-valued data` | [#144233](https://github.com/elastic/elasticsearch/pull/144233) |
| [#144240](https://github.com/elastic/elasticsearch/issues/144240) | `CsvIT` csv-spec `approximation.Approximate stats by with zero variance` | [#144233](https://github.com/elastic/elasticsearch/pull/144233) |
| [#144246](https://github.com/elastic/elasticsearch/issues/144246) | `EsqlSpecIT` csv-spec `approximation.Approximate stats by with zero variance` | [#144233](https://github.com/elastic/elasticsearch/pull/144233) |
| [#144249](https://github.com/elastic/elasticsearch/issues/144249) | `AuthorizationTaskExecutorIT.testEndpointGetsUpdated_GivenFingerprintChanges_FromNull` | [#144312](https://github.com/elastic/elasticsearch/pull/144312) |
| [#144392](https://github.com/elastic/elasticsearch/issues/144392) | `TransportBulkActionTests.testProhibitAppendWritesInBackingIndicesSkippedForSeqNoDisabled` | [#144389](https://github.com/elastic/elasticsearch/pull/144389) |

### Note

Issue [#138012](https://github.com/elastic/elasticsearch/issues/138012) is also still muted on the `9.3` branch. The fix ([#144312](https://github.com/elastic/elasticsearch/pull/144312)) was labeled `v9.4.0` only (no backport to 9.3), so the 9.3 entry may need separate attention.
