### PR TITLE
Turn on test that was muted on issue #144379

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -312,9 +312,6 @@ tests:
 - class: org.elasticsearch.entitlement.qa.EntitlementsAllowedNonModularIT
   method: "testAction {actionName=createLDAPCertStore}"
   issue: https://github.com/elastic/elasticsearch/issues/144376
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/172_knn_query_base64_vectors/kNN query with ambiguous hex/base64 byte string prefers hex}
-  issue: https://github.com/elastic/elasticsearch/issues/144379
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:approximation.Approximate stats by on large single-valued data}
   issue: https://github.com/elastic/elasticsearch/issues/144382


### PR DESCRIPTION
The suite may have some areas for improvement, but I assess that this specific test is not problematic.

see: [144379](https://github.com/elastic/elasticsearch/issues/144379)