### PR TITLE
Fix SnapshotStatusApisIT TestFailedSnapshot

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -180,9 +180,6 @@ tests:
 - class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
   method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
   issue: https://github.com/elastic/elasticsearch/issues/141200
-- class: org.elasticsearch.snapshots.SnapshotStatusApisIT
-  method: testFailedSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/141279
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:boolean.convertFromIntAndLong}
   issue: https://github.com/elastic/elasticsearch/issues/141375

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -844,7 +844,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         final String repository = "test-repo";
         createRepository(repository, "mock");
         final String indexName = "test-idx";
-        indexRandomDocs(indexName, 100000);
+        createIndexWithContent(indexName, singleShardOneNode(dataNode));
         blockAndFailDataNode(repository, dataNode);
 
         String snapshotName = "failing-snapshot";


### PR DESCRIPTION
Forces the snapshot to be on the node that is blocked, to guarantee that
 the snapshot fails.

 Closes https://github.com/elastic/elasticsearch/issues/141279

