### PR TITLE
Fix compile (conflicting PRs merged at the same time)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -435,9 +435,7 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
     }
 
     public void testDanglingOrderByMvExpand() {
-        var testAnalyzer = analyzer().addIndex("test", "mapping-default.json")
-            .addAnalysisTestsLookupResolutions()
-            .addAnalysisTestsEnrichResolution();
+        var testAnalyzer = analyzer().addDefaultIndex().addLanguagesLookup().addTestLookup().addAnalysisTestsEnrichResolution();
 
         var err = error(testAnalyzer.query("""
             FROM test


### PR DESCRIPTION
Two ES|QL PRs got merged at the same time (one is [this](https://github.com/elastic/elasticsearch/pull/144638), the other one is [this](https://github.com/elastic/elasticsearch/pull/144515)), one of the two removed a method that the other used.
Fixing the compile problem