### PR TITLE
[9.3] Permit version-bumping no-op index settings updates (#144584)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -1000,7 +1000,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             if (currentSettingsVersion == newSettingsVersion) {
                 assert updateIndexSettings == false : "No index updates are expected as index settings version has not changed";
             } else {
-                assert updateIndexSettings : "Index updates are expected as index settings version has changed";
                 assert currentSettingsVersion < newSettingsVersion
                     : "expected current settings version ["
                         + currentSettingsVersion


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Permit version-bumping no-op index settings updates (#144584)