### PR TITLE
[ML] Fix test XPackRestIT#test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_start_stop.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_start_stop.yml
@@ -248,6 +248,7 @@ teardown:
   - do:
       transform.start_transform:
         transform_id: "airline-transform-start-stop-continuous"
+        timeout: "10m"
   - match: { acknowledged: true }
 
   - do:
@@ -274,6 +275,7 @@ teardown:
   - do:
       transform.start_transform:
         transform_id: "airline-transform-start-stop-continuous"
+        timeout: "10m"
   - match: { acknowledged: true }
 
   - do:


### PR DESCRIPTION
1. **Root cause:** The `start_transform` API call for restarting continuous transform `airline-transform-start-stop-continuous` uses the default 30s timeout, which is occasionally insufficient under CI load due to the heavier initialization of continuous transforms (sync mechanism + checkpoint setup).

2. **Hypothesis:** Persistent task re-assignment and sync initialization for a continuous transform restart exceeds the default 30s timeout under CI resource contention (0.6% failure rate, only affects the continuous variant, not the batch variant of the same test pattern).

3. **File changes:**
   - **File:** `x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_start_stop.yml`
   - **Change 1 (~line 243):** In the "Test start/stop/start continuous transform" test, add `timeout: "10m"` to the first `transform.start_transform` call:
     ```yaml
     - do:
         transform.start_transform:
           transform_id: "airline-transform-start-stop-continuous"
           timeout: "10m"
     ```
   - **Change 2 (~line 269):** In the same test, add `timeout: "10m"` to the second `transform.start_transform` call (the one that actually times out):
     ```yaml
     - do:
         transform.start_transform:
           transform_id: "airline-transform-start-stop-continuous"
           timeout: "10m"
     ```

Fixes https://github.com/elastic/elasticsearch/issues/126755