### PR TITLE
Tests: Fix StoreDirectoryMetricsIT testDirectoryMetrics

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -241,9 +241,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/144672
-- class: org.elasticsearch.index.store.StoreDirectoryMetricsIT
-  method: testDirectoryMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/144702
 - class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
   method: testDisablePitWhenCrossProjectSearchIsEnabled
   issue: https://github.com/elastic/elasticsearch/issues/144822

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/StoreDirectoryMetricsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.store;
 
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -27,8 +28,9 @@ import java.util.stream.IntStream;
 import static org.hamcrest.Matchers.equalTo;
 
 public class StoreDirectoryMetricsIT extends ESIntegTestCase {
+
     public void testDirectoryMetrics() throws IOException {
-        assumeTrue("directry metrics feature flag must be enabled for test", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
+        assumeTrue("directory metrics feature flag must be enabled for test", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
 
         final String indexName = randomIndexName();
         createIndex(indexName, 1, 0);
@@ -42,10 +44,12 @@ public class StoreDirectoryMetricsIT extends ESIntegTestCase {
         final ShardId shardId = new ShardId(clusterService().state().metadata().getProject().index(indexName).getIndex(), 0);
 
         IndexShard searchShard = indicesService.getShardOrNull(shardId);
-        Tuple<Long, DirectoryMetrics> tuple = indicesService.withDirectoryMetrics(() -> {
-            try (Engine.Searcher searcher = searchShard.acquireSearcher("test")) {
-                Directory directory = searcher.getDirectoryReader().directory();
-                Collection<String> files = searcher.getDirectoryReader().getIndexCommit().getFileNames();
+
+        try (Engine.IndexCommitRef commitRef = searchShard.acquireLastIndexCommit(true)) {
+            final IndexCommit commit = commitRef.getIndexCommit();
+            Tuple<Long, DirectoryMetrics> tuple = indicesService.withDirectoryMetrics(() -> {
+                Directory directory = commit.getDirectory();
+                Collection<String> files = commit.getFileNames();
                 long reads = 0;
                 for (String file : files) {
                     IndexInput indexInput = directory.openInput(
@@ -60,10 +64,10 @@ public class StoreDirectoryMetricsIT extends ESIntegTestCase {
                     indexInput.close();
                 }
                 return reads;
-            }
-        });
-        DirectoryMetrics metrics = tuple.v2();
-        StoreMetrics storeMetrics = metrics.metrics("store").cast(StoreMetrics.class);
-        assertThat(storeMetrics.getBytesRead(), equalTo(tuple.v1()));
+            });
+            DirectoryMetrics metrics = tuple.v2();
+            StoreMetrics storeMetrics = metrics.metrics("store").cast(StoreMetrics.class);
+            assertThat(storeMetrics.getBytesRead(), equalTo(tuple.v1()));
+        }
     }
 }


### PR DESCRIPTION
The underlying problem of this test is, that an outdated segments file has been accessed, that gets removed while the test is running.

The workaround here is to use the last index commit as the searcher commit lists a segments file with an older generation. Using acquireIndexCommit here should ensure files exist until finished, due to refcounting.

Closes #144702