### PR TITLE
Update serverless status to unavailable for `_routing` field

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-routing-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-routing-field.md
@@ -1,7 +1,7 @@
 ---
 applies_to:
   stack:
-  serverless:
+  serverless: unavailable
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html
 ---


### PR DESCRIPTION
closes https://github.com/elastic/docs-content/issues/5475
