### PR TITLE
Add PaginatedHitSource Tests

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
@@ -14,9 +14,12 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.search.TransportClearScrollAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
@@ -37,12 +40,15 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -52,6 +58,7 @@ import java.util.stream.IntStream;
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
@@ -157,8 +164,56 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
             new SearchRequest().scroll(timeValueSeconds(10))
         );
 
+        paginatedHitSource.setScroll("scroll_id");
         paginatedHitSource.startNextScroll(timeValueSeconds(100));
         client.validateRequest(TransportSearchScrollAction.TYPE, (SearchScrollRequest r) -> assertEquals(r.scroll().seconds(), 110));
+    }
+
+    /** When scroll ID is empty or null, close runs cleanup immediately without calling clearScroll. */
+    public void testCloseWhenScrollIdEmpty() {
+        MockClient client = new MockClient(threadPool);
+        TaskId parentTask = new TaskId("thenode", randomInt());
+        ClientScrollablePaginatedHitSource paginatedHitSource = new ClientScrollablePaginatedHitSource(
+            logger,
+            BackoffPolicy.constantBackoff(TimeValue.ZERO, 0),
+            threadPool,
+            Assert::fail,
+            r -> fail(),
+            e -> fail(),
+            new ParentTaskAssigningClient(client, parentTask),
+            new SearchRequest().scroll(timeValueSeconds(10))
+        );
+        AtomicBoolean closeCallbackCalled = new AtomicBoolean();
+
+        paginatedHitSource.close(() -> closeCallbackCalled.set(true));
+
+        assertTrue(closeCallbackCalled.get());
+        assertFalse(client.hasExecuted(TransportClearScrollAction.TYPE));
+    }
+
+    /** When scroll ID is set, close calls clearScroll and runs cleanup after it completes. */
+    public void testCloseWhenScrollIdSet() throws InterruptedException {
+        MockClient client = new MockClient(threadPool);
+        TaskId parentTask = new TaskId("thenode", randomInt());
+        ClientScrollablePaginatedHitSource paginatedHitSource = new ClientScrollablePaginatedHitSource(
+            logger,
+            BackoffPolicy.constantBackoff(TimeValue.ZERO, 0),
+            threadPool,
+            Assert::fail,
+            r -> fail(),
+            e -> fail(),
+            new ParentTaskAssigningClient(client, parentTask),
+            new SearchRequest().scroll(timeValueSeconds(10))
+        );
+        paginatedHitSource.setScroll("scroll_123");
+        AtomicBoolean closeCallbackCalled = new AtomicBoolean();
+
+        paginatedHitSource.close(() -> closeCallbackCalled.set(true));
+
+        client.awaitOperation();
+        client.validateRequest(TransportClearScrollAction.TYPE, (ClearScrollRequest r) -> assertThat(r.getScrollIds(), contains("scroll_123")));
+        client.respond(TransportClearScrollAction.TYPE, new ClearScrollResponse(true, 1));
+        assertTrue(closeCallbackCalled.get());
     }
 
     private SearchResponse createSearchResponse() {
@@ -214,6 +269,7 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
 
     private static class MockClient extends AbstractClient {
         private ExecuteRequest<?, ?> executeRequest;
+        private final List<ActionType<?>> executedActions = new ArrayList<>();
 
         MockClient(ThreadPool threadPool) {
             super(Settings.EMPTY, threadPool, TestProjectResolvers.alwaysThrow());
@@ -225,9 +281,13 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
             Request request,
             ActionListener<Response> listener
         ) {
-
+            executedActions.add(action);
             this.executeRequest = new ExecuteRequest<>(action, request, listener);
             this.notifyAll();
+        }
+
+        boolean hasExecuted(ActionType<?> action) {
+            return executedActions.contains(action);
         }
 
         @SuppressWarnings("unchecked")

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
@@ -211,7 +211,10 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
         paginatedHitSource.close(() -> closeCallbackCalled.set(true));
 
         client.awaitOperation();
-        client.validateRequest(TransportClearScrollAction.TYPE, (ClearScrollRequest r) -> assertThat(r.getScrollIds(), contains("scroll_123")));
+        client.validateRequest(
+            TransportClearScrollAction.TYPE,
+            (ClearScrollRequest r) -> assertThat(r.getScrollIds(), contains("scroll_123"))
+        );
         client.respond(TransportClearScrollAction.TYPE, new ClearScrollResponse(true, 1));
         assertTrue(closeCallbackCalled.get());
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
@@ -28,6 +28,7 @@ import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
+import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.ParsingException;
@@ -76,6 +77,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -430,6 +432,41 @@ public class RemoteScrollablePaginatedHitSourceTests extends ESTestCase {
         paginatedHitSource.cleanup(() -> cleanupCallbackCalled.set(true));
         verify(client).close();
         assertTrue(cleanupCallbackCalled.get());
+    }
+
+    /** When scroll ID is empty or null, close runs cleanup immediately without calling clearScroll. */
+    public void testCloseWhenScrollIdEmpty() throws Exception {
+        RestClient client = mock(RestClient.class);
+        RemoteInfo remoteInfo = remoteInfo();
+        TestRemoteScrollablePaginatedHitSource paginatedHitSource = new TestRemoteScrollablePaginatedHitSource(client, remoteInfo);
+        AtomicBoolean closeCallbackCalled = new AtomicBoolean();
+
+        paginatedHitSource.close(() -> closeCallbackCalled.set(true));
+
+        assertTrue(closeCallbackCalled.get());
+        verify(client, never()).performRequestAsync(any(), any());
+        verify(client).close();
+    }
+
+    /** When scroll ID is set, close calls clearScroll and runs cleanup after it completes. */
+    public void testCloseWhenScrollIdSet() throws Exception {
+        RestClient client = mock(RestClient.class);
+        when(client.performRequestAsync(any(), any())).thenAnswer(invocation -> {
+            ResponseListener listener = invocation.getArgument(1);
+            listener.onSuccess(mock(org.elasticsearch.client.Response.class));
+            return null;
+        });
+        RemoteInfo remoteInfo = remoteInfo();
+        TestRemoteScrollablePaginatedHitSource paginatedHitSource = new TestRemoteScrollablePaginatedHitSource(client, remoteInfo);
+        paginatedHitSource.remoteVersion = Version.CURRENT;
+        paginatedHitSource.setScroll("scroll_123");
+        AtomicBoolean closeCallbackCalled = new AtomicBoolean();
+
+        paginatedHitSource.close(() -> closeCallbackCalled.set(true));
+
+        assertTrue(closeCallbackCalled.get());
+        verify(client).performRequestAsync(any(), any());
+        verify(client).close();
     }
 
     private RemoteScrollablePaginatedHitSource sourceWithMockedRemoteCall(String... paths) throws Exception {


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/144339 I make a minor refactor to the `PaginatedHitSource` `close()` method by moving logic into the children classes. I want to add tests for both `ClientScrollablePaginatedHitSource` and `RemoteScrollablePaginatedHitSource` to validate the behaviour of the `close` method so I'll be able to catch any regressions in https://github.com/elastic/elasticsearch/pull/144339

Relates: https://github.com/elastic/elasticsearch-team/issues/2088

