### PR TITLE
Add PR number suffix versioning for simdvec native library builds

### DIFF
--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,9 @@ configurations {
 }
 
 var zstdVersion = "1.5.7"
-var vecVersion = "1.0.44"
+// Allow vecVersion to be overridden via Gradle property (-PvecVersion=...)
+// Default to the base version; PR builds should override via -PvecVersion=1.0.58-pr144631.1
+var vecVersion = project.hasProperty("vecVersion") ? project.property("vecVersion") : "1.0.58"
 
 repositories {
   exclusiveContent {

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -20,12 +20,41 @@ if [ -z "$ARTIFACTORY_API_KEY" ]; then
   exit 1;
 fi
 
-VERSION="1.0.44"
+# Parse command line arguments
+PR_NUMBER=""
+ITERATION="1"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --pr)
+      PR_NUMBER="$2"
+      shift 2
+      ;;
+    --iter)
+      ITERATION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--pr <PR_NUMBER>] [--iter <ITERATION>]"
+      exit 1
+      ;;
+  esac
+done
+
+VERSION="1.0.58"
 ARTIFACTORY_REPOSITORY="${ARTIFACTORY_REPOSITORY:-https://artifactory.elastic.dev/artifactory/elasticsearch-native/}"
 TEMP=$(mktemp -d)
 
-if curl -sS -I --fail --location "${ARTIFACTORY_REPOSITORY}/org/elasticsearch/vec/${VERSION}/vec-${VERSION}.zip" > /dev/null 2>&1; then
-  echo "Error: Artifacts already exist for version '${VERSION}'. Bump version before republishing."
+# Determine artifact version based on whether this is a PR build
+if [ -n "$PR_NUMBER" ]; then
+  ARTIFACT_VERSION="${VERSION}-pr${PR_NUMBER}.${ITERATION}"
+else
+  ARTIFACT_VERSION="${VERSION}"
+fi
+
+if curl -sS -I --fail --location "${ARTIFACTORY_REPOSITORY}/org/elasticsearch/vec/${ARTIFACT_VERSION}/vec-${ARTIFACT_VERSION}.zip" > /dev/null 2>&1; then
+  echo "Error: Artifacts already exist for version '${ARTIFACT_VERSION}'. Bump version before republishing."
   exit 1;
 fi
 
@@ -50,6 +79,6 @@ cp build/libs/vec/shared/aarch64/libvec.so $TEMP/linux-aarch64/
 cp build/libs/vec/shared/amd64/libvec.so $TEMP/linux-x64/
 
 echo 'Uploading to Artifactory...'
-(cd $TEMP && zip -rq - .) | curl -sS -X PUT -H "X-JFrog-Art-Api: ${ARTIFACTORY_API_KEY}" --data-binary @- --location "${ARTIFACTORY_REPOSITORY}/org/elasticsearch/vec/${VERSION}/vec-${VERSION}.zip"
+(cd $TEMP && zip -rq - .) | curl -sS -X PUT -H "X-JFrog-Art-Api: ${ARTIFACTORY_API_KEY}" --data-binary @- --location "${ARTIFACTORY_REPOSITORY}/org/elasticsearch/vec/${ARTIFACT_VERSION}/vec-${ARTIFACT_VERSION}.zip"
 
 rm -rf $TEMP


### PR DESCRIPTION
## Summary

This PR implements Option 1 from issue #144631 to allow publishing intermediate native library artifacts without bumping the mainline version number.

## Changes

### libs/simdvec/native/publish_vec_binaries.sh
- Added `--pr` and `--iter` command line arguments
- When `--pr` is provided, publishes artifacts with version suffix `-pr<PR_NUMBER>.<ITER>`

### libs/native/libraries/build.gradle
- Made `vecVersion` configurable via Gradle property `-PvecVersion=...`

Closes #144631