### PR TITLE
Fix REJECT_LOADING_FLATTENED_SUBFIELDS capability missing snapshot gate

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2361,7 +2361,7 @@ public class EsqlCapabilities {
          * Reject loading sub-fields of flattened fields when {@code unmapped_fields="load"}
          * See https://github.com/elastic/elasticsearch/issues/143494
          */
-        REJECT_LOADING_FLATTENED_SUBFIELDS,
+        REJECT_LOADING_FLATTENED_SUBFIELDS(Build.current().isSnapshot()),
 
         FIX_DIV_ERROR_MESSAGE,
 


### PR DESCRIPTION
The capability was always-enabled, but unmapped_fields="load" is only valid when OPTIONAL_FIELDS_V2 is enabled (snapshot builds). In release CI runs, the 260_flattened_subfield YAML tests ran but failed with parsing_exception instead of the expected verification_exception.

Gate the capability with Build.current().isSnapshot() so tests are skipped in non-snapshot builds where LOAD is not a valid value.