### PR TITLE
Temporarily allow warning header pattern to match with or without semantic version

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -54,8 +54,8 @@ public class HeaderWarning {
     static Pattern getPatternWithSemanticVersion() {
         return Pattern.compile("299 " + // log level code
             "Elasticsearch-" + // warn agent
-            semanticVersionPattern + "-" + // warn agent: semantic version
-            "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent: hash
+            "(?:" + semanticVersionPattern + "-)?" + // warn agent: optional semantic version
+            "(?:[a-f0-9]{7,40}|unknown) " + // warn agent: hash
             // quoted warning value, captured. Do not add more greedy qualifiers later to avoid excessive backtracking
             "\"(?<quotedStringValue>.*)\"( " +
             // quoted RFC 1123 date format


### PR DESCRIPTION
The warning header agent pattern is selected at startup based on
whether the current build has a semantic version. When a build
extension changes the version from a non-semantic value (e.g. a hash)
to a real semantic version, the pattern must still match warning
headers produced by older nodes using the previous format. Make the
semantic version portion optional and the hash portion always required.

This is a temporary change needed during the transition period where
mixed clusters may contain nodes using both formats.