### PR TITLE
Don't allow querying views with DLS or FLS

### DIFF
--- a/docs/changelog/144903.yaml
+++ b/docs/changelog/144903.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 144903
+summary: Don't allow querying views with DLS or FLS
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -547,6 +547,8 @@ public final class IndicesPermission {
                 return List.of();
             } else if (indexAbstraction.getType() == IndexAbstraction.Type.CONCRETE_INDEX) {
                 return List.of(indexAbstraction.getName());
+            } else if (indexAbstraction.getType() == IndexAbstraction.Type.VIEW) {
+                return List.of(indexAbstraction.getName());
             } else if (IndexComponentSelector.FAILURES.equals(selector)) {
                 final List<String> concreteIndexNames = new ArrayList<>(failureIndices.size());
                 for (var idx : failureIndices) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -542,7 +542,12 @@ public final class IndicesPermission {
             }
         }
 
-        public Collection<String> resolveConcreteIndices(List<Index> failureIndices) {
+        /**
+         * Returns the collection of concrete indices that this IndexResource resolves to, including failure indices if the selector is FAILURES.
+         * In case when the IndexResource is a view, it returns the view name only.
+         * The returned collection is the one that DLS or FLS permissions need to be checked for.
+         */
+        public Collection<String> resolveConcreteIndicesAndViews(List<Index> failureIndices) {
             if (indexAbstraction == null) {
                 return List.of();
             } else if (indexAbstraction.getType() == IndexAbstraction.Type.CONCRETE_INDEX) {
@@ -566,7 +571,9 @@ public final class IndicesPermission {
         }
 
         public boolean canHaveBackingIndices() {
-            return indexAbstraction != null && indexAbstraction.getType() != IndexAbstraction.Type.CONCRETE_INDEX;
+            return indexAbstraction != null
+                && indexAbstraction.getType() != IndexAbstraction.Type.CONCRETE_INDEX
+                && indexAbstraction.getType() != IndexAbstraction.Type.VIEW;
         }
 
         public String nameWithSelector() {
@@ -648,7 +655,7 @@ public final class IndicesPermission {
             boolean granted = false;
             final String resourceName = resourceEntry.getKey();
             final IndexResource resource = resourceEntry.getValue();
-            final Collection<String> concreteIndices = resource.resolveConcreteIndices(
+            final Collection<String> concreteIndicesAndViews = resource.resolveConcreteIndicesAndViews(
                 failureIndicesByIndexResource.get(resourceEntry.getKey())
             );
             for (Group group : groups) {
@@ -660,8 +667,8 @@ public final class IndicesPermission {
                             && false == resource.isPartOfDataStream()
                             && containsPrivilegeThatGrantsMappingUpdatesForBwc(group))) {
                         granted = true;
-                        // propagate DLS and FLS permissions over the concrete indices
-                        for (String index : concreteIndices) {
+                        // propagate DLS and FLS permissions over the concrete indices and views
+                        for (String index : concreteIndicesAndViews) {
                             final Set<FieldPermissions> fieldPermissions = fieldPermissionsByIndex.compute(index, (k, existingSet) -> {
                                 if (existingSet == null) {
                                     // Most indices rely on the default (empty) field permissions object, so we optimize for that case
@@ -709,7 +716,7 @@ public final class IndicesPermission {
                 grantedResources.add(resourceName);
 
                 if (resource.canHaveBackingIndices()) {
-                    for (String concreteIndex : concreteIndices) {
+                    for (String concreteIndex : concreteIndicesAndViews) {
                         // If the name appears directly as part of the requested indices, it takes precedence over implicit access
                         if (false == requestedResources.containsKey(concreteIndex)) {
                             grantedResources.add(concreteIndex);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -543,7 +543,8 @@ public final class IndicesPermission {
         }
 
         /**
-         * Returns the collection of concrete indices that this IndexResource resolves to, including failure indices if the selector is FAILURES.
+         * Returns the collection of concrete indices that this IndexResource resolves to,
+         * including failure indices if the selector is FAILURES.
          * In case when the IndexResource is a view, it returns the view name only.
          * The returned collection is the one that DLS or FLS permissions need to be checked for.
          */

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -611,10 +611,6 @@ public class EsqlSecurityIT extends ESRestTestCase {
         validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
-    /**
-     * tests a scenario where the parent view has DLS and the nested view has permissions that would allow access if the parent view
-     * didn't have DLS. This ensures that the DLS check is applied at the parent view level
-     */
     public void testViewDlsOnNestedViewOuter() throws Exception {
         createView("test-admin", "nested-dls-view-no-dls", "FROM view-user* | STATS sum=sum(value)");
         createView("test-admin", "nested-dls-view-dls", "FROM nested-dls-view-no-dls");
@@ -625,10 +621,6 @@ public class EsqlSecurityIT extends ESRestTestCase {
         validateDlsFlsViewException(resp.getResponse(), "nested-dls-view-dls");
     }
 
-    /**
-     * tests a scenario, where the parent view has no dls or fls, but the nested view has DLS.
-     * This ensures that the DLS check is applied at the child view level
-     */
     public void testViewDlsOnNestedViewInner() throws Exception {
         createView("test-admin", "nested-dls-view-dls", "FROM view-user* | STATS sum=sum(value)");
         createView("test-admin", "nested-dls-view-no-dls", "FROM nested-dls-view-dls");
@@ -642,19 +634,6 @@ public class EsqlSecurityIT extends ESRestTestCase {
     public void testUserCanQueryViewWhileHavingDlsOnUnderlyingIndices() throws Exception {
         Response resp = runESQLCommand("view_index_dls_user", "FROM view-user1 | STATS sum=sum(value)");
         assertOK(resp);
-        Map<String, Object> respMap = entityAsMap(resp);
-
-        // this is the expected response:
-        // "values": [[10.0]]
-        if (respMap.get("values") instanceof List<?> v1
-            && v1.isEmpty() == false
-            && v1.getFirst() instanceof List<?> v2
-            && v2.isEmpty() == false
-            && v2.getFirst() instanceof Double v) {
-            assertEquals(10.0d, v, 0.001d);
-        } else {
-            fail("unexpected response format: " + respMap);
-        }
     }
 
     public void testDocumentLevelSecurity() throws Exception {

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -611,6 +611,10 @@ public class EsqlSecurityIT extends ESRestTestCase {
         validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
+    /**
+     * Tests a scenario, where the parent view has DLS, but the nested view has no DLS or FLS.
+     * This ensures that the DLS check is applied at the parent view level
+     */
     public void testViewDlsOnNestedViewOuter() throws Exception {
         createView("test-admin", "nested-dls-view-no-dls", "FROM view-user* | STATS sum=sum(value)");
         createView("test-admin", "nested-dls-view-dls", "FROM nested-dls-view-no-dls");
@@ -621,6 +625,10 @@ public class EsqlSecurityIT extends ESRestTestCase {
         validateDlsFlsViewException(resp.getResponse(), "nested-dls-view-dls");
     }
 
+    /**
+     * Tests a scenario, where the parent view has no DLS or FLS, but the nested view has DLS.
+     * This ensures that the DLS check is applied at the child view level
+     */
     public void testViewDlsOnNestedViewInner() throws Exception {
         createView("test-admin", "nested-dls-view-dls", "FROM view-user* | STATS sum=sum(value)");
         createView("test-admin", "nested-dls-view-no-dls", "FROM nested-dls-view-dls");

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -84,6 +85,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .user("user_without_monitor_privileges", "x-pack-test-password", "user_without_monitor_privileges", false)
         .user("user_with_monitor_privileges", "x-pack-test-password", "user_with_monitor_privileges", false)
         .user("view_dls_user", "x-pack-test-password", "view_dls_user", false)
+        .user("view_index_dls_user", "x-pack-test-password", "view_index_dls_user", false)
         .user("view_dls_nested_view_user", "x-pack-test-password", "view_dls_nested_view_user", false)
         .user("view_fls_user", "x-pack-test-password", "view_fls_user", false)
         .user("view_dls_fls_user", "x-pack-test-password", "view_dls_fls_user", false)
@@ -582,10 +584,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_dls_user", "FROM view-user1 | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("view-user1"));
+        validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
     public void testViewWithFieldLevelSecurity() throws Exception {
@@ -593,10 +592,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_fls_user", "FROM view-user1 | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("view-user1"));
+        validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
     public void testViewWithDocumentAndFieldLevelSecurity() throws Exception {
@@ -604,10 +600,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_dls_fls_user", "FROM view-user1 | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("view-user1"));
+        validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
     public void testViewDlsOnWildcardPattern() throws Exception {
@@ -615,10 +608,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_dls_user", "FROM view-user* | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("view-user1"));
+        validateDlsFlsViewException(resp.getResponse(), "view-user1");
     }
 
     /**
@@ -632,10 +622,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_dls_nested_view_user", "FROM nested-dls-view-dls | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("nested-dls-view-dls"));
+        validateDlsFlsViewException(resp.getResponse(), "nested-dls-view-dls");
     }
 
     /**
@@ -649,10 +636,25 @@ public class EsqlSecurityIT extends ESRestTestCase {
             ResponseException.class,
             () -> runESQLCommand("view_dls_nested_view_user", "FROM nested-dls-view-no-dls | STATS sum=sum(value)")
         );
-        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
-        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
-        assertThat(errorMessage, containsString("nested-dls-view-dls"));
+        validateDlsFlsViewException(resp.getResponse(), "nested-dls-view-dls");
+    }
+
+    public void testUserCanQueryViewWhileHavingDlsOnUnderlyingIndices() throws Exception {
+        Response resp = runESQLCommand("view_index_dls_user", "FROM view-user1 | STATS sum=sum(value)");
+        assertOK(resp);
+        Map<String, Object> respMap = entityAsMap(resp);
+
+        // this is the expected response:
+        // "values": [[10.0]]
+        if (respMap.get("values") instanceof List<?> v1
+            && v1.isEmpty() == false
+            && v1.getFirst() instanceof List<?> v2
+            && v2.isEmpty() == false
+            && v2.getFirst() instanceof Double v) {
+            assertEquals(10.0d, v, 0.001d);
+        } else {
+            fail("unexpected response format: " + respMap);
+        }
     }
 
     public void testDocumentLevelSecurity() throws Exception {
@@ -815,6 +817,27 @@ public class EsqlSecurityIT extends ESRestTestCase {
             assertThat("Should have optimized physical plan", hasOptimizedPhysicalPlan, is(true));
             assertThat("Should have optimized local logical plan from data node", hasLocalLogicalPlan, is(true));
             assertThat("Should have local physical plan from data node", hasLocalPhysicalPlan, is(true));
+        }
+    }
+
+    private void validateDlsFlsViewException(Response response, String expectedViewNames) throws IOException {
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        Map<String, Object> entity = entityAsMap(response.getEntity());
+        assertThat(entity, hasKey("error"));
+        Object error = entity.get("error");
+        if (error instanceof Map<?, ?> errorMap) {
+            assertThat(errorMap, hasKey("reason"));
+            assertThat(errorMap, hasKey("views_with_dls_or_fls"));
+            assertThat(
+                errorMap.get("reason"),
+                equalTo(
+                    "Views with document or field level security restrictions are not supported."
+                        + " Remove DLS/FLS restrictions from the affected views in the role definition, or exclude the views from the request."
+                )
+            );
+            assertThat(errorMap.get("views_with_dls_or_fls"), equalTo(expectedViewNames));
+        } else {
+            fail("unexpected error format: " + error);
         }
     }
 

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -83,6 +83,10 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .user("logs_foo_after_2021_alias", "x-pack-test-password", "logs_foo_after_2021_alias", false)
         .user("user_without_monitor_privileges", "x-pack-test-password", "user_without_monitor_privileges", false)
         .user("user_with_monitor_privileges", "x-pack-test-password", "user_with_monitor_privileges", false)
+        .user("view_dls_user", "x-pack-test-password", "view_dls_user", false)
+        .user("view_dls_nested_view_user", "x-pack-test-password", "view_dls_nested_view_user", false)
+        .user("view_fls_user", "x-pack-test-password", "view_fls_user", false)
+        .user("view_dls_fls_user", "x-pack-test-password", "view_dls_fls_user", false)
         .feature(FeatureFlag.ESQL_VIEWS)
         .build();
 
@@ -571,6 +575,84 @@ public class EsqlSecurityIT extends ESRestTestCase {
         String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
         assertThat(errorMessage, containsString("Unknown index [first-alias]"));
         assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+    }
+
+    public void testViewWithDocumentLevelSecurity() throws Exception {
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_dls_user", "FROM view-user1 | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("view-user1"));
+    }
+
+    public void testViewWithFieldLevelSecurity() throws Exception {
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_fls_user", "FROM view-user1 | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("view-user1"));
+    }
+
+    public void testViewWithDocumentAndFieldLevelSecurity() throws Exception {
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_dls_fls_user", "FROM view-user1 | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("view-user1"));
+    }
+
+    public void testViewDlsOnWildcardPattern() throws Exception {
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_dls_user", "FROM view-user* | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("view-user1"));
+    }
+
+    /**
+     * tests a scenario where the parent view has DLS and the nested view has permissions that would allow access if the parent view
+     * didn't have DLS. This ensures that the DLS check is applied at the parent view level
+     */
+    public void testViewDlsOnNestedViewOuter() throws Exception {
+        createView("test-admin", "nested-dls-view-no-dls", "FROM view-user* | STATS sum=sum(value)");
+        createView("test-admin", "nested-dls-view-dls", "FROM nested-dls-view-no-dls");
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_dls_nested_view_user", "FROM nested-dls-view-dls | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("nested-dls-view-dls"));
+    }
+
+    /**
+     * tests a scenario, where the parent view has no dls or fls, but the nested view has DLS.
+     * This ensures that the DLS check is applied at the child view level
+     */
+    public void testViewDlsOnNestedViewInner() throws Exception {
+        createView("test-admin", "nested-dls-view-dls", "FROM view-user* | STATS sum=sum(value)");
+        createView("test-admin", "nested-dls-view-no-dls", "FROM nested-dls-view-dls");
+        ResponseException resp = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("view_dls_nested_view_user", "FROM nested-dls-view-no-dls | STATS sum=sum(value)")
+        );
+        assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        String errorMessage = EntityUtils.toString(resp.getResponse().getEntity());
+        assertThat(errorMessage, containsString("DLS/FLS restrictions applied"));
+        assertThat(errorMessage, containsString("nested-dls-view-dls"));
     }
 
     public void testDocumentLevelSecurity() throws Exception {

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -248,3 +248,38 @@ user_without_monitor_privileges:
 user_with_monitor_privileges:
   cluster:
     - monitor_esql
+
+view_dls_user:
+  cluster: []
+  indices:
+    - names: [ 'view-user1' ]
+      privileges: [ 'read' ]
+      query: '{"match": {"org": "devs"}}'
+    - names: [ 'view-user2' ]
+      privileges: [ 'read' ]
+
+view_dls_nested_view_user:
+  cluster: []
+  indices:
+    - names: [ 'nested-dls-view-no-dls' ]
+      privileges: [ 'read' ]
+    - names: [ 'nested-dls-view-dls' ]
+      privileges: [ 'read' ]
+      query: '{"match": {"org": "devs"}}'
+
+view_fls_user:
+  cluster: []
+  indices:
+    - names: [ 'view-user1' ]
+      privileges: [ 'read' ]
+      field_security:
+        grant: [ "value" ]
+
+view_dls_fls_user:
+  cluster: []
+  indices:
+    - names: [ 'view-user1' ]
+      privileges: [ 'read' ]
+      query: '{"match": {"org": "sales"}}'
+      field_security:
+        grant: [ "value" ]

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -254,9 +254,18 @@ view_dls_user:
   indices:
     - names: [ 'view-user1' ]
       privileges: [ 'read' ]
-      query: '{"match": {"org": "devs"}}'
+      query: '{"match": {"org": "sales"}}'
     - names: [ 'view-user2' ]
       privileges: [ 'read' ]
+
+view_index_dls_user:
+  cluster: []
+  indices:
+    - names: [ 'view-user1' ]
+      privileges: [ 'read' ]
+    - names: [ 'index' ]
+      privileges: [ 'read' ]
+      query: '{"match": {"org": "sales"}}'
 
 view_dls_nested_view_user:
   cluster: []
@@ -265,7 +274,7 @@ view_dls_nested_view_user:
       privileges: [ 'read' ]
     - names: [ 'nested-dls-view-dls' ]
       privileges: [ 'read' ]
-      query: '{"match": {"org": "devs"}}'
+      query: '{"match": {"org": "sales"}}'
 
 view_fls_user:
   cluster: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -340,6 +340,7 @@ import org.elasticsearch.xpack.security.authz.interceptor.SearchRequestIntercept
 import org.elasticsearch.xpack.security.authz.interceptor.ShardSearchRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.interceptor.UpdateRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.interceptor.ValidateRequestInterceptor;
+import org.elasticsearch.xpack.security.authz.interceptor.ViewDlsFlsRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import org.elasticsearch.xpack.security.authz.store.DeprecationRoleDescriptorConsumer;
 import org.elasticsearch.xpack.security.authz.store.FileRolesStore;
@@ -1146,7 +1147,11 @@ public class Security extends Plugin
                     new BulkShardRequestInterceptor(threadPool, getLicenseState()),
                     new DlsFlsLicenseRequestInterceptor(threadPool.getThreadContext(), getLicenseState()),
                     new SearchRequestCacheDisablingInterceptor(threadPool, getLicenseState()),
-                    new ValidateRequestInterceptor(threadPool, getLicenseState())
+                    new ValidateRequestInterceptor(threadPool, getLicenseState()),
+                    new ViewDlsFlsRequestInterceptor(
+                        threadPool.getThreadContext(),
+                        () -> projectResolver.getProjectMetadata(clusterService.state())
+                    )
                 )
             );
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsInterceptorUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsInterceptorUtils.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.security.authz.RBACEngine;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_VALUE;
 
 class DlsFlsInterceptorUtils {
-    public static boolean mayCurrentRoleHaveDlsOrFls(ThreadContext threadContext) {
+    public static boolean isCurrentRoleNullOrHasDlsFlsPermissions(ThreadContext threadContext) {
         final Role role = RBACEngine.maybeGetRBACEngineRole(AUTHORIZATION_INFO_VALUE.get(threadContext));
         // if role is null, it means a custom authorization engine is in use, and we have to directly go check indicesAccessControl
         return role == null || role.hasFieldOrDocumentLevelSecurity();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsInterceptorUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsInterceptorUtils.java
@@ -13,12 +13,10 @@ import org.elasticsearch.xpack.security.authz.RBACEngine;
 
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_VALUE;
 
-class InterceptorUtils {
+class DlsFlsInterceptorUtils {
     public static boolean mayCurrentRoleHaveDlsOrFls(ThreadContext threadContext) {
         final Role role = RBACEngine.maybeGetRBACEngineRole(AUTHORIZATION_INFO_VALUE.get(threadContext));
-        // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency because indicesAccessControl
-        // can contain a long list of indices
-        // But if role is null, it means a custom authorization engine is in use and we have to directly go check indicesAccessControl
+        // if role is null, it means a custom authorization engine is in use, and we have to directly go check indicesAccessControl
         return role == null || role.hasFieldOrDocumentLevelSecurity();
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
@@ -19,13 +19,10 @@ import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
-import org.elasticsearch.xpack.core.security.authz.permission.Role;
-import org.elasticsearch.xpack.security.authz.RBACEngine;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_VALUE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
 public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
@@ -45,61 +42,59 @@ public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
         AuthorizationEngine authorizationEngine,
         AuthorizationInfo authorizationInfo
     ) {
-        if (requestInfo.getRequest() instanceof IndicesRequest && false == TransportActionProxy.isProxyAction(requestInfo.getAction())) {
-            final Role role = RBACEngine.maybeGetRBACEngineRole(AUTHORIZATION_INFO_VALUE.get(threadContext));
-            // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency because indicesAccessControl
-            // can contain a long list of indices
-            // But if role is null, it means a custom authorization engine is in use and we have to directly go check indicesAccessControl
-            if (role == null || role.hasFieldOrDocumentLevelSecurity()) {
-                logger.trace("Role has DLS or FLS. Checking for whether the request touches any indices that have DLS or FLS configured");
-                final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
-                if (indicesAccessControl != null) {
-                    final XPackLicenseState frozenLicenseState = licenseState.copyCurrentLicenseState();
-                    if (logger.isDebugEnabled()) {
-                        final IndicesAccessControl.DlsFlsUsage dlsFlsUsage = indicesAccessControl.getFieldAndDocumentLevelSecurityUsage();
-                        if (dlsFlsUsage.hasFieldLevelSecurity()) {
-                            logger.debug(
-                                () -> format(
-                                    "User [%s] has field level security on [%s]",
-                                    requestInfo.getAuthentication(),
-                                    indicesAccessControl.getIndicesWithFieldLevelSecurity()
-                                )
-                            );
-                        }
-                        if (dlsFlsUsage.hasDocumentLevelSecurity()) {
-                            logger.debug(
-                                () -> format(
-                                    "User [%s] has document level security on [%s]",
-                                    requestInfo.getAuthentication(),
-                                    indicesAccessControl.getIndicesWithDocumentLevelSecurity()
-                                )
-                            );
-                        }
-                    }
-                    if (false == DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(frozenLicenseState)
-                        || false == FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(frozenLicenseState)) {
-                        boolean incompatibleLicense = false;
-                        IndicesAccessControl.DlsFlsUsage dlsFlsUsage = indicesAccessControl.getFieldAndDocumentLevelSecurityUsage();
-                        if (dlsFlsUsage.hasDocumentLevelSecurity() && false == DOCUMENT_LEVEL_SECURITY_FEATURE.check(frozenLicenseState)) {
-                            incompatibleLicense = true;
-                        }
-                        if (dlsFlsUsage.hasFieldLevelSecurity() && false == FIELD_LEVEL_SECURITY_FEATURE.check(frozenLicenseState)) {
-                            incompatibleLicense = true;
-                        }
+        if (requestInfo.getRequest() instanceof IndicesRequest
+            && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
+            && InterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext)) {
 
-                        if (incompatibleLicense) {
-                            final ElasticsearchSecurityException licenseException = LicenseUtils.newComplianceException(
-                                "field and document level security"
-                            );
-                            licenseException.addMetadata(
-                                "es.indices_with_dls_or_fls",
-                                indicesAccessControl.getIndicesWithFieldOrDocumentLevelSecurity()
-                            );
-                            return SubscribableListener.newFailed(licenseException);
-                        }
+            logger.trace("Role has DLS or FLS. Checking for whether the request touches any indices that have DLS or FLS configured");
+            final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
+            if (indicesAccessControl != null) {
+                final XPackLicenseState frozenLicenseState = licenseState.copyCurrentLicenseState();
+                if (logger.isDebugEnabled()) {
+                    final IndicesAccessControl.DlsFlsUsage dlsFlsUsage = indicesAccessControl.getFieldAndDocumentLevelSecurityUsage();
+                    if (dlsFlsUsage.hasFieldLevelSecurity()) {
+                        logger.debug(
+                            () -> format(
+                                "User [%s] has field level security on [%s]",
+                                requestInfo.getAuthentication(),
+                                indicesAccessControl.getIndicesWithFieldLevelSecurity()
+                            )
+                        );
+                    }
+                    if (dlsFlsUsage.hasDocumentLevelSecurity()) {
+                        logger.debug(
+                            () -> format(
+                                "User [%s] has document level security on [%s]",
+                                requestInfo.getAuthentication(),
+                                indicesAccessControl.getIndicesWithDocumentLevelSecurity()
+                            )
+                        );
+                    }
+                }
+                if (false == DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(frozenLicenseState)
+                    || false == FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(frozenLicenseState)) {
+                    boolean incompatibleLicense = false;
+                    IndicesAccessControl.DlsFlsUsage dlsFlsUsage = indicesAccessControl.getFieldAndDocumentLevelSecurityUsage();
+                    if (dlsFlsUsage.hasDocumentLevelSecurity() && false == DOCUMENT_LEVEL_SECURITY_FEATURE.check(frozenLicenseState)) {
+                        incompatibleLicense = true;
+                    }
+                    if (dlsFlsUsage.hasFieldLevelSecurity() && false == FIELD_LEVEL_SECURITY_FEATURE.check(frozenLicenseState)) {
+                        incompatibleLicense = true;
+                    }
+
+                    if (incompatibleLicense) {
+                        final ElasticsearchSecurityException licenseException = LicenseUtils.newComplianceException(
+                            "field and document level security"
+                        );
+                        licenseException.addMetadata(
+                            "es.indices_with_dls_or_fls",
+                            indicesAccessControl.getIndicesWithFieldOrDocumentLevelSecurity()
+                        );
+                        return SubscribableListener.newFailed(licenseException);
                     }
                 }
             }
+
         }
         return SubscribableListener.nullSuccess();
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
@@ -42,9 +42,10 @@ public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
         AuthorizationEngine authorizationEngine,
         AuthorizationInfo authorizationInfo
     ) {
-        if (requestInfo.getRequest() instanceof IndicesRequest
-            && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
-            && InterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext)) {
+        if (requestInfo.getRequest() instanceof IndicesRequest && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
+        // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency
+        // because indicesAccessControl can contain a long list of indices
+            && DlsFlsInterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext)) {
 
             logger.trace("Role has DLS or FLS. Checking for whether the request touches any indices that have DLS or FLS configured");
             final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
@@ -45,7 +45,7 @@ public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
         if (requestInfo.getRequest() instanceof IndicesRequest && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
         // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency
         // because indicesAccessControl can contain a long list of indices
-            && DlsFlsInterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext)) {
+            && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
 
             logger.trace("Role has DLS or FLS. Checking for whether the request touches any indices that have DLS or FLS configured");
             final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/InterceptorUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/InterceptorUtils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.interceptor;
+
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.xpack.core.security.authz.permission.Role;
+import org.elasticsearch.xpack.security.authz.RBACEngine;
+
+import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_VALUE;
+
+class InterceptorUtils {
+    public static boolean mayCurrentRoleHaveDlsOrFls(ThreadContext threadContext) {
+        final Role role = RBACEngine.maybeGetRBACEngineRole(AUTHORIZATION_INFO_VALUE.get(threadContext));
+        // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency because indicesAccessControl
+        // can contain a long list of indices
+        // But if role is null, it means a custom authorization engine is in use and we have to directly go check indicesAccessControl
+        return role == null || role.hasFieldOrDocumentLevelSecurity();
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.security.authz.interceptor;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -18,11 +20,8 @@ import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
@@ -31,6 +30,8 @@ import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceFi
  * If so, then the request is rejected, because Views are not compatible with DLS or FLS.
  */
 public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
+    private static final Logger logger = LogManager.getLogger(ViewDlsFlsRequestInterceptor.class);
+
     private final ThreadContext threadContext;
     private final Supplier<ProjectMetadata> projectMetadataSupplier;
 
@@ -45,34 +46,49 @@ public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
         AuthorizationEngine authorizationEngine,
         AuthorizationEngine.AuthorizationInfo authorizationInfo
     ) {
-        if (requestInfo.getRequest() instanceof IndicesRequest.Replaceable indicesRequest
-            && indicesRequest.indicesOptions().indexAbstractionOptions().resolveViews()
-            && TransportActionProxy.isProxyAction(requestInfo.getAction()) == false
-            && indicesRequest.indices() != null
-            && indicesRequest.indices().length > 0) {
+        if (requestInfo.getRequest() instanceof IndicesRequest indicesRequest
+            && isInterceptorApplicable(indicesRequest, requestInfo.getAction())) {
 
             final ProjectMetadata projectMetadata = projectMetadataSupplier.get();
             List<String> requestedViews = Arrays.stream(indicesRequest.indices()).filter(projectMetadata::hasView).toList();
 
             if (requestedViews.isEmpty() == false) {
                 final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
-                Set<String> indicesWithDlsOrFls = new HashSet<>(indicesAccessControl.getIndicesWithFieldOrDocumentLevelSecurity());
-                String viewsWithDlsOrFls = requestedViews.stream().filter(indicesWithDlsOrFls::contains).collect(Collectors.joining(","));
+                if (indicesAccessControl != null) {
+                    List<String> viewsWithDlsOrFls = requestedViews.stream().filter(view -> {
+                        var indexAccessControl = indicesAccessControl.getIndexPermissions(view);
+                        return indexAccessControl != null
+                            && (indexAccessControl.getFieldPermissions().hasFieldLevelSecurity()
+                                || indexAccessControl.getDocumentPermissions().hasDocumentLevelPermissions());
+                    }).toList();
 
-                if (viewsWithDlsOrFls.isEmpty() == false) {
-                    ElasticsearchSecurityException dlsFlsException = getDlsFlsException(viewsWithDlsOrFls);
-                    return SubscribableListener.newFailed(dlsFlsException);
+                    if (viewsWithDlsOrFls.isEmpty() == false) {
+                        logger.debug(
+                            "User [{}] requested views with DLS or FLS: [{}]",
+                            requestInfo.getAuthentication(),
+                            String.join(",", viewsWithDlsOrFls)
+                        );
+                        ElasticsearchSecurityException dlsFlsException = getDlsFlsException(viewsWithDlsOrFls);
+                        return SubscribableListener.newFailed(dlsFlsException);
+                    }
                 }
             }
         }
         return SubscribableListener.nullSuccess();
     }
 
-    private static ElasticsearchSecurityException getDlsFlsException(String viewsWithDlsOrFls) {
+    private boolean isInterceptorApplicable(IndicesRequest indicesRequest, String action) {
+        return indicesRequest.indicesOptions().indexAbstractionOptions().resolveViews()
+            && TransportActionProxy.isProxyAction(action) == false
+            && indicesRequest.indices() != null
+            && InterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext);
+    }
+
+    private static ElasticsearchSecurityException getDlsFlsException(List<String> viewsWithDlsOrFls) {
         ElasticsearchSecurityException dlsFlsException = new ElasticsearchSecurityException(
-            "The request contains views on which the querying user's role has DLS/FLS restrictions applied."
-                + " Neither DLS nor FLS may be applied to views. Fix the permissions not to include the views,"
-                + " or change the query, so that it doesn't include the affected views.",
+            "Views with document or field level security restrictions are not supported."
+                + " Remove DLS/FLS restrictions from the affected views in the role definition,"
+                + " or exclude the views from the request.",
             RestStatus.FORBIDDEN
         );
         dlsFlsException.addMetadata("es.views_with_dls_or_fls", viewsWithDlsOrFls);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.interceptor;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
+import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
+
+/**
+ * An interceptor which checks if the requested View has any DLS or FLS permissions applied.
+ * If so, then the request is rejected, because Views are not compatible with DLS or FLS.
+ */
+public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
+    private final ThreadContext threadContext;
+    private final Supplier<ProjectMetadata> projectMetadataSupplier;
+
+    public ViewDlsFlsRequestInterceptor(ThreadContext threadContext, Supplier<ProjectMetadata> projectMetadataSupplier) {
+        this.threadContext = threadContext;
+        this.projectMetadataSupplier = projectMetadataSupplier;
+    }
+
+    @Override
+    public SubscribableListener<Void> intercept(
+        AuthorizationEngine.RequestInfo requestInfo,
+        AuthorizationEngine authorizationEngine,
+        AuthorizationEngine.AuthorizationInfo authorizationInfo
+    ) {
+        if (requestInfo.getRequest() instanceof IndicesRequest.Replaceable indicesRequest
+            && TransportActionProxy.isProxyAction(requestInfo.getAction()) == false
+            && indicesRequest.indices() != null
+            && indicesRequest.indices().length > 0) {
+
+            final ProjectMetadata projectMetadata = projectMetadataSupplier.get();
+            List<String> requestedViews = Arrays.stream(indicesRequest.indices()).filter(projectMetadata::hasView).toList();
+
+            if (requestedViews.isEmpty() == false) {
+                final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
+                Set<String> indicesWithDlsOrFls = new HashSet<>(indicesAccessControl.getIndicesWithFieldOrDocumentLevelSecurity());
+                String viewsWithDlsOrFls = requestedViews.stream().filter(indicesWithDlsOrFls::contains).collect(Collectors.joining(","));
+
+                if (viewsWithDlsOrFls.isEmpty() == false) {
+                    ElasticsearchSecurityException dlsFlsException = getDlsFlsException(viewsWithDlsOrFls);
+                    return SubscribableListener.newFailed(dlsFlsException);
+                }
+            }
+        }
+        return SubscribableListener.nullSuccess();
+    }
+
+    private static ElasticsearchSecurityException getDlsFlsException(String viewsWithDlsOrFls) {
+        ElasticsearchSecurityException dlsFlsException = new ElasticsearchSecurityException(
+            "The request contains views on which the querying user's role has DLS/FLS restrictions applied."
+                + " Neither DLS nor FLS may be applied to views. Fix the permissions not to include the views,"
+                + " or change the query, so that it doesn't include the affected views.",
+            RestStatus.FORBIDDEN
+        );
+        dlsFlsException.addMetadata("es.views_with_dls_or_fls", viewsWithDlsOrFls);
+        return dlsFlsException;
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
@@ -46,6 +46,7 @@ public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
         AuthorizationEngine.AuthorizationInfo authorizationInfo
     ) {
         if (requestInfo.getRequest() instanceof IndicesRequest.Replaceable indicesRequest
+            && indicesRequest.indicesOptions().indexAbstractionOptions().resolveViews()
             && TransportActionProxy.isProxyAction(requestInfo.getAction()) == false
             && indicesRequest.indices() != null
             && indicesRequest.indices().length > 0) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
@@ -79,7 +79,7 @@ public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
             && indicesRequest.indices() != null
             // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency
             // because indicesAccessControl can contain a long list of indices
-            && DlsFlsInterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext);
+            && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext);
     }
 
     private static ElasticsearchSecurityException getDlsFlsException(List<String> viewsWithDlsOrFls) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptor.java
@@ -63,11 +63,7 @@ public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
                     }).toList();
 
                     if (viewsWithDlsOrFls.isEmpty() == false) {
-                        logger.debug(
-                            "User [{}] requested views with DLS or FLS: [{}]",
-                            requestInfo.getAuthentication(),
-                            String.join(",", viewsWithDlsOrFls)
-                        );
+                        logger.debug("User [{}] requested views with DLS or FLS: {}", requestInfo.getAuthentication(), viewsWithDlsOrFls);
                         ElasticsearchSecurityException dlsFlsException = getDlsFlsException(viewsWithDlsOrFls);
                         return SubscribableListener.newFailed(dlsFlsException);
                     }
@@ -81,7 +77,9 @@ public class ViewDlsFlsRequestInterceptor implements RequestInterceptor {
         return indicesRequest.indicesOptions().indexAbstractionOptions().resolveViews()
             && TransportActionProxy.isProxyAction(action) == false
             && indicesRequest.indices() != null
-            && InterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext);
+            // Checking whether role has FLS or DLS first before checking indicesAccessControl for efficiency
+            // because indicesAccessControl can contain a long list of indices
+            && DlsFlsInterceptorUtils.mayCurrentRoleHaveDlsOrFls(threadContext);
     }
 
     private static ElasticsearchSecurityException getDlsFlsException(List<String> viewsWithDlsOrFls) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptorTests.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.interceptor;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
+import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.RequestInfo;
+import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
+import org.elasticsearch.xpack.core.security.authz.permission.DocumentPermissions;
+import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissions;
+import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissionsDefinition;
+import org.elasticsearch.xpack.core.security.user.User;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
+
+    private ThreadContext threadContext;
+    private Authentication authentication;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadContext = new ThreadContext(Settings.EMPTY);
+        authentication = AuthenticationTestHelper.builder()
+            .user(new User("test-user", "test-role"))
+            .realmRef(new Authentication.RealmRef("realm", "type", "node", null))
+            .build();
+    }
+
+    public void testRejectsViewWithDls() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
+
+        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+
+        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
+        assertThat(ex.getMessage(), containsString("DLS/FLS restrictions applied"));
+        assertThat(ex.getMetadata("es.views_with_dls_or_fls").toString(), containsString(viewName));
+    }
+
+    public void testRejectsViewWithFls() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        FieldPermissions fieldPerms = new FieldPermissions(new FieldPermissionsDefinition(new String[] { "value" }, null));
+        setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(fieldPerms, DocumentPermissions.allowAll())));
+
+        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+
+        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
+        assertThat(ex.getMessage(), containsString("DLS/FLS restrictions applied"));
+        assertThat(ex.getMetadata("es.views_with_dls_or_fls").toString(), containsString(viewName));
+    }
+
+    public void testRejectsViewWithBothDlsAndFls() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        FieldPermissions fieldPerms = new FieldPermissions(new FieldPermissionsDefinition(new String[] { "value" }, null));
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(fieldPerms, docPerms)));
+
+        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+
+        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
+    }
+
+    public void testAllowsViewWithoutDlsOrFls() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        setAccessControl(
+            Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, DocumentPermissions.allowAll()))
+        );
+
+        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        future.actionGet();
+    }
+
+    public void testAllowsNonViewIndexWithDls() {
+        String indexName = "regular-index";
+        ProjectMetadata projectMetadata = mockProjectMetadata();
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(Map.of(indexName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
+
+        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(indexName), "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        future.actionGet();
+    }
+
+    public void testMetadataContainsMultipleViewNames() {
+        String view1 = "view-a";
+        String view2 = "view-b";
+        ProjectMetadata projectMetadata = mock(ProjectMetadata.class);
+        when(projectMetadata.hasView(view1)).thenReturn(true);
+        when(projectMetadata.hasView(view2)).thenReturn(true);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(
+            Map.of(
+                view1,
+                new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms),
+                view2,
+                new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)
+            )
+        );
+
+        SearchRequest searchRequest = new SearchRequest(view1, view2);
+        RequestInfo requestInfo = new RequestInfo(authentication, searchRequest, "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        String metadata = ex.getMetadata("es.views_with_dls_or_fls").toString();
+
+        assertThat(metadata, containsString(view1));
+        assertThat(metadata, containsString(view2));
+    }
+
+    public void testMixedViewsAndIndicesOnlyReportsViews() {
+        String viewName = "test-view";
+        String indexName = "regular-index";
+        ProjectMetadata projectMetadata = mock(ProjectMetadata.class);
+        when(projectMetadata.hasView(viewName)).thenReturn(true);
+        when(projectMetadata.hasView(indexName)).thenReturn(false);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(
+            Map.of(
+                viewName,
+                new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms),
+                indexName,
+                new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)
+            )
+        );
+
+        SearchRequest searchRequest = new SearchRequest(viewName, indexName);
+        RequestInfo requestInfo = new RequestInfo(authentication, searchRequest, "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        String metadata = ex.getMetadata("es.views_with_dls_or_fls").toString();
+
+        assertThat(metadata, containsString(viewName));
+    }
+
+    private void setAccessControl(Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions) {
+        IndicesAccessControl accessControl = new IndicesAccessControl(true, indexPermissions);
+        new SecurityContext(Settings.EMPTY, threadContext).putIndicesAccessControl(accessControl);
+    }
+
+    private static ProjectMetadata mockProjectMetadata(String... viewNames) {
+        ProjectMetadata projectMetadata = mock(ProjectMetadata.class);
+        for (String viewName : viewNames) {
+            when(projectMetadata.hasView(viewName)).thenReturn(true);
+        }
+        return projectMetadata;
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ViewDlsFlsRequestInterceptorTests.java
@@ -8,7 +8,8 @@
 package org.elasticsearch.xpack.security.authz.interceptor;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -16,6 +17,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
@@ -26,11 +28,13 @@ import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissions;
 import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissionsDefinition;
 import org.elasticsearch.xpack.core.security.user.User;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,14 +61,12 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
         DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
         setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
 
-        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        RequestInfo requestInfo = new RequestInfo(authentication, buildIndicesRequest(viewName), "indices:data/read/esql", null);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         interceptor.intercept(requestInfo, null, null).addListener(future);
         ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
 
-        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
-        assertThat(ex.getMessage(), containsString("DLS/FLS restrictions applied"));
-        assertThat(ex.getMetadata("es.views_with_dls_or_fls").toString(), containsString(viewName));
+        validateException(ex, viewName);
     }
 
     public void testRejectsViewWithFls() {
@@ -75,14 +77,12 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
         FieldPermissions fieldPerms = new FieldPermissions(new FieldPermissionsDefinition(new String[] { "value" }, null));
         setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(fieldPerms, DocumentPermissions.allowAll())));
 
-        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        RequestInfo requestInfo = new RequestInfo(authentication, buildIndicesRequest(viewName), "indices:data/read/esql", null);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         interceptor.intercept(requestInfo, null, null).addListener(future);
         ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
 
-        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
-        assertThat(ex.getMessage(), containsString("DLS/FLS restrictions applied"));
-        assertThat(ex.getMetadata("es.views_with_dls_or_fls").toString(), containsString(viewName));
+        validateException(ex, viewName);
     }
 
     public void testRejectsViewWithBothDlsAndFls() {
@@ -94,12 +94,12 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
         DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
         setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(fieldPerms, docPerms)));
 
-        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
+        RequestInfo requestInfo = new RequestInfo(authentication, buildIndicesRequest(viewName), "indices:data/read/esql", null);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         interceptor.intercept(requestInfo, null, null).addListener(future);
         ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
 
-        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
+        validateException(ex, viewName);
     }
 
     public void testAllowsViewWithoutDlsOrFls() {
@@ -111,10 +111,7 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
             Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, DocumentPermissions.allowAll()))
         );
 
-        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(viewName), "indices:data/read/esql", null);
-        PlainActionFuture<Void> future = new PlainActionFuture<>();
-        interceptor.intercept(requestInfo, null, null).addListener(future);
-        future.actionGet();
+        validateNoException(interceptor, buildIndicesRequest(viewName));
     }
 
     public void testAllowsNonViewIndexWithDls() {
@@ -125,10 +122,34 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
         DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
         setAccessControl(Map.of(indexName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
 
-        RequestInfo requestInfo = new RequestInfo(authentication, new SearchRequest(indexName), "indices:data/read/esql", null);
-        PlainActionFuture<Void> future = new PlainActionFuture<>();
-        interceptor.intercept(requestInfo, null, null).addListener(future);
-        future.actionGet();
+        validateNoException(interceptor, buildIndicesRequest(indexName));
+    }
+
+    public void testIgnoresNonIndexRequest() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
+        TransportRequest request = mock(TransportRequest.class);
+
+        validateNoException(interceptor, request);
+    }
+
+    public void testIgnoresRequestWithNoResolveViews() {
+        String viewName = "test-view";
+        ProjectMetadata projectMetadata = mockProjectMetadata(viewName);
+        ViewDlsFlsRequestInterceptor interceptor = new ViewDlsFlsRequestInterceptor(threadContext, () -> projectMetadata);
+
+        DocumentPermissions docPerms = DocumentPermissions.filteredBy(Set.of(new BytesArray("{\"terms\" : { \"tk1\" : [\"tv1\"] } }")));
+        setAccessControl(Map.of(viewName, new IndicesAccessControl.IndexAccessControl(FieldPermissions.DEFAULT, docPerms)));
+        TestIndicesRequest request = buildIndicesRequest(viewName);
+
+        // override the indices options to disable resolve views, which should cause the interceptor to skip the DLS/FLS checks
+        doReturn(IndicesOptions.builder().build()).when(request).indicesOptions();
+
+        validateNoException(interceptor, request);
     }
 
     public void testMetadataContainsMultipleViewNames() {
@@ -149,15 +170,11 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
             )
         );
 
-        SearchRequest searchRequest = new SearchRequest(view1, view2);
-        RequestInfo requestInfo = new RequestInfo(authentication, searchRequest, "indices:data/read/esql", null);
+        RequestInfo requestInfo = new RequestInfo(authentication, buildIndicesRequest(view1, view2), "indices:data/read/esql", null);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         interceptor.intercept(requestInfo, null, null).addListener(future);
         ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
-        String metadata = ex.getMetadata("es.views_with_dls_or_fls").toString();
-
-        assertThat(metadata, containsString(view1));
-        assertThat(metadata, containsString(view2));
+        validateException(ex, view1, view2);
     }
 
     public void testMixedViewsAndIndicesOnlyReportsViews() {
@@ -178,14 +195,44 @@ public class ViewDlsFlsRequestInterceptorTests extends ESTestCase {
             )
         );
 
-        SearchRequest searchRequest = new SearchRequest(viewName, indexName);
-        RequestInfo requestInfo = new RequestInfo(authentication, searchRequest, "indices:data/read/esql", null);
+        RequestInfo requestInfo = new RequestInfo(authentication, buildIndicesRequest(viewName, indexName), "indices:data/read/esql", null);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         interceptor.intercept(requestInfo, null, null).addListener(future);
         ElasticsearchSecurityException ex = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
-        String metadata = ex.getMetadata("es.views_with_dls_or_fls").toString();
+        validateException(ex, viewName);
+    }
 
-        assertThat(metadata, containsString(viewName));
+    private interface TestIndicesRequest extends IndicesRequest, TransportRequest {}
+
+    private TestIndicesRequest buildIndicesRequest(String... indices) {
+        TestIndicesRequest request = mock(TestIndicesRequest.class);
+        when(request.indices()).thenReturn(indices);
+        when(request.indicesOptions()).thenReturn(
+            IndicesOptions.builder()
+                .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveViews(true).build())
+                .build()
+        );
+        return request;
+    }
+
+    private void validateNoException(ViewDlsFlsRequestInterceptor interceptor, TransportRequest request) {
+        RequestInfo requestInfo = new RequestInfo(authentication, request, "indices:data/read/esql", null);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        interceptor.intercept(requestInfo, null, null).addListener(future);
+        future.actionGet();
+    }
+
+    private void validateException(ElasticsearchSecurityException ex, String... expectedViewNames) {
+        assertThat(ex.status(), equalTo(RestStatus.FORBIDDEN));
+        assertThat(
+            ex.getMessage(),
+            equalTo(
+                "Views with document or field level security restrictions are not supported."
+                    + " Remove DLS/FLS restrictions from the affected views in the role definition, or exclude the views from the request."
+            )
+        );
+        List<String> metadata = ex.getMetadata("es.views_with_dls_or_fls");
+        assertThat(metadata, containsInAnyOrder(expectedViewNames));
     }
 
     private void setAccessControl(Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions) {


### PR DESCRIPTION
DLS and FLS are not applicable to ESQL views. To avoid confusion and ambiguity, all queries which include such views are failed.
