### PR TITLE
Removing team inference from coder rabbit

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -7,5 +7,4 @@ reviews:
   auto_review:
     labels:
       - "Team:Delivery"
-      - "Team:Search - Inference"
       - "Team:Core/Infra"


### PR DESCRIPTION
Removing team inference from coder rabbit