### PR TITLE
[9.3] Fix request cache invalidation to use ES cache helper consistently (#144581)

### DIFF
--- a/docs/changelog/144581.yaml
+++ b/docs/changelog/144581.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 144581
+summary: Fix request cache invalidation to use ES cache helper consistently
+type: bug

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -44,9 +44,6 @@ import java.util.concurrent.ConcurrentMap;
  * <p>
  * Currently, the cache is only enabled for count requests, and can only be opted in on an index
  * level setting that can be dynamically changed and defaults to false.
- * <p>
- * There are still several TODOs left in this class, some easily addressable, some more complex, but the support
- * is functional.
  */
 public final class IndicesRequestCache implements Closeable {
 
@@ -111,7 +108,7 @@ public final class IndicesRequestCache implements Closeable {
         BytesReference value = cache.computeIfAbsent(key, cacheLoader);
         if (cacheLoader.isLoaded()) {
             key.entity.onMiss();
-            // see if its the first time we see this reader, and make sure to register a cleanup key
+            // see if it's the first time we see this reader, and make sure to register a cleanup key
             CleanupKey cleanupKey = new CleanupKey(cacheEntity, cacheHelper.getKey());
             if (registeredClosedListeners.containsKey(cleanupKey) == false) {
                 Boolean previous = registeredClosedListeners.putIfAbsent(cleanupKey, Boolean.TRUE);
@@ -135,14 +132,16 @@ public final class IndicesRequestCache implements Closeable {
     }
 
     /**
-     * Invalidates the given the cache entry for the given key and it's context
+     * Invalidates the given cache entry for the given key and its context
      * @param cacheEntity the cache entity to invalidate for
+     * @param mappingCacheKey the mapping cache key to invalidate the cache entry for
      * @param reader the reader to invalidate the cache entry for
      * @param cacheKey the cache key to invalidate
      */
     void invalidate(CacheEntity cacheEntity, MappingLookup.CacheKey mappingCacheKey, DirectoryReader reader, BytesReference cacheKey) {
-        assert reader.getReaderCacheHelper() != null;
-        cache.invalidate(new Key(cacheEntity, mappingCacheKey, reader.getReaderCacheHelper().getKey(), cacheKey));
+        final ESCacheHelper cacheHelper = ElasticsearchDirectoryReader.getESReaderCacheHelper(reader);
+        assert cacheHelper != null;
+        cache.invalidate(new Key(cacheEntity, mappingCacheKey, cacheHelper.getKey(), cacheKey));
     }
 
     private static class Loader implements CacheLoader<Key, BytesReference> {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -506,6 +506,60 @@ public class IndicesRequestCacheTests extends ESTestCase {
         assertEquals(0, cache.numRegisteredCloseListeners());
     }
 
+    public void testInvalidateWithCustomCacheHelper() throws Exception {
+        ShardRequestCache requestCacheStats = new ShardRequestCache();
+        IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+
+        writer.addDocument(newDoc(0, "foo"));
+        MappingLookup.CacheKey mappingKey = MappingLookup.EMPTY.cacheKey();
+
+        // Wrap with a custom ESCacheHelper whose key differs from Lucene's native reader cache key,
+        // simulating FrozenEngine behavior where a stable cacheIdentity outlives individual readers.
+        Object cacheIdentity = new Object();
+        ESCacheHelper customCacheHelper = new ESCacheHelper() {
+            @Override
+            public Object getKey() {
+                return cacheIdentity;
+            }
+
+            @Override
+            public void addClosedListener(ClosedListener listener) {}
+        };
+        DirectoryReader reader = ElasticsearchDirectoryReader.wrap(
+            DirectoryReader.open(writer),
+            new ShardId("foo", "bar", 1),
+            customCacheHelper
+        );
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
+        BytesReference termBytes = XContentHelper.toXContent(termQuery, XContentType.JSON, false);
+        AtomicBoolean indexShard = new AtomicBoolean(true);
+
+        // populate the cache
+        TestEntity entity = new TestEntity(requestCacheStats, indexShard);
+        Loader loader = new Loader(reader, 0);
+        BytesReference value = cache.getOrCompute(entity, loader, mappingKey, reader, termBytes);
+        assertEquals("foo", value.streamInput().readString());
+        assertFalse(loader.loadedFromCache);
+        assertEquals(1, cache.count());
+
+        // invalidate should remove the entry even though the ES cache key differs from Lucene's native key
+        entity = new TestEntity(requestCacheStats, indexShard);
+        cache.invalidate(entity, mappingKey, reader, termBytes);
+        assertEquals(0, cache.count());
+
+        // subsequent get should be a cache miss
+        entity = new TestEntity(requestCacheStats, indexShard);
+        loader = new Loader(reader, 0);
+        value = cache.getOrCompute(entity, loader, mappingKey, reader, termBytes);
+        assertEquals("foo", value.streamInput().readString());
+        assertFalse(loader.loadedFromCache);
+        assertEquals(2, requestCacheStats.stats().getMissCount());
+
+        IOUtils.close(reader, writer, dir, cache);
+    }
+
     public void testKeyEqualsAndHashCode() throws IOException {
         AtomicBoolean trueBoolean = new AtomicBoolean(true);
         AtomicBoolean falseBoolean = new AtomicBoolean(false);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.aggregation.blockhash;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -61,6 +63,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 //@TestLogging(value = "org.elasticsearch.compute:TRACE", reason = "debug")
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class BlockHashRandomizedTests extends ESTestCase {
     @ParametersFactory
     public static List<Object[]> params() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix request cache invalidation to use ES cache helper consistently (#144581)](https://github.com/elastic/elasticsearch/pull/144581)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)