### PR TITLE
ESQL: Fix union types with date_nanos conversion bug

### DIFF
--- a/docs/changelog/144877.yaml
+++ b/docs/changelog/144877.yaml
@@ -1,6 +1,13 @@
 area: ES|QL
+breaking:
+  area: ES|QL
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false
+  title: Fix union types with `date_nanos` conversion bug
 issues:
  - 144870
 pr: 144877
 summary: Fix union types with `date_nanos` conversion bug
-type: bug
+type: "breaking, bug"

--- a/docs/changelog/144877.yaml
+++ b/docs/changelog/144877.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 144870
+pr: 144877
+summary: Fix union types with `date_nanos` conversion bug
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -665,6 +665,24 @@ sample_data_ts_nanos | 2023-10-23T12:27:28.948Z  |  172.21.2.113  |  2764889    
 sample_data_ts_nanos | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
 ;
 
+multiIndexUnionTimestampCastLongComposesWithImplicitNanos
+required_capability: to_date_nanos
+required_capability: union_types
+required_capability: union_types_remove_fields
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_nanos
+| WHERE event_duration == 8268153 AND message == "Connection error"
+| EVAL ts = @timestamp::long
+| KEEP ts, event_duration
+| SORT ts ASC
+;
+
+ts:long              | event_duration:long
+1698069175015000000 | 8268153
+1698069175015123456 | 8268153
+;
+
 multiIndexTsNanosRenameToNanos
 required_capability: to_date_nanos
 required_capability: union_types

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2460,8 +2460,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         for (Map.Entry<String, Expression> entry : mtf.getIndexToConversionExpressions().entrySet()) {
                             String indexName = entry.getKey();
                             AbstractConvertFunction originalConversionFunction = (AbstractConvertFunction) entry.getValue();
-                            Expression originalField = originalConversionFunction.field();
-                            Expression newConvertFunction = convertExpression.replaceChildren(Collections.singletonList(originalField));
+                            Expression newConvertFunction = convertExpression.replaceChildren(
+                                Collections.singletonList(originalConversionFunction)
+                            );
                             indexToConversionExpressions.put(indexName, newConvertFunction);
                         }
                         MultiTypeEsField multiTypeEsField = new MultiTypeEsField(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerGoldenTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.analysis;
+
+import org.elasticsearch.xpack.esql.optimizer.GoldenTestCase;
+
+import java.util.EnumSet;
+
+/**
+ * Analyzer golden tests backed by {@link org.elasticsearch.xpack.esql.CsvTests#testDatasets} CSV datasets
+ * (e.g. union-typed {@code sample_data} / {@code sample_data_ts_nanos}).
+ */
+public class AnalyzerGoldenTests extends GoldenTestCase {
+
+    private static final EnumSet<Stage> ANALYSIS_ONLY = EnumSet.of(Stage.ANALYSIS);
+
+    /**
+     * Explicit {@code ::long} on {@code @timestamp} must compose with implicit millis→nanos unification:
+     * {@code TOLONG} wraps {@code TO_DATE_NANOS}, not the raw field.
+     */
+    public void testUnionTimestampExplicitLongComposesWithImplicitNanos() throws Exception {
+        runGoldenTest("""
+            FROM sample_data, sample_data_ts_nanos
+            | EVAL ts = @timestamp::long
+            """, ANALYSIS_ONLY);
+    }
+}

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerGoldenTests/testUnionTimestampExplicitLongComposesWithImplicitNanos/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerGoldenTests/testUnionTimestampExplicitLongComposesWithImplicitNanos/analysis.expected
@@ -1,0 +1,4 @@
+Project[[@timestamp{f(MultiTypeEsField)}#0, client_ip{f}#1, event_duration{f}#2, message{f}#3, ts{r}#4]]
+\_Limit[1000[INTEGER],false,false]
+  \_Eval[[$$@timestamp$converted_to$long{f(MultiTypeEsField)$}#5 AS ts#4]]
+    \_EsRelation[sample_data,sample_data_ts_nanos][@timestamp{f(MultiTypeEsField)}#0, client_ip{f}#1, event_duration{f}#2, message{f}#3, $$@timestamp$converted_to$long{f(MultiTypeEsField)$}#5]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerGoldenTests/testUnionTimestampExplicitLongComposesWithImplicitNanos/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerGoldenTests/testUnionTimestampExplicitLongComposesWithImplicitNanos/query.esql
@@ -1,0 +1,2 @@
+FROM sample_data, sample_data_ts_nanos
+| EVAL ts = @timestamp::long


### PR DESCRIPTION
## Problem
When a field was already unified from mixed `date` and `date_nanos` via implicit `ToDateNanos` per index, an explicit cast like `::long` rebuilds the cast using `originalConversionFunction.field()` (the raw field) instead of the full `originalConversionFunction`. That dropped the millis→nanos step for the date legs, so `::long` returned epoch millis on some indices and epoch nanos on others.

## The fix
In `ResolveUnionTypes.resolveConvertFunction`, build the new explicit conversion as `convertExpression.replaceChildren(Collections.singletonList(originalConversionFunction))` so the explicit cast wraps the existing per-index implicit conversion instead of replacing it.

Resolves #144870.