### PR TITLE
Add index pattern path param to Prometheus query_range endpoint

### DIFF
--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusQueryRangeRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusQueryRangeRestIT.java
@@ -66,6 +66,13 @@ public class PrometheusQueryRangeRestIT extends ESRestTestCase {
         assertMetricResults(responsePath);
     }
 
+    public void testQueryRangeWithIndexPattern() throws Exception {
+        ingestTestData();
+
+        ObjectPath responsePath = executeQueryRangeWithIndex("metrics-generic.prometheus-*");
+        assertMetricResults(responsePath);
+    }
+
     private static void assertMetricResults(ObjectPath responsePath) throws IOException {
         assertThat(responsePath.evaluate("data.result"), hasSize(1));
         assertThat(responsePath.evaluate("data.result.0.metric.job"), equalTo("test_job"));
@@ -74,7 +81,12 @@ public class PrometheusQueryRangeRestIT extends ESRestTestCase {
     }
 
     private ObjectPath executeQueryRange() throws Exception {
-        Request request = new Request("GET", "/_prometheus/api/v1/query_range");
+        return executeQueryRangeWithIndex(null);
+    }
+
+    private ObjectPath executeQueryRangeWithIndex(String index) throws Exception {
+        String path = index == null ? "/_prometheus/api/v1/query_range" : "/_prometheus/" + index + "/api/v1/query_range";
+        Request request = new Request("GET", path);
         request.addParameter("query", "test_gauge_qr{job=\"test_job\"}");
         request.addParameter("start", "2026-01-01T00:00:00Z");
         request.addParameter("end", "2026-01-01T00:05:00Z");

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
@@ -62,10 +62,7 @@ public class PrometheusQueryRangeRestAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(
-            new Route(GET, "/_prometheus/api/v1/query_range"),
-            new Route(GET, "/_prometheus/{index}/api/v1/query_range")
-        );
+        return List.of(new Route(GET, "/_prometheus/api/v1/query_range"), new Route(GET, "/_prometheus/{index}/api/v1/query_range"));
     }
 
     @Override

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
@@ -62,7 +62,10 @@ public class PrometheusQueryRangeRestAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_prometheus/api/v1/query_range"));
+        return List.of(
+            new Route(GET, "/_prometheus/api/v1/query_range"),
+            new Route(GET, "/_prometheus/{index}/api/v1/query_range")
+        );
     }
 
     @Override
@@ -71,9 +74,10 @@ public class PrometheusQueryRangeRestAction extends BaseRestHandler {
         String start = getRequiredParam(request, START_PARAM);
         String end = getRequiredParam(request, END_PARAM);
         String step = getRequiredParam(request, PrometheusQueryRangeResponseListener.STEP_PARAM);
+        String index = request.param(INDEX_PARAM, "*");
 
         EsqlQueryRequest esqlRequest = EsqlQueryRequest.syncEsqlQueryRequest(ESQL_QUERY);
-        esqlRequest.params(buildQueryParams(query, "*", start, end, step));
+        esqlRequest.params(buildQueryParams(query, index, start, end, step));
 
         return channel -> client.execute(EsqlQueryAction.INSTANCE, esqlRequest, new PrometheusQueryRangeResponseListener(channel));
     }


### PR DESCRIPTION
Adds a second route `/_prometheus/{index}/api/v1/query_range` that lets callers scope queries to a specific index pattern instead of the default `*`.

When the `{index}` path parameter is present it replaces the `*` wildcard passed to the underlying `PROMQL` ES|QL command. The original `/_prometheus/api/v1/query_range` route is unchanged.