### PR TITLE
ESQL: Aggregate pushdown for external sources (COUNT, MIN, MAX)

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcAggregatePushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcAggregatePushdownSupport.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.orc;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+
+import java.util.List;
+
+/**
+ * ORC supports COUNT(*), MIN(column), MAX(column) from stripe statistics.
+ */
+public class OrcAggregatePushdownSupport implements AggregatePushdownSupport {
+
+    @Override
+    public Pushability canPushAggregates(List<Expression> aggregates, List<Expression> groupings) {
+        if (groupings.isEmpty() == false) {
+            return Pushability.NO;
+        }
+        for (int i = 0; i < aggregates.size(); i++) {
+            Expression agg = aggregates.get(i);
+            if (agg instanceof Count) {
+                continue;
+            } else if (agg instanceof Min min) {
+                if (min.field() instanceof Attribute == false) {
+                    return Pushability.NO;
+                }
+            } else if (agg instanceof Max max) {
+                if (max.field() instanceof Attribute == false) {
+                    return Pushability.NO;
+                }
+            } else {
+                return Pushability.NO;
+            }
+        }
+        return Pushability.YES;
+    }
+}

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -288,6 +289,11 @@ public class OrcFormatReader implements FormatReader {
                 includeColumnForType(include, child);
             }
         }
+    }
+
+    @Override
+    public AggregatePushdownSupport aggregatePushdownSupport() {
+        return new OrcAggregatePushdownSupport();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetAggregatePushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetAggregatePushdownSupport.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+
+import java.util.List;
+
+/**
+ * Parquet supports COUNT(*), MIN(column), MAX(column) from row-group statistics.
+ */
+public class ParquetAggregatePushdownSupport implements AggregatePushdownSupport {
+
+    @Override
+    public Pushability canPushAggregates(List<Expression> aggregates, List<Expression> groupings) {
+        if (groupings.isEmpty() == false) {
+            return Pushability.NO;
+        }
+        for (int i = 0; i < aggregates.size(); i++) {
+            Expression agg = aggregates.get(i);
+            if (agg instanceof Count) {
+                continue;
+            } else if (agg instanceof Min min) {
+                if (min.field() instanceof Attribute == false) {
+                    return Pushability.NO;
+                }
+            } else if (agg instanceof Max max) {
+                if (max.field() instanceof Attribute == false) {
+                    return Pushability.NO;
+                }
+            } else {
+                return Pushability.NO;
+            }
+        }
+        return Pushability.YES;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
@@ -266,6 +267,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
         String createdBy = fileMetaData.getCreatedBy();
         return new ParquetColumnIterator(reader, projectedSchema, projectedAttributes, batchSize, blockFactory, rowLimit, createdBy);
+    }
+
+    @Override
+    public AggregatePushdownSupport aggregatePushdownSupport() {
+        return new ParquetAggregatePushdownSupport();
     }
 
     @Override

--- a/x-pack/plugin/esql/AGGREGATE_PUSHDOWN_PLAN.md
+++ b/x-pack/plugin/esql/AGGREGATE_PUSHDOWN_PLAN.md
@@ -1,0 +1,225 @@
+# Aggregate Pushdown for External Sources — Implementation Plan
+
+## Design Principle
+
+Replace `AggregateExec → ExternalSourceExec` with `LocalSourceExec` on each data node.
+The coordinator's FINAL AggregateExec is never touched — it merges intermediate values
+from all data nodes regardless of whether each data node pushed down or scanned.
+
+Each data node decides independently based on statistics availability:
+- All splits have statistics → precompute from stats, no scanning
+- Any split lacks statistics → normal scan for ALL splits (all-or-nothing)
+  Parquet and ORC always write statistics, so this is the common case.
+  Mixed-mode (precompute some, scan others) deferred to future work.
+
+## Phase 1: Data Node Footer Reading
+
+### Overview
+
+On each data node, the local physical optimizer replaces the aggregate subtree with
+a `LocalSourceExec` whose `LocalSupplier` reads file footers at execution time.
+Files WITH statistics get their values from the footer. Files WITHOUT statistics
+fall back to the normal scan path (the original AggregateExec → ExternalSourceExec
+is kept for those splits).
+
+### Hook for Phase 2
+
+`FileSplit` gets a `@Nullable SourceStatistics statistics` field.
+In Phase 1, this is always null — the supplier reads footers on the data node.
+In Phase 2 (union-by-name), the coordinator populates this from schema merging.
+The optimizer rule checks split statistics first and skips footer reads when present.
+
+### Step 1: Add statistics field to FileSplit
+
+Add `@Nullable SourceStatistics statistics` to `FileSplit`.
+Phase 1: always null. Phase 2: populated by coordinator.
+Update serialization to handle nullable statistics (write a boolean flag + data).
+
+Files:
+- `FileSplit.java` — add field, constructor, accessor, serialization
+- `FileSplitProvider.java` — pass null for statistics in Phase 1
+
+### Step 2: Rewrite PushAggregatesToExternalSource optimizer rule
+
+Replace current approach (eliminate AggregateExec, set hint on ExternalSourceExec)
+with the LocalSourceExec approach.
+
+The rule:
+1. Matches `AggregateExec(any mode) → ExternalSourceExec`
+2. Checks: ungrouped only, format supports pushdown
+3. Checks: all splits have statistics in FileSplit? (Phase 2 fast path)
+   - Yes: build intermediate page from split stats, return LocalSourceExec
+4. No pre-populated stats: check if format reader supports aggregate pushdown
+   - Yes: return LocalSourceExec with FileStatsSupplier (Phase 1 lazy path)
+   - No: return original plan (normal scan)
+
+Output attributes:
+- SINGLE mode: final aggregate attributes from AggregateExec.output()
+- INITIAL mode: intermediate attributes from AggregateExec.intermediateAttributes()
+
+Files:
+- `PushAggregatesToExternalSource.java` — rewrite rule logic
+
+### Step 3: Implement FileStatsSupplier
+
+A `LocalSupplier` that reads file footers at execution time.
+
+For each assigned split:
+1. If split.statistics() != null → use pre-populated stats (Phase 2 path)
+2. If split.statistics() == null → open file footer, extract statistics
+3. If a file lacks statistics → that split cannot be pushed down
+
+Merge strategy across splits:
+- COUNT_STAR: sum of per-file row counts
+- MIN: minimum of per-file minimums
+- MAX: maximum of per-file maximums
+
+If ALL splits yield statistics, produce a single intermediate format page:
+- SINGLE mode: [count, min_salary, max_age]
+- INITIAL mode: [count, seen=true, min_salary, seen=true, max_age, seen=true]
+
+All-or-nothing: if ANY split lacks statistics, the supplier signals failure
+and the optimizer keeps the original plan (normal scan for all splits).
+Parquet and ORC always write statistics so this fallback is rare.
+
+The supplier needs:
+- List of splits (captured from ExternalSourceExec)
+- Source config (for creating StorageProvider)
+- Source type (for resolving FormatReader)
+- AggregateSpec list (what to compute)
+- AggregatorMode (SINGLE vs INITIAL determines output format)
+- FormatReaderRegistry (for opening files)
+
+Files:
+- `FileStatsSupplier.java` (new) — implements LocalSupplier
+
+### Step 4: Remove execution-path aggregate pushdown
+
+Remove all hint-through-execution-chain infrastructure since the optimizer
+handles everything via LocalSourceExec.
+
+Remove:
+- `ExternalSourceExec.PushedAggregate` record and related fields
+- `FormatReader.withPushedAggregate()` default method
+- `SourceOperatorContext.pushedAggregate` field and builder method
+- `FileSourceFactory` aggregate hint plumbing
+- `AsyncExternalSourceOperatorFactory` aggregate merge logic
+- `AggregatePageMerger` class
+- `ParquetFormatReader.createAggregateResultIterator()` and `createStatBlock()`
+- `OrcFormatReader.createAggregateResultIterator()` and `createStatBlock()`
+- `LocalExecutionPlanner` projectedColumns aggregate check
+
+Keep:
+- `AggregateSpec` record in SPI (used by optimizer rule and supplier)
+- `AggregatePushdownSupport` interface (format capability declaration)
+- `FormatReader.aggregatePushdownSupport()` (optimizer probes capability)
+- `FormatReaderRegistry.findByName()` (nullable lookup for optimizer)
+- `ParquetAggregatePushdownSupport` and `OrcAggregatePushdownSupport`
+
+### Step 5: Footer statistics extraction
+
+Move statistics extraction logic from format readers into reusable utilities
+that FileStatsSupplier can call.
+
+For Parquet: read footer → iterate row groups → extract min/max/count
+For ORC: open reader → get file-level statistics → extract min/max/count
+
+These are the same operations as the current createAggregateResultIterator
+methods but returning SourceStatistics instead of Page.
+
+Files:
+- `ParquetFileStatistics.java` (new) — extracts SourceStatistics from Parquet footer
+- `OrcFileStatistics.java` (new) — extracts SourceStatistics from ORC file stats
+
+### Step 6: Intermediate format production
+
+Build blocks in the correct format based on AggregatorMode.
+
+SINGLE mode output (final values):
+  Block[0] = count (LONG)
+  Block[1] = min_salary (LONG)
+  Block[2] = max_age (INT)
+
+INITIAL mode output (intermediate channels):
+  Block[0] = count (LONG)
+  Block[1] = seen (BOOLEAN = true)
+  Block[2] = min_salary (LONG)
+  Block[3] = seen (BOOLEAN = true)
+  Block[4] = max_age (INT)
+  Block[5] = seen (BOOLEAN = true)
+
+The intermediate attributes come from AggregateFunction.intermediateAttributes()
+for each aggregate in the plan.
+
+### Step 7: Update tests
+
+- Rewrite PushAggregatesToExternalSourceTests for LocalSourceExec output
+- Rewrite AggregatePageMergerTests → remove (merger removed)
+- Adapt ParquetAggregatePushdownTests to test via FileStatsSupplier
+- Adapt OrcAggregatePushdownTests to test via FileStatsSupplier
+- Add tests for INITIAL mode intermediate format production
+- Add tests for mixed statistics (some splits have stats, some don't → fallback)
+- Add tests for multi-split merge (3 files, merge counts/mins/maxes)
+
+## Phase 2: Coordinator Pre-Populates Statistics (Future — Union-by-Name)
+
+### When this activates
+
+When union-by-name / schema merging lands, the coordinator reads ALL file
+metadata to merge schemas. At that point, collecting per-file statistics
+is free — the footer is already in memory.
+
+### What changes
+
+1. **FileSplitProvider**: When creating splits, populate `statistics` field
+   from the metadata that was already read during schema merging.
+
+2. **ExternalSourceResolver**: During multi-file resolution, collect
+   SourceStatistics for each file alongside the schema.
+
+3. **Optimizer rule (no changes needed)**: The existing rule checks
+   `split.statistics() != null` first. Phase 2 pre-populates this,
+   so the rule takes the fast path (no file I/O on data node).
+
+4. **Coordinator-level pushdown (optional optimization)**: For SINGLE mode
+   queries where the coordinator has all statistics, the coordinator's
+   local optimizer can replace the entire plan with LocalSourceExec
+   without sending anything to data nodes. This is an optimization
+   over Phase 1 where data nodes do the work.
+
+### Cost analysis
+
+Phase 1 (data node footer reads):
+- Per file: one range read of footer (4-32KB, one HTTP round-trip)
+- 100 files on one data node: 100 footer reads (~100ms on S3)
+- Memory: ~100 bytes per column stat × columns × files (temporary)
+- Compare to full scan: orders of magnitude less I/O
+
+Phase 2 (pre-populated from schema merge):
+- Zero incremental I/O (metadata already read for schema)
+- Per split serialization overhead: ~100 bytes per column per file
+- 1000 files × 20 columns: ~2MB in split serialization (negligible)
+- Data node: zero file I/O for aggregate pushdown
+
+### Hints for Phase 2 implementer
+
+When implementing union-by-name schema merging:
+
+1. The `FormatReader.metadata(StorageObject)` method already returns
+   `SourceMetadata` which contains `Optional<SourceStatistics>`.
+   Store this per-file alongside the schema.
+
+2. When creating FileSplits in `FileSplitProvider`, pass the
+   `SourceStatistics` from the metadata into the split constructor.
+   The nullable field is already there from Phase 1.
+
+3. The optimizer rule `PushAggregatesToExternalSource` already checks
+   `split.statistics() != null` as its first code path. When statistics
+   are pre-populated, this path fires and the FileStatsSupplier is
+   never created — no file I/O on the data node.
+
+4. For coordinator-level pushdown in SINGLE mode: add a check in the
+   rule for when ALL splits have statistics AND mode is SINGLE.
+   In that case, build the final-values page directly in the rule
+   (no LocalSupplier needed) and return LocalSourceExec immediately.
+   This avoids sending splits to data nodes entirely.

--- a/x-pack/plugin/esql/ESQL_DATASOURCES_ARCHITECTURE.md
+++ b/x-pack/plugin/esql/ESQL_DATASOURCES_ARCHITECTURE.md
@@ -1,0 +1,196 @@
+# ES|QL External Data Sources — System Design
+
+**Author:** Costin Leau | **Date:** March 2026 | **Status:** Living Document
+
+---
+
+## 1. Architecture Overview
+
+ES|QL external data sources allow queries to read directly from files (Parquet, CSV, ORC, NDJSON) and table systems (Iceberg, Flight) alongside native Elasticsearch indices. The architecture is built on a pluggable SPI that keeps the core query engine format-agnostic.
+
+```
+                           ┌──────────────────────────────────────────────────────┐
+                           │                    COORDINATOR                       │
+                           │                                                      │
+  FROM "s3://…/*.parquet"  │  ┌─────────┐    ┌──────────┐    ┌───────────────┐   │
+  WHERE ts > now() - 1d    │  │  Parse & │───▶│ Metadata │───▶│   Physical    │   │
+  | STATS count(*)         │  │ Analyze  │    │ Resolve  │    │   Planning    │   │
+                           │  └─────────┘    └──────────┘    └───────┬───────┘   │
+                           │                                         │           │
+                           │                 ┌───────────────────────▼────────┐   │
+                           │                 │     Split Discovery &          │   │
+                           │                 │     Distribution Strategy      │   │
+                           │                 └──┬────────────┬────────────┬──┘   │
+                           └────────────────────┼────────────┼────────────┼──────┘
+                                    ┌───────────▼──┐  ┌──────▼──────┐  ┌─▼──────────┐
+                                    │  Data Node 0 │  │ Data Node 1 │  │ Data Node 2│
+                                    │              │  │             │  │            │
+                                    │ Local Optim. │  │ Local Optim.│  │ Local Opt. │
+                                    │ Filter Push  │  │ Filter Push │  │ Filter Push│
+                                    │ Read Splits  │  │ Read Splits │  │ Read Splits│
+                                    │              │  │             │  │            │
+                                    └──────┬───────┘  └──────┬──────┘  └─────┬──────┘
+                                           │                 │               │
+                                           └────────────┬────┘               │
+                                      Exchange ────────▶│◀───────────────────┘
+                                                        ▼
+                                                   ┌─────────┐
+                                                   │  Final   │
+                                                   │  Merge   │
+                                                   └─────────┘
+```
+
+The system is decomposed into **four functional areas**, each described below.
+
+---
+
+## 2. Metadata Resolution
+
+Metadata resolution runs **asynchronously on the coordinator**, in parallel with ES index field-caps resolution, so neither blocks the other.
+
+```
+  ┌─────────────────────┐          ┌───────────────────────┐
+  │   Index Resolver     │          │ External Source        │
+  │ (FieldCapsRequest)  │  async   │ Resolver               │
+  │                     ├──────────┤                        │
+  │  ES index schemas   │  parallel│  Glob expand paths     │
+  │                     │          │  Open first file        │
+  └─────────┬───────────┘          │  Read footer/schema    │
+            │                      │  Extract statistics     │
+            │                      └───────────┬────────────┘
+            └──────────┬───────────────────────┘
+                       ▼
+                Unified Schema (List<Attribute>)
+```
+
+**How it works.** The `ExternalSourceResolver` iterates registered `ExternalSourceFactory` implementations to find one that can handle the given path. The matching factory delegates to a `FormatReader` which opens the file (e.g., reads the Parquet footer), extracts the schema and column/row-group statistics, and returns a `SourceMetadata` object.
+
+For multi-file sources (globs, comma-separated paths), a `GlobExpander` resolves all matching files via the `StorageProvider`. Schema is taken from the first file (future: strict/union modes). Hive partition columns discovered from directory structure are appended to the schema.
+
+**Trade-offs.**
+- *First-file-wins schema* is fast (one file open) but can miss schema drift across files — acceptable for the common case; strict mode planned for safety-critical workloads.
+- *Parallel resolution* adds complexity but eliminates the latency penalty of external I/O on the planning critical path.
+- *Statistics at planning time* enable aggregate pushdown (see §5) but require reading file metadata eagerly — a worthwhile cost since the footer is small relative to data.
+
+---
+
+## 3. Query Execution Pipeline
+
+A query flows through three plan representations, each adding execution detail:
+
+```
+  Logical Plan                Physical Plan              Operators
+  ─────────────              ──────────────              ─────────
+  ExternalRelation    ──▶    ExternalSourceExec    ──▶   AsyncExternalSourceOperator
+    sourcePath                 + splits                    + FormatReader
+    schema                     + config                    + StorageProvider
+    statistics                 + pushed filter/limit       + SliceQueue
+```
+
+**ExternalSourceExec** is the single physical node for all external sources. It carries generic `Map<String, Object>` for both configuration and source-specific metadata — this keeps the core planner decoupled from format libraries (Parquet, Arrow, AWS SDK).
+
+**Key design decision: local-only optimization hints.** Pushed filters and limits are **not serialized** across nodes. They are opaque objects (e.g., Parquet `FilterPredicate`) created during `LocalPhysicalPlanOptimizer` on each data node. This avoids serialization of format-specific types and ensures each node applies optimizations independently.
+
+**Operator model.** The operator factory creates either:
+- **Sync operators** — for simple formats (CSV, NDJSON) where the reader returns `Iterator<Page>` directly.
+- **Async operators** — for formats with expensive I/O (Parquet, remote storage). A background thread reads pages into an `AsyncExternalSourceBuffer` with byte-based backpressure; the driver polls without blocking.
+
+**Performance characteristics.**
+- Backpressure buffer defaults to ~640KB (10 × page size), bounding memory per operator while keeping the pipeline fed.
+- For multi-split queries, a `SliceQueue` lets multiple driver threads claim splits work-stealing style — no central scheduling overhead.
+
+---
+
+## 4. Dispatch & Distribution
+
+After planning, the coordinator decides **where** to execute external source reads.
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │                    Distribution Decision                             │
+  │                                                                      │
+  │   Splits discovered  ──▶  Strategy evaluates:                       │
+  │                           • Split count vs. node count              │
+  │                           • Query shape (has aggregates? limit?)    │
+  │                           • Split sizes (weighted assignment?)      │
+  │                                                                      │
+  │   ┌─────────────────┐  ┌──────────────┐  ┌───────────────────────┐  │
+  │   │  Coordinator-   │  │  Round-Robin  │  │  Weighted Round-Robin │  │
+  │   │  Only            │  │              │  │  (LPT algorithm)      │  │
+  │   │                 │  │  Even split   │  │  Largest splits first,│  │
+  │   │  Single split   │  │  cycling      │  │  assigned to least-   │  │
+  │   │  or LIMIT-only  │  │              │  │  loaded node           │  │
+  │   └─────────────────┘  └──────────────┘  └───────────────────────┘  │
+  │                                                                      │
+  │                     ▲ Adaptive (default): picks based on query ▲     │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+**Split discovery** runs on the coordinator. The `SplitProvider` converts the resolved `FileSet` into parallelizable units — one per file for small files, or multiple per file aligned to Parquet row-groups / ORC stripes for large files. Ancestor filter predicates are evaluated against partition values for **L1 partition pruning** (skip entire files before reading).
+
+**Distribution uses the standard Exchange.** Once splits are assigned, the coordinator sends each data node a serialized plan with its split subset. Data nodes execute locally, write pages to `ExchangeSinkExec`, and the coordinator collects via `ExchangeSourceExec` — the **same exchange infrastructure** used for ES index queries. No special data path.
+
+**Trade-offs.**
+- *Adaptive strategy* avoids distribution overhead for trivial queries (single file, LIMIT 10) while parallelizing large scans — good default, overridable via query pragma.
+- *Weighted assignment* requires all splits to report size; falls back to round-robin otherwise. Split sizes come from file metadata (cheap) but may not reflect actual read cost (compression ratio, filter selectivity).
+- *Partial results*: if a data node fails, the query can optionally return partial results (configurable) rather than failing entirely — important for large multi-file scans.
+
+---
+
+## 5. Pushdown Optimizations
+
+Three pushdown optimizations reduce I/O and computation, applied during `LocalPhysicalPlanOptimizer` on each data node:
+
+| Optimization | What Gets Pushed | Where It Runs | Format Support |
+|---|---|---|---|
+| **Filter pushdown** | WHERE predicates → row-group/stripe skip | FormatReader via FilterPredicate | Parquet (stats, bloom, dict), ORC |
+| **Limit pushdown** | LIMIT N → early termination | FormatReader stops after N rows | All formats |
+| **Aggregate pushdown** | COUNT/MIN/MAX → file statistics | Replaces AggregateExec with constants | Parquet, ORC (stats required) |
+
+```
+  Before pushdown:                    After pushdown:
+
+  LimitExec(100)                      LimitExec(100)
+    FilterExec(ts > X)                  FilterExec(ts > X)          ← safety net
+      AggregateExec(count)                ExternalSourceExec
+        ExternalSourceExec                  pushedFilter: ts > X    ← row-group skip
+                                            pushedLimit: 100        ← early stop
+
+  Aggregate-only case:
+  AggregateExec(count(*))             LocalSourceExec
+    ExternalSourceExec         ──▶      [single page: count=1_000_000]
+      statistics.rowCount=1M            (no file reads at all)
+```
+
+**Filter pushdown uses RECHECK semantics**: filters are pushed to the source for row-group skipping but **remain** in the `FilterExec` node for correctness — the source may return false positives (e.g., a row within a matching row-group that doesn't actually satisfy the predicate). This is a deliberate correctness-over-performance trade-off: the source does coarse pruning, the engine does exact filtering.
+
+**Aggregate pushdown from statistics** is the most aggressive optimization: if the query is an ungrouped `COUNT(*)`, `MIN(col)`, or `MAX(col)` and file-level statistics are available, the entire scan is eliminated — replaced with a constant-value `LocalSourceExec`. For distributed queries, this produces intermediate aggregation values (value + seen-boolean) that the coordinator merges.
+
+---
+
+## 6. Plugin SPI
+
+The system is composed through four SPI interfaces, each responsible for one concern:
+
+```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  DataSourcePlugin (entry point, registered via ES plugin system) │
+  │                                                                  │
+  │  ┌──────────────┐  ┌──────────────┐  ┌────────────────────────┐ │
+  │  │StorageProvider│  │ FormatReader  │  │ExternalSourceFactory   │ │
+  │  │              │  │              │  │  (unified: connectors, │ │
+  │  │ s3://, gs://, │  │ .parquet,    │  │   catalogs, files)    │ │
+  │  │ http://, file │  │ .csv, .orc,  │  │                       │ │
+  │  │              │  │ .ndjson      │  │  resolveMetadata()     │ │
+  │  │ newObject()  │  │ read()       │  │  splitProvider()       │ │
+  │  │ listObjects()│  │ metadata()   │  │  operatorFactory()     │ │
+  │  └──────────────┘  └──────────────┘  └────────────────────────┘ │
+  └──────────────────────────────────────────────────────────────────┘
+
+  Composition: StorageProvider + FormatReader = FileSourceFactory
+               (handles any scheme × format combination)
+```
+
+**Lazy loading.** Plugins declare capabilities (supported schemes, formats) without loading heavy dependencies. Actual class loading (Parquet, Arrow, AWS SDK) happens only when a query first uses that format — via `LazyPluginState` wrappers in `DataSourceModule`.
+
+**Generic configuration.** All source-specific config flows as `Map<String, Object>` — the core engine never imports S3Configuration, IcebergConfig, etc. Only the plugin interprets its own keys. This keeps the module dependency graph clean and enables new sources without modifying core.

--- a/x-pack/plugin/esql/SCHEMA_RECONCILIATION_DESIGN.md
+++ b/x-pack/plugin/esql/SCHEMA_RECONCILIATION_DESIGN.md
@@ -1,0 +1,679 @@
+# Schema Reconciliation for Multi-File External Sources — Design Proposal
+
+**Author**: costin
+**Date**: 2026-03-26
+**Status**: Draft — for team review
+**Branch**: costin/aggregate-pushdown-v3
+**Related**: aggregate pushdown Phase 2 depends on union-by-name (see `AGGREGATE_PUSHDOWN_PLAN.md`)
+
+---
+
+## Problem Statement
+
+ESQL datasources currently support only `FIRST_FILE_WINS` when reading multiple files from
+blob storage via glob patterns. The first file's schema becomes the planning-phase schema for
+all subsequent files. Schema differences in subsequent files are silently ignored, which can
+cause data corruption (wrong column mapping) or runtime errors.
+
+Two additional strategies are needed:
+
+1. **STRICT** — validate that all files share the exact same schema; fail fast if they don't.
+2. **UNION_BY_NAME** — merge schemas from all files into a superset, filling missing columns
+   with nulls and resolving compatible type differences.
+
+These are defined as placeholders in `FormatReader.SchemaResolution` but unimplemented.
+
+---
+
+## Current Architecture
+
+### Resolution Flow (Planning Phase)
+
+```
+Query: FROM "s3://bucket/data/*.parquet"
+  → GlobExpander.expandGlob()           # list all matching files
+  → ExternalSourceResolver              # take first file's schema
+    .resolveMultiFileSource()
+  → resolveSingleSource(firstFile)       # read metadata from first file only
+  → enrichSchemaWithPartitionColumns()   # add Hive partition columns
+  → ResolvedSource(metadata, fileSet)    # planning-phase schema + file list
+```
+
+### Key Observations
+
+- **Metadata per file is cheap**: `FormatReader.metadata(StorageObject)` reads only the file
+  footer (Parquet: 4–32 KB, ORC: similar). It does NOT read data.
+- **Column matching is by name**: both Parquet and ORC use named columns, not positional.
+- **Schema → Attribute list**: each file's schema becomes `List<Attribute>` where each
+  attribute is a `ReferenceAttribute(name, DataType, Nullability)`.
+- **Statistics come with metadata**: `SourceMetadata.statistics()` returns per-file column
+  statistics (min/max/null count/row count). This is relevant for aggregate pushdown Phase 2.
+- **File count**: typical use cases range from tens to thousands of files per glob.
+
+---
+
+## Industry Survey
+
+### DuckDB
+
+| Aspect | Behavior |
+|--------|----------|
+| **Default** | Union by position. Schema from first file. Fails on type/column count mismatch. |
+| **`union_by_name=true`** | Reads ALL file metadata upfront. Union of all column names. Missing columns → NULL. |
+| **Type conflicts** | Safe numeric widening (int→bigint, float→double). Cross-category (int→string) → error. |
+| **Schema scanning** | Eager: all file metadata read during bind phase. Parallelized since v1.1. |
+| **Performance** | 1000 small CSV files: 0.6s with parallel scanning. ~10% overhead vs positional. |
+| **Strict mode** | Default behavior IS strict (by position). Named matching is the "lenient" option. |
+| **`schema` param** | Explicit schema declaration using Parquet field IDs. Cannot combine with `union_by_name`. |
+
+**Key insight**: DuckDB treats strict-by-position as the default and union-by-name as the opt-in.
+Type widening is limited to safe numeric promotions. The `filename` virtual column helps users
+debug which file contributed which rows.
+
+### Apache Spark
+
+| Aspect | Behavior |
+|--------|----------|
+| **Default** | `mergeSchema=false`. Schema from `_common_metadata` summary file, `_metadata`, or a random file. |
+| **`mergeSchema=true`** | Reads ALL file footers in parallel across executors. `StructType.merge()` unions fields by name. |
+| **Type conflicts** | `StructType.merge()` is STRICT: int vs long → **error** (no auto-widening at merge time). |
+| **Read-time widening** | Separate from merge: vectorized reader supports int32→int64, float→double, etc. |
+| **Nested schemas** | Recursive merge of structs, arrays, maps. |
+| **ORC vs Parquet** | Same merge logic. ORC native reader has broader type conversion support. |
+| **Performance** | Parallel footer reading on executors. Driver collects partial results. Can be slow for large footer files on S3. |
+
+**Key insight**: Spark separates schema merge (strict equality except nullability) from read-time
+type promotion (vectorized reader does widening). This two-layer design is worth considering.
+Spark's `mergeSchema` is off by default because it's expensive.
+
+### ClickHouse
+
+| Aspect | Behavior |
+|--------|----------|
+| **Default** | `schema_inference_mode='default'`. First file only. Missing columns → fill with defaults/NULL. |
+| **Union mode** | `schema_inference_mode='union'`. Reads ALL file metadata. Union by name. `getLeastSupertype()` for type conflicts. |
+| **Type promotion** | Numeric widening within signed/unsigned families. int+float→float64. String+numeric → **error** (no common type). |
+| **Missing columns** | `input_format_parquet_allow_missing_columns=true` (default). Fills with type defaults. |
+| **Extra columns** | Silently ignored (column projection). |
+| **Variant fallback** | `input_format_try_infer_variants=true` enables Variant type for truly incompatible types. |
+
+**Key insight**: ClickHouse's `allow_missing_columns` setting (on by default for Parquet, off for ORC)
+is a pragmatic middle ground — it allows FIRST_FILE_WINS to handle added columns without erroring.
+Their `getLeastSupertype` is well-defined with clear failure modes.
+
+### Cribl
+
+| Aspect | Behavior |
+|--------|----------|
+| **Model** | Event-centric (per-event fields), not table-centric. |
+| **Schema merge** | None. Each file is read independently. Events simply lack missing fields. |
+| **Type handling** | Strict on writes (type violation → drop row). Undocumented on reads. |
+| **Philosophy** | "Schema-on-need" — normalize upstream (Stream) not at query time (Search). |
+
+**Key insight**: Cribl's event-centric model avoids schema reconciliation entirely. Not applicable
+to our table-oriented query engine, but their "normalize early" philosophy is worth noting —
+users who need guaranteed consistency should use a table format (Iceberg/Delta) over raw files.
+
+---
+
+## Comparative Summary
+
+| Feature | DuckDB | Spark | ClickHouse | **Our Proposal** |
+|---------|--------|-------|------------|-------------------|
+| Default mode | Strict (positional) | Random file | First file | FIRST_FILE_WINS (current) |
+| Union by name | Opt-in param | Opt-in param | Opt-in setting | Opt-in WITH clause |
+| Strict validation | Default behavior | Not available | Not available | Opt-in WITH clause |
+| Type widening | Safe numeric | None at merge | Safe numeric | Safe numeric |
+| Metadata scanning | All files eagerly | All files in parallel | All files eagerly | All files in parallel |
+| Missing columns | NULL | NULL | Type default / NULL | NULL |
+| Cross-category types | Error | Error | Error | Error |
+
+---
+
+## Proposed Design
+
+### Strategy Selection
+
+Users select the strategy via the WITH clause:
+
+```sql
+-- Current default (no change)
+FROM "s3://bucket/data/*.parquet"
+
+-- Explicit first-file-wins
+FROM "s3://bucket/data/*.parquet" WITH schema_resolution = "first_file_wins"
+
+-- Strict: all files must match
+FROM "s3://bucket/data/*.parquet" WITH schema_resolution = "strict"
+
+-- Union by name: merge all schemas
+FROM "s3://bucket/data/*.parquet" WITH schema_resolution = "union_by_name"
+```
+
+The format reader's `defaultSchemaResolution()` determines the default when no explicit value
+is provided. Initially all formats default to `FIRST_FILE_WINS` (preserving current behavior).
+
+> **Open question 1**: Should the default eventually change to STRICT for Parquet/ORC once the
+> feature is proven stable? STRICT is the safest default and matches DuckDB's philosophy. Users
+> with heterogeneous files would opt into `union_by_name`.
+
+### Strategy 1: STRICT
+
+#### Behavior
+
+All files in the glob must have the **exact same schema** (column names, types, and order).
+If any file differs, the query fails at planning time with a descriptive error.
+
+#### What "exact match" means
+
+- Same column count
+- Same column names (case-sensitive; case-insensitive as a future option)
+- Same data types (no implicit widening — int32 ≠ int64)
+- Nullability differences are tolerated (a non-nullable column is compatible with nullable)
+
+> **Open question 2**: Should we allow safe numeric widening in STRICT mode? DuckDB's strict
+> mode does NOT allow it (int32 ≠ int64 is an error). Spark's `StructType.merge()` also rejects
+> it. Both require explicit action to handle type differences. Our recommendation is to NOT
+> allow widening in STRICT — if you need widening, use UNION_BY_NAME.
+
+#### Error messages
+
+Errors must identify:
+- Which file has the mismatch (absolute path)
+- What the mismatch is (missing column, extra column, type difference)
+- What the reference schema is (from the first file)
+
+Example:
+```
+Schema mismatch in file [s3://bucket/data/2024-02.parquet]:
+  Column [salary] has type [LONG] but first file [s3://bucket/data/2024-01.parquet] has type [INTEGER].
+  Use schema_resolution = "union_by_name" to merge schemas automatically.
+```
+
+#### Implementation: scanning strategy
+
+**Option A: Scan all files eagerly (recommended)**
+
+Read metadata from ALL files during planning. Compare each file's schema against the first.
+Fail on the first mismatch.
+
+- **Pro**: Immediate, deterministic errors. No surprises at execution time.
+- **Pro**: Enables collecting per-file statistics for aggregate pushdown (Phase 2).
+- **Con**: Planning time grows linearly with file count. ~100ms per 100 files on S3 (footer reads).
+- **Mitigation**: Parallelize footer reads. Use thread pool already available in `ExternalSourceResolver`.
+
+**Option B: Validate lazily at execution time**
+
+Read only the first file at planning. Validate each subsequent file when its split is read
+by the data node.
+
+- **Pro**: Zero overhead at planning time.
+- **Con**: Errors surface mid-query, potentially after significant work. Non-deterministic
+  error timing depending on which data node hits a mismatched file first.
+- **Con**: Cannot collect per-file statistics for aggregate pushdown.
+
+**Recommendation**: Option A. The cost of reading file footers (not data) is trivial compared
+to reading the actual data. Eager validation provides a much better user experience. This also
+enables aggregate pushdown Phase 2.
+
+#### Implementation: validation depth
+
+**Level 1 — Schema only**: Read the file footer schema. Compare column names and types.
+Do not read column statistics. This is sufficient for STRICT validation.
+
+**Level 2 — Schema + statistics**: Read the file footer schema AND statistics. Compare
+schemas for STRICT, and store statistics for aggregate pushdown. This is a natural extension
+once we're reading all footers anyway.
+
+**Recommendation**: Implement Level 2 from the start. The incremental cost is zero (statistics
+are in the same footer). This unblocks aggregate pushdown Phase 2 for free.
+
+### Strategy 2: UNION_BY_NAME
+
+#### Behavior
+
+The unified schema is the **union of all column names** across all files. Columns missing from
+a file are filled with NULL when reading that file. Type differences on the same column name
+are resolved by type widening where possible, or produce an error.
+
+#### Schema merge algorithm
+
+```
+unified_schema = {}
+
+for each file in file_set:
+    file_schema = read_metadata(file).schema()
+    for each column in file_schema:
+        if column.name not in unified_schema:
+            unified_schema[column.name] = column (made nullable)
+        else:
+            existing = unified_schema[column.name]
+            unified_schema[column.name] = merge(existing, column)
+
+function merge(a, b):
+    if a.type == b.type:
+        return a.withNullability(a.nullable || b.nullable)
+    widened = tryWiden(a.type, b.type)
+    if widened != null:
+        return a.withType(widened).withNullability(true)
+    else:
+        error("Cannot merge column [name]: type [a.type] and [b.type] are incompatible")
+```
+
+#### Type widening rules
+
+Follow the same rules as DuckDB and ClickHouse — safe numeric promotions only:
+
+| From | To | Allowed |
+|------|----|---------|
+| BYTE → SHORT | yes | Lossless |
+| SHORT → INTEGER | yes | Lossless |
+| INTEGER → LONG | yes | Lossless |
+| FLOAT → DOUBLE | yes | Lossless |
+| UNSIGNED_LONG → ??? | no | No safe supertype in ESQL |
+| INTEGER → DOUBLE | yes | Lossless (int32 fits in float64) |
+| LONG → DOUBLE | **no** | Lossy (int64 > 2^53 loses precision) |
+| Any numeric → KEYWORD/TEXT | **no** | Cross-category |
+| KEYWORD → TEXT | **no** | Different semantics |
+| DATE → DATETIME | **TBD** | Semantically reasonable |
+
+> **Open question 3**: Should we support LONG→DOUBLE widening? DuckDB does not (it's lossy).
+> Spark does not. ClickHouse does (int+float→float64). Our recommendation is NO — follow
+> DuckDB/Spark and reject lossy promotions.
+
+> **Open question 4**: Should DATE→DATETIME widening be supported? Spark doesn't (they're
+> incompatible). DuckDB does. It's semantically reasonable (date is a datetime at midnight).
+> Our recommendation is to defer this and start strict — only the numeric widening ladder.
+
+#### Nullability handling
+
+- A column that exists in ALL files: nullable if ANY file declares it nullable.
+- A column that is missing from at least one file: **always nullable** (it will be NULL-filled
+  for files that lack it).
+
+This matches DuckDB and Spark behavior.
+
+#### Column ordering in the unified schema
+
+Columns appear in **first-seen order**: the first file's columns come first (in their original
+order), then new columns from subsequent files are appended in the order they're first
+encountered.
+
+This is the same approach as DuckDB's `union_by_name`.
+
+> **Open question 5**: Should column ordering be deterministic? Currently files are sorted by
+> path in `GlobExpander`, so the ordering IS deterministic. We should preserve this.
+
+#### Per-file column mapping
+
+For each file, the system maintains a mapping from the unified schema to the file's local schema:
+
+```java
+record FileColumnMapping(
+    int[] localToGlobalIndex,    // file column i → unified column index
+    Set<Integer> missingColumns  // unified column indices absent from this file
+)
+```
+
+This mapping is computed once during schema merge and stored alongside the file entry.
+At read time:
+- Present columns → read from file, cast to unified type if needed
+- Missing columns → emit NULL block of the appropriate type
+
+#### Implementation: metadata scanning
+
+Same approach as STRICT Option A: read metadata from ALL files during planning, in parallel.
+
+**Performance characteristics** (based on DuckDB/Spark experience):
+
+| File count | Estimated planning overhead (S3) | Notes |
+|------------|----------------------------------|-------|
+| 10 files | ~50ms | Negligible |
+| 100 files | ~200ms | Acceptable |
+| 1,000 files | ~2s | Noticeable, parallelism critical |
+| 10,000 files | ~15s | Heavy. Consider sampling/caching. |
+
+**Parallelization**: Use the existing executor in `ExternalSourceResolver`. Submit metadata
+reads as tasks to a thread pool. Merge schemas as results arrive.
+
+> **Open question 6**: For very large file sets (10,000+), should we support a sampling mode
+> that reads N random files and uses their merged schema? This is risky (may miss columns) but
+> could be a future opt-in. DuckDB doesn't offer this — they always read everything.
+> Our recommendation: don't implement sampling. If the user has 10,000 files with different
+> schemas, they should use a table format (Iceberg/Delta) that maintains a catalog.
+
+#### Read-time behavior: NULL filling for missing columns
+
+When reading a file that is missing columns from the unified schema, the reader must produce
+NULL values for those columns. There are two approaches:
+
+**Option A: Reader-level NULL injection**
+
+The `FormatReader.read()` method is aware of the unified schema and injects NULL blocks for
+missing columns. Each format reader handles this internally.
+
+- **Pro**: No changes to the execution engine.
+- **Con**: Every format reader must implement NULL injection logic. Duplicated code.
+
+**Option B: Wrapper/adapter layer**
+
+A `SchemaAdaptingIterator` wraps the format reader's output and:
+1. Reads the file with only the columns it has (column projection)
+2. Creates NULL blocks for missing columns
+3. Reorders columns to match the unified schema
+
+- **Pro**: Format readers don't need changes. Single implementation in the framework.
+- **Con**: Extra object creation per page. Minor.
+
+**Recommendation**: Option B. A `SchemaAdaptingIterator` in the datasource framework keeps
+format readers simple and avoids duplicating NULL-injection logic across Parquet, ORC, CSV, etc.
+
+```java
+class SchemaAdaptingIterator implements CloseableIterator<Page> {
+    private final CloseableIterator<Page> delegate;  // reads only present columns
+    private final List<Attribute> unifiedSchema;
+    private final FileColumnMapping mapping;
+
+    @Override
+    public Page next() {
+        Page filePage = delegate.next();
+        int positions = filePage.getPositionCount();
+
+        Block[] unifiedBlocks = new Block[unifiedSchema.size()];
+        for (int i = 0; i < unifiedSchema.size(); i++) {
+            if (mapping.missingColumns().contains(i)) {
+                unifiedBlocks[i] = createNullBlock(unifiedSchema.get(i).dataType(), positions);
+            } else {
+                int localIndex = mapping.globalToLocalIndex(i);
+                unifiedBlocks[i] = maybeCast(filePage.getBlock(localIndex), unifiedSchema.get(i));
+            }
+        }
+        return new Page(positions, unifiedBlocks);
+    }
+}
+```
+
+#### Read-time behavior: type casting for widened columns
+
+When a column exists in a file but with a narrower type than the unified schema (e.g., file
+has INT32, unified schema has INT64), the reader must cast the values.
+
+Options:
+- **In the SchemaAdaptingIterator**: cast blocks inline during page adaptation.
+- **In the format reader**: read with explicit type casting (Parquet/ORC readers support this natively).
+
+**Recommendation**: Use format-native casting where possible (Parquet and ORC readers support
+reading INT32 columns as INT64 via their projection schemas). Fall back to block-level casting
+in the adapter for formats that don't support native widening.
+
+### Integration with Existing Features
+
+#### Hive Partition Columns
+
+Partition columns are currently appended after schema resolution (in `enrichSchemaWithPartitionColumns`).
+This works with all three strategies:
+
+- **FIRST_FILE_WINS**: Partition columns appended after first file's schema (current behavior).
+- **STRICT**: Partition columns appended after validation. Partition columns are NOT subject to
+  strict validation — they come from paths, not file schemas.
+- **UNION_BY_NAME**: Partition columns appended after merge. If a partition column name conflicts
+  with a data column, the partition column wins (current behavior).
+
+No changes needed.
+
+#### Filter Pushdown
+
+Filter pushdown currently produces per-query filter predicates (e.g., Parquet `FilterPredicate`).
+These predicates reference column names from the planning-phase schema.
+
+- **STRICT**: No change — all files have the same schema, same column names.
+- **UNION_BY_NAME**: The filter may reference columns that don't exist in some files. For files
+  missing a filtered column, the filter should evaluate to "unknown" (include the row group).
+  Parquet's `FilterPredicate` already handles this gracefully — a predicate on a missing column
+  returns "unknown" which means "don't skip". ORC behaves similarly.
+
+No changes needed for basic filter pushdown. However, if we push type-widened filters (e.g.,
+filter says `salary > 50000` with LONG type but the file has INT32), the Parquet/ORC reader
+needs to handle the type mismatch in the predicate. This needs investigation.
+
+#### Aggregate Pushdown (Phase 2)
+
+UNION_BY_NAME is the **enabler** for aggregate pushdown Phase 2. When reading all file metadata
+for schema merging, per-file statistics are available for free:
+
+1. During schema merge, collect `SourceStatistics` for each file
+2. Store statistics in `FileSplit.statistics` (the nullable field from Phase 1)
+3. The optimizer rule `PushAggregatesToExternalSource` finds pre-populated statistics
+   and takes the fast path (no file I/O on data nodes)
+
+This is already designed in `AGGREGATE_PUSHDOWN_PLAN.md` Phase 2. UNION_BY_NAME makes it
+free because we're reading footers anyway.
+
+For STRICT mode, the same optimization applies — all files are scanned, statistics are available.
+
+#### Column Projection
+
+Currently, the optimizer pushes column projection to the format reader (read only needed columns).
+With UNION_BY_NAME:
+
+- The projected columns are a subset of the UNIFIED schema.
+- For each file, the projected columns are intersected with the file's actual columns.
+- Missing projected columns → NULL blocks (handled by SchemaAdaptingIterator).
+- This is a natural composition — no special handling needed.
+
+### Error Policy Interaction
+
+`FormatReader` already has an `ErrorPolicy` (STRICT vs LENIENT). This is orthogonal to
+`SchemaResolution`:
+
+- `SchemaResolution` governs planning-time schema decisions.
+- `ErrorPolicy` governs execution-time data reading errors (malformed rows, parse failures).
+
+They are independent axes. A query can use `schema_resolution = "union_by_name"` (lenient
+about schema differences) with `error_policy = "strict"` (fail on malformed data), or vice versa.
+
+### Data Structures
+
+#### SchemaReconciliationResult
+
+The output of schema reconciliation during planning:
+
+```java
+record SchemaReconciliationResult(
+    List<Attribute> unifiedSchema,
+    Map<StoragePath, FileSchemaInfo> perFileInfo
+)
+
+record FileSchemaInfo(
+    List<Attribute> fileSchema,         // original file schema
+    @Nullable FileColumnMapping mapping, // null for FIRST_FILE_WINS
+    @Nullable SourceStatistics statistics // null if not collected
+)
+
+record FileColumnMapping(
+    int[] globalToLocalIndex,   // unified column i → file column index (-1 if missing)
+    DataType[] casts            // null entries = no cast needed; non-null = cast to this type
+)
+```
+
+For `FIRST_FILE_WINS`, `perFileInfo` contains only the first file (backward compatible).
+For `STRICT`, `perFileInfo` contains all files (for statistics), mappings are identity.
+For `UNION_BY_NAME`, `perFileInfo` contains all files with mappings and casts.
+
+#### Extended FileSet
+
+The existing `FileSet` carries the list of files. It should be extended to carry per-file
+schema info:
+
+```java
+// FileSet already has:
+List<StorageEntry> files();
+PartitionMetadata partitionMetadata();
+
+// Add:
+@Nullable Map<StoragePath, FileSchemaInfo> fileSchemaInfo();
+// null for FIRST_FILE_WINS (backward compatible)
+// populated for STRICT and UNION_BY_NAME
+```
+
+This allows per-file metadata to flow from planning through to execution without changing
+the existing plumbing significantly.
+
+### Serialization Considerations
+
+Per-file schema info must be serialized when `FileSet` is sent from coordinator to data nodes.
+The `FileSchemaInfo` per file includes:
+- Column mapping (int array + DataType array) — compact
+- Statistics (existing `SourceStatistics` serialization) — already handled
+
+For 1,000 files × 20 columns: ~80 KB for mappings + ~200 KB for statistics = ~280 KB total.
+Negligible compared to the data being transferred.
+
+---
+
+## Implementation Phases
+
+### Phase A: STRICT Mode
+
+**Scope**: Validate all file schemas match. Collect statistics opportunistically.
+
+1. Add `schema_resolution` WITH clause parameter parsing
+2. Implement parallel metadata scanning in `ExternalSourceResolver`
+3. Implement schema comparison logic
+4. Implement `SchemaReconciliationResult` data structures
+5. Wire statistics into `FileSplit` (aggregate pushdown Phase 2)
+6. Add tests for: matching schemas, column count mismatch, type mismatch, name mismatch,
+   nullability tolerance, partition column interaction, error messages
+7. Add CSV-spec tests demonstrating the feature
+
+**Estimated complexity**: Medium. Mostly new code in `ExternalSourceResolver` + data structures.
+
+### Phase B: UNION_BY_NAME
+
+**Scope**: Merge schemas, adapt reads.
+
+1. Implement schema merge algorithm with type widening
+2. Implement `FileColumnMapping` computation
+3. Implement `SchemaAdaptingIterator` for NULL filling and type casting
+4. Wire into the execution path (format reader wrapping or operator adaptation)
+5. Handle filter pushdown with missing/widened columns
+6. Add tests for: added columns, removed columns, type widening, mixed schemas,
+   null filling, column ordering, filter pushdown interaction, aggregate pushdown interaction
+7. Add CSV-spec tests demonstrating the feature
+
+**Estimated complexity**: High. Requires changes across planning, optimization, and execution.
+
+### Phase C: Polish & Defaults (Future)
+
+1. Consider changing default to STRICT for Parquet/ORC
+2. Add `filename` virtual column (DuckDB-inspired) to help users debug which file contributed rows
+3. Case-insensitive column matching option
+4. Metadata caching for repeated queries on the same glob
+
+---
+
+## Trade-off Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Metadata scanning | Eager (all files) | Better UX, enables statistics collection |
+| STRICT type widening | No | Matches DuckDB/Spark. Use UNION_BY_NAME for widening. |
+| UNION_BY_NAME type widening | Safe numeric only | Matches industry. Lossy/cross-category = error. |
+| NULL filling implementation | Adapter layer | Single implementation, format readers stay simple. |
+| Column matching | By name (case-sensitive) | Parquet/ORC use named columns. Case-insensitive as future option. |
+| Column ordering | First-seen order | Deterministic, matches DuckDB. |
+| LONG→DOUBLE widening | No | Lossy. Matches DuckDB/Spark consensus. |
+| Sampling for large file sets | No | Risky. Use table formats for 10K+ heterogeneous files. |
+| Default strategy | FIRST_FILE_WINS (now), STRICT (future) | Backward compatible now. Revisit after proving stability. |
+
+---
+
+## Open Questions for Team Discussion
+
+1. **Default strategy**: Should we plan to change the default to STRICT once the feature is
+   stable? This is the safest default but would be a breaking change for users with
+   heterogeneous files who rely on silent schema ignorance.
+
+2. **Type widening in STRICT mode**: Should STRICT allow safe numeric widening (int→long)?
+   Or should it be truly strict (exact type match)?
+
+3. **LONG→DOUBLE widening**: Allow it (ClickHouse does) or reject it (DuckDB/Spark don't)?
+
+4. **DATE→DATETIME widening**: Allow in UNION_BY_NAME?
+
+5. **`filename` column**: Should we add a virtual column showing the source file path?
+   Useful for debugging UNION_BY_NAME queries. DuckDB has this.
+
+6. **Sampling mode**: For 10K+ file globs, should we offer a `schema_sample_size = N` option
+   that reads only N file schemas? Or just recommend table formats?
+
+7. **Case sensitivity**: Should column name matching be case-sensitive by default?
+   Parquet column names are case-sensitive. ORC column names are case-insensitive by convention.
+   Should we follow the format's convention or be consistently case-sensitive?
+
+8. **WITH clause vs format reader default**: Should individual format readers be able to
+   set their own default strategy? E.g., Parquet defaults to STRICT, CSV defaults to
+   FIRST_FILE_WINS? Or one global default for all formats?
+
+---
+
+## Appendix: Detailed Type Widening Matrix
+
+The full proposed type widening hierarchy for UNION_BY_NAME:
+
+```
+BYTE → SHORT → INTEGER → LONG
+                            ↑ (no further widening to DOUBLE — lossy)
+FLOAT → DOUBLE
+          ↑ (INTEGER → DOUBLE allowed — lossless for int32)
+
+KEYWORD  (no widening to/from TEXT or any numeric)
+TEXT     (no widening to/from KEYWORD or any numeric)
+BOOLEAN  (no widening)
+DATE     (no widening — TBD)
+DATETIME (no widening — TBD)
+IP       (no widening)
+VERSION  (no widening)
+GEO_POINT (no widening)
+GEO_SHAPE (no widening)
+```
+
+Widening is transitive: if file A has BYTE and file B has LONG, the unified type is LONG
+(BYTE→SHORT→INTEGER→LONG).
+
+Widening is commutative: the order files are scanned doesn't affect the result.
+
+---
+
+## Appendix: Comparison of Error Messages
+
+### DuckDB (strict mode)
+```
+Schema mismatch in Parquet glob: column "id" in parquet file "file2.parquet"
+is of type BIGINT, but in the original file "file1.parquet" this column is of type INTEGER
+```
+
+### Spark (mergeSchema=true, incompatible types)
+```
+Failed to merge incompatible data types LongType and StringType
+```
+
+### ClickHouse (no common type)
+```
+NO_COMMON_TYPE: There is no supertype for types UInt64 and String
+```
+
+### Proposed (STRICT mode)
+```
+Schema mismatch in [s3://bucket/data/2024-02.parquet]:
+  Column [salary] has type [LONG] but reference file [s3://bucket/data/2024-01.parquet] has type [INTEGER].
+  Hint: use schema_resolution = "union_by_name" to automatically merge different schemas.
+```
+
+### Proposed (UNION_BY_NAME, incompatible types)
+```
+Cannot merge schemas for column [status]:
+  File [s3://bucket/data/2024-01.parquet] has type [INTEGER]
+  File [s3://bucket/data/2024-02.parquet] has type [KEYWORD]
+  No compatible supertype exists. Consider using an explicit CAST in your query.
+```

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
@@ -88,6 +88,18 @@ public class FormatReaderRegistry {
         return supplier.get();
     }
 
+    /**
+     * Look up a format reader by name, returning null if not registered.
+     * Use for speculative lookups where a missing format is normal (e.g., optimizer probing).
+     */
+    public FormatReader findByName(String formatName) {
+        if (Strings.isNullOrEmpty(formatName)) {
+            return null;
+        }
+        Supplier<FormatReader> supplier = byName.get(formatName.toLowerCase(Locale.ROOT));
+        return supplier != null ? supplier.get() : null;
+    }
+
     public void registerExtension(String extension, String formatName) {
         String normalizedExt = extension.toLowerCase(Locale.ROOT);
         if (normalizedExt.startsWith(".") == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AggregatePushdownSupport.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AggregatePushdownSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+
+import java.util.List;
+
+/**
+ * SPI for declaring that a format can compute aggregates from file-level statistics.
+ * Implementations are queried by the optimizer to determine if aggregates can be
+ * pushed down. The actual computation happens via file footer reads at execution time.
+ */
+public interface AggregatePushdownSupport {
+
+    enum Pushability {
+        YES,
+        NO
+    }
+
+    Pushability canPushAggregates(List<Expression> aggregates, List<Expression> groupings);
+
+    AggregatePushdownSupport UNSUPPORTED = (aggregates, groupings) -> Pushability.NO;
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AggregateSpec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AggregateSpec.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+/**
+ * Specification for a single aggregate to be computed from file-level statistics.
+ *
+ * @param type       the aggregate function type
+ * @param columnName the column to aggregate (null for COUNT_STAR)
+ * @param resultType the expected ESQL data type of the result
+ */
+public record AggregateSpec(AggType type, String columnName, DataType resultType) {
+
+    public enum AggType {
+        COUNT_STAR,
+        MIN,
+        MAX
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -148,6 +148,14 @@ public interface FormatReader extends Closeable {
     }
 
     /**
+     * Returns the aggregate pushdown support for this format.
+     * Only format readers with column statistics in their metadata (Parquet, ORC) override this.
+     */
+    default AggregatePushdownSupport aggregatePushdownSupport() {
+        return AggregatePushdownSupport.UNSUPPORTED;
+    }
+
+    /**
      * Returns a format reader configured with the schema attributes.
      * <p>
      * The schema is determined during the planning phase (via {@link #metadata(StorageObject)})

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.EnableSpatialDistancePushdown;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ExtractDimensionFieldsAfterAggregation;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushAggregatesToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushCountQueryAndTagsToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToExternalSource;
@@ -84,6 +85,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         if (optimizeForEsSource) {
             esSourceRules.add(new PushStatsToSource());
             esSourceRules.add(new PushStatsToExternalSource());
+            esSourceRules.add(new PushAggregatesToExternalSource());
             esSourceRules.add(new EnableSpatialDistancePushdown());
         }
         esSourceRules.add(new ReplaceSampledStatsBySampleAndStats());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Replaces {@code AggregateExec → ExternalSourceExec} with {@code LocalSourceExec}
+ * when ungrouped aggregates (COUNT(*), MIN, MAX) can be computed from file-level statistics.
+ * <p>
+ * Works in both SINGLE mode (coordinator-only) and INITIAL mode (data node in distributed execution).
+ * The coordinator's FINAL AggregateExec is never touched — it merges intermediate values from all
+ * data nodes regardless of whether each data node pushed down or scanned.
+ * <p>
+ * Statistics come from {@code ExternalSourceExec.sourceMetadata()} which is populated at planning time.
+ * In Phase 2 (union-by-name), per-split statistics in {@code FileSplit.statistics()} will enable
+ * pushdown even when per-query metadata only has first-file stats.
+ */
+public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
+    AggregateExec,
+    LocalPhysicalOptimizerContext> {
+
+    @Override
+    protected PhysicalPlan rule(AggregateExec aggregateExec, LocalPhysicalOptimizerContext ctx) {
+        if (aggregateExec.child() instanceof ExternalSourceExec == false) {
+            return aggregateExec;
+        }
+        ExternalSourceExec externalExec = (ExternalSourceExec) aggregateExec.child();
+
+        // Phase 1: Ungrouped only
+        if (aggregateExec.groupings().isEmpty() == false) {
+            return aggregateExec;
+        }
+
+        // Check format supports aggregate pushdown
+        FormatReaderRegistry formatReaderRegistry = ctx != null ? ctx.formatReaderRegistry() : null;
+        if (formatReaderRegistry == null) {
+            return aggregateExec;
+        }
+        FormatReader formatReader = formatReaderRegistry.findByName(externalExec.sourceType());
+        if (formatReader == null || formatReader.aggregatePushdownSupport() == AggregatePushdownSupport.UNSUPPORTED) {
+            return aggregateExec;
+        }
+
+        // Extract aggregate functions and check pushability
+        List<Expression> aggFunctions = extractAggregateFunctions(aggregateExec.aggregates());
+        if (aggFunctions.isEmpty()) {
+            return aggregateExec;
+        }
+        if (formatReader.aggregatePushdownSupport()
+            .canPushAggregates(aggFunctions, List.of()) != AggregatePushdownSupport.Pushability.YES) {
+            return aggregateExec;
+        }
+
+        // Try to resolve all aggregate values from sourceMetadata
+        Map<String, Object> sourceMetadata = externalExec.sourceMetadata();
+        List<Object> values = resolveAggregateValues(aggregateExec.aggregates(), sourceMetadata);
+        if (values == null) {
+            return aggregateExec; // Some aggregate couldn't be resolved from metadata
+        }
+
+        // Build the output page based on mode
+        AggregatorMode mode = aggregateExec.getMode();
+        List<Attribute> outputAttrs;
+        Block[] blocks;
+
+        if (mode == AggregatorMode.SINGLE) {
+            // Final values — same as PushStatsToExternalSource
+            outputAttrs = new ArrayList<>(aggregateExec.aggregates().size());
+            for (NamedExpression agg : aggregateExec.aggregates()) {
+                outputAttrs.add(agg.toAttribute());
+            }
+            blocks = buildFinalBlocks(values);
+        } else {
+            // Intermediate format — value + seen boolean for each aggregate
+            outputAttrs = aggregateExec.intermediateAttributes();
+            blocks = buildIntermediateBlocks(values);
+        }
+
+        return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
+    }
+
+    /**
+     * Resolve aggregate values from sourceMetadata. Returns null if any value can't be resolved.
+     */
+    private List<Object> resolveAggregateValues(List<? extends NamedExpression> aggregates, Map<String, Object> sourceMetadata) {
+        List<Object> values = new ArrayList<>(aggregates.size());
+        for (int i = 0; i < aggregates.size(); i++) {
+            NamedExpression agg = aggregates.get(i);
+            if (agg instanceof Alias == false) {
+                return null;
+            }
+            Expression child = ((Alias) agg).child();
+            Object value = resolveFromMetadata(child, sourceMetadata);
+            if (value == null) {
+                return null;
+            }
+            values.add(value);
+        }
+        return values;
+    }
+
+    private Object resolveFromMetadata(Expression aggFunction, Map<String, Object> sourceMetadata) {
+        if (aggFunction instanceof Count count) {
+            if (count.hasFilter()) {
+                return null;
+            }
+            Expression target = count.field();
+            if (target.foldable()) {
+                // COUNT(*)
+                OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+                return rc.isPresent() ? rc.getAsLong() : null;
+            }
+            if (target instanceof Attribute ref) {
+                OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+                OptionalLong nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
+                if (rc.isPresent() && nc.isPresent()) {
+                    return rc.getAsLong() - nc.getAsLong();
+                }
+            }
+            return null;
+        } else if (aggFunction instanceof Min min) {
+            if (min.hasFilter()) {
+                return null;
+            }
+            if (min.field() instanceof Attribute ref) {
+                Optional<Object> minVal = SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
+                return minVal.orElse(null);
+            }
+            return null;
+        } else if (aggFunction instanceof Max max) {
+            if (max.hasFilter()) {
+                return null;
+            }
+            if (max.field() instanceof Attribute ref) {
+                Optional<Object> maxVal = SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
+                return maxVal.orElse(null);
+            }
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Build blocks for SINGLE mode (final values).
+     */
+    private static Block[] buildFinalBlocks(List<Object> values) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        Block[] blocks = new Block[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            blocks[i] = buildBlock(blockFactory, values.get(i));
+        }
+        return blocks;
+    }
+
+    /**
+     * Build blocks for INITIAL mode (intermediate format: value + seen boolean per aggregate).
+     */
+    private static Block[] buildIntermediateBlocks(List<Object> values) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        // Each aggregate produces 2 intermediate channels: value + seen
+        Block[] blocks = new Block[values.size() * 2];
+        for (int i = 0; i < values.size(); i++) {
+            blocks[i * 2] = buildBlock(blockFactory, values.get(i));
+            blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
+        }
+        return blocks;
+    }
+
+    private static Block buildBlock(org.elasticsearch.compute.data.BlockFactory blockFactory, Object value) {
+        if (value instanceof Long l) {
+            return blockFactory.newConstantLongBlockWith(l, 1);
+        } else if (value instanceof Integer n) {
+            return blockFactory.newConstantIntBlockWith(n, 1);
+        } else if (value instanceof Double d) {
+            return blockFactory.newConstantDoubleBlockWith(d, 1);
+        } else if (value instanceof Boolean b) {
+            return blockFactory.newConstantBooleanBlockWith(b, 1);
+        } else if (value instanceof String s) {
+            return blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
+        } else if (value instanceof Number n) {
+            return blockFactory.newConstantLongBlockWith(n.longValue(), 1);
+        } else {
+            return blockFactory.newConstantNullBlock(1);
+        }
+    }
+
+    private List<Expression> extractAggregateFunctions(List<? extends NamedExpression> aggregates) {
+        List<Expression> result = new ArrayList<>();
+        for (int i = 0; i < aggregates.size(); i++) {
+            NamedExpression agg = aggregates.get(i);
+            Expression toCheck = agg;
+            if (agg instanceof Alias alias) {
+                toCheck = alias.child();
+            }
+            if (toCheck instanceof AggregateFunction == false) {
+                continue;
+            }
+            result.add(toCheck);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Replace `AggregateExec → ExternalSourceExec` with `LocalSourceExec` when ungrouped aggregates (COUNT(*), MIN, MAX) can be computed from file-level statistics in sourceMetadata, without scanning data.

## Summary

- **SPI**: `AggregateSpec` record and `AggregatePushdownSupport` interface for format capability declaration
- **Optimizer rule**: `PushAggregatesToExternalSource` replaces the aggregate subtree with `LocalSourceExec` containing precomputed values from metadata
- **Dual mode**: SINGLE mode produces final values; INITIAL mode produces intermediate format (value + seen boolean) for distributed execution
- **Coordinator untouched**: the FINAL `AggregateExec` merges intermediate values from data nodes regardless of whether each node pushed down or scanned
- **Parquet/ORC**: both declare pushdown support for COUNT/MIN/MAX

Developed with AI-assisted tooling