### PR TITLE
Gate tests on TRANSFORM_CROSS_PROJECT

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -384,6 +384,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
     }
 
     public void testDisablePitWhenCrossProjectSearchIsEnabled() throws InterruptedException {
+        assumeTrue("Only relevant if feature flag is enabled", TransformConfig.TRANSFORM_CROSS_PROJECT.isEnabled());
         var crossProjectModeDecider = mock(CrossProjectModeDecider.class);
         when(crossProjectModeDecider.crossProjectEnabled()).thenReturn(true);
 


### PR DESCRIPTION
When running the test in non-snapshot mode the feature flag would be disabled and `ClientTransformIndexer` would run with crossProjectEnabled=false
```
crossProjectEnabled = transformServices.crossProjectModeDecider().crossProjectEnabled()
    && TransformConfig.TRANSFORM_CROSS_PROJECT.isEnabled();
```
which result in test failing with
```
ClientTransformIndexerTests >
testDisablePitWhenCrossProjectSearchIsEnabled FAILED
java.lang.AssertionError: expected null,
but was:<org.elasticsearch.common.bytes.CompositeBytesReference@a72e3d5d>
```

The test only make sense if the feature flag is enabled so now we gate the test on that.

The failure can (could) be reproduced with:
```
 ./gradlew ":x-pack:plugin:transform:test" \--tests "org.elasticsearch
 .xpack.transform.transforms.ClientTransformIndexerTests.testDisablePitWhenCrossProjectSearchIsEnabled" -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dlicense.key=x-pack/license-tools/src/test/resources/public.key
```
Functionality was introduced here: https://github.com/elastic/elasticsearch/pull/144254