### PR TITLE
[8.19] CCR follower index needs to copy transport version from CCR leader index (#145035)

### DIFF
--- a/docs/changelog/145035.yaml
+++ b/docs/changelog/145035.yaml
@@ -1,0 +1,5 @@
+area: CCR
+issues: []
+pr: 145035
+summary: CCR follower index needs to copy transport version from CCR leader index
+type: bug

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -199,6 +199,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
 
         // UUID is changed so that we can follow indexes on same cluster
         assertNotEquals(leaderMetadata.getIndexUUID(), followerMetadata.getIndexUUID());
+        assertEquals(leaderMetadata.getTransportVersion(), followerMetadata.getTransportVersion());
     }
 
     public void testDocsAreRecovered() throws Exception {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -309,6 +309,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         imdBuilder.putCustom(Ccr.CCR_CUSTOM_METADATA_KEY, customMetadata);
 
         imdBuilder.settings(leaderIndexMetadata.getSettings());
+        imdBuilder.transportVersion(leaderIndexMetadata.getTransportVersion());
 
         // Copy mappings from leader IMD to follow IMD
         imdBuilder.putMapping(leaderIndexMetadata.mapping());


### PR DESCRIPTION
Backports the following commits to 8.19:
 - CCR follower index needs to copy transport version from CCR leader index (#145035)