### PR TITLE
[9.3] Fix up exception messages in `AzureBlobStore` (#144654)

### DIFF
--- a/docs/changelog/144654.yaml
+++ b/docs/changelog/144654.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 144654
+summary: Fix up exception messages in `AzureBlobStore`
+type: bug

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -753,7 +753,7 @@ public class AzureBlobStore implements BlobStore {
                 }
                 if (numOfBytesRead == -1 && currentTotalLength.get() < length) {
                     throw new IllegalStateException(
-                        "InputStream provided" + currentTotalLength + " bytes, less than the expected" + length + " bytes"
+                        "InputStream provided " + currentTotalLength.get() + " bytes, less than the expected" + length + " bytes"
                     );
                 }
                 return ByteBuffer.wrap(buffer);
@@ -886,14 +886,14 @@ public class AzureBlobStore implements BlobStore {
                 }
                 if (numOfBytesRead == -1 && bytesRead.get() < length) {
                     throw new IllegalStateException(
-                        format("Input stream [%s] emitted %d bytes, less than the expected %d bytes.", stream, bytesRead, length)
+                        format("Input stream [%s] emitted %d bytes, less than the expected %d bytes.", stream, bytesRead.get(), length)
                     );
                 }
                 return ByteBuffer.wrap(buffer);
             })).doOnComplete(() -> {
                 if (bytesRead.get() > length) {
                     throw new IllegalStateException(
-                        format("Input stream [%s] emitted %d bytes, more than the expected %d bytes.", stream, bytesRead, length)
+                        format("Input stream [%s] emitted %d bytes, more than the expected %d bytes.", stream, bytesRead.get(), length)
                     );
                 }
             });


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix up exception messages in `AzureBlobStore` (#144654)