### PR TITLE
Fix MetadataCreateIndexServiceTests.testBatchedIndexCreationAndReroute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -371,9 +371,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:k8s-timeseries-avg-over-time.avg_over_time_of_integer}
   issue: https://github.com/elastic/elasticsearch/issues/144719
-- class: org.elasticsearch.cluster.metadata.MetadataCreateIndexServiceTests
-  method: testBatchedIndexCreationAndReroute
-  issue: https://github.com/elastic/elasticsearch/issues/144723
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testEndpointGetsUpdated_GivenFingerprintChanges_FromNonNull
   issue: https://github.com/elastic/elasticsearch/issues/144731

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1960,7 +1960,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 clusterService,
                 mockIndicesService(),
                 allocationService,
-                createTestShardLimitService(randomIntBetween(1, 1000), clusterService),
+                createTestShardLimitService(randomIntBetween(10, 1000), clusterService),
                 newEnvironment(),
                 new IndexScopedSettings(Settings.EMPTY, IndexScopedSettings.BUILT_IN_INDEX_SETTINGS),
                 threadPool,


### PR DESCRIPTION
The shard limit was randomIntBetween(1, 1000). With up to 5 tasks × 2 shards each, the shard limit could fire and throw a `ValidationException`, failing the test. Changed minimum shard limit from 1 to 10.
 
Thanks to @masseyke for pre-investigating this.

Closes #144723

Ran the test both with the failing seed and then 6000 times, no failures