### PR TITLE
Shortcut for round_to with fixed intervals

### DIFF
--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToDouble.java
@@ -44,7 +44,9 @@ class RoundToDouble {
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> new RoundToDoubleBinarySearchEvaluator.Factory(source, field, f);
+            default -> {
+                yield new RoundToDoubleBinarySearchEvaluator.Factory(source, field, f);
+            }
         };
     };
 

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToInt.java
@@ -44,7 +44,14 @@ class RoundToInt {
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> new RoundToIntBinarySearchEvaluator.Factory(source, field, f);
+            default -> {
+                int interval = extractFixedInterval(f);
+                if (interval > 0) {
+                    yield new RoundToIntFixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
+                } else {
+                    yield new RoundToIntBinarySearchEvaluator.Factory(source, field, f);
+                }
+            }
         };
     };
 
@@ -52,6 +59,27 @@ class RoundToInt {
     static int process(int field, @Fixed(includeInToString = false) int[] points) {
         int idx = Arrays.binarySearch(points, field);
         return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
+    }
+
+    private static int extractFixedInterval(int[] points) {
+        int interval = (points[points.length - 1] - points[0]) / (points.length - 1);
+        for (int i = 1; i < points.length; i++) {
+            if (points[i] - points[i - 1] != interval) {
+                return -1;
+            }
+        }
+        return interval;
+    }
+
+    @Evaluator(extraName = "FixedInterval")
+    static int processFixed(int field, @Fixed int first, @Fixed int last, @Fixed int interval) {
+        if (field < first) {
+            return first; // almost never true in practice; predictor skips this
+        }
+        if (field > last) {
+            return last; // almost never true in practice; predictor skips this
+        }
+        return field - (field - first) % interval;
     }
 
     @Evaluator(extraName = "1")

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLong.java
@@ -44,7 +44,14 @@ class RoundToLong {
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> new RoundToLongBinarySearchEvaluator.Factory(source, field, f);
+            default -> {
+                long interval = extractFixedInterval(f);
+                if (interval > 0) {
+                    yield new RoundToLongFixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
+                } else {
+                    yield new RoundToLongBinarySearchEvaluator.Factory(source, field, f);
+                }
+            }
         };
     };
 
@@ -52,6 +59,27 @@ class RoundToLong {
     static long process(long field, @Fixed(includeInToString = false) long[] points) {
         int idx = Arrays.binarySearch(points, field);
         return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
+    }
+
+    private static long extractFixedInterval(long[] points) {
+        long interval = (points[points.length - 1] - points[0]) / (points.length - 1);
+        for (int i = 1; i < points.length; i++) {
+            if (points[i] - points[i - 1] != interval) {
+                return -1;
+            }
+        }
+        return interval;
+    }
+
+    @Evaluator(extraName = "FixedInterval")
+    static long processFixed(long field, @Fixed long first, @Fixed long last, @Fixed long interval) {
+        if (field < first) {
+            return first; // almost never true in practice; predictor skips this
+        }
+        if (field > last) {
+            return last; // almost never true in practice; predictor skips this
+        }
+        return field - (field - first) % interval;
     }
 
     @Evaluator(extraName = "1")

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFixedIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToIntFixedIntervalEvaluator.java
@@ -1,0 +1,148 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToInt}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToIntFixedIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToIntFixedIntervalEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator field;
+
+  private final int first;
+
+  private final int last;
+
+  private final int interval;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToIntFixedIntervalEvaluator(Source source, ExpressionEvaluator field, int first,
+      int last, int interval, DriverContext driverContext) {
+    this.source = source;
+    this.field = field;
+    this.first = first;
+    this.last = last;
+    this.interval = interval;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock fieldBlock = (IntBlock) field.eval(page)) {
+      IntVector fieldVector = fieldBlock.asVector();
+      if (fieldVector == null) {
+        return eval(page.getPositionCount(), fieldBlock);
+      }
+      return eval(page.getPositionCount(), fieldVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += field.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public IntBlock eval(int positionCount, IntBlock fieldBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (fieldBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        int field = fieldBlock.getInt(fieldBlock.getFirstValueIndex(p));
+        result.appendInt(RoundToInt.processFixed(field, this.first, this.last, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  public IntVector eval(int positionCount, IntVector fieldVector) {
+    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        int field = fieldVector.getInt(p);
+        result.appendInt(p, RoundToInt.processFixed(field, this.first, this.last, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToIntFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(field);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory field;
+
+    private final int first;
+
+    private final int last;
+
+    private final int interval;
+
+    public Factory(Source source, ExpressionEvaluator.Factory field, int first, int last,
+        int interval) {
+      this.source = source;
+      this.field = field;
+      this.first = first;
+      this.last = last;
+      this.interval = interval;
+    }
+
+    @Override
+    public RoundToIntFixedIntervalEvaluator get(DriverContext context) {
+      return new RoundToIntFixedIntervalEvaluator(source, field.get(context), first, last, interval, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToIntFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFixedIntervalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToLongFixedIntervalEvaluator.java
@@ -1,0 +1,148 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RoundToLong}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RoundToLongFixedIntervalEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoundToLongFixedIntervalEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator field;
+
+  private final long first;
+
+  private final long last;
+
+  private final long interval;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RoundToLongFixedIntervalEvaluator(Source source, ExpressionEvaluator field, long first,
+      long last, long interval, DriverContext driverContext) {
+    this.source = source;
+    this.field = field;
+    this.first = first;
+    this.last = last;
+    this.interval = interval;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock fieldBlock = (LongBlock) field.eval(page)) {
+      LongVector fieldVector = fieldBlock.asVector();
+      if (fieldVector == null) {
+        return eval(page.getPositionCount(), fieldBlock);
+      }
+      return eval(page.getPositionCount(), fieldVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += field.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public LongBlock eval(int positionCount, LongBlock fieldBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (fieldBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long field = fieldBlock.getLong(fieldBlock.getFirstValueIndex(p));
+        result.appendLong(RoundToLong.processFixed(field, this.first, this.last, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  public LongVector eval(int positionCount, LongVector fieldVector) {
+    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long field = fieldVector.getLong(p);
+        result.appendLong(p, RoundToLong.processFixed(field, this.first, this.last, this.interval));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RoundToLongFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(field);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory field;
+
+    private final long first;
+
+    private final long last;
+
+    private final long interval;
+
+    public Factory(Source source, ExpressionEvaluator.Factory field, long first, long last,
+        long interval) {
+      this.source = source;
+      this.field = field;
+      this.first = first;
+      this.last = last;
+      this.interval = interval;
+    }
+
+    @Override
+    public RoundToLongFixedIntervalEvaluator get(DriverContext context) {
+      return new RoundToLongFixedIntervalEvaluator(source, field.get(context), first, last, interval, context);
+    }
+
+    @Override
+    public String toString() {
+      return "RoundToLongFixedIntervalEvaluator[" + "field=" + field + ", first=" + first + ", last=" + last + ", interval=" + interval + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/X-RoundTo.java.st
@@ -44,7 +44,18 @@ class RoundTo$Type$ {
              * Break point of 10 experimentally derived on Nik's laptop (13th Gen Intel(R) Core(TM) i7-1370P)
              * on 2025-05-22.
              */
-            default -> new RoundTo$Type$BinarySearchEvaluator.Factory(source, field, f);
+            default -> {
+$if(long||int)$
+                $type$ interval = extractFixedInterval(f);
+                if (interval > 0) {
+                    yield new RoundTo$Type$FixedIntervalEvaluator.Factory(source, field, f[0], f[f.length - 1], interval);
+                } else {
+                    yield new RoundTo$Type$BinarySearchEvaluator.Factory(source, field, f);
+                }
+$else$
+                yield new RoundTo$Type$BinarySearchEvaluator.Factory(source, field, f);
+$endif$
+            }
         };
     };
 
@@ -53,6 +64,29 @@ class RoundTo$Type$ {
         int idx = Arrays.binarySearch(points, field);
         return points[idx >= 0 ? idx : Math.max(0, -idx - 2)];
     }
+
+$if(long||int)$
+    private static $type$ extractFixedInterval($type$[] points) {
+        $type$ interval = (points[points.length - 1] - points[0]) / (points.length - 1);
+        for (int i = 1; i < points.length; i++) {
+            if (points[i] - points[i - 1] != interval) {
+                return -1;
+            }
+        }
+        return interval;
+    }
+
+    @Evaluator(extraName = "FixedInterval")
+    static $type$ processFixed($type$ field, @Fixed $type$ first, @Fixed $type$ last, @Fixed $type$ interval) {
+        if (field < first) {
+            return first; // almost never true in practice; predictor skips this
+        }
+        if (field > last) {
+            return last; // almost never true in practice; predictor skips this
+        }
+        return field - (field - first) % interval;
+    }
+$endif$
 
     @Evaluator(extraName = "1")
     static $type$ process($type$ field, @Fixed $type$ p0) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
@@ -146,6 +146,8 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         suppliers.add(supplier(1.5, 1.0, 0.0, 1.0, 100.0));
         suppliers.add(supplier(200, 100, 0.0, 1.0, 100.0));
 
+        addFixedIntervalCases(suppliers);
+
         return parameterSuppliersFromTypedDataWithDefaultChecks(
             (int nullPosition, DataType nullValueDataType, TestCaseSupplier.TestCase original) -> {
                 if (nullValueDataType != DataType.NULL) {
@@ -163,6 +165,75 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
             },
             randomizeBytesRefsOffset(suppliers)
         );
+    }
+
+    private static void addFixedIntervalCases(List<TestCaseSupplier> suppliers) {
+        for (int numPoints : new int[] { 11, 15, 20 }) {
+            final int n = numPoints;
+            suppliers.add(
+                fixedIntervalLongs(
+                    "<long, " + n + " fixed-interval longs>",
+                    DataType.LONG,
+                    () -> randomLongBetween(0, (long) (n - 1) * 100),
+                    IntStream.range(0, n).mapToObj(i -> DataType.LONG).toList(),
+                    () -> IntStream.range(0, n).mapToObj(i -> (long) i * 100).toList()
+                )
+            );
+            suppliers.add(
+                fixedIntervalInts(
+                    "<int, " + n + " fixed-interval ints>",
+                    DataType.INTEGER,
+                    () -> randomIntBetween(0, (n - 1) * 100),
+                    IntStream.range(0, n).mapToObj(i -> DataType.INTEGER).toList(),
+                    () -> IntStream.range(0, n).mapToObj(i -> i * 100).toList()
+                )
+            );
+            suppliers.add(
+                fixedIntervalLongs(
+                    "<date, " + n + " fixed-interval dates>",
+                    DataType.DATETIME,
+                    () -> randomLongBetween(0, (long) (n - 1) * 300_000),
+                    IntStream.range(0, n).mapToObj(i -> DataType.DATETIME).toList(),
+                    () -> IntStream.range(0, n).mapToObj(i -> (long) i * 300_000).toList()
+                )
+            );
+        }
+    }
+
+    private static TestCaseSupplier fixedIntervalLongs(
+        String name,
+        DataType fieldType,
+        Supplier<Number> fieldSupplier,
+        List<DataType> pointsTypes,
+        Supplier<List<Long>> pointsSupplier
+    ) {
+        return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
+            long max = p.stream().mapToLong(l -> l).min().getAsLong();
+            for (long l : p) {
+                if (l > max && f.doubleValue() > l) {
+                    max = l;
+                }
+            }
+            return max;
+        }, "FixedInterval");
+    }
+
+    private static TestCaseSupplier fixedIntervalInts(
+        String name,
+        DataType fieldType,
+        Supplier<Number> fieldSupplier,
+        List<DataType> pointsTypes,
+        Supplier<List<Integer>> pointsSupplier
+    ) {
+        return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
+            int max = p.stream().mapToInt(i -> i).min().getAsInt();
+            for (int l : p) {
+                if (l > max && f.doubleValue() > l) {
+                    max = l;
+                }
+            }
+            return max;
+        }, "FixedInterval");
     }
 
     private static TestCaseSupplier supplier(double f, double expected, double... points) {
@@ -244,6 +315,18 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         Supplier<List<P>> pointsSupplier,
         BiFunction<Number, List<P>, Number> expected
     ) {
+        return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, expected, null);
+    }
+
+    private static <P> TestCaseSupplier supplier(
+        String name,
+        DataType fieldType,
+        Supplier<Number> fieldSupplier,
+        List<DataType> pointsTypes,
+        Supplier<List<P>> pointsSupplier,
+        BiFunction<Number, List<P>, Number> expected,
+        String forcedSpecialization
+    ) {
         List<DataType> types = new ArrayList<>(pointsTypes.size() + 1);
         types.add(fieldType);
         types.addAll(pointsTypes);
@@ -264,14 +347,28 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
                 case DATETIME, DATE_NANOS, LONG -> "Long";
                 default -> throw new UnsupportedOperationException();
             };
-            Matcher<String> expectedEvaluatorName = startsWith("RoundTo" + type + specialization(points.size()) + "Evaluator");
+            String spec = forcedSpecialization != null ? forcedSpecialization : specialization(points.size(), fieldType, points);
+            Matcher<String> expectedEvaluatorName = startsWith("RoundTo" + type + spec + "Evaluator");
             return new TestCaseSupplier.TestCase(params, expectedEvaluatorName, expectedType, equalTo(expected.apply(field, points)));
         });
     }
 
-    private static String specialization(int pointsSize) {
+    private static <P> String specialization(int pointsSize, DataType dataType, List<P> points) {
         if (pointsSize < 11) {
             return Integer.toString(pointsSize);
+        }
+        // fixed intervals?
+        if (dataType == DataType.INTEGER || dataType == DataType.LONG || dataType == DataType.DATETIME || dataType == DataType.DATE_NANOS) {
+            int size = points.size();
+            long p0 = ((Number) points.get(0)).longValue();
+            long pn = ((Number) points.get(size - 1)).longValue();
+            long interval = (pn - p0) / (size - 1);
+            for (int i = 1; i < size; i++) {
+                if (((Number) points.get(i)).longValue() - ((Number) points.get(i - 1)).longValue() != interval) {
+                    return "BinarySearch";
+                }
+            }
+            return "FixedInterval";
         }
         return "BinarySearch";
     }


### PR DESCRIPTION
This change adds an optimization for round_to when the rounding points are evenly spaced and exceed 10, the threshold where hand-unrolled comparisons are no longer effective. Instead of binary search, we use a single modulo operation. Binary search: 15.4 ns/row. Fixed interval: 3.5 ns/row (~4.5x faster). This should not be a big improvement for small datasets, but for big datasets, it can save a few hundred millis.

```json
{
    "operator": "EvalOperator[evaluator=RoundToLongBinarySearchEvaluator[field=Attribute[channel=3]]]",
    "status": {
        "process_nanos": 1131400350,
        "pages_processed": 36506,
        "rows_received": 73272960,
        "rows_emitted": 73272960
    }
}
```

```json
{
    "operator": "EvalOperator[evaluator=RoundToLongFixedIntervalEvaluator[field=Attribute[channel=3], first=1774535400000, last=1774549800000, interval=300000]]",
    "status": {
        "process_nanos": 242542491,
        "pages_processed": 34818,
        "rows_received": 69851520,
        "rows_emitted": 69851520
    }
}
```