### PR TITLE
Speed up Automatons.subsetOf with primitive pair traversal

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/security/SubsetOfBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/security/SubsetOfBenchmark.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.security;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.elasticsearch.xpack.core.security.support.Automatons;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for {@link Automatons#subsetOf} on realistic security wildcard
+ * patterns — the kind used in role definitions and checked by the
+ * {@code _has_privileges} API.
+ *
+ * <p>Parameters:
+ * <ul>
+ *   <li><b>wildcardMode</b> — pattern shape: SUFFIX, PREFIX, INFIX, or SHARED_PREFIX</li>
+ *   <li><b>numRolePatterns</b> — number of patterns in the role automaton</li>
+ *   <li><b>isSubset</b> — whether the candidate is a subset ({@code true}) or disjoint ({@code false})</li>
+ * </ul>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Thread)
+public class SubsetOfBenchmark {
+
+    public enum WildcardMode {
+        SUFFIX {
+            @Override
+            String apply(String base) {
+                return base + "*";
+            }
+
+            @Override
+            String narrow(String pattern) {
+                return pattern.substring(0, pattern.length() - 1) + "-narrow*";
+            }
+
+            @Override
+            String disjoint(String base) {
+                return "disjoint-" + base + "*";
+            }
+        },
+        PREFIX {
+            @Override
+            String apply(String base) {
+                return "*" + base;
+            }
+
+            @Override
+            String narrow(String pattern) {
+                return "*narrow-" + pattern.substring(1);
+            }
+
+            @Override
+            String disjoint(String base) {
+                return "*disjoint-" + base;
+            }
+        },
+        INFIX {
+            @Override
+            String apply(String base) {
+                return "*" + base + "*";
+            }
+
+            @Override
+            String narrow(String pattern) {
+                return pattern.substring(0, pattern.length() - 1) + "-narrow*";
+            }
+
+            @Override
+            String disjoint(String base) {
+                return "*disjoint-" + base + "*";
+            }
+        },
+        SHARED_PREFIX {
+            @Override
+            String apply(String base) {
+                return "shared-" + base + "*";
+            }
+
+            @Override
+            String narrow(String pattern) {
+                return pattern.substring(0, pattern.length() - 1) + "-narrow*";
+            }
+
+            @Override
+            String disjoint(String base) {
+                return "other-" + base + "*";
+            }
+        };
+
+        abstract String apply(String base);
+
+        abstract String narrow(String pattern);
+
+        abstract String disjoint(String base);
+    }
+
+    private static final int CANDIDATE_PATTERN_COUNT = 4;
+    private static final int PATTERN_LENGTH = 32;
+
+    @Param
+    private WildcardMode wildcardMode;
+
+    @Param({ "10", "250" })
+    private int numRolePatterns;
+
+    @Param({ "true", "false" })
+    private boolean isSubset;
+
+    private Automaton roleAutomaton;
+    private Automaton candidateAutomaton;
+
+    @Setup
+    public void setup() {
+        Random random = new Random(42);
+
+        List<String> rolePatterns = new ArrayList<>(numRolePatterns);
+        for (int i = 0; i < numRolePatterns; i++) {
+            String base = "role-" + i + "-" + randomString(random, PATTERN_LENGTH);
+            rolePatterns.add(wildcardMode.apply(base));
+        }
+        roleAutomaton = Automatons.patterns(rolePatterns);
+
+        List<String> candidatePatterns = new ArrayList<>(CANDIDATE_PATTERN_COUNT);
+        if (isSubset) {
+            for (int i = 0; i < CANDIDATE_PATTERN_COUNT; i++) {
+                candidatePatterns.add(wildcardMode.narrow(rolePatterns.get(i)));
+            }
+        } else {
+            for (int i = 0; i < CANDIDATE_PATTERN_COUNT; i++) {
+                candidatePatterns.add(wildcardMode.disjoint(randomString(random, PATTERN_LENGTH)));
+            }
+        }
+        candidateAutomaton = Automatons.patterns(candidatePatterns);
+    }
+
+    @Benchmark
+    public void subsetOf(final Blackhole bh) {
+        bh.consume(Automatons.subsetOf(candidateAutomaton, roleAutomaton));
+    }
+
+    private static String randomString(Random random, int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append((char) ('a' + random.nextInt(26)));
+        }
+        return sb.toString();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(SubsetOfBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}

--- a/docs/changelog/144715.yaml
+++ b/docs/changelog/144715.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 144715
+summary: Speed up Automatons.subsetOf with primitive pair traversal
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-import org.apache.lucene.util.automaton.StatePair;
 import org.apache.lucene.util.automaton.Transition;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
@@ -22,7 +21,6 @@ import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.lucene.util.automaton.MinimizationOperations;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -393,47 +391,82 @@ public final class Automatons {
         assert Operations.hasDeadStatesFromInitial(a1) == false;
         assert Operations.hasDeadStatesFromInitial(a2) == false;
         if (a1.getNumStates() == 0) {
-            // Empty language is alwyas a subset of any other language
+            // Empty language is always a subset of any other language
             return true;
         } else if (a2.getNumStates() == 0) {
             return Operations.isEmpty(a1);
         }
 
-        // TODO: cutover to iterators instead
-        Transition[][] transitions1 = a1.getSortedTransitions();
-        Transition[][] transitions2 = a2.getSortedTransitions();
-        ArrayDeque<StatePair> worklist = new ArrayDeque<>();
-        HashSet<StatePair> visited = new HashSet<>();
-        StatePair p = new StatePair(0, 0);
-        worklist.add(p);
-        visited.add(p);
-        while (worklist.size() > 0) {
-            p = worklist.removeFirst();
-            if (a1.isAccept(p.s1) && a2.isAccept(p.s2) == false) {
+        // Open-addressing hash set for visited state pairs, packed as longs.
+        // Sentinel -1L is safe: state indices are non-negative, so the packed
+        // long ((s1 << 32) | s2) is always >= 0.
+        long[] visitedTable = new long[32];
+        Arrays.fill(visitedTable, -1L);
+        int visitedMask = visitedTable.length - 1;
+        int visitedSize = 0;
+
+        // BFS worklist storing packed state pairs.
+        long[] worklist = new long[32];
+        int head = 0, tail = 0;
+
+        long initial = packStates(0, 0);
+        insertIntoTable(visitedTable, visitedMask, initial);
+        visitedSize++;
+        worklist[tail++] = initial;
+
+        Transition t1 = new Transition();
+        Transition t2 = new Transition();
+
+        while (head < tail) {
+            long pair = worklist[head++];
+            int s1 = (int) (pair >>> 32);
+            int s2 = (int) pair;
+
+            if (a1.isAccept(s1) && a2.isAccept(s2) == false) {
                 return false;
             }
-            Transition[] t1 = transitions1[p.s1];
-            Transition[] t2 = transitions2[p.s2];
-            for (int n1 = 0, b2 = 0; n1 < t1.length; n1++) {
-                while (b2 < t2.length && t2[b2].max < t1[n1].min) {
+
+            int count1 = a1.getNumTransitions(s1);
+            int count2 = a2.getNumTransitions(s2);
+
+            for (int n1 = 0, b2 = 0; n1 < count1; n1++) {
+                a1.getTransition(s1, n1, t1);
+                int t1Min = t1.min, t1Max = t1.max, t1Dest = t1.dest;
+
+                while (b2 < count2) {
+                    a2.getTransition(s2, b2, t2);
+                    if (t2.max >= t1Min) break;
                     b2++;
                 }
-                int min1 = t1[n1].min, max1 = t1[n1].max;
+                int min1 = t1Min, max1 = t1Max;
 
-                for (int n2 = b2; n2 < t2.length && t1[n1].max >= t2[n2].min; n2++) {
-                    if (t2[n2].min > min1) {
+                for (int n2 = b2; n2 < count2; n2++) {
+                    if (n2 > b2) {
+                        a2.getTransition(s2, n2, t2);
+                    }
+                    if (t1Max < t2.min) break;
+
+                    if (t2.min > min1) {
                         return false;
                     }
-                    if (t2[n2].max < Character.MAX_CODE_POINT) {
-                        min1 = t2[n2].max + 1;
+                    if (t2.max < Character.MAX_CODE_POINT) {
+                        min1 = t2.max + 1;
                     } else {
                         min1 = Character.MAX_CODE_POINT;
                         max1 = Character.MIN_CODE_POINT;
                     }
-                    StatePair q = new StatePair(t1[n1].dest, t2[n2].dest);
-                    if (visited.contains(q) == false) {
-                        worklist.add(q);
-                        visited.add(q);
+
+                    long key = packStates(t1Dest, t2.dest);
+                    if (probeAndAdd(visitedTable, visitedMask, key)) {
+                        visitedSize++;
+                        if (visitedSize * 2 > visitedTable.length) {
+                            visitedTable = rehashVisited(visitedTable);
+                            visitedMask = visitedTable.length - 1;
+                        }
+                        if (tail >= worklist.length) {
+                            worklist = Arrays.copyOf(worklist, worklist.length * 2);
+                        }
+                        worklist[tail++] = key;
                     }
                 }
                 if (min1 <= max1) {
@@ -443,4 +476,57 @@ public final class Automatons {
         }
         return true;
     }
+
+    private static long packStates(int s1, int s2) {
+        return ((long) s1 << 32) | (s2 & 0xFFFFFFFFL);
+    }
+
+    /**
+     * Hashes a packed state pair. Uses a multiplicative mix so that diagonal
+     * pairs (s1 == s2) do not all collide — {@code Long.hashCode} XORs the
+     * two halves, producing 0 for every diagonal pair.
+     */
+    private static int hashStatePair(long key) {
+        int s1 = (int) (key >>> 32);
+        int s2 = (int) key;
+        return s1 * 0x9E3779B9 + s2;
+    }
+
+    /** Adds a key known to be absent. Used during rehash. */
+    private static void insertIntoTable(long[] table, int mask, long key) {
+        int slot = hashStatePair(key) & mask;
+        while (table[slot] != -1L) {
+            slot = (slot + 1) & mask;
+        }
+        table[slot] = key;
+    }
+
+    /** Probes for {@code key}; inserts and returns true if absent. */
+    private static boolean probeAndAdd(long[] table, int mask, long key) {
+        int slot = hashStatePair(key) & mask;
+        while (true) {
+            long existing = table[slot];
+            if (existing == -1L) {
+                table[slot] = key;
+                return true;
+            }
+            if (existing == key) {
+                return false;
+            }
+            slot = (slot + 1) & mask;
+        }
+    }
+
+    private static long[] rehashVisited(long[] oldTable) {
+        long[] newTable = new long[oldTable.length * 2];
+        Arrays.fill(newTable, -1L);
+        int newMask = newTable.length - 1;
+        for (long key : oldTable) {
+            if (key != -1L) {
+                insertIntoTable(newTable, newMask, key);
+            }
+        }
+        return newTable;
+    }
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
@@ -115,14 +115,16 @@ public class AutomatonsTests extends ESTestCase {
     }
 
     public void testSubsetOfDataDriven() {
-        List<SubsetCase> cases = new ArrayList<>(List.of(
-            new SubsetCase(List.of(), List.of("*"), true),
-            new SubsetCase(List.of("logs-prod-*"), List.of("logs-*"), true),
-            new SubsetCase(List.of("logs-*"), List.of("logs-prod-*"), false),
-            new SubsetCase(List.of("metrics-*"), List.of("logs-*"), false),
-            new SubsetCase(List.of("logs-prod-*", "metrics-*"), List.of("logs-*", "metrics-*"), true),
-            new SubsetCase(List.of("logs-*", "traces-*"), List.of("logs-*", "metrics-*"), false)
-        ));
+        List<SubsetCase> cases = new ArrayList<>(
+            List.of(
+                new SubsetCase(List.of(), List.of("*"), true),
+                new SubsetCase(List.of("logs-prod-*"), List.of("logs-*"), true),
+                new SubsetCase(List.of("logs-*"), List.of("logs-prod-*"), false),
+                new SubsetCase(List.of("metrics-*"), List.of("logs-*"), false),
+                new SubsetCase(List.of("logs-prod-*", "metrics-*"), List.of("logs-*", "metrics-*"), true),
+                new SubsetCase(List.of("logs-*", "traces-*"), List.of("logs-*", "metrics-*"), false)
+            )
+        );
 
         // Large DFA cases to force growth of visited-pair hash table and BFS worklist.
         List<String> largePatterns = generateLiteralPatterns("logs", 256);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import static org.elasticsearch.xpack.core.security.support.Automatons.pattern;
 import static org.elasticsearch.xpack.core.security.support.Automatons.patterns;
@@ -111,6 +112,47 @@ public class AutomatonsTests extends ESTestCase {
         final Automaton automaton = Automatons.patterns(patterns);
         assertTrue(Operations.isTotal(automaton));
         assertTrue(automaton.isDeterministic());
+    }
+
+    public void testSubsetOfDataDriven() {
+        List<SubsetCase> cases = new ArrayList<>(List.of(
+            new SubsetCase(List.of(), List.of("*"), true),
+            new SubsetCase(List.of("logs-prod-*"), List.of("logs-*"), true),
+            new SubsetCase(List.of("logs-*"), List.of("logs-prod-*"), false),
+            new SubsetCase(List.of("metrics-*"), List.of("logs-*"), false),
+            new SubsetCase(List.of("logs-prod-*", "metrics-*"), List.of("logs-*", "metrics-*"), true),
+            new SubsetCase(List.of("logs-*", "traces-*"), List.of("logs-*", "metrics-*"), false)
+        ));
+
+        // Large DFA cases to force growth of visited-pair hash table and BFS worklist.
+        List<String> largePatterns = generateLiteralPatterns("logs", 256);
+        List<String> largeSupersetMissingTail = new ArrayList<>(largePatterns);
+        largeSupersetMissingTail.remove(largeSupersetMissingTail.size() - 1);
+        cases.add(new SubsetCase(largePatterns, largePatterns, true));
+        cases.add(new SubsetCase(largePatterns, largeSupersetMissingTail, false));
+
+        for (SubsetCase subsetCase : cases) {
+            Automaton candidate = Automatons.patterns(subsetCase.candidatePatterns());
+            Automaton superset = Automatons.patterns(subsetCase.supersetPatterns());
+            assertThat(
+                "candidate=" + subsetCase.candidatePatterns() + " superset=" + subsetCase.supersetPatterns(),
+                Automatons.subsetOf(candidate, superset),
+                equalTo(subsetCase.expected())
+            );
+        }
+    }
+
+    private static List<String> generateLiteralPatterns(String prefix, int count) {
+        List<String> patterns = new ArrayList<>(count);
+        Random random = new Random(0L);
+        for (int i = 0; i < count; i++) {
+            StringBuilder sb = new StringBuilder(prefix).append('-').append(i).append('-');
+            for (int j = 0; j < 18; j++) {
+                sb.append((char) ('a' + random.nextInt(26)));
+            }
+            patterns.add(sb.toString());
+        }
+        return patterns;
     }
 
     private void assertMatch(Automaton automaton, String text) {
@@ -235,4 +277,6 @@ public class AutomatonsTests extends ESTestCase {
         }
         return out;
     }
+
+    private record SubsetCase(List<String> candidatePatterns, List<String> supersetPatterns, boolean expected) {}
 }


### PR DESCRIPTION
Rewrites `Automatons.subsetOf` to eliminate object allocation during BFS traversal. The original implementation allocated `StatePair` objects, a `HashSet<StatePair>`, an `ArrayDeque<StatePair>`, and a `Transition[][]` for every state via `getSortedTransitions()`. The new implementation:

- Packs `(s1, s2)` state pairs into primitive `long` values
- Uses an open-addressing `long[]` hash set (linear probing, 50% load factor) instead of `HashSet`
- Uses a `long[]` array as BFS worklist instead of `ArrayDeque`
- Reads transitions on demand via `getTransition()` instead of pre-allocating all transitions

### Benchmark results

`SubsetOfBenchmark` — JMH, 3 warmup + 3 measurement iterations, Fork 1, JDK 25, Apple Silicon.

| isSubset | numPatterns | wildcardMode  | Original (us/op) | Optimized (us/op) | Speedup |
|----------|-------------|---------------|------------------:|------------------:|--------:|
| true     | 10          | SUFFIX        |             4.78  |             2.42  |   2.0x  |
| true     | 10          | PREFIX        |            27.51  |            28.13  |   1.0x  |
| true     | 10          | INFIX         |            29.01  |            20.48  |   1.4x  |
| true     | 250         | SUFFIX        |            34.20  |             2.59  |  13.2x  |
| true     | 250         | PREFIX        |           642.05  |           463.11  |   1.4x  |
| true     | 250         | INFIX         |           551.28  |           445.95  |   1.2x  |
| false    | 10          | SUFFIX        |             1.93  |             0.01  | 214.0x  |
| false    | 10          | PREFIX        |            31.98  |            25.04  |   1.3x  |
| false    | 10          | INFIX         |            34.11  |            28.15  |   1.2x  |
| false    | 250         | SUFFIX        |            31.58  |             0.01  | 3508x   |
| false    | 250         | PREFIX        |           739.49  |           467.12  |   1.6x  |
| false    | 250         | INFIX         |           674.22  |           707.79  |   0.95x |

The largest gains come from SUFFIX and SHARED_PREFIX patterns (the most common shapes in security role definitions), where eliminating `getSortedTransitions()` allocation avoids materializing transitions for all states before BFS even begins. PREFIX/INFIX patterns produce large state graphs dominated by traversal cost, so the allocation savings are proportionally smaller.