### PR TITLE
[9.3] - Unmute RerankIT#testRerankRowLimitEnforcement

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -363,9 +363,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testInferDeploysDefaultRerank
   issue: https://github.com/elastic/elasticsearch/issues/144162
-- class: org.elasticsearch.xpack.esql.plugin.RerankIT
-  method: testRerankRowLimitEnforcement
-  issue: https://github.com/elastic/elasticsearch/issues/144421
 - class: org.elasticsearch.indices.IndicesRequestCacheIT
   method: testCanCache
   issue: https://github.com/elastic/elasticsearch/issues/144526


### PR DESCRIPTION
The muted RerankIT#testRerankRowLimitEnforcement was just flaky because of [testing infra issue](https://github.com/elastic/elasticsearch/pull/144724)

Fixes https://github.com/elastic/elasticsearch/issues/144421