### PR TITLE
[jdk-ea] Use 26 for testing, now that 26 GA is released

### DIFF
--- a/.buildkite/pipelines/periodic-java-ea.template.yml
+++ b/.buildkite/pipelines/periodic-java-ea.template.yml
@@ -1,5 +1,5 @@
 env:
-  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
+  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26}"
   EXTRA_GRADLE_ARGS: "--continue"
 
 steps:

--- a/.buildkite/pipelines/periodic-java-ea.yml
+++ b/.buildkite/pipelines/periodic-java-ea.yml
@@ -1,6 +1,6 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-java-ea.template.yml
 env:
-  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
+  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26}"
   EXTRA_GRADLE_ARGS: "--continue"
 
 steps:


### PR DESCRIPTION
`26-pre` is failing