### PR TITLE
fix: pin 3 unpinned action(s)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+    uses: elastic/docs-builder/.github/workflows/preview-build.yml@42b43e9b1093f392298afa717c8bf9c67e47e4c7 # main
     with:
       enable-vale-linting: true
       include-paths: |

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
+    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@42b43e9b1093f392298afa717c8bf9c67e47e4c7 # main
     permissions:
       contents: none
       id-token: write

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -49,7 +49,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: elastic/oblt-actions/updatecli/run@v1
+      - uses: elastic/oblt-actions/updatecli/run@31fd8582a94d1829536be22c624697f851fdf60e # v1
         with:
           # Runs in "--debug" mode to provide logs if the PR creation fails
           command: --experimental compose apply --debug


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/docs-build.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/docs-cleanup.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/updatecli-compose.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-005 | medium | `.github/workflows/docs-build.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/docs-cleanup.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.