### PR TITLE
Gate ReorderLimitProjectAndOrderByGoldenTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReorderLimitProjectAndOrderByGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReorderLimitProjectAndOrderByGoldenTests.java
@@ -23,6 +23,7 @@ public class ReorderLimitProjectAndOrderByGoldenTests extends GoldenTestCase {
      * In this case the 2*salary AS language_name ends up in a Project and LimitBy references it, so LimitBy -> Project cannot be swapped
      */
     public void testLimitByAndProjectNotSwapped() {
+        assumeTrue("SORT | LIMIT BY requires snapshot builds", EsqlCapabilities.Cap.ESQL_TOPN_BY.isEnabled());
         runGoldenTest("""
             FROM employees
             | RENAME languages AS language_code


### PR DESCRIPTION
Feature is hidden behind capability so should only run when capability is enabled