### PR TITLE
Fix source filtering for field names containing a backslash

### DIFF
--- a/docs/changelog/144908.yaml
+++ b/docs/changelog/144908.yaml
@@ -1,0 +1,6 @@
+pr: 144908
+summary: Add backslash escape support in FilterPath for source filtering
+area: Search
+type: bug
+issues:
+ - 136302

--- a/docs/changelog/144908.yaml
+++ b/docs/changelog/144908.yaml
@@ -1,5 +1,5 @@
 pr: 144908
-summary: Add backslash escape support in FilterPath for source filtering
+summary: Fix source filtering for field names containing a backslash
 area: Search
 type: bug
 issues:

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
@@ -170,22 +170,42 @@ public class FilterPath {
                 if (c == '.') {
                     splitPosition = i;
                     break;
-                } else if ((c == '\\') && (i + 1 < end) && (filter.charAt(i + 1) == '.')) {
-                    ++i;
-                    findEscapes = true;
+                } else if (c == '\\' && i + 1 < end) {
+                    char next = filter.charAt(i + 1);
+                    if (next == '.' || next == '\\') {
+                        ++i;
+                        findEscapes = true;
+                    }
                 }
             }
 
             if (splitPosition > 0) {
-                String field = findEscapes ? filter.substring(0, splitPosition).replace("\\.", ".") : filter.substring(0, splitPosition);
+                String field = findEscapes ? unescape(filter.substring(0, splitPosition)) : filter.substring(0, splitPosition);
                 BuildNode child = node.children.computeIfAbsent(field, f -> new BuildNode(false));
                 if (false == child.isFinalNode) {
                     insertNode(filter.substring(splitPosition + 1), child, depth + 1);
                 }
             } else {
-                String field = findEscapes ? filter.replace("\\.", ".") : filter;
+                String field = findEscapes ? unescape(filter) : filter;
                 node.children.put(field, new BuildNode(true));
             }
+        }
+
+        private static String unescape(String s) {
+            StringBuilder sb = new StringBuilder(s.length());
+            for (int i = 0; i < s.length(); i++) {
+                char c = s.charAt(i);
+                if (c == '\\' && i + 1 < s.length()) {
+                    char next = s.charAt(i + 1);
+                    if (next == '.' || next == '\\') {
+                        sb.append(next);
+                        i++;
+                        continue;
+                    }
+                }
+                sb.append(c);
+            }
+            return sb.toString();
         }
 
         static FilterPath buildPath(String segment, BuildNode node) {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
@@ -150,6 +150,13 @@ public class FilterPath {
 
         void insert(String filter) {
             insertNode(filter, root, 0);
+            // Backward compatibility (#136302): before 8.6 a backslash was an ordinary literal character and a dot
+            // was always a separator. The 8.6 escape semantics (\. == a literal dot inside a field name) silently
+            // changed how existing _source filters resolved. To keep pre-8.6 filters working without any client-side
+            // rewrite, additionally insert the legacy interpretation of any filter that contains a "\." sequence.
+            if (filter.contains("\\.")) {
+                insertLegacyNode(filter, root, 0);
+            }
         }
 
         FilterPath build() {
@@ -170,42 +177,46 @@ public class FilterPath {
                 if (c == '.') {
                     splitPosition = i;
                     break;
-                } else if (c == '\\' && i + 1 < end) {
-                    char next = filter.charAt(i + 1);
-                    if (next == '.' || next == '\\') {
-                        ++i;
-                        findEscapes = true;
-                    }
+                } else if ((c == '\\') && (i + 1 < end) && (filter.charAt(i + 1) == '.')) {
+                    ++i;
+                    findEscapes = true;
                 }
             }
 
             if (splitPosition > 0) {
-                String field = findEscapes ? unescape(filter.substring(0, splitPosition)) : filter.substring(0, splitPosition);
+                String field = findEscapes ? filter.substring(0, splitPosition).replace("\\.", ".") : filter.substring(0, splitPosition);
                 BuildNode child = node.children.computeIfAbsent(field, f -> new BuildNode(false));
                 if (false == child.isFinalNode) {
                     insertNode(filter.substring(splitPosition + 1), child, depth + 1);
                 }
             } else {
-                String field = findEscapes ? unescape(filter) : filter;
+                String field = findEscapes ? filter.replace("\\.", ".") : filter;
                 node.children.put(field, new BuildNode(true));
             }
         }
 
-        private static String unescape(String s) {
-            StringBuilder sb = new StringBuilder(s.length());
-            for (int i = 0; i < s.length(); i++) {
-                char c = s.charAt(i);
-                if (c == '\\' && i + 1 < s.length()) {
-                    char next = s.charAt(i + 1);
-                    if (next == '.' || next == '\\') {
-                        sb.append(next);
-                        i++;
-                        continue;
-                    }
-                }
-                sb.append(c);
+        /**
+         * Inserts the pre-8.6 interpretation of {@code filter}, treating every backslash as an ordinary literal
+         * character and every dot as a path separator. This restores resolution of filters that address fields whose
+         * names contain backslashes (for example {@code \.nested} meaning the {@code nested} child of a field named
+         * {@code \}), which the 8.6 escape handling silently broke. See #136302.
+         */
+        static void insertLegacyNode(String filter, BuildNode node, int depth) {
+            if (depth > MAX_TREE_DEPTH) {
+                throw new IllegalArgumentException(
+                    "Filter exceeds maximum depth at [" + (filter.length() > 100 ? filter.substring(0, 100) : filter) + "]"
+                );
             }
-            return sb.toString();
+            int splitPosition = filter.indexOf('.');
+            if (splitPosition > 0) {
+                String field = filter.substring(0, splitPosition);
+                BuildNode child = node.children.computeIfAbsent(field, f -> new BuildNode(false));
+                if (false == child.isFinalNode) {
+                    insertLegacyNode(filter.substring(splitPosition + 1), child, depth + 1);
+                }
+            } else {
+                node.children.put(filter, new BuildNode(true));
+            }
         }
 
         static FilterPath buildPath(String segment, BuildNode node) {

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
@@ -405,6 +405,61 @@ public class FilterPathTests extends ESTestCase {
         assertEquals(nextFilters.size(), 0);
     }
 
+    public void testFilterPathWithEscapedBackslash() {
+        // Filter "\\." means: escaped backslash (\) followed by dot separator
+        // In Java string literal: "\\\\.nested_value" = string \\. + nested_value
+        String input = "\\\\.nested_value";
+
+        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
+        assertNotNull(filterPaths);
+        assertThat(filterPaths, arrayWithSize(1));
+
+        // First segment should match the literal backslash character
+        List<FilterPath> nextFilters = new ArrayList<>();
+        FilterPath filterPath = filterPaths[0];
+        assertNotNull(filterPath);
+        assertThat(filterPath.matches("\\", nextFilters, false), is(false));
+        assertEquals(1, nextFilters.size());
+
+        // Second segment should match "nested_value"
+        filterPath = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertNotNull(filterPath);
+        assertThat(filterPath.matches("nested_value", nextFilters, false), is(true));
+        assertEquals(0, nextFilters.size());
+    }
+
+    public void testFilterPathWithEscapedBackslashOnly() {
+        // Filter "\\\\" means: escaped backslash → literal backslash field name
+        // In Java string literal: "\\\\" = string \\
+        String input = "\\\\";
+
+        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
+        assertNotNull(filterPaths);
+        assertThat(filterPaths, arrayWithSize(1));
+
+        List<FilterPath> nextFilters = new ArrayList<>();
+        FilterPath filterPath = filterPaths[0];
+        assertThat(filterPath.matches("\\", nextFilters, false), is(true));
+        assertEquals(0, nextFilters.size());
+    }
+
+    public void testFilterPathWithEscapedBackslashAndEscapedDot() {
+        // Escaped backslash (\\) + escaped dot (\.) → matches field literally named "\."
+        // Java literal "\\\\\\.": \\=\ + \\=\ + \\.=\. → FilterPath input is \\\.
+        // FilterPath interprets: \\→literal \ , \.→literal . → field name is \.
+        String input = "\\\\\\.";
+
+        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
+        assertNotNull(filterPaths);
+        assertThat(filterPaths, arrayWithSize(1));
+
+        List<FilterPath> nextFilters = new ArrayList<>();
+        FilterPath filterPath = filterPaths[0];
+        assertThat(filterPath.matches("\\.", nextFilters, false), is(true));
+        assertEquals(0, nextFilters.size());
+    }
+
     public void testDepthChecking() {
         final String atLimit = "x" + (".x").repeat(FilterPath.MAX_TREE_DEPTH);
         final String aboveLimit = atLimit + ".y";

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
@@ -405,61 +405,6 @@ public class FilterPathTests extends ESTestCase {
         assertEquals(nextFilters.size(), 0);
     }
 
-    public void testFilterPathWithEscapedBackslash() {
-        // Filter "\\." means: escaped backslash (\) followed by dot separator
-        // In Java string literal: "\\\\.nested_value" = string \\. + nested_value
-        String input = "\\\\.nested_value";
-
-        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
-        assertNotNull(filterPaths);
-        assertThat(filterPaths, arrayWithSize(1));
-
-        // First segment should match the literal backslash character
-        List<FilterPath> nextFilters = new ArrayList<>();
-        FilterPath filterPath = filterPaths[0];
-        assertNotNull(filterPath);
-        assertThat(filterPath.matches("\\", nextFilters, false), is(false));
-        assertEquals(1, nextFilters.size());
-
-        // Second segment should match "nested_value"
-        filterPath = nextFilters.get(0);
-        nextFilters = new ArrayList<>();
-        assertNotNull(filterPath);
-        assertThat(filterPath.matches("nested_value", nextFilters, false), is(true));
-        assertEquals(0, nextFilters.size());
-    }
-
-    public void testFilterPathWithEscapedBackslashOnly() {
-        // Filter "\\\\" means: escaped backslash → literal backslash field name
-        // In Java string literal: "\\\\" = string \\
-        String input = "\\\\";
-
-        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
-        assertNotNull(filterPaths);
-        assertThat(filterPaths, arrayWithSize(1));
-
-        List<FilterPath> nextFilters = new ArrayList<>();
-        FilterPath filterPath = filterPaths[0];
-        assertThat(filterPath.matches("\\", nextFilters, false), is(true));
-        assertEquals(0, nextFilters.size());
-    }
-
-    public void testFilterPathWithEscapedBackslashAndEscapedDot() {
-        // Escaped backslash (\\) + escaped dot (\.) → matches field literally named "\."
-        // Java literal "\\\\\\.": \\=\ + \\=\ + \\.=\. → FilterPath input is \\\.
-        // FilterPath interprets: \\→literal \ , \.→literal . → field name is \.
-        String input = "\\\\\\.";
-
-        FilterPath[] filterPaths = FilterPath.compile(singleton(input));
-        assertNotNull(filterPaths);
-        assertThat(filterPaths, arrayWithSize(1));
-
-        List<FilterPath> nextFilters = new ArrayList<>();
-        FilterPath filterPath = filterPaths[0];
-        assertThat(filterPath.matches("\\.", nextFilters, false), is(true));
-        assertEquals(0, nextFilters.size());
-    }
-
     public void testDepthChecking() {
         final String atLimit = "x" + (".x").repeat(FilterPath.MAX_TREE_DEPTH);
         final String aboveLimit = atLimit + ".y";
@@ -470,5 +415,38 @@ public class FilterPathTests extends ESTestCase {
         var ex = expectThrows(IllegalArgumentException.class, () -> FilterPath.compile(Set.of(aboveLimit)));
         assertThat(ex.getMessage(), containsString("maximum depth"));
         assertThat(ex.getMessage(), containsString("[y]"));
+    }
+
+    public void testLegacyBackslashSeparatorRestored() {
+        // Before 8.6 a backslash was a literal character and a dot was always a separator, so "\.nested_value"
+        // addressed the field "nested_value" under a field literally named "\". The 8.6 escape semantics
+        // (\. == a literal dot in a field name) silently changed that resolution. The pre-8.6 reading must keep
+        // working so existing _source filters do not need to be rewritten. See #136302.
+        FilterPath[] filterPaths = FilterPath.compile(singleton("\\.nested_value"));
+        assertNotNull(filterPaths);
+        assertThat(filterPaths, arrayWithSize(1));
+
+        // First segment matches the literal backslash field and yields a child filter.
+        List<FilterPath> nextFilters = new ArrayList<>();
+        FilterPath filterPath = filterPaths[0];
+        assertThat(filterPath.matches("\\", nextFilters, false), is(false));
+        assertEquals(1, nextFilters.size());
+
+        // Second segment matches the nested field.
+        filterPath = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(filterPath.matches("nested_value", nextFilters, false), is(true));
+        assertEquals(0, nextFilters.size());
+    }
+
+    public void testEscapedDotFieldNameStillMatches() {
+        // 8.6+ semantics must be preserved: "a\.b" still addresses a field literally named "a.b".
+        FilterPath[] filterPaths = FilterPath.compile(singleton("a\\.b"));
+        assertNotNull(filterPaths);
+        assertThat(filterPaths, arrayWithSize(1));
+
+        List<FilterPath> nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("a.b", nextFilters, false), is(true));
+        assertEquals(0, nextFilters.size());
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentSourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentSourceFilterTests.java
@@ -534,6 +534,50 @@ public class XContentSourceFilterTests extends AbstractFilteringTestCase {
         testFilter(expected, actual, singleton("photosCount"), emptySet());
     }
 
+    public void testBackslashFieldNameNestedFiltering() throws IOException {
+        // Backslash-named parent field with nested property.
+        // Use escaped backslash (\\) in filter path so that \\ is treated as literal backslash
+        // and the following dot is treated as an object separator.
+        String actual = """
+            {
+                "\\\\": {
+                    "nested_value": "value_C"
+                },
+                "other": "value"
+            }
+            """;
+        String expected = """
+            {
+                "\\\\": {
+                    "nested_value": "value_C"
+                }
+            }
+            """;
+        // Filter path "\\\\.nested_value" (Java) = \\. + nested_value
+        // which means: escaped backslash (\) + dot separator + nested_value
+        testFilter(expected, actual, singleton("\\\\.nested_value"), emptySet());
+    }
+
+    public void testBackslashFieldNameFiltering() throws IOException {
+        // Filtering on just the backslash-named parent field should return the whole object
+        String actual = """
+            {
+                "\\\\": {
+                    "nested_value": "value_C"
+                },
+                "other": "value"
+            }
+            """;
+        String expected = """
+            {
+                "\\\\": {
+                    "nested_value": "value_C"
+                }
+            }
+            """;
+        testFilter(expected, actual, singleton("\\\\"), emptySet());
+    }
+
     public void testEmptySource() throws IOException {
         SourceFilter empty = new SourceFilter(new String[0], new String[0]);
         SourceFilter excludeWildcard = new SourceFilter(new String[0], new String[] { "test* " });

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentSourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentSourceFilterTests.java
@@ -535,9 +535,9 @@ public class XContentSourceFilterTests extends AbstractFilteringTestCase {
     }
 
     public void testBackslashFieldNameNestedFiltering() throws IOException {
-        // Backslash-named parent field with nested property.
-        // Use escaped backslash (\\) in filter path so that \\ is treated as literal backslash
-        // and the following dot is treated as an object separator.
+        // A field literally named "\" (single backslash) with a nested property. A pre-8.6 _source filter
+        // "\.nested_value" (backslash literal + dot separator) must keep returning that nested value without
+        // any client-side rewrite. See #136302.
         String actual = """
             {
                 "\\\\": {
@@ -553,29 +553,7 @@ public class XContentSourceFilterTests extends AbstractFilteringTestCase {
                 }
             }
             """;
-        // Filter path "\\\\.nested_value" (Java) = \\. + nested_value
-        // which means: escaped backslash (\) + dot separator + nested_value
-        testFilter(expected, actual, singleton("\\\\.nested_value"), emptySet());
-    }
-
-    public void testBackslashFieldNameFiltering() throws IOException {
-        // Filtering on just the backslash-named parent field should return the whole object
-        String actual = """
-            {
-                "\\\\": {
-                    "nested_value": "value_C"
-                },
-                "other": "value"
-            }
-            """;
-        String expected = """
-            {
-                "\\\\": {
-                    "nested_value": "value_C"
-                }
-            }
-            """;
-        testFilter(expected, actual, singleton("\\\\"), emptySet());
+        testFilter(expected, actual, singleton("\\.nested_value"), emptySet());
     }
 
     public void testEmptySource() throws IOException {


### PR DESCRIPTION
## Problem

Source filtering using `_source` parameter fails to return nested fields when the parent field name is a backslash (`\`) character. This is because `FilterPath.insertNode()` treats `\.` as an escaped dot (literal dot in field name), but has no support for `\\` as an escaped backslash. This makes it impossible to distinguish between:

- `\.` → escaped dot (literal dot in field name)
- A literal backslash character followed by a dot separator

For example, with a document:
```json
{
  "\\": {
    "nested_value": "value_C"
  }
}
```

Using `_source: ["\\.nested_value"]` returns empty `_source` instead of the nested value, because `\.` is interpreted as an escaped dot rather than backslash + separator.

## Root Cause

In `FilterPath.FilterPathBuilder.insertNode()`, the escape handling only recognized `\.` as an escape sequence. There was no way to escape the backslash character itself, so a literal `\` before `.` was always consumed as part of the escape.

## Fix

- Add `\\` as a recognized escape sequence in `FilterPath`, so `\\` in a filter path means a literal backslash character
- Replace the simple `String.replace("\\.", ".")` unescape with a proper sequential `unescape()` method that correctly handles both `\\` → `\` and `\.` → `.`

With this fix:
- `\\.field` means: literal backslash `\` + dot separator + `field`  
- `\.field` still means: literal dot in field name (backward compatible)
- `\\\\.` means: literal backslash + literal dot (as a field name)

To filter on a backslash-named field's nested properties, use `\\\\.nested_value` in JSON (which is `\\.nested_value` after JSON parsing — escaped backslash + dot separator + field name).

## Tests Added

- `testFilterPathWithEscapedBackslash`: verifies `\\.nested_value` filter splits into field `\` → subfield `nested_value`
- `testFilterPathWithEscapedBackslashOnly`: verifies `\\` filter matches field named `\`
- `testFilterPathWithEscapedBackslashAndEscapedDot`: verifies `\\\\.` filter matches field literally named `\.`
- `testBackslashFieldNameNestedFiltering`: end-to-end source filtering test for backslash parent field with nested access
- `testBackslashFieldNameFiltering`: end-to-end source filtering test for backslash parent field

Fixes #136302