### PR TITLE
Remove the double semicolon of the class field.

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -80,7 +80,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
     }
 
     private static final String OPERATOR_AUTH_HEADER = "Basic "
-        + Base64.getEncoder().encodeToString("test_operator:x-pack-test-password".getBytes(StandardCharsets.UTF_8));;
+        + Base64.getEncoder().encodeToString("test_operator:x-pack-test-password".getBytes(StandardCharsets.UTF_8));
 
     @SuppressWarnings("unchecked")
     @Override


### PR DESCRIPTION
Remove unnecessary semicolons from the static variable OPERATOR_AUTH_HEADER.

```java
private static final String OPERATOR_AUTH_HEADER = "Basic "
     private static final String OPERATOR_AUTH_HEADER = "Basic "
        + Base64.getEncoder().encodeToString("test_operator:x-pack-test-password".getBytes(StandardCharsets.UTF_8));;
```

**Changes made:**
- Removed redundant `;;` in the static variable `OPERATOR_AUTH_HEADER` to improve code readability and maintain standard Java conventions.

```java
private static final String OPERATOR_AUTH_HEADER = "Basic "
        + Base64.getEncoder().encodeToString("test_operator:x-pack-test-password".getBytes(StandardCharsets.UTF_8));
```

It's a minor formatting fix. Thank you!