### PR TITLE
[8.19] Fix system index mapping update for reindexed indices after migration (#144782)

### DIFF
--- a/docs/changelog/144782.yaml
+++ b/docs/changelog/144782.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues:
+ - 144764
+pr: 144782
+summary: Fix system index mapping update for reindexed indices after migration
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
@@ -117,7 +117,7 @@ public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
         ensureGreen(reindexedIndexName);
         assertAcked(
             indicesAdmin().aliases(
-                new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).addAliasAction(
+                new IndicesAliasesRequest().addAliasAction(
                     IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(PRIMARY_INDEX_NAME)
                 ).addAliasAction(IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(INDEX_NAME))
             ).actionGet()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.indices;
 
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
@@ -94,6 +96,40 @@ public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
     }
 
     /**
+     * Reproduces a bug where system index mappings are not updated after a major-version reindex migration.
+     * <a href="https://github.com/elastic/elasticsearch/issues/144764"></a>
+     */
+    public void testSystemIndexManagerUpgradesMappingsOfReindexedIndex() throws Exception {
+        internalCluster().startNodes(1);
+
+        // Directly set up the post-migration state: a reindexed concrete index with old mappings,
+        // and the original primary index name as an alias pointing to it.
+        // Use MIGRATE_SYSTEM_INDEX_CAUSE so that TransportCreateIndexAction allows creating a system
+        // index whose name is not the descriptor's primary index, mirroring SystemIndexMigrator.
+        final String reindexedIndexName = PRIMARY_INDEX_NAME + SystemIndices.UPGRADED_INDEX_SUFFIX;
+        assertAcked(
+            indicesAdmin().create(
+                new CreateIndexRequest(reindexedIndexName).cause(SystemIndices.MIGRATE_SYSTEM_INDEX_CAUSE)
+                    .settings(TestSystemIndexDescriptor.SETTINGS)
+                    .mapping(TestSystemIndexDescriptor.getOldMappings())
+            ).actionGet()
+        );
+        ensureGreen(reindexedIndexName);
+        assertAcked(
+            indicesAdmin().aliases(
+                new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).addAliasAction(
+                    IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(PRIMARY_INDEX_NAME)
+                ).addAliasAction(IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(INDEX_NAME))
+            ).actionGet()
+        );
+
+        TestSystemIndexDescriptor.useNewMappings.set(true);
+        triggerClusterStateUpdates();
+
+        assertBusy(() -> assertMappingsAndSettings(TestSystemIndexDescriptor.getNewMappings(), reindexedIndexName));
+    }
+
+    /**
      * Ensures that we can clear any blocks that get set on managed system indices.
      *
      * See https://github.com/elastic/elasticsearch/issues/80814
@@ -119,27 +155,31 @@ public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
         indicesAdmin().putTemplate(new PutIndexTemplateRequest(name).patterns(List.of(name))).actionGet();
     }
 
+    private void assertMappingsAndSettings(String expectedMappings) {
+        assertMappingsAndSettings(expectedMappings, PRIMARY_INDEX_NAME);
+    }
+
     /**
      * Fetch the mappings and settings for {@link TestSystemIndexDescriptor#INDEX_NAME} and verify that they match the expected values.
      */
-    private void assertMappingsAndSettings(String expectedMappings) {
+    private void assertMappingsAndSettings(String expectedMappings, String primaryIndexName) {
         final GetMappingsResponse getMappingsResponse = indicesAdmin().getMappings(new GetMappingsRequest().indices(INDEX_NAME))
             .actionGet();
 
         final Map<String, MappingMetadata> mappings = getMappingsResponse.getMappings();
         assertThat(
-            "Expected mappings to contain a key for [" + PRIMARY_INDEX_NAME + "], but found: " + mappings.toString(),
-            mappings.containsKey(PRIMARY_INDEX_NAME),
+            "Expected mappings to contain a key for [" + primaryIndexName + "], but found: " + mappings.toString(),
+            mappings.containsKey(primaryIndexName),
             equalTo(true)
         );
-        final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).getSourceAsMap();
+        final Map<String, Object> sourceAsMap = mappings.get(primaryIndexName).getSourceAsMap();
 
         assertThat(sourceAsMap, equalTo(XContentHelper.convertToMap(XContentType.JSON.xContent(), expectedMappings, false)));
 
         final GetSettingsResponse getSettingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(INDEX_NAME))
             .actionGet();
 
-        final Settings actual = getSettingsResponse.getIndexToSettings().get(PRIMARY_INDEX_NAME);
+        final Settings actual = getSettingsResponse.getIndexToSettings().get(primaryIndexName);
 
         for (String settingName : TestSystemIndexDescriptor.SETTINGS.keySet()) {
             assertThat(actual.get(settingName), equalTo(TestSystemIndexDescriptor.SETTINGS.get(settingName)));

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterIndexHealth;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -228,7 +229,7 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
      * @return a summary of the index state, or <code>null</code> if the index doesn't exist
      */
     static State calculateIndexState(ClusterState state, SystemIndexDescriptor descriptor) {
-        final IndexMetadata indexMetadata = state.metadata().index(descriptor.getPrimaryIndex());
+        IndexMetadata indexMetadata = getSystemIndexMetadata(state, descriptor);
 
         if (indexMetadata == null) {
             return null;
@@ -255,6 +256,21 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
         }
 
         return new State(indexState, indexHealth, isIndexUpToDate, isMappingIsUpToDate);
+    }
+
+    private static IndexMetadata getSystemIndexMetadata(ProjectState state, SystemIndexDescriptor descriptor) {
+        String primaryIndexName = descriptor.getPrimaryIndex();
+        ProjectMetadata projectMetadata = state.metadata();
+        IndexMetadata indexMetadata = projectMetadata.index(primaryIndexName);
+        if (indexMetadata == null) {
+            // The primary index name might be an alias pointing to the concrete index
+            // (e.g. ".fleet-agents-7" → ".fleet-agents-7-reindexed-for-9").
+            IndexAbstraction indexAbstraction = projectMetadata.getIndicesLookup().get(primaryIndexName);
+            if (indexAbstraction != null && indexAbstraction.getWriteIndex() != null) {
+                indexMetadata = projectMetadata.getIndexSafe(indexAbstraction.getWriteIndex());
+            }
+        }
+        return indexMetadata;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -229,7 +229,7 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
      * @return a summary of the index state, or <code>null</code> if the index doesn't exist
      */
     static State calculateIndexState(ClusterState state, SystemIndexDescriptor descriptor) {
-        IndexMetadata indexMetadata = getSystemIndexMetadata(state, descriptor);
+        IndexMetadata indexMetadata = getSystemIndexMetadata(state.metadata(), descriptor);
 
         if (indexMetadata == null) {
             return null;
@@ -258,16 +258,15 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
         return new State(indexState, indexHealth, isIndexUpToDate, isMappingIsUpToDate);
     }
 
-    private static IndexMetadata getSystemIndexMetadata(ProjectState state, SystemIndexDescriptor descriptor) {
+    private static IndexMetadata getSystemIndexMetadata(Metadata metadata, SystemIndexDescriptor descriptor) {
         String primaryIndexName = descriptor.getPrimaryIndex();
-        ProjectMetadata projectMetadata = state.metadata();
-        IndexMetadata indexMetadata = projectMetadata.index(primaryIndexName);
+        IndexMetadata indexMetadata = metadata.index(primaryIndexName);
         if (indexMetadata == null) {
             // The primary index name might be an alias pointing to the concrete index
             // (e.g. ".fleet-agents-7" → ".fleet-agents-7-reindexed-for-9").
-            IndexAbstraction indexAbstraction = projectMetadata.getIndicesLookup().get(primaryIndexName);
+            IndexAbstraction indexAbstraction = metadata.getIndicesLookup().get(primaryIndexName);
             if (indexAbstraction != null && indexAbstraction.getWriteIndex() != null) {
-                indexMetadata = projectMetadata.getIndexSafe(indexAbstraction.getWriteIndex());
+                indexMetadata = metadata.getIndexSafe(indexAbstraction.getWriteIndex());
             }
         }
         return indexMetadata;

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.TestShardRoutingRoleStrategies;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -279,7 +280,6 @@ public class SystemIndexMappingUpdateServiceTests extends ESTestCase {
      */
     public void testManagerDetectsOutdatedMappingsInReindexedIndex() {
         final String reindexedIndexName = SYSTEM_INDEX_NAME + SystemIndices.UPGRADED_INDEX_SUFFIX;
-        final var projectId = randomProjectIdOrDefault();
 
         // Simulate the post-migration state: the concrete index has the reindexed suffix and an
         // outdated managed_index_mappings_version, while the original primary index name and the
@@ -290,21 +290,19 @@ public class SystemIndexMappingUpdateServiceTests extends ESTestCase {
             .putAlias(AliasMetadata.builder(SYSTEM_INDEX_NAME).build())
             .putAlias(AliasMetadata.builder(DESCRIPTOR.getAliasName()).build());
 
-        final Metadata metadata = Metadata.builder()
-            .generateClusterUuidIfNeeded()
-            .put(ProjectMetadata.builder(projectId).put(reindexedIndexMeta))
-            .build();
+        final Metadata metadata = Metadata.builder().generateClusterUuidIfNeeded().put(reindexedIndexMeta).build();
         final DiscoveryNode node = DiscoveryNodeUtils.builder("1").roles(new HashSet<>(DiscoveryNodeRole.roles())).build();
         final DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).masterNodeId(node.getId()).localNodeId(node.getId()).build();
         final ClusterState clusterState = ClusterState.builder(CLUSTER_NAME)
             .nodes(nodes)
             .metadata(metadata)
-            .routingTable(GlobalRoutingTableTestHelper.buildRoutingTable(metadata, RoutingTable.Builder::addAsNew))
+            .routingTable(
+                RoutingTable.builder(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY).addAsNew(metadata.index(reindexedIndexName))
+            )
             .build();
-        ProjectState projectState = clusterState.projectState(projectId);
 
         assertThat(
-            SystemIndexMappingUpdateService.getUpgradeStatus(projectState, DESCRIPTOR),
+            SystemIndexMappingUpdateService.getUpgradeStatus(clusterState, DESCRIPTOR),
             equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
         );
     }

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
@@ -274,6 +274,42 @@ public class SystemIndexMappingUpdateServiceTests extends ESTestCase {
     }
 
     /**
+     * Reproduces a bug where SystemIndexMappingUpdateService incorrectly reports UP_TO_DATE for an index whose mappings are
+     * outdated after a major-version migration (reindex).
+     */
+    public void testManagerDetectsOutdatedMappingsInReindexedIndex() {
+        final String reindexedIndexName = SYSTEM_INDEX_NAME + SystemIndices.UPGRADED_INDEX_SUFFIX;
+        final var projectId = randomProjectIdOrDefault();
+
+        // Simulate the post-migration state: the concrete index has the reindexed suffix and an
+        // outdated managed_index_mappings_version, while the original primary index name and the
+        // alias are both aliases pointing to the new concrete index.
+        IndexMetadata.Builder reindexedIndexMeta = IndexMetadata.builder(reindexedIndexName)
+            .settings(Settings.builder().put(getSettings()).put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), 6))
+            .putMapping(Strings.toString(getMappings("1.0.0", 4)))
+            .putAlias(AliasMetadata.builder(SYSTEM_INDEX_NAME).build())
+            .putAlias(AliasMetadata.builder(DESCRIPTOR.getAliasName()).build());
+
+        final Metadata metadata = Metadata.builder()
+            .generateClusterUuidIfNeeded()
+            .put(ProjectMetadata.builder(projectId).put(reindexedIndexMeta))
+            .build();
+        final DiscoveryNode node = DiscoveryNodeUtils.builder("1").roles(new HashSet<>(DiscoveryNodeRole.roles())).build();
+        final DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).masterNodeId(node.getId()).localNodeId(node.getId()).build();
+        final ClusterState clusterState = ClusterState.builder(CLUSTER_NAME)
+            .nodes(nodes)
+            .metadata(metadata)
+            .routingTable(GlobalRoutingTableTestHelper.buildRoutingTable(metadata, RoutingTable.Builder::addAsNew))
+            .build();
+        ProjectState projectState = clusterState.projectState(projectId);
+
+        assertThat(
+            SystemIndexMappingUpdateService.getUpgradeStatus(projectState, DESCRIPTOR),
+            equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
+        );
+    }
+
+    /**
      * Check that this
      */
     public void testCanHandleIntegerMetaVersion() {


### PR DESCRIPTION

SystemIndexMappingUpdateService used projectMetadata.hasIndexAbstraction(d.getPrimaryIndex()) to collect system indices descriptors to check mappings, but then used state.metadata().index(descriptor.getPrimaryIndex()) to get IndexMetadata. This works with indices that were not reindexed, since their name is always the same as the system index's primary name, but after reindexing during migration, the index gains -reindexed-for-<version> suffix and has an alias with the primary name pointing to it. However, index method doesn't support aliases, therefore, IndexMetadata wasn't resolved and mappings were not checked.

This change fixes that by introducing use of indices lookup, if there is no metadata for the primary index.

(cherry picked from commit 29d7e2a610e2b99f17d865f0af25f3007b1fd028)