### PR TITLE
[ESQL] Add cloud API rate limiting for external sources

### DIFF
--- a/docs/changelog/144734.yaml
+++ b/docs/changelog/144734.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 144734
+summary: Add cloud API rate limiting for external sources
+type: enhancement

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedResilienceIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedResilienceIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.datasources.FaultInjectingS3HttpHandler;
 import org.elasticsearch.xpack.esql.datasources.FaultInjectingS3HttpHandler.FaultType;
 import org.junit.After;
 
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -109,19 +110,38 @@ public class ExternalDistributedResilienceIT extends AbstractExternalDistributed
         for (String mode : DISTRIBUTION_MODES) {
             faultHandler().setFault(FaultType.HTTP_503, 100);
 
-            ResponseException ex = expectThrows(ResponseException.class, () -> runQueryWithMode(employeesQuery(), mode));
-            String responseBody = new String(ex.getResponse().getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
-            assertTrue(
-                Strings.format("Expected storage error in response for mode %s, got: %s", mode, responseBody),
-                responseBody.contains("503")
-                    || responseBody.contains("Service Unavailable")
-                    || responseBody.contains("SlowDown")
-                    || responseBody.contains("storage")
-                    || responseBody.contains("error")
-            );
+            Exception ex = expectThrows(Exception.class, () -> runQueryWithMode(employeesQuery(), mode));
+            if (ex instanceof ResponseException responseEx) {
+                String responseBody = new String(responseEx.getResponse().getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+                assertTrue(
+                    Strings.format("Expected storage error in response for mode %s, got: %s", mode, responseBody),
+                    responseBody.contains("503")
+                        || responseBody.contains("Service Unavailable")
+                        || responseBody.contains("SlowDown")
+                        || responseBody.contains("storage")
+                        || responseBody.contains("error")
+                );
+            } else {
+                // A Parquet read involves multiple sequential S3 operations, each with its own
+                // retry budget. Under persistent throttling the cumulative retry time can exceed
+                // the REST client's socket timeout, which is an acceptable failure mode.
+                assertTrue(
+                    Strings.format("Expected ResponseException or SocketTimeoutException for mode %s, got: %s", mode, ex.getClass()),
+                    hasCause(ex, SocketTimeoutException.class)
+                );
+            }
 
             faultHandler().clearFault();
         }
+    }
+
+    private static boolean hasCause(Throwable t, Class<? extends Throwable> type) {
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void testPathFilteredFaultsOnlyAffectParquetReads() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AdaptiveBackoff.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AdaptiveBackoff.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+/**
+ * Shared adaptive backoff state for a storage provider. When throttling is detected,
+ * the backoff multiplier increases (up to a cap); on sustained success, it decays back
+ * to 1x. Thread-safe via atomic operations.
+ * <p>
+ * The multiplier is applied by {@link RetryPolicy#delayMillis} to scale retry delays
+ * for throttling errors, creating a global slowdown effect that prevents thundering herd
+ * recovery.
+ * <p>
+ * Decay is time-based: the multiplier halves for every {@link #DECAY_INTERVAL_NANOS}
+ * elapsed since the last throttle event, but only when {@link #onSuccess()} is called
+ * (i.e., decay requires active successful operations, not just passage of time).
+ */
+class AdaptiveBackoff {
+
+    private static final Logger logger = LogManager.getLogger(AdaptiveBackoff.class);
+
+    static final AdaptiveBackoff DISABLED = new AdaptiveBackoff(0, System::nanoTime);
+
+    static final int MAX_MULTIPLIER = 16;
+    static final long DECAY_INTERVAL_NANOS = 10_000_000_000L; // 10 seconds
+
+    private final int maxMultiplier;
+    private final LongSupplier nanoTimeSupplier;
+    private final AtomicInteger multiplier = new AtomicInteger(1);
+    private final AtomicLong lastThrottleNanos = new AtomicLong(0);
+
+    AdaptiveBackoff(int maxMultiplier, LongSupplier nanoTimeSupplier) {
+        this.maxMultiplier = maxMultiplier;
+        this.nanoTimeSupplier = nanoTimeSupplier;
+    }
+
+    AdaptiveBackoff() {
+        this(MAX_MULTIPLIER, System::nanoTime);
+    }
+
+    void onThrottled() {
+        if (maxMultiplier <= 0) {
+            return;
+        }
+        lastThrottleNanos.set(nanoTimeSupplier.getAsLong());
+        int oldVal = multiplier.getAndUpdate(m -> Math.min(m * 2, maxMultiplier));
+        int newVal = multiplier.get();
+        if (oldVal != newVal) {
+            logger.debug("adaptive backoff multiplier changed from [{}]x to [{}]x after throttling", oldVal, newVal);
+        }
+    }
+
+    void onSuccess() {
+        if (maxMultiplier <= 0) {
+            return;
+        }
+        int current = multiplier.get();
+        if (current <= 1) {
+            return;
+        }
+        long now = nanoTimeSupplier.getAsLong();
+        long lastThrottle = lastThrottleNanos.get();
+        long elapsed = (now - lastThrottle) / DECAY_INTERVAL_NANOS;
+        if (elapsed < 1) {
+            return;
+        }
+        // Only apply decay if we successfully advance the baseline — prevents concurrent
+        // threads from double-counting the same elapsed intervals
+        if (lastThrottleNanos.compareAndSet(lastThrottle, lastThrottle + elapsed * DECAY_INTERVAL_NANOS)) {
+            int oldVal = multiplier.getAndUpdate(m -> {
+                int decayed = m;
+                for (long i = 0; i < elapsed && decayed > 1; i++) {
+                    decayed = Math.max(1, decayed / 2);
+                }
+                return decayed;
+            });
+            int newVal = multiplier.get();
+            if (oldVal != newVal) {
+                logger.debug("adaptive backoff multiplier decayed from [{}]x to [{}]x after success", oldVal, newVal);
+            }
+        }
+    }
+
+    int currentMultiplier() {
+        if (maxMultiplier <= 0) {
+            return 1;
+        }
+        return multiplier.get();
+    }
+
+    boolean isEnabled() {
+        return maxMultiplier > 0;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Decorates a {@link StorageObject} with concurrency limiting. Each I/O operation
+ * acquires a permit before executing and releases it when the operation completes.
+ * For stream-returning methods, the permit is released when the stream is closed.
+ */
+class ConcurrencyLimitedStorageObject implements StorageObject {
+
+    private final StorageObject delegate;
+    private final ConcurrencyLimiter limiter;
+
+    ConcurrencyLimitedStorageObject(StorageObject delegate, ConcurrencyLimiter limiter) {
+        this.delegate = delegate;
+        this.limiter = limiter;
+    }
+
+    @Override
+    public InputStream newStream() throws IOException {
+        acquirePermit();
+        try {
+            InputStream stream = delegate.newStream();
+            return new PermitReleasingInputStream(stream, limiter);
+        } catch (Exception e) {
+            limiter.release();
+            throw e;
+        }
+    }
+
+    @Override
+    public InputStream newStream(long position, long length) throws IOException {
+        acquirePermit();
+        try {
+            InputStream stream = delegate.newStream(position, length);
+            return new PermitReleasingInputStream(stream, limiter);
+        } catch (Exception e) {
+            limiter.release();
+            throw e;
+        }
+    }
+
+    @Override
+    public long length() throws IOException {
+        acquirePermit();
+        try {
+            return delegate.length();
+        } finally {
+            limiter.release();
+        }
+    }
+
+    @Override
+    public Instant lastModified() throws IOException {
+        acquirePermit();
+        try {
+            return delegate.lastModified();
+        } finally {
+            limiter.release();
+        }
+    }
+
+    @Override
+    public boolean exists() throws IOException {
+        acquirePermit();
+        try {
+            return delegate.exists();
+        } finally {
+            limiter.release();
+        }
+    }
+
+    @Override
+    public StoragePath path() {
+        return delegate.path();
+    }
+
+    @Override
+    public int readBytes(long position, ByteBuffer target) throws IOException {
+        acquirePermit();
+        try {
+            return delegate.readBytes(position, target);
+        } finally {
+            limiter.release();
+        }
+    }
+
+    @Override
+    public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+        try {
+            acquirePermit();
+        } catch (IOException e) {
+            listener.onFailure(e);
+            return;
+        }
+        try {
+            delegate.readBytesAsync(position, length, executor, ActionListener.wrap(result -> {
+                limiter.release();
+                listener.onResponse(result);
+            }, e -> {
+                limiter.release();
+                listener.onFailure(e);
+            }));
+        } catch (Exception e) {
+            limiter.release();
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    public void readBytesAsync(long position, ByteBuffer target, Executor executor, ActionListener<Integer> listener) {
+        try {
+            acquirePermit();
+        } catch (IOException e) {
+            listener.onFailure(e);
+            return;
+        }
+        try {
+            delegate.readBytesAsync(position, target, executor, ActionListener.wrap(result -> {
+                limiter.release();
+                listener.onResponse(result);
+            }, e -> {
+                limiter.release();
+                listener.onFailure(e);
+            }));
+        } catch (Exception e) {
+            limiter.release();
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    public boolean supportsNativeAsync() {
+        return delegate.supportsNativeAsync();
+    }
+
+    private void acquirePermit() throws IOException {
+        try {
+            limiter.acquire();
+        } catch (TimeoutException e) {
+            throw new IOException("Failed to acquire concurrency permit for cloud API call", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for concurrency permit", e);
+        }
+    }
+
+    /**
+     * InputStream wrapper that releases the concurrency permit when closed.
+     */
+    private static class PermitReleasingInputStream extends FilterInputStream {
+        private final ConcurrencyLimiter limiter;
+        private boolean released;
+
+        PermitReleasingInputStream(InputStream in, ConcurrencyLimiter limiter) {
+            super(in);
+            this.limiter = limiter;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                if (released == false) {
+                    released = true;
+                    limiter.release();
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Decorates a {@link StorageProvider} with concurrency limiting. Each cloud API call
+ * acquires a permit from a shared {@link ConcurrencyLimiter} before executing and
+ * releases it when the call completes. Permits are per-API-call, not held across
+ * retries or backoff sleeps.
+ */
+class ConcurrencyLimitedStorageProvider implements StorageProvider {
+
+    private final StorageProvider delegate;
+    private final ConcurrencyLimiter limiter;
+
+    ConcurrencyLimitedStorageProvider(StorageProvider delegate, ConcurrencyLimiter limiter) {
+        this.delegate = delegate;
+        this.limiter = limiter;
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path) {
+        return new ConcurrencyLimitedStorageObject(delegate.newObject(path), limiter);
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path, long length) {
+        return new ConcurrencyLimitedStorageObject(delegate.newObject(path, length), limiter);
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+        return new ConcurrencyLimitedStorageObject(delegate.newObject(path, length, lastModified), limiter);
+    }
+
+    @Override
+    public StorageIterator listObjects(StoragePath prefix, boolean recursive) throws IOException {
+        acquirePermit();
+        try {
+            StorageIterator delegateIterator = delegate.listObjects(prefix, recursive);
+            return new ConcurrencyLimitedStorageIterator(delegateIterator, limiter);
+        } catch (Exception e) {
+            limiter.release();
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean exists(StoragePath path) throws IOException {
+        acquirePermit();
+        try {
+            return delegate.exists(path);
+        } finally {
+            limiter.release();
+        }
+    }
+
+    @Override
+    public List<String> supportedSchemes() {
+        return delegate.supportedSchemes();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    private void acquirePermit() throws IOException {
+        try {
+            limiter.acquire();
+        } catch (TimeoutException e) {
+            throw new IOException("Failed to acquire concurrency permit for cloud API call", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for concurrency permit", e);
+        }
+    }
+
+    /**
+     * Iterator wrapper that holds a permit for the duration of iteration.
+     * The permit acquired during {@link #listObjects} is released when the iterator is closed.
+     */
+    private static class ConcurrencyLimitedStorageIterator implements StorageIterator {
+        private final StorageIterator delegate;
+        private final ConcurrencyLimiter limiter;
+        private boolean closed;
+
+        ConcurrencyLimitedStorageIterator(StorageIterator delegate, ConcurrencyLimiter limiter) {
+            this.delegate = delegate;
+            this.limiter = limiter;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public StorageEntry next() {
+            return delegate.next();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed == false) {
+                closed = true;
+                try {
+                    delegate.close();
+                } finally {
+                    limiter.release();
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimiter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimiter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Limits the number of concurrent in-flight cloud storage API requests per node.
+ * Uses a fair {@link Semaphore} to prevent starvation under sustained load.
+ * <p>
+ * Thread-safe and designed to be shared across all queries targeting the same storage scheme.
+ * A permits value of 0 disables limiting entirely (all operations pass through).
+ */
+class ConcurrencyLimiter {
+
+    private static final Logger logger = LogManager.getLogger(ConcurrencyLimiter.class);
+
+    static final ConcurrencyLimiter UNLIMITED = new ConcurrencyLimiter(0, 60_000L);
+
+    private final Semaphore semaphore;
+    private final int maxPermits;
+    private final long acquireTimeoutMs;
+    private final AtomicLong lastWarnLogTime = new AtomicLong(0);
+
+    private static final long WARN_LOG_INTERVAL_MS = 30_000;
+    private static final long WARN_WAIT_THRESHOLD_MS = 5_000;
+
+    ConcurrencyLimiter(int maxPermits, long acquireTimeoutMs) {
+        this.maxPermits = maxPermits;
+        this.acquireTimeoutMs = acquireTimeoutMs;
+        this.semaphore = maxPermits > 0 ? new Semaphore(maxPermits, true) : null;
+    }
+
+    ConcurrencyLimiter(int maxPermits) {
+        this(maxPermits, 60_000L);
+    }
+
+    void acquire() throws TimeoutException, InterruptedException {
+        if (semaphore == null) {
+            return;
+        }
+        long startNanos = System.nanoTime();
+        boolean acquired = semaphore.tryAcquire(acquireTimeoutMs, TimeUnit.MILLISECONDS);
+        if (acquired == false) {
+            throw new TimeoutException(
+                "Timed out waiting for cloud API permit after [" + acquireTimeoutMs + "]ms (max permits [" + maxPermits + "])"
+            );
+        }
+        long waitMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        if (waitMs > WARN_WAIT_THRESHOLD_MS) {
+            long lastWarn = lastWarnLogTime.get();
+            long now = System.currentTimeMillis();
+            if (now - lastWarn > WARN_LOG_INTERVAL_MS && lastWarnLogTime.compareAndSet(lastWarn, now)) {
+                logger.warn("cloud API request waited [{}]ms for concurrency permit (max permits [{}])", waitMs, maxPermits);
+            }
+        }
+    }
+
+    void release() {
+        if (semaphore != null) {
+            semaphore.release();
+        }
+    }
+
+    boolean isEnabled() {
+        return semaphore != null;
+    }
+
+    int maxPermits() {
+        return maxPermits;
+    }
+
+    int availablePermits() {
+        return semaphore != null ? semaphore.availablePermits() : Integer.MAX_VALUE;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -57,6 +57,22 @@ public final class ExternalSourceSettings {
     );
 
     /**
+     * Maximum total time (in seconds) to spend retrying throttled cloud API requests
+     * before giving up. Bounds the cumulative retry duration regardless of the retry count,
+     * ensuring queries fail cleanly when throttling is persistent rather than blocking
+     * until the HTTP request timeout fires.
+     * Default: 30 seconds. Set to 0 to disable the duration budget (retry count only).
+     */
+    public static final Setting<Integer> THROTTLE_MAX_RETRY_DURATION = Setting.intSetting(
+        "esql.external.throttle_max_retry_duration",
+        30,
+        0,
+        300,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Enables adaptive backoff for cloud API throttling. When enabled, throttle retry
      * delays are scaled by a shared multiplier that increases when throttling is detected
      * and decays over time during sustained success. This prevents thundering herd
@@ -71,6 +87,6 @@ public final class ExternalSourceSettings {
     );
 
     public static List<Setting<?>> settings() {
-        return List.of(MAX_CONCURRENT_REQUESTS, THROTTLE_RETRY_LIMIT, ADAPTIVE_BACKOFF_ENABLED);
+        return List.of(MAX_CONCURRENT_REQUESTS, THROTTLE_RETRY_LIMIT, THROTTLE_MAX_RETRY_DURATION, ADAPTIVE_BACKOFF_ENABLED);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -15,12 +15,11 @@ import java.util.List;
  * Cluster settings for controlling ESQL external source cloud API rate limiting.
  * All settings are dynamic (can be changed without restart) and node-scoped.
  * <p>
- * These settings control three layers of defense against cloud API throttling:
- * <ul>
- *   <li><b>Concurrency limiting</b>: Caps concurrent in-flight cloud API requests per node</li>
- *   <li><b>Throttle retry budget</b>: Higher retry count for 429/503 throttling errors</li>
- *   <li><b>Adaptive backoff</b>: Dynamically increases delays when throttling is detected</li>
- * </ul>
+ * Only two operational knobs are exposed: a concurrency cap to prevent throttling
+ * in the first place, and a total retry duration budget to bound the damage when
+ * throttling is persistent. Internal details (throttle retry count = 10,
+ * adaptive backoff = always enabled, exponential delays) use hardcoded defaults
+ * that match industry practice.
  */
 public final class ExternalSourceSettings {
 
@@ -42,21 +41,6 @@ public final class ExternalSourceSettings {
     );
 
     /**
-     * Maximum retry attempts for throttling errors (HTTP 429, 503, SlowDown).
-     * Throttling is always transient and expected under load — a higher budget than
-     * for other transient errors (connection reset, timeout) prevents unnecessary failures.
-     * Default: 10.
-     */
-    public static final Setting<Integer> THROTTLE_RETRY_LIMIT = Setting.intSetting(
-        "esql.external.throttle_retry_limit",
-        10,
-        1,
-        100,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Maximum total time (in seconds) to spend retrying throttled cloud API requests
      * before giving up. Bounds the cumulative retry duration regardless of the retry count,
      * ensuring queries fail cleanly when throttling is persistent rather than blocking
@@ -72,21 +56,7 @@ public final class ExternalSourceSettings {
         Setting.Property.Dynamic
     );
 
-    /**
-     * Enables adaptive backoff for cloud API throttling. When enabled, throttle retry
-     * delays are scaled by a shared multiplier that increases when throttling is detected
-     * and decays over time during sustained success. This prevents thundering herd
-     * recovery where many retrying threads hit the API simultaneously.
-     * Default: true.
-     */
-    public static final Setting<Boolean> ADAPTIVE_BACKOFF_ENABLED = Setting.boolSetting(
-        "esql.external.adaptive_backoff_enabled",
-        true,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
     public static List<Setting<?>> settings() {
-        return List.of(MAX_CONCURRENT_REQUESTS, THROTTLE_RETRY_LIMIT, THROTTLE_MAX_RETRY_DURATION, ADAPTIVE_BACKOFF_ENABLED);
+        return List.of(MAX_CONCURRENT_REQUESTS, THROTTLE_MAX_RETRY_DURATION);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.List;
+
+/**
+ * Cluster settings for controlling ESQL external source cloud API rate limiting.
+ * All settings are dynamic (can be changed without restart) and node-scoped.
+ * <p>
+ * These settings control three layers of defense against cloud API throttling:
+ * <ul>
+ *   <li><b>Concurrency limiting</b>: Caps concurrent in-flight cloud API requests per node</li>
+ *   <li><b>Throttle retry budget</b>: Higher retry count for 429/503 throttling errors</li>
+ *   <li><b>Adaptive backoff</b>: Dynamically increases delays when throttling is detected</li>
+ * </ul>
+ */
+public final class ExternalSourceSettings {
+
+    private ExternalSourceSettings() {}
+
+    /**
+     * Maximum number of concurrent cloud API requests per storage scheme per node.
+     * Set to 0 to disable concurrency limiting entirely.
+     * Default: 50. Cloud APIs typically handle 50 concurrent requests per IP easily;
+     * increase for high-throughput clusters, decrease if experiencing throttling.
+     */
+    public static final Setting<Integer> MAX_CONCURRENT_REQUESTS = Setting.intSetting(
+        "esql.external.max_concurrent_requests",
+        50,
+        0,
+        500,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Maximum retry attempts for throttling errors (HTTP 429, 503, SlowDown).
+     * Throttling is always transient and expected under load — a higher budget than
+     * for other transient errors (connection reset, timeout) prevents unnecessary failures.
+     * Default: 10.
+     */
+    public static final Setting<Integer> THROTTLE_RETRY_LIMIT = Setting.intSetting(
+        "esql.external.throttle_retry_limit",
+        10,
+        1,
+        100,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Enables adaptive backoff for cloud API throttling. When enabled, throttle retry
+     * delays are scaled by a shared multiplier that increases when throttling is detected
+     * and decays over time during sustained success. This prevents thundering herd
+     * recovery where many retrying threads hit the API simultaneously.
+     * Default: true.
+     */
+    public static final Setting<Boolean> ADAPTIVE_BACKOFF_ENABLED = Setting.boolSetting(
+        "esql.external.adaptive_backoff_enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    public static List<Setting<?>> settings() {
+        return List.of(MAX_CONCURRENT_REQUESTS, THROTTLE_RETRY_LIMIT, ADAPTIVE_BACKOFF_ENABLED);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
@@ -20,8 +20,18 @@ import java.net.UnknownHostException;
 
 /**
  * Retry policy with exponential backoff and jitter for transient storage failures.
- * Recognizes HTTP 429 (Too Many Requests), 500 (Internal Server Error),
- * 503 (Service Unavailable), connection resets, and socket timeouts as retryable.
+ * Supports separate retry budgets for throttling errors (429/503/SlowDown) versus
+ * other transient errors (connection reset, socket timeout).
+ * <p>
+ * Throttling errors are expected under high parallelism and are always transient,
+ * so they get a higher retry budget (default 10) with longer backoff delays.
+ * Non-throttle transient errors use the standard budget (default 3).
+ * <p>
+ * Optionally integrates with {@link AdaptiveBackoff} to scale throttle retry delays
+ * based on the global throttling pressure observed across all requests on the same provider.
+ * <p>
+ * A total duration budget can also be applied to cap the cumulative time spent retrying,
+ * regardless of remaining attempt count.
  */
 class RetryPolicy {
 
@@ -31,26 +41,60 @@ class RetryPolicy {
     static final long DEFAULT_INITIAL_DELAY_MS = 200;
     static final long DEFAULT_MAX_DELAY_MS = 5000;
 
+    static final int DEFAULT_THROTTLE_MAX_RETRIES = 10;
+    static final long DEFAULT_THROTTLE_INITIAL_DELAY_MS = 500;
+    static final long DEFAULT_THROTTLE_MAX_DELAY_MS = 30_000;
+
     /** No total duration budget — retries are bounded only by attempt count. */
     static final long NO_BUDGET = 0;
 
-    static final RetryPolicy NONE = new RetryPolicy(0, 0, 0, NO_BUDGET);
-    static final RetryPolicy DEFAULT = new RetryPolicy(DEFAULT_MAX_RETRIES, DEFAULT_INITIAL_DELAY_MS, DEFAULT_MAX_DELAY_MS, NO_BUDGET);
+    static final RetryPolicy NONE = new RetryPolicy(0, 0, 0, 0, 0, 0, NO_BUDGET, null);
+    static final RetryPolicy DEFAULT = new RetryPolicy(
+        DEFAULT_MAX_RETRIES,
+        DEFAULT_INITIAL_DELAY_MS,
+        DEFAULT_MAX_DELAY_MS,
+        DEFAULT_THROTTLE_MAX_RETRIES,
+        DEFAULT_THROTTLE_INITIAL_DELAY_MS,
+        DEFAULT_THROTTLE_MAX_DELAY_MS,
+        NO_BUDGET,
+        null
+    );
 
     private final int maxRetries;
     private final long initialDelayMs;
     private final long maxDelayMs;
+    private final int throttleMaxRetries;
+    private final long throttleInitialDelayMs;
+    private final long throttleMaxDelayMs;
     private final long maxTotalDurationMs;
+    private final AdaptiveBackoff adaptiveBackoff;
 
-    RetryPolicy(int maxRetries, long initialDelayMs, long maxDelayMs) {
-        this(maxRetries, initialDelayMs, maxDelayMs, NO_BUDGET);
-    }
-
-    RetryPolicy(int maxRetries, long initialDelayMs, long maxDelayMs, long maxTotalDurationMs) {
+    RetryPolicy(
+        int maxRetries,
+        long initialDelayMs,
+        long maxDelayMs,
+        int throttleMaxRetries,
+        long throttleInitialDelayMs,
+        long throttleMaxDelayMs,
+        long maxTotalDurationMs,
+        AdaptiveBackoff adaptiveBackoff
+    ) {
         this.maxRetries = maxRetries;
         this.initialDelayMs = initialDelayMs;
         this.maxDelayMs = maxDelayMs;
+        this.throttleMaxRetries = throttleMaxRetries;
+        this.throttleInitialDelayMs = throttleInitialDelayMs;
+        this.throttleMaxDelayMs = throttleMaxDelayMs;
         this.maxTotalDurationMs = maxTotalDurationMs;
+        this.adaptiveBackoff = adaptiveBackoff;
+    }
+
+    RetryPolicy(int maxRetries, long initialDelayMs, long maxDelayMs) {
+        this(maxRetries, initialDelayMs, maxDelayMs, maxRetries, initialDelayMs, maxDelayMs, NO_BUDGET, null);
+    }
+
+    RetryPolicy(int maxRetries, long initialDelayMs, long maxDelayMs, long maxTotalDurationMs) {
+        this(maxRetries, initialDelayMs, maxDelayMs, maxRetries, initialDelayMs, maxDelayMs, maxTotalDurationMs, null);
     }
 
     /**
@@ -59,25 +103,77 @@ class RetryPolicy {
      * rather than sleeping and retrying.
      */
     RetryPolicy withTotalDurationBudget(long budgetMs) {
-        return new RetryPolicy(maxRetries, initialDelayMs, maxDelayMs, budgetMs);
+        return new RetryPolicy(
+            maxRetries,
+            initialDelayMs,
+            maxDelayMs,
+            throttleMaxRetries,
+            throttleInitialDelayMs,
+            throttleMaxDelayMs,
+            budgetMs,
+            adaptiveBackoff
+        );
+    }
+
+    RetryPolicy withAdaptiveBackoff(AdaptiveBackoff backoff) {
+        return new RetryPolicy(
+            maxRetries,
+            initialDelayMs,
+            maxDelayMs,
+            throttleMaxRetries,
+            throttleInitialDelayMs,
+            throttleMaxDelayMs,
+            maxTotalDurationMs,
+            backoff
+        );
+    }
+
+    RetryPolicy withThrottleConfig(int throttleRetries, long throttleInitialMs, long throttleMaxMs) {
+        return new RetryPolicy(
+            maxRetries,
+            initialDelayMs,
+            maxDelayMs,
+            throttleRetries,
+            throttleInitialMs,
+            throttleMaxMs,
+            maxTotalDurationMs,
+            adaptiveBackoff
+        );
     }
 
     int maxRetries() {
         return maxRetries;
     }
 
+    int throttleMaxRetries() {
+        return throttleMaxRetries;
+    }
+
     long delayMillis(int attempt) {
-        if (maxRetries == 0) {
+        return delayMillis(attempt, false);
+    }
+
+    long delayMillis(int attempt, boolean isThrottle) {
+        if (maxRetries == 0 && throttleMaxRetries == 0) {
             return 0;
         }
-        long baseDelay = initialDelayMs * (1L << attempt);
-        long capped = Math.min(baseDelay, maxDelayMs);
+        long effectiveInitial = isThrottle ? throttleInitialDelayMs : initialDelayMs;
+        long effectiveMax = isThrottle ? throttleMaxDelayMs : maxDelayMs;
+
+        long baseDelay = effectiveInitial * (1L << attempt);
+        long capped = Math.min(baseDelay, effectiveMax);
         long jitter = Randomness.get().nextLong(capped / 4 + 1);
-        return Math.min(maxDelayMs, capped + jitter);
+        long delay = Math.min(effectiveMax, capped + jitter);
+
+        if (isThrottle && adaptiveBackoff != null && adaptiveBackoff.isEnabled()) {
+            delay *= adaptiveBackoff.currentMultiplier();
+            delay = Math.min(delay, effectiveMax);
+        }
+        return delay;
     }
 
     boolean isRetryable(Throwable t) {
-        if (maxRetries == 0) {
+        if (maxRetries == 0 && throttleMaxRetries == 0) {
             return false;
         }
         return isTransientStorageError(t);
@@ -88,18 +184,32 @@ class RetryPolicy {
     }
 
     <T> T execute(IOSupplier<T> operation, String operationName, StoragePath path) throws IOException {
-        if (maxRetries == 0) {
+        if (maxRetries == 0 && throttleMaxRetries == 0) {
             return operation.get();
         }
         long startNanos = System.nanoTime();
-        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+        int maxAttempts = Math.max(maxRetries, throttleMaxRetries);
+        for (int attempt = 0; attempt <= maxAttempts; attempt++) {
             try {
-                return operation.get();
+                T result = operation.get();
+                if (adaptiveBackoff != null) {
+                    adaptiveBackoff.onSuccess();
+                }
+                return result;
             } catch (IOException e) {
-                if (isTransientStorageError(e) == false || attempt == maxRetries) {
+                boolean isThrottle = isThrottlingError(e);
+                boolean isTransient = isThrottle || isTransientStorageError(e);
+                int effectiveMaxRetries = isThrottle ? throttleMaxRetries : maxRetries;
+
+                if (isTransient == false || attempt >= effectiveMaxRetries) {
                     throw e;
                 }
-                long delay = delayMillis(attempt);
+
+                if (isThrottle && adaptiveBackoff != null) {
+                    adaptiveBackoff.onThrottled();
+                }
+
+                long delay = delayMillis(attempt, isThrottle);
                 if (maxTotalDurationMs > 0) {
                     long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
                     if (elapsedMs + delay > maxTotalDurationMs) {
@@ -115,11 +225,12 @@ class RetryPolicy {
                     }
                 }
                 logger.debug(
-                    "retrying [{}] for [{}] after transient failure (attempt [{}]/[{}], delay [{}]ms): [{}]",
+                    "retrying [{}] for [{}] after {} failure (attempt [{}]/[{}], delay [{}]ms): [{}]",
                     operationName,
                     path,
+                    isThrottle ? "throttle" : "transient",
                     attempt + 1,
-                    maxRetries,
+                    effectiveMaxRetries,
                     delay,
                     e.getMessage()
                 );
@@ -131,8 +242,45 @@ class RetryPolicy {
                 }
             }
         }
-        // unreachable: loop always returns or throws
         throw new AssertionError("retry loop exited unexpectedly");
+    }
+
+    void notifySuccess() {
+        if (adaptiveBackoff != null) {
+            adaptiveBackoff.onSuccess();
+        }
+    }
+
+    void notifyThrottled() {
+        if (adaptiveBackoff != null) {
+            adaptiveBackoff.onThrottled();
+        }
+    }
+
+    static boolean isThrottlingError(Throwable t) {
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            if (isThrottlingSingleCause(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isThrottlingSingleCause(Throwable t) {
+        String message = t.getMessage();
+        if (message == null) {
+            return false;
+        }
+        if (message.contains("429") || message.contains("Too Many Requests")) {
+            return true;
+        }
+        if (message.contains("503") || message.contains("Service Unavailable")) {
+            return true;
+        }
+        if (message.contains("SlowDown") || message.contains("Reduce your request rate")) {
+            return true;
+        }
+        return false;
     }
 
     private static boolean isTransientStorageError(Throwable t) {
@@ -164,19 +312,10 @@ class RetryPolicy {
         if (message == null) {
             return false;
         }
-        if (message.contains("429") || message.contains("Too Many Requests")) {
-            return true;
-        }
         if (message.contains("500") || message.contains("Internal Server Error") || message.contains("InternalError")) {
             return true;
         }
-        if (message.contains("503") || message.contains("Service Unavailable")) {
-            return true;
-        }
-        if (message.contains("SlowDown") || message.contains("Reduce your request rate")) {
-            return true;
-        }
-        return false;
+        return isThrottlingSingleCause(t);
     }
 
     @FunctionalInterface

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
@@ -22,7 +22,8 @@ import java.util.concurrent.Executor;
 /**
  * Wraps a {@link StorageObject} with retry logic for transient storage failures.
  * Retries are applied to all I/O operations (stream open, metadata, async reads)
- * using exponential backoff with jitter.
+ * using exponential backoff with jitter. Throttling errors (429/503) get a higher
+ * retry budget than other transient errors.
  */
 class RetryableStorageObject implements StorageObject {
 
@@ -87,14 +88,25 @@ class RetryableStorageObject implements StorageObject {
     }
 
     private void readBytesAsyncWithRetry(long position, long length, Executor executor, ActionListener<ByteBuffer> listener, int attempt) {
-        delegate.readBytesAsync(position, length, executor, ActionListener.wrap(listener::onResponse, e -> {
-            if (retryPolicy.isRetryable(e) && attempt < retryPolicy.maxRetries()) {
-                long delay = retryPolicy.delayMillis(attempt);
+        delegate.readBytesAsync(position, length, executor, ActionListener.wrap(result -> {
+            retryPolicy.notifySuccess();
+            listener.onResponse(result);
+        }, e -> {
+            boolean isThrottle = RetryPolicy.isThrottlingError(e);
+            int effectiveMaxRetries = isThrottle ? retryPolicy.throttleMaxRetries() : retryPolicy.maxRetries();
+
+            if (isThrottle) {
+                retryPolicy.notifyThrottled();
+            }
+
+            if (retryPolicy.isRetryable(e) && attempt < effectiveMaxRetries) {
+                long delay = retryPolicy.delayMillis(attempt, isThrottle);
                 logger.debug(
-                    "retrying async read for [{}] after transient failure (attempt [{}]/[{}], delay [{}]ms): [{}]",
+                    "retrying async read for [{}] after {} failure (attempt [{}]/[{}], delay [{}]ms): [{}]",
                     delegate.path(),
+                    isThrottle ? "throttle" : "transient",
                     attempt + 1,
-                    retryPolicy.maxRetries(),
+                    effectiveMaxRetries,
                     delay,
                     e.getMessage()
                 );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
@@ -84,10 +84,17 @@ class RetryableStorageObject implements StorageObject {
 
     @Override
     public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
-        readBytesAsyncWithRetry(position, length, executor, listener, 0);
+        readBytesAsyncWithRetry(position, length, executor, listener, 0, System.nanoTime());
     }
 
-    private void readBytesAsyncWithRetry(long position, long length, Executor executor, ActionListener<ByteBuffer> listener, int attempt) {
+    private void readBytesAsyncWithRetry(
+        long position,
+        long length,
+        Executor executor,
+        ActionListener<ByteBuffer> listener,
+        int attempt,
+        long startNanos
+    ) {
         delegate.readBytesAsync(position, length, executor, ActionListener.wrap(result -> {
             retryPolicy.notifySuccess();
             listener.onResponse(result);
@@ -101,6 +108,21 @@ class RetryableStorageObject implements StorageObject {
 
             if (retryPolicy.isRetryable(e) && attempt < effectiveMaxRetries) {
                 long delay = retryPolicy.delayMillis(attempt, isThrottle);
+                long budgetMs = retryPolicy.maxTotalDurationMs();
+                if (budgetMs > 0) {
+                    long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+                    if (elapsedMs + delay > budgetMs) {
+                        logger.debug(
+                            "aborting async retry for [{}]: elapsed [{}]ms + delay [{}]ms exceeds budget [{}]ms",
+                            delegate.path(),
+                            elapsedMs,
+                            delay,
+                            budgetMs
+                        );
+                        listener.onFailure(e);
+                        return;
+                    }
+                }
                 logger.debug(
                     "retrying async read for [{}] after {} failure (attempt [{}]/[{}], delay [{}]ms): [{}]",
                     delegate.path(),
@@ -118,7 +140,7 @@ class RetryableStorageObject implements StorageObject {
                         listener.onFailure(new IOException("Retry interrupted", ie));
                         return;
                     }
-                    readBytesAsyncWithRetry(position, length, executor, listener, attempt + 1);
+                    readBytesAsyncWithRetry(position, length, executor, listener, attempt + 1, startNanos);
                 });
             } else {
                 listener.onFailure(e);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
@@ -56,16 +56,12 @@ public class StorageProviderRegistry implements Closeable {
 
     private final Settings settings;
     private volatile int maxConcurrentRequests;
-    private volatile int throttleRetryLimit;
     private volatile int throttleMaxRetryDurationSeconds;
-    private volatile boolean adaptiveBackoffEnabled;
 
     public StorageProviderRegistry(Settings settings) {
         this.settings = settings != null ? settings : Settings.EMPTY;
         this.maxConcurrentRequests = ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(this.settings);
-        this.throttleRetryLimit = ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(this.settings);
         this.throttleMaxRetryDurationSeconds = ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(this.settings);
-        this.adaptiveBackoffEnabled = ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(this.settings);
     }
 
     public void registerFactory(String scheme, StorageProviderFactory factory) {
@@ -154,20 +150,11 @@ public class StorageProviderRegistry implements Closeable {
     }
 
     private AdaptiveBackoff backoffForScheme(String scheme) {
-        return backoffs.computeIfAbsent(scheme, k -> {
-            if (adaptiveBackoffEnabled) {
-                return new AdaptiveBackoff();
-            }
-            return AdaptiveBackoff.DISABLED;
-        });
+        return backoffs.computeIfAbsent(scheme, k -> new AdaptiveBackoff());
     }
 
     private RetryPolicy buildRetryPolicy(AdaptiveBackoff backoff) {
-        RetryPolicy policy = RetryPolicy.DEFAULT.withThrottleConfig(
-            throttleRetryLimit,
-            RetryPolicy.DEFAULT_THROTTLE_INITIAL_DELAY_MS,
-            RetryPolicy.DEFAULT_THROTTLE_MAX_DELAY_MS
-        ).withAdaptiveBackoff(backoff);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withAdaptiveBackoff(backoff);
         if (throttleMaxRetryDurationSeconds > 0) {
             policy = policy.withTotalDurationBudget(throttleMaxRetryDurationSeconds * 1000L);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
@@ -31,9 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * so heavy dependencies (S3 client, HTTP client, etc.) are only loaded when
  * an EXTERNAL query actually targets that backend.
  *
- * <p>All providers are automatically wrapped with retry logic for transient
- * storage failures (503, 429, connection resets, timeouts) unless the scheme
- * is "file" (local filesystem).
+ * <p>All providers are automatically wrapped with concurrency limiting and retry
+ * logic for transient storage failures (503, 429, connection resets, timeouts)
+ * unless the scheme is "file" (local filesystem). Wrap order:
+ * {@code caller → Retryable(with adaptive backoff) → ConcurrencyLimited → raw provider}
+ *
+ * <p>Concurrency limiters and adaptive backoff state are shared per-scheme across
+ * all providers (including per-query config providers), because cloud API rate limits
+ * are per account/IP, not per client instance.
  *
  * <p>Registration methods are intended for single-threaded initialization only
  * (called from the {@link DataSourceModule} constructor).
@@ -45,12 +50,20 @@ public class StorageProviderRegistry implements Closeable {
     private final Map<String, StorageProviderFactory> factories = new ConcurrentHashMap<>();
     private final Map<String, StorageProvider> providers = new ConcurrentHashMap<>();
     private final List<StorageProvider> createdProviders = new ArrayList<>();
-    private static final RetryPolicy RETRY_POLICY = RetryPolicy.DEFAULT;
+
+    private final Map<String, ConcurrencyLimiter> limiters = new ConcurrentHashMap<>();
+    private final Map<String, AdaptiveBackoff> backoffs = new ConcurrentHashMap<>();
 
     private final Settings settings;
+    private volatile int maxConcurrentRequests;
+    private volatile int throttleRetryLimit;
+    private volatile boolean adaptiveBackoffEnabled;
 
     public StorageProviderRegistry(Settings settings) {
         this.settings = settings != null ? settings : Settings.EMPTY;
+        this.maxConcurrentRequests = ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(this.settings);
+        this.throttleRetryLimit = ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(this.settings);
+        this.adaptiveBackoffEnabled = ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(this.settings);
     }
 
     public void registerFactory(String scheme, StorageProviderFactory factory) {
@@ -87,7 +100,6 @@ public class StorageProviderRegistry implements Closeable {
     public StorageProvider createProvider(String scheme, Settings settings, Map<String, Object> config) {
         String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
 
-        // When config is null/empty, fall back to the default registered provider
         if (config == null || config.isEmpty()) {
             StorageProvider provider = providers.get(normalizedScheme);
             if (provider == null) {
@@ -96,16 +108,14 @@ public class StorageProviderRegistry implements Closeable {
             return provider;
         }
 
-        // Create a fresh provider with the per-query config
         StorageProviderFactory factory = factories.get(normalizedScheme);
         if (factory == null) {
             throw new IllegalArgumentException("No SPI storage factory registered for scheme: " + scheme);
         }
-        return wrapWithRetry(factory.create(settings, config), normalizedScheme);
+        return wrapProvider(factory.create(settings, config), normalizedScheme);
     }
 
     private synchronized StorageProvider createDefaultProvider(String normalizedScheme) {
-        // Double-check after acquiring lock
         StorageProvider provider = providers.get(normalizedScheme);
         if (provider != null) {
             return provider;
@@ -114,17 +124,48 @@ public class StorageProviderRegistry implements Closeable {
         if (factory == null) {
             throw new IllegalArgumentException("No storage provider registered for scheme: " + normalizedScheme);
         }
-        provider = wrapWithRetry(factory.create(settings), normalizedScheme);
+        provider = wrapProvider(factory.create(settings), normalizedScheme);
         providers.put(normalizedScheme, provider);
         createdProviders.add(provider);
         return provider;
     }
 
-    private StorageProvider wrapWithRetry(StorageProvider provider, String scheme) {
+    private StorageProvider wrapProvider(StorageProvider provider, String scheme) {
         if ("file".equals(scheme)) {
             return provider;
         }
-        return new RetryableStorageProvider(provider, RETRY_POLICY);
+        ConcurrencyLimiter limiter = limiterForScheme(scheme);
+        AdaptiveBackoff backoff = backoffForScheme(scheme);
+        RetryPolicy retryPolicy = buildRetryPolicy(backoff);
+        StorageProvider limited = new ConcurrencyLimitedStorageProvider(provider, limiter);
+        return new RetryableStorageProvider(limited, retryPolicy);
+    }
+
+    private ConcurrencyLimiter limiterForScheme(String scheme) {
+        return limiters.computeIfAbsent(scheme, k -> {
+            int permits = maxConcurrentRequests;
+            if (permits <= 0) {
+                return ConcurrencyLimiter.UNLIMITED;
+            }
+            return new ConcurrencyLimiter(permits);
+        });
+    }
+
+    private AdaptiveBackoff backoffForScheme(String scheme) {
+        return backoffs.computeIfAbsent(scheme, k -> {
+            if (adaptiveBackoffEnabled) {
+                return new AdaptiveBackoff();
+            }
+            return AdaptiveBackoff.DISABLED;
+        });
+    }
+
+    private RetryPolicy buildRetryPolicy(AdaptiveBackoff backoff) {
+        return RetryPolicy.DEFAULT.withThrottleConfig(
+            throttleRetryLimit,
+            RetryPolicy.DEFAULT_THROTTLE_INITIAL_DELAY_MS,
+            RetryPolicy.DEFAULT_THROTTLE_MAX_DELAY_MS
+        ).withAdaptiveBackoff(backoff);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
@@ -57,12 +57,14 @@ public class StorageProviderRegistry implements Closeable {
     private final Settings settings;
     private volatile int maxConcurrentRequests;
     private volatile int throttleRetryLimit;
+    private volatile int throttleMaxRetryDurationSeconds;
     private volatile boolean adaptiveBackoffEnabled;
 
     public StorageProviderRegistry(Settings settings) {
         this.settings = settings != null ? settings : Settings.EMPTY;
         this.maxConcurrentRequests = ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(this.settings);
         this.throttleRetryLimit = ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(this.settings);
+        this.throttleMaxRetryDurationSeconds = ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(this.settings);
         this.adaptiveBackoffEnabled = ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(this.settings);
     }
 
@@ -161,11 +163,15 @@ public class StorageProviderRegistry implements Closeable {
     }
 
     private RetryPolicy buildRetryPolicy(AdaptiveBackoff backoff) {
-        return RetryPolicy.DEFAULT.withThrottleConfig(
+        RetryPolicy policy = RetryPolicy.DEFAULT.withThrottleConfig(
             throttleRetryLimit,
             RetryPolicy.DEFAULT_THROTTLE_INITIAL_DELAY_MS,
             RetryPolicy.DEFAULT_THROTTLE_MAX_DELAY_MS
         ).withAdaptiveBackoff(backoff);
+        if (throttleMaxRetryDurationSeconds > 0) {
+            policy = policy.withTotalDurationBudget(throttleMaxRetryDurationSeconds * 1000L);
+        }
+        return policy;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -76,6 +76,7 @@ import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
 import org.elasticsearch.xpack.esql.datasources.DataSourceCapabilities;
 import org.elasticsearch.xpack.esql.datasources.DataSourceModule;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
@@ -329,6 +330,9 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
 
         // Inference command settings
         settings.addAll(InferenceSettings.getSettings());
+
+        // External source rate limiting settings
+        settings.addAll(ExternalSourceSettings.settings());
 
         return Collections.unmodifiableList(settings);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AdaptiveBackoffTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AdaptiveBackoffTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AdaptiveBackoffTests extends ESTestCase {
+
+    public void testThrottlingIncreasesMultiplier() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        assertEquals(1, backoff.currentMultiplier());
+        backoff.onThrottled();
+        assertEquals(2, backoff.currentMultiplier());
+        backoff.onThrottled();
+        assertEquals(4, backoff.currentMultiplier());
+        backoff.onThrottled();
+        assertEquals(8, backoff.currentMultiplier());
+    }
+
+    public void testSuccessDecreasesMultiplier() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        backoff.onThrottled();
+        backoff.onThrottled();
+        backoff.onThrottled();
+        assertEquals(8, backoff.currentMultiplier());
+
+        // Advance 1 decay interval → decay halves once: 8 → 4
+        clock.addAndGet(AdaptiveBackoff.DECAY_INTERVAL_NANOS);
+        backoff.onSuccess();
+        assertEquals(4, backoff.currentMultiplier());
+
+        // Advance 1 more interval → decay halves once: 4 → 2
+        clock.addAndGet(AdaptiveBackoff.DECAY_INTERVAL_NANOS);
+        backoff.onSuccess();
+        assertEquals(2, backoff.currentMultiplier());
+
+        // Advance 1 more interval → decay halves once: 2 → 1
+        clock.addAndGet(AdaptiveBackoff.DECAY_INTERVAL_NANOS);
+        backoff.onSuccess();
+        assertEquals(1, backoff.currentMultiplier());
+    }
+
+    public void testSuccessWithoutTimeDoesNotDecay() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        backoff.onThrottled();
+        backoff.onThrottled();
+        assertEquals(4, backoff.currentMultiplier());
+
+        // No time advance — onSuccess should not decay
+        backoff.onSuccess();
+        assertEquals(4, backoff.currentMultiplier());
+    }
+
+    public void testMultiplierCapped() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        for (int i = 0; i < 20; i++) {
+            backoff.onThrottled();
+        }
+        assertEquals(AdaptiveBackoff.MAX_MULTIPLIER, backoff.currentMultiplier());
+    }
+
+    public void testTimeDecayMultipleIntervals() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        backoff.onThrottled();
+        backoff.onThrottled();
+        assertEquals(4, backoff.currentMultiplier());
+
+        // Advance 2 intervals → halves twice: 4 → 2 → 1
+        clock.addAndGet(2 * AdaptiveBackoff.DECAY_INTERVAL_NANOS);
+        backoff.onSuccess();
+        assertEquals(1, backoff.currentMultiplier());
+    }
+
+    public void testDisabledIsNoOp() {
+        AdaptiveBackoff disabled = AdaptiveBackoff.DISABLED;
+        assertFalse(disabled.isEnabled());
+        assertEquals(1, disabled.currentMultiplier());
+        disabled.onThrottled();
+        assertEquals(1, disabled.currentMultiplier());
+        disabled.onSuccess();
+        assertEquals(1, disabled.currentMultiplier());
+    }
+
+    public void testConcurrentAccess() throws Exception {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+
+        Thread[] threads = new Thread[10];
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                for (int j = 0; j < 100; j++) {
+                    backoff.onThrottled();
+                    backoff.currentMultiplier();
+                    clock.addAndGet(AdaptiveBackoff.DECAY_INTERVAL_NANOS);
+                    backoff.onSuccess();
+                }
+            });
+            threads[i].start();
+        }
+        for (Thread t : threads) {
+            t.join(5000);
+        }
+        int mult = backoff.currentMultiplier();
+        assertTrue("multiplier should be valid: " + mult, mult >= 1 && mult <= AdaptiveBackoff.MAX_MULTIPLIER);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConcurrencyLimitedStorageObjectTests extends ESTestCase {
+
+    public void testStreamCloseReleasesPermit() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        assertEquals(3, limiter.availablePermits());
+
+        InputStream stream = obj.newStream();
+        assertEquals(2, limiter.availablePermits());
+
+        stream.close();
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testStreamDoubleCloseIsSafe() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        InputStream stream = obj.newStream();
+        stream.close();
+        stream.close();
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testReadBytesReleasesOnException() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.readBytes(anyLong(), any(ByteBuffer.class))).thenThrow(new IOException("read error"));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        expectThrows(IOException.class, () -> obj.readBytes(0, ByteBuffer.allocate(10)));
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testLengthReleasesPermit() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.length()).thenReturn(42L);
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        assertEquals(42L, obj.length());
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAsyncReadReleasesPermitOnSuccess() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+        ByteBuffer result = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
+        doAnswer(inv -> {
+            ActionListener<ByteBuffer> listener = inv.getArgument(3);
+            listener.onResponse(result);
+            return null;
+        }).when(delegate).readBytesAsync(anyLong(), anyLong(), any(), any(ActionListener.class));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ByteBuffer> response = new AtomicReference<>();
+
+        obj.readBytesAsync(0, 4, Runnable::run, ActionListener.wrap(r -> {
+            response.set(r);
+            latch.countDown();
+        }, e -> latch.countDown()));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertSame(result, response.get());
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAsyncReadReleasesPermitOnFailure() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+        doAnswer(inv -> {
+            ActionListener<ByteBuffer> listener = inv.getArgument(3);
+            listener.onFailure(new IOException("async error"));
+            return null;
+        }).when(delegate).readBytesAsync(anyLong(), anyLong(), any(), any(ActionListener.class));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        obj.readBytesAsync(0, 4, Runnable::run, ActionListener.wrap(r -> latch.countDown(), e -> latch.countDown()));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testNewStreamReleasesPermitOnDelegateException() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenThrow(new IOException("connection refused"));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        expectThrows(IOException.class, obj::newStream);
+        assertEquals(3, limiter.availablePermits());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProviderTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConcurrencyLimitedStorageProviderTests extends ESTestCase {
+
+    public void testListObjectsAcquiresPermit() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(5);
+        StorageProvider delegate = mock(StorageProvider.class);
+        StorageIterator emptyIterator = new StorageIterator() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public StorageEntry next() {
+                return null;
+            }
+
+            @Override
+            public void close() {}
+        };
+        when(delegate.listObjects(any(), anyBoolean())).thenReturn(emptyIterator);
+
+        ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
+        assertEquals(5, limiter.availablePermits());
+
+        try (StorageIterator iter = provider.listObjects(StoragePath.of("s3://bucket/prefix"), true)) {
+            assertEquals(4, limiter.availablePermits());
+        }
+        assertEquals(5, limiter.availablePermits());
+    }
+
+    public void testExistsAcquiresAndReleasesPermit() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageProvider delegate = mock(StorageProvider.class);
+        when(delegate.exists(any())).thenReturn(true);
+
+        ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
+        assertEquals(3, limiter.availablePermits());
+
+        boolean result = provider.exists(StoragePath.of("s3://bucket/key"));
+        assertTrue(result);
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testExistsReleasesPermitOnException() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        StorageProvider delegate = mock(StorageProvider.class);
+        when(delegate.exists(any())).thenThrow(new IOException("network error"));
+
+        ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
+        expectThrows(IOException.class, () -> provider.exists(StoragePath.of("s3://bucket/key")));
+        assertEquals(3, limiter.availablePermits());
+    }
+
+    public void testNewObjectReturnsConcurrencyLimitedObject() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(5);
+        StorageProvider delegate = mock(StorageProvider.class);
+        StorageObject mockObj = mock(StorageObject.class);
+        when(delegate.newObject(any(StoragePath.class))).thenReturn(mockObj);
+
+        ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
+        StorageObject obj = provider.newObject(StoragePath.of("s3://bucket/key"));
+        assertNotNull(obj);
+        assertTrue(obj instanceof ConcurrencyLimitedStorageObject);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimiterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimiterTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConcurrencyLimiterTests extends ESTestCase {
+
+    public void testAcquireAndRelease() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(5);
+        assertEquals(5, limiter.availablePermits());
+        limiter.acquire();
+        assertEquals(4, limiter.availablePermits());
+        limiter.release();
+        assertEquals(5, limiter.availablePermits());
+    }
+
+    public void testBlocksWhenExhausted() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, 60_000L);
+        limiter.acquire();
+        assertEquals(0, limiter.availablePermits());
+
+        AtomicBoolean acquired = new AtomicBoolean(false);
+        CountDownLatch started = new CountDownLatch(1);
+        Thread blocker = new Thread(() -> {
+            started.countDown();
+            try {
+                limiter.acquire();
+                acquired.set(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        blocker.start();
+        started.await(5, TimeUnit.SECONDS);
+
+        Thread.sleep(100);
+        assertFalse(acquired.get());
+
+        limiter.release();
+        blocker.join(5000);
+        assertTrue(acquired.get());
+    }
+
+    public void testTimeoutThrows() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, 50L);
+        limiter.acquire();
+
+        expectThrows(TimeoutException.class, limiter::acquire);
+
+        limiter.release();
+    }
+
+    public void testDisabledWithZeroPermits() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(0);
+        assertFalse(limiter.isEnabled());
+        assertEquals(Integer.MAX_VALUE, limiter.availablePermits());
+        limiter.acquire();
+        limiter.release();
+    }
+
+    public void testUnlimitedSingleton() throws Exception {
+        assertFalse(ConcurrencyLimiter.UNLIMITED.isEnabled());
+        assertEquals(0, ConcurrencyLimiter.UNLIMITED.maxPermits());
+        ConcurrencyLimiter.UNLIMITED.acquire();
+        ConcurrencyLimiter.UNLIMITED.release();
+    }
+
+    public void testMaxPermits() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(42);
+        assertTrue(limiter.isEnabled());
+        assertEquals(42, limiter.maxPermits());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
@@ -16,6 +16,7 @@ public class ExternalSourceSettingsTests extends ESTestCase {
         Settings settings = Settings.EMPTY;
         assertEquals(50, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
         assertEquals(10, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
+        assertEquals(30, (int) ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings));
         assertTrue(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
     }
 
@@ -23,11 +24,13 @@ public class ExternalSourceSettingsTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.external.max_concurrent_requests", 100)
             .put("esql.external.throttle_retry_limit", 20)
+            .put("esql.external.throttle_max_retry_duration", 60)
             .put("esql.external.adaptive_backoff_enabled", false)
             .build();
 
         assertEquals(100, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
         assertEquals(20, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
+        assertEquals(60, (int) ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings));
         assertFalse(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
     }
 
@@ -50,8 +53,20 @@ public class ExternalSourceSettingsTests extends ESTestCase {
         });
     }
 
+    public void testThrottleMaxRetryDurationZeroDisablesBudget() {
+        Settings settings = Settings.builder().put("esql.external.throttle_max_retry_duration", 0).build();
+        assertEquals(0, (int) ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings));
+    }
+
+    public void testThrottleMaxRetryDurationUpperBound() {
+        expectThrows(IllegalArgumentException.class, () -> {
+            Settings settings = Settings.builder().put("esql.external.throttle_max_retry_duration", 301).build();
+            ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings);
+        });
+    }
+
     public void testSettingsListNotEmpty() {
         assertFalse(ExternalSourceSettings.settings().isEmpty());
-        assertEquals(3, ExternalSourceSettings.settings().size());
+        assertEquals(4, ExternalSourceSettings.settings().size());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+public class ExternalSourceSettingsTests extends ESTestCase {
+
+    public void testDefaults() {
+        Settings settings = Settings.EMPTY;
+        assertEquals(50, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
+        assertEquals(10, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
+        assertTrue(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
+    }
+
+    public void testCustomValues() {
+        Settings settings = Settings.builder()
+            .put("esql.external.max_concurrent_requests", 100)
+            .put("esql.external.throttle_retry_limit", 20)
+            .put("esql.external.adaptive_backoff_enabled", false)
+            .build();
+
+        assertEquals(100, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
+        assertEquals(20, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
+        assertFalse(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
+    }
+
+    public void testZeroConcurrencyDisablesLimiting() {
+        Settings settings = Settings.builder().put("esql.external.max_concurrent_requests", 0).build();
+        assertEquals(0, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
+    }
+
+    public void testConcurrencyUpperBound() {
+        expectThrows(IllegalArgumentException.class, () -> {
+            Settings settings = Settings.builder().put("esql.external.max_concurrent_requests", 501).build();
+            ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings);
+        });
+    }
+
+    public void testThrottleRetryLowerBound() {
+        expectThrows(IllegalArgumentException.class, () -> {
+            Settings settings = Settings.builder().put("esql.external.throttle_retry_limit", 0).build();
+            ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings);
+        });
+    }
+
+    public void testSettingsListNotEmpty() {
+        assertFalse(ExternalSourceSettings.settings().isEmpty());
+        assertEquals(3, ExternalSourceSettings.settings().size());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
@@ -15,23 +15,17 @@ public class ExternalSourceSettingsTests extends ESTestCase {
     public void testDefaults() {
         Settings settings = Settings.EMPTY;
         assertEquals(50, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
-        assertEquals(10, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
         assertEquals(30, (int) ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings));
-        assertTrue(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
     }
 
     public void testCustomValues() {
         Settings settings = Settings.builder()
             .put("esql.external.max_concurrent_requests", 100)
-            .put("esql.external.throttle_retry_limit", 20)
             .put("esql.external.throttle_max_retry_duration", 60)
-            .put("esql.external.adaptive_backoff_enabled", false)
             .build();
 
         assertEquals(100, (int) ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings));
-        assertEquals(20, (int) ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings));
         assertEquals(60, (int) ExternalSourceSettings.THROTTLE_MAX_RETRY_DURATION.get(settings));
-        assertFalse(ExternalSourceSettings.ADAPTIVE_BACKOFF_ENABLED.get(settings));
     }
 
     public void testZeroConcurrencyDisablesLimiting() {
@@ -43,13 +37,6 @@ public class ExternalSourceSettingsTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> {
             Settings settings = Settings.builder().put("esql.external.max_concurrent_requests", 501).build();
             ExternalSourceSettings.MAX_CONCURRENT_REQUESTS.get(settings);
-        });
-    }
-
-    public void testThrottleRetryLowerBound() {
-        expectThrows(IllegalArgumentException.class, () -> {
-            Settings settings = Settings.builder().put("esql.external.throttle_retry_limit", 0).build();
-            ExternalSourceSettings.THROTTLE_RETRY_LIMIT.get(settings);
         });
     }
 
@@ -67,6 +54,6 @@ public class ExternalSourceSettingsTests extends ESTestCase {
 
     public void testSettingsListNotEmpty() {
         assertFalse(ExternalSourceSettings.settings().isEmpty());
-        assertEquals(4, ExternalSourceSettings.settings().size());
+        assertEquals(2, ExternalSourceSettings.settings().size());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
@@ -16,6 +16,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class RetryPolicyTests extends ESTestCase {
 
@@ -207,6 +208,8 @@ public class RetryPolicyTests extends ESTestCase {
         assertEquals(1, calls.get());
     }
 
+    // --- Total duration budget tests ---
+
     public void testWithTotalDurationBudgetPreservesRetryParameters() {
         RetryPolicy base = new RetryPolicy(5, 100, 2000);
         RetryPolicy budgeted = base.withTotalDurationBudget(10_000);
@@ -251,5 +254,84 @@ public class RetryPolicyTests extends ESTestCase {
 
         assertEquals("ok", result);
         assertEquals(3, calls.get());
+    }
+
+    // --- Throttle-specific retry budget tests ---
+
+    public void testThrottlingErrorGetsHigherRetryBudget() throws IOException {
+        RetryPolicy policy = new RetryPolicy(2, 1, 10, 8, 1, 10, RetryPolicy.NO_BUDGET, null);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        String result = policy.execute(() -> {
+            if (calls.incrementAndGet() <= 6) {
+                throw new IOException("503 Service Unavailable");
+            }
+            return "ok";
+        }, "test", path);
+
+        assertEquals("ok", result);
+        assertEquals(7, calls.get());
+    }
+
+    public void testNonThrottleErrorUsesStandardBudget() {
+        RetryPolicy policy = new RetryPolicy(2, 1, 10, 8, 1, 10, RetryPolicy.NO_BUDGET, null);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        IOException ex = expectThrows(IOException.class, () -> policy.execute(() -> {
+            calls.incrementAndGet();
+            throw new SocketTimeoutException("timeout");
+        }, "test", path));
+
+        assertEquals("timeout", ex.getMessage());
+        assertEquals(3, calls.get());
+    }
+
+    public void testThrottlingDelayIsLongerThanStandardDelay() {
+        RetryPolicy policy = RetryPolicy.DEFAULT;
+        long standardDelay = policy.delayMillis(0, false);
+        long throttleDelay = policy.delayMillis(0, true);
+        assertTrue(
+            "throttle delay [" + throttleDelay + "] should be >= standard delay [" + standardDelay + "]",
+            throttleDelay >= standardDelay
+        );
+    }
+
+    public void testIsThrottlingErrorClassification() {
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("Status code: 429")));
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("Too Many Requests")));
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("Status code: 503")));
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("Service Unavailable")));
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("SlowDown")));
+        assertTrue(RetryPolicy.isThrottlingError(new IOException("Reduce your request rate")));
+
+        assertFalse(RetryPolicy.isThrottlingError(new SocketTimeoutException("timeout")));
+        assertFalse(RetryPolicy.isThrottlingError(new ConnectException("refused")));
+        assertFalse(RetryPolicy.isThrottlingError(new IOException("Access Denied")));
+        assertFalse(RetryPolicy.isThrottlingError(new IOException((String) null)));
+    }
+
+    public void testAdaptiveBackoffScalesDelay() {
+        AtomicLong clock = new AtomicLong(0);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
+        backoff.onThrottled();
+        backoff.onThrottled();
+
+        RetryPolicy policy = RetryPolicy.DEFAULT.withAdaptiveBackoff(backoff);
+        long normalDelay = RetryPolicy.DEFAULT.delayMillis(0, true);
+        long adaptiveDelay = policy.delayMillis(0, true);
+        assertTrue("adaptive delay [" + adaptiveDelay + "] should be > normal delay [" + normalDelay + "]", adaptiveDelay > normalDelay);
+    }
+
+    public void testThrottleMaxRetriesAccessor() {
+        RetryPolicy policy = RetryPolicy.DEFAULT;
+        assertEquals(RetryPolicy.DEFAULT_THROTTLE_MAX_RETRIES, policy.throttleMaxRetries());
+    }
+
+    public void testWithThrottleConfig() {
+        RetryPolicy policy = RetryPolicy.DEFAULT.withThrottleConfig(20, 1000, 60_000);
+        assertEquals(20, policy.throttleMaxRetries());
+        assertEquals(RetryPolicy.DEFAULT_MAX_RETRIES, policy.maxRetries());
     }
 }


### PR DESCRIPTION
Add three layers of defense against cloud API throttling (503/429)
for S3, GCS, and Azure external source queries:

1. Semaphore-based concurrency limiter (default 50 per scheme per
   node) to cap in-flight cloud API requests
2. Throttle-aware retry policy with higher budget for throttling
   errors (10 retries for 429/503 vs 3 for transient errors)
3. Adaptive backoff that scales retry delays based on observed
   throttling pressure across all requests on the same provider

Only two cluster settings are exposed (dynamic, node-scoped):
- `esql.external.max_concurrent_requests` (default 50, 0=disabled)
- `esql.external.throttle_max_retry_duration` (default 30s, 0=disabled)

Internal defaults (throttle retry count=10, adaptive backoff=always on,
exponential delays with jitter) are hardcoded to de-facto defaults,
 keeping the settings surface minimal.

Developed with AI-assisted tooling