### PR TITLE
[TEST] Exclude updated tsid format from testParsedDescriptionWithIndexDimensions

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -369,14 +369,9 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/144699
-- class: org.elasticsearch.index.mapper.TsidExtractingIdFieldMapperTests
-  method: testParsedDescriptionWithIndexDimensions
-  issue: https://github.com/elastic/elasticsearch/issues/144678
 - class: org.elasticsearch.index.store.StoreDirectoryMetricsIT
   method: testDirectoryMetrics
   issue: https://github.com/elastic/elasticsearch/issues/144702
-- class: org.elasticsearch.index.mapper.TsidExtractingIdFieldMapperTests
-  issue: https://github.com/elastic/elasticsearch/issues/144678
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   issue: https://github.com/elastic/elasticsearch/issues/144709
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
@@ -1142,7 +1142,10 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
         IndexVersion minimumVersion = useSyntheticId
             ? IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_94
             : IndexVersions.TSID_CREATED_DURING_ROUTING;
-        IndexVersion version = IndexVersionUtils.randomVersionOnOrAfter(minimumVersion);
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(
+            minimumVersion,
+            IndexVersionUtils.getPreviousVersion(IndexVersions.TSID_SINGLE_PREFIX_BYTE_FEATURE_FLAG)
+        );
         assertThat(
             TsidExtractingIdFieldMapper.INSTANCE.documentDescription(parse(mapperService(true, useSyntheticId, version), testCase.source)),
             equalTo(


### PR DESCRIPTION
#143955 introduced a new format for TSID that doesn't match the hard-coded version in this test. The expected format will be updated for all tests in `TsidExtractingIdFieldMapperTests` before removing the guarding feature flag.

Fixes #144678 