### PR TITLE
[CI] Use newly added GCP zones for agents

### DIFF
--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -22,6 +22,7 @@ steps:
 
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -15,6 +15,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
@@ -27,6 +28,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
@@ -39,6 +41,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
@@ -51,6 +54,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
@@ -63,6 +67,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
@@ -75,6 +80,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/docs-check.yml
+++ b/.buildkite/pipelines/pull-request/docs-check.yml
@@ -9,6 +9,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -13,6 +13,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -10,6 +10,7 @@ steps:
         timeout_in_minutes: 300
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
@@ -20,6 +20,7 @@ steps:
               - destructiveDistroTest.archives
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
           machineType: custom-16-32768

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -35,6 +35,7 @@ steps:
               - archives
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
           machineType: custom-16-32768

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -17,6 +17,7 @@ steps:
               - default-windows-archive
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-32-98304
           diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -16,6 +16,7 @@ steps:
               - default-windows-archive
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-32-98304
           diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -15,6 +15,7 @@ steps:
               - ubuntu-2404
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-1-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-2-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-3-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-4-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-5-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
@@ -8,6 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -7,6 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-6-windows.yml
@@ -6,6 +6,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-windows-2022
       machineType: custom-32-98304
       diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -5,6 +5,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -9,6 +9,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/promql-compliance-bench.yml
+++ b/.buildkite/pipelines/pull-request/promql-compliance-bench.yml
@@ -10,6 +10,7 @@ steps:
     timeout_in_minutes: 10
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-2
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/release-tests.yml
+++ b/.buildkite/pipelines/pull-request/release-tests.yml
@@ -18,6 +18,7 @@ steps:
               - checkPart6
         agents:
           provider: gcp
+          zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
           image: family/elasticsearch-ubuntu-2404
           diskSizeGb: 350
           machineType: custom-32-98304

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
+      zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -34,6 +34,7 @@ steps:
           timeout_in_minutes: 300
           agents:
             provider: gcp
+            zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
             image: family/elasticsearch-ubuntu-2004
             machineType: n1-standard-32
             buildDirectory: /dev/shm/bk


### PR DESCRIPTION
The default set of zones (`us-central1`) are having major capacity issues, so EngProd has added new regions to be available. Let's use these zones for PR jobs.