### PR TITLE
ESQL: Fix golden test case name parsing

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
@@ -75,6 +75,12 @@ import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // ExtrasFS can create extraneous files in the output directory.
 public abstract class GoldenTestCase extends ESTestCase {
     private static final Logger logger = LogManager.getLogger(GoldenTestCase.class);
+
+    /**
+     * RandomizedRunner appends {@code {seed=[...]}} to {@link #getTestName()} for {@code -Dtests.iters} / {@code @Repeat} (See #144763).
+     */
+    private static final Pattern RANDOMIZED_RUNNER_SEED_SUFFIX_AT_END = Pattern.compile("(?:\\s+\\{seed=\\[[^\\]]+\\]\\})+$");
+
     private final Path baseFile;
 
     public GoldenTestCase() {
@@ -103,7 +109,7 @@ public abstract class GoldenTestCase extends ESTestCase {
         TransportVersion transportVersion,
         String... nestedPath
     ) {
-        String testName = extractTestName();
+        String testName = RANDOMIZED_RUNNER_SEED_SUFFIX_AT_END.matcher(getTestName()).replaceFirst("");
         new Test(baseFile, testName, nestedPath, esqlQuery, stages, searchStats, transportVersion).doTest();
     }
 
@@ -532,10 +538,6 @@ public abstract class GoldenTestCase extends ESTestCase {
 
     private static String normalize(String s) {
         return s.lines().map(String::strip).collect(Collectors.joining("\n"));
-    }
-
-    private String extractTestName() {
-        return getTestName();
     }
 
     /**


### PR DESCRIPTION
## Problem
- Each iteration therefore pointed at a **different** tree, so the harness treated runs as missing goldens and tried to create new files, or failed outright.
- On some environments the `:` inside the seed segment can make the path segment **invalid** (`InvalidPathException`), so tests fail instead of leaving untracked dirs.

## Fix

Strip **all** trailing `RandomizedRunner` seed fragments at the **end** of `getTestName()` before using it as the directory name.

Resolves #144763.