### PR TITLE
[ESQL] GCS native async I/O via ReadChannel

### DIFF
--- a/docs/changelog/144733.yaml
+++ b/docs/changelog/144733.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144733
+summary: GCS native async I/O via `ReadChannel`
+type: enhancement

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
@@ -14,6 +14,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -161,7 +162,7 @@ public final class GcsStorageObject implements StorageObject {
                 reader.limit(position + target.remaining());
                 int totalRead = 0;
                 while (target.hasRemaining()) {
-                    int n = reader.read(target);
+                    int n = readFromChannel(reader, target);
                     if (n < 0) {
                         break;
                     }
@@ -196,7 +197,7 @@ public final class GcsStorageObject implements StorageObject {
                     reader.limit(position + length);
                     ByteBuffer buffer = ByteBuffer.allocate((int) length);
                     while (buffer.hasRemaining()) {
-                        int n = reader.read(buffer);
+                        int n = readFromChannel(reader, buffer);
                         if (n < 0) {
                             break;
                         }
@@ -219,6 +220,11 @@ public final class GcsStorageObject implements StorageObject {
     @Override
     public boolean supportsNativeAsync() {
         return true;
+    }
+
+    @SuppressForbidden(reason = "GCS ReadChannel is not a FileChannel; Channels.* helpers do not apply")
+    private static int readFromChannel(ReadChannel reader, ByteBuffer target) throws IOException {
+        return reader.read(target);
     }
 
     private void fetchMetadata() throws IOException {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
@@ -195,7 +195,7 @@ public final class GcsStorageObject implements StorageObject {
                 try (ReadChannel reader = storage.reader(blobId)) {
                     reader.seek(position);
                     reader.limit(position + length);
-                    ByteBuffer buffer = ByteBuffer.allocate((int) length);
+                    ByteBuffer buffer = ByteBuffer.allocate(Math.toIntExact(length));
                     while (buffer.hasRemaining()) {
                         int n = readFromChannel(reader, buffer);
                         if (n < 0) {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
@@ -13,17 +13,33 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.time.Instant;
+import java.util.concurrent.Executor;
 
 /**
  * StorageObject implementation for Google Cloud Storage.
- * Supports full and range reads, and metadata retrieval with caching.
+ * Supports full and range reads, metadata retrieval with caching, and efficient positional
+ * byte reads via {@link ReadChannel#read(ByteBuffer)}.
+ * <p>
+ * In addition to the required stream-based API, this class overrides:
+ * <ul>
+ *   <li>{@link #readBytes(long, ByteBuffer)} — uses {@code ReadChannel.read(ByteBuffer)} for
+ *       direct buffer reads without intermediate byte[] allocation.</li>
+ *   <li>{@link #readBytesAsync(long, long, Executor, ActionListener)} — executor-wrapped
+ *       ReadChannel reads for the async API.</li>
+ *   <li>{@link #supportsNativeAsync()} — returns {@code true} because this class provides custom
+ *       async and byte-read implementations that are more efficient than the default InputStream
+ *       wrappers. Note: the async path is executor-based (blocking a worker thread), not truly
+ *       non-blocking like {@code HttpClient.sendAsync()} or {@code S3AsyncClient}.</li>
+ * </ul>
  */
 public final class GcsStorageObject implements StorageObject {
     private final Storage storage;
@@ -131,6 +147,78 @@ public final class GcsStorageObject implements StorageObject {
     @Override
     public StoragePath path() {
         return path;
+    }
+
+    @Override
+    public int readBytes(long position, ByteBuffer target) throws IOException {
+        if (target.hasRemaining() == false) {
+            return 0;
+        }
+        try {
+            BlobId blobId = BlobId.of(bucket, objectName);
+            try (ReadChannel reader = storage.reader(blobId)) {
+                reader.seek(position);
+                reader.limit(position + target.remaining());
+                int totalRead = 0;
+                while (target.hasRemaining()) {
+                    int n = reader.read(target);
+                    if (n < 0) {
+                        break;
+                    }
+                    totalRead += n;
+                }
+                return totalRead == 0 ? -1 : totalRead;
+            }
+        } catch (StorageException e) {
+            if (e.getCode() == 404) {
+                throw new IOException("Object not found: " + path, e);
+            }
+            throw new IOException("Failed to read bytes from " + path, e);
+        }
+    }
+
+    @Override
+    public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+        if (position < 0) {
+            listener.onFailure(new IllegalArgumentException("position must be non-negative, got: " + position));
+            return;
+        }
+        if (length < 0) {
+            listener.onFailure(new IllegalArgumentException("length must be non-negative, got: " + length));
+            return;
+        }
+
+        executor.execute(() -> {
+            try {
+                BlobId blobId = BlobId.of(bucket, objectName);
+                try (ReadChannel reader = storage.reader(blobId)) {
+                    reader.seek(position);
+                    reader.limit(position + length);
+                    ByteBuffer buffer = ByteBuffer.allocate((int) length);
+                    while (buffer.hasRemaining()) {
+                        int n = reader.read(buffer);
+                        if (n < 0) {
+                            break;
+                        }
+                    }
+                    buffer.flip();
+                    listener.onResponse(buffer);
+                }
+            } catch (StorageException e) {
+                if (e.getCode() == 404) {
+                    listener.onFailure(new IOException("Object not found: " + path, e));
+                } else {
+                    listener.onFailure(new IOException("Failed to read bytes from " + path, e));
+                }
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    @Override
+    public boolean supportsNativeAsync() {
+        return true;
     }
 
     private void fetchMetadata() throws IOException {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
@@ -88,10 +88,7 @@ public final class GcsStorageObject implements StorageObject {
             ReadChannel reader = storage.reader(blobId);
             return Channels.newInputStream(reader);
         } catch (StorageException e) {
-            if (e.getCode() == 404) {
-                throw new IOException("Object not found: " + path, e);
-            }
-            throw new IOException("Failed to read object from " + path, e);
+            throw wrapException(e, "Failed to read object from");
         }
     }
 
@@ -111,10 +108,7 @@ public final class GcsStorageObject implements StorageObject {
             reader.limit(position + length);
             return Channels.newInputStream(reader);
         } catch (StorageException e) {
-            if (e.getCode() == 404) {
-                throw new IOException("Object not found: " + path, e);
-            }
-            throw new IOException("Range request failed for " + path, e);
+            throw wrapException(e, "Range request failed for");
         }
     }
 
@@ -171,10 +165,7 @@ public final class GcsStorageObject implements StorageObject {
                 return totalRead == 0 ? -1 : totalRead;
             }
         } catch (StorageException e) {
-            if (e.getCode() == 404) {
-                throw new IOException("Object not found: " + path, e);
-            }
-            throw new IOException("Failed to read bytes from " + path, e);
+            throw wrapException(e, "Failed to read bytes from");
         }
     }
 
@@ -206,11 +197,7 @@ public final class GcsStorageObject implements StorageObject {
                     listener.onResponse(buffer);
                 }
             } catch (StorageException e) {
-                if (e.getCode() == 404) {
-                    listener.onFailure(new IOException("Object not found: " + path, e));
-                } else {
-                    listener.onFailure(new IOException("Failed to read bytes from " + path, e));
-                }
+                listener.onFailure(wrapException(e, "Failed to read bytes from"));
             } catch (Exception e) {
                 listener.onFailure(e);
             }
@@ -225,6 +212,11 @@ public final class GcsStorageObject implements StorageObject {
     @SuppressForbidden(reason = "GCS ReadChannel is not a FileChannel; Channels.* helpers do not apply")
     private static int readFromChannel(ReadChannel reader, ByteBuffer target) throws IOException {
         return reader.read(target);
+    }
+
+    private IOException wrapException(StorageException e, String operation) {
+        String message = e.getCode() == 404 ? "Object not found: " + path : operation + " " + path;
+        return new IOException(message, e);
     }
 
     private void fetchMetadata() throws IOException {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProvider.java
@@ -42,10 +42,13 @@ import java.util.NoSuchElementException;
  *   <li>Application Default Credentials (ADC) — environment variable, metadata server, etc.</li>
  * </ul>
  * <p>
- * Note: this implementation does not currently provide native async support
- * ({@code readBytesAsync} / {@code supportsNativeAsync}). The GCS Java client does support
- * async operations, and adding native async would improve Parquet parallel column chunk reads.
- * TODO: implement native async via the GCS async client for improved Parquet read performance.
+ * {@link GcsStorageObject} provides optimized I/O via GCS {@link com.google.cloud.ReadChannel}:
+ * <ul>
+ *   <li>{@code readBytes} reads directly into {@link java.nio.ByteBuffer} without intermediate copies</li>
+ *   <li>{@code readBytesAsync} uses executor-based async with efficient ReadChannel reads</li>
+ * </ul>
+ * The async path blocks a worker thread (not truly non-blocking like HTTP sendAsync or S3AsyncClient)
+ * but avoids the byte[] allocation overhead of the default InputStream-based wrappers.
  */
 public final class GcsStorageProvider implements StorageProvider {
     private volatile Storage storage;

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -281,7 +282,7 @@ public class GcsStorageObjectTests extends ESTestCase {
         when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
         doAnswer(invocation -> {
             ByteBuffer buf = invocation.getArgument(0);
-            byte[] data = "hello".getBytes();
+            byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
             buf.put(data);
             return data.length;
         }).when(mockReader).read(any(ByteBuffer.class));
@@ -351,7 +352,7 @@ public class GcsStorageObjectTests extends ESTestCase {
         when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
         doAnswer(invocation -> {
             ByteBuffer buf = invocation.getArgument(0);
-            byte[] data = "async".getBytes();
+            byte[] data = "async".getBytes(StandardCharsets.UTF_8);
             buf.put(data);
             return data.length;
         }).when(mockReader).read(any(ByteBuffer.class));

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
@@ -13,16 +13,22 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +37,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for GcsStorageObject.
  * Tests constructor validation, accessor methods, cached metadata behavior,
- * stream operations, and error handling.
+ * stream operations, readBytes, readBytesAsync, and error handling.
  */
 public class GcsStorageObjectTests extends ESTestCase {
 
@@ -266,5 +272,172 @@ public class GcsStorageObjectTests extends ESTestCase {
 
         assertEquals(4096L, obj.length());
         verify(mockStorage, times(0)).get(any(BlobId.class));
+    }
+
+    // === readBytes tests ===
+
+    public void testReadBytesUsesReadChannel() throws IOException {
+        ReadChannel mockReader = mock(ReadChannel.class);
+        when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
+        doAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte[] data = "hello".getBytes();
+            buf.put(data);
+            return data.length;
+        }).when(mockReader).read(any(ByteBuffer.class));
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        ByteBuffer target = ByteBuffer.allocate(5);
+        int bytesRead = obj.readBytes(100, target);
+
+        assertEquals(5, bytesRead);
+        assertEquals(0, target.remaining());
+        verify(mockReader).seek(100);
+        verify(mockReader).limit(105);
+        verify(mockReader).close();
+    }
+
+    public void testReadBytesEmptyBufferReturnsZero() throws IOException {
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        ByteBuffer target = ByteBuffer.allocate(0);
+        int result = obj.readBytes(0, target);
+        assertEquals(0, result);
+    }
+
+    public void testReadBytesReturnsMinusOneAtEof() throws IOException {
+        ReadChannel mockReader = mock(ReadChannel.class);
+        when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
+        when(mockReader.read(any(ByteBuffer.class))).thenReturn(-1);
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        ByteBuffer target = ByteBuffer.allocate(10);
+        int result = obj.readBytes(9999, target);
+        assertEquals(-1, result);
+        verify(mockReader).close();
+    }
+
+    public void testReadBytesWraps404AsIOException() {
+        when(mockStorage.reader(any(BlobId.class))).thenThrow(new StorageException(404, "Not Found"));
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        ByteBuffer target = ByteBuffer.allocate(10);
+        IOException e = expectThrows(IOException.class, () -> obj.readBytes(0, target));
+        assertTrue(e.getMessage().contains("Object not found"));
+    }
+
+    public void testReadBytesWrapsOtherStorageExceptionAsIOException() {
+        when(mockStorage.reader(any(BlobId.class))).thenThrow(new StorageException(500, "Internal Error"));
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        ByteBuffer target = ByteBuffer.allocate(10);
+        IOException e = expectThrows(IOException.class, () -> obj.readBytes(0, target));
+        assertTrue(e.getMessage().contains("Failed to read bytes from"));
+    }
+
+    // === readBytesAsync tests ===
+
+    public void testReadBytesAsyncReturnsData() throws Exception {
+        ReadChannel mockReader = mock(ReadChannel.class);
+        when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
+        doAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte[] data = "async".getBytes();
+            buf.put(data);
+            return data.length;
+        }).when(mockReader).read(any(ByteBuffer.class));
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ByteBuffer> result = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(10, 5, Runnable::run, ActionListener.wrap(buf -> {
+            result.set(buf);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertNotNull(result.get());
+        assertEquals(5, result.get().remaining());
+        verify(mockReader).seek(10);
+        verify(mockReader).limit(15);
+    }
+
+    public void testReadBytesAsyncNegativePositionFails() throws Exception {
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(-1, 10, Runnable::run, ActionListener.wrap(buf -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get() instanceof IllegalArgumentException);
+        assertTrue(error.get().getMessage().contains("position must be non-negative"));
+    }
+
+    public void testReadBytesAsyncNegativeLengthFails() throws Exception {
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(0, -1, Runnable::run, ActionListener.wrap(buf -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get() instanceof IllegalArgumentException);
+        assertTrue(error.get().getMessage().contains("length must be non-negative"));
+    }
+
+    public void testReadBytesAsync404Fails() throws Exception {
+        when(mockStorage.reader(any(BlobId.class))).thenThrow(new StorageException(404, "Not Found"));
+
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(0, 10, Runnable::run, ActionListener.wrap(buf -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get() instanceof IOException);
+        assertTrue(error.get().getMessage().contains("Object not found"));
+    }
+
+    public void testSupportsNativeAsyncReturnsTrue() {
+        StoragePath path = StoragePath.of("gs://my-bucket/data/file.parquet");
+        GcsStorageObject obj = new GcsStorageObject(mockStorage, "my-bucket", "data/file.parquet", path);
+        assertTrue(obj.supportsNativeAsync());
     }
 }


### PR DESCRIPTION
Add `readBytes` and `readBytesAsync` overrides to `GcsStorageObject` using GCS `ReadChannel` for direct `ByteBuffer` reads without intermediate `byte[]` allocation. Follows the pattern established by `S3StorageObject`.

**Changes:**
- Override `readBytes(long, ByteBuffer)` with `ReadChannel.read` for zero-copy positional reads
- Override `readBytesAsync(long, long, Executor, ActionListener)` with executor-wrapped ReadChannel reads
- Set `supportsNativeAsync()` to `true`
- Update `GcsStorageProvider` javadoc (remove TODO)
- Add 10 unit tests covering readBytes, readBytesAsync, error handling, and edge cases

**Design notes:**
The async path is executor-based (blocking a worker thread on `ReadChannel`), not truly non-blocking like `HttpClient.sendAsync()` or `S3AsyncClient` — the GCS Java client library does not provide a `CompletableFuture`-based async read API ([googleapis/google-cloud-java#12642](https://github.com/googleapis/google-cloud-java/issues/12642)). The `readBytes` override uses `ReadChannel.read(ByteBuffer)` directly, avoiding the InputStream→byte[]→ByteBuffer copy chain in the default implementation.

This is API-readiness for future parallel column chunk reads. The current Parquet path (`ParquetStorageObjectAdapter`) uses `newStream()` not `readBytes` — end-to-end Parquet improvement requires separate adapter changes.

Developed with AI-assisted tooling