### PR TITLE
fix/unmute ServiceAccountIT.testAuthenticateShouldNotFallThroughInCaseOfFailure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -285,9 +285,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testJvmMetrics {withOTel=false}
   issue: https://github.com/elastic/elasticsearch/issues/144167
-- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-  issue: https://github.com/elastic/elasticsearch/issues/144262
 - class: org.elasticsearch.test.apmintegration.MetricsApmIT
   method: testApmIntegration {withOTel=false}
   issue: https://github.com/elastic/elasticsearch/issues/144282

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -517,24 +517,17 @@ public class ServiceAccountIT extends ESRestTestCase {
     }
 
     public void testAuthenticateShouldNotFallThroughInCaseOfFailure() throws IOException {
-        final boolean securityIndexExists = randomBoolean();
-        if (securityIndexExists) {
-            final Request createRoleRequest = new Request("POST", "_security/role/dummy_role");
-            createRoleRequest.setJsonEntity("{\"cluster\":[]}");
-            assertOK(adminClient().performRequest(createRoleRequest));
-        }
+        final Request createRoleRequest = new Request("POST", "_security/role/dummy_role");
+        createRoleRequest.setJsonEntity("{\"cluster\":[]}");
+        assertOK(adminClient().performRequest(createRoleRequest));
         final Request request = new Request("GET", "_security/_authenticate");
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + INVALID_SERVICE_TOKEN));
         final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(401));
-        if (securityIndexExists) {
-            assertThat(
-                e.getMessage(),
-                containsString("failed to authenticate service account [elastic/fleet-server] with token name [token1]")
-            );
-        } else {
-            assertThat(e.getMessage(), containsString("no such index [.security]"));
-        }
+        assertThat(
+            e.getMessage(),
+            containsString("failed to authenticate service account [elastic/fleet-server] with token name [token1]")
+        );
     }
 
     public void testAuthenticateShouldWorkWithOAuthBearerToken() throws IOException {


### PR DESCRIPTION
Resolves #144262
See also #120902

I believe the issue with this test is it assumes the security index doesn't exist by default, but this is untrue as of bf1c0fe0778 and 52e0f21bdd0.

Further complicating matters: if this test runs first in the suite, `.security-7` is automatically created on cluster startup, leading to the CI failures we've seen; if another test runs first, the post-test teardown deletes the automatically created `.security-7` index, which means this test always passes. 

The above means we need to always send a POST request of some kind to a security endpoint, to ensure the security index always exists, regardless of test order.

I'm assuming don't actually need to test the "missing security index" scenario any more