### PR TITLE
Add missing testBulkIllegalDims for INT8 and FLOAT32

### DIFF
--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
@@ -226,6 +226,26 @@ public class JDKVectorLibraryFloat32Tests extends VectorSimilarityFunctionsTests
         assertArrayEquals(expectedScores, bulkScores, delta);
     }
 
+    public void testBulkIllegalDims() {
+        assumeTrue(notSupportedMsg(), supported());
+        var segA = arena.allocate((long) size * 3 * Float.BYTES);
+        var segB = arena.allocate((long) size * 3 * Float.BYTES);
+        var segS = arena.allocate((long) size * Float.BYTES);
+
+        Exception ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, 4, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, -1, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, -1, 3, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        var tooSmall = arena.allocate((long) 3 * Float.BYTES - 1);
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, 3, tooSmall));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+    }
+
     public void testIllegalDims() {
         assumeTrue(notSupportedMsg(), supported());
         var segment = arena.allocate((long) size * 3 * Float.BYTES);

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
@@ -197,6 +197,26 @@ public class JDKVectorLibraryInt8Tests extends VectorSimilarityFunctionsTests {
         assertArrayEquals(expectedScores, bulkScores, delta);
     }
 
+    public void testBulkIllegalDims() {
+        assumeTrue(notSupportedMsg(), supported());
+        var segA = arena.allocate((long) size * 3);
+        var segB = arena.allocate((long) size * 3);
+        var segS = arena.allocate((long) size * Float.BYTES);
+
+        Exception ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, 4, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, -1, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, -1, 3, segS));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+
+        var tooSmall = arena.allocate((long) 3 * Float.BYTES - 1);
+        ex = expectThrows(IOOBE, () -> similarityBulk(segA, segB, size, 3, tooSmall));
+        assertThat(ex.getMessage(), containsString("out of bounds for length"));
+    }
+
     public void testIllegalDims() {
         assumeTrue(notSupportedMsg(), supported());
         var segment = arena.allocate((long) size * 3);


### PR DESCRIPTION
While working on bulk sparse scoring (#144557), I noticed that INT8 and FLOAT32 were missing `testBulkIllegalDims` coverage that INT7U, INT4, and BBQ already have. Extracting this into a small targeted PR.

Both new tests verify IOOBE for count overflow, negative count, negative dims, and undersized result buffer, matching the existing pattern in `JDKVectorLibraryInt7uTests`.
