### PR TITLE
ESQL: Fix test bug

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -357,9 +357,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReorderLimitProjectAndOrderByGoldenTests
   method: testLimitByAndProjectNotSwapped
   issue: https://github.com/elastic/elasticsearch/issues/144978
-- class: org.elasticsearch.compute.OperatorTests
-  method: testQueryOperator
-  issue: https://github.com/elastic/elasticsearch/issues/145001
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidBigDecimalFromFloatWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145036

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -115,8 +115,13 @@ public class OperatorTests extends MapperServiceTestCase {
             );
             List<Driver> drivers = new ArrayList<>();
             try {
+                /*
+                 * If we match no documents the factory wants 0 concurrency. But in
+                 * production we accept no less than 1 driver.
+                 */
+                int driverCount = Math.max(1, factory.taskConcurrency());
                 Set<Integer> actualDocIds = ConcurrentCollections.newConcurrentSet();
-                for (int t = 0; t < factory.taskConcurrency(); t++) {
+                for (int t = 0; t < driverCount; t++) {
                     PageConsumerOperator docCollector = new PageConsumerOperator(page -> {
                         DocVector docVector = page.<DocBlock>getBlock(0).asVector();
                         IntVector doc = docVector.docs();

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/TestDriverRunner.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/TestDriverRunner.java
@@ -35,8 +35,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import static org.elasticsearch.test.ESTestCase.assertThat;
 import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.terminate;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Utility for running {@link Driver} with configurations customized for tests.
@@ -100,6 +103,7 @@ public class TestDriverRunner {
      * Run many drivers.
      */
     public void run(List<Driver> drivers) {
+        assertThat("We can't run 0 drivers. Production runs at least one, even if we match no documents.", drivers, not(empty()));
         drivers = new ArrayList<>(drivers);
         int dummyDrivers = between(0, 10);
         for (int i = 0; i < dummyDrivers; i++) {


### PR DESCRIPTION
Fix an old test bug that fails on rare seeds. The test creates 0 driver which the driver runner hates. It needs to run at least one driver. In production we run at least one driver. This updates the test to run at least one driver. And it makes the test failure more obvious.

Closes #145001
