### PR TITLE
Added Gating so VectorScorerInt4BenchmarkTests and VectorScorerInt4BulkBenchmarkTests Ignored on Java 21

### DIFF
--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BenchmarkTests.java
@@ -59,13 +59,13 @@ public class VectorScorerInt4BenchmarkTests extends ESTestCase {
 
             try {
                 float expected = scalar.score();
-                if(supportsHeapSegments()) {
+                if (supportsHeapSegments()) {
                     assertEquals("LUCENE score", expected, lucene.score(), delta);
                     assertEquals("NATIVE score", expected, nativeBench.score(), delta);
                 }
             } finally {
                 scalar.teardown();
-                if(supportsHeapSegments()) {
+                if (supportsHeapSegments()) {
                     lucene.teardown();
                     nativeBench.teardown();
                 }
@@ -86,13 +86,13 @@ public class VectorScorerInt4BenchmarkTests extends ESTestCase {
 
             try {
                 float expected = scalar.scoreQuery();
-                if(supportsHeapSegments()) {
+                if (supportsHeapSegments()) {
                     assertEquals("LUCENE scoreQuery", expected, lucene.scoreQuery(), delta);
                     assertEquals("NATIVE scoreQuery", expected, nativeBench.scoreQuery(), delta);
                 }
             } finally {
                 scalar.teardown();
-                if(supportsHeapSegments()) {
+                if (supportsHeapSegments()) {
                     lucene.teardown();
                     nativeBench.teardown();
                 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BenchmarkTests.java
@@ -19,6 +19,8 @@ import org.openjdk.jmh.annotations.Param;
 
 import java.util.Arrays;
 
+import static org.elasticsearch.benchmark.vector.scorer.BenchmarkUtils.supportsHeapSegments;
+
 public class VectorScorerInt4BenchmarkTests extends ESTestCase {
 
     private final double delta = 1e-3;
@@ -48,17 +50,25 @@ public class VectorScorerInt4BenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var data = new VectorScorerInt4Benchmark.VectorData(dims);
             var scalar = createBench(VectorImplementation.SCALAR, data);
-            var lucene = createBench(VectorImplementation.LUCENE, data);
-            var nativeBench = createBench(VectorImplementation.NATIVE, data);
+            VectorScorerInt4Benchmark lucene = null;
+            VectorScorerInt4Benchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, data);
+                nativeBench = createBench(VectorImplementation.NATIVE, data);
+            }
 
             try {
                 float expected = scalar.score();
-                assertEquals("LUCENE score", expected, lucene.score(), delta);
-                assertEquals("NATIVE score", expected, nativeBench.score(), delta);
+                if(supportsHeapSegments()) {
+                    assertEquals("LUCENE score", expected, lucene.score(), delta);
+                    assertEquals("NATIVE score", expected, nativeBench.score(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if(supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
@@ -67,17 +77,25 @@ public class VectorScorerInt4BenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var data = new VectorScorerInt4Benchmark.VectorData(dims);
             var scalar = createBench(VectorImplementation.SCALAR, data);
-            var lucene = createBench(VectorImplementation.LUCENE, data);
-            var nativeBench = createBench(VectorImplementation.NATIVE, data);
+            VectorScorerInt4Benchmark lucene = null;
+            VectorScorerInt4Benchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, data);
+                nativeBench = createBench(VectorImplementation.NATIVE, data);
+            }
 
             try {
                 float expected = scalar.scoreQuery();
-                assertEquals("LUCENE scoreQuery", expected, lucene.scoreQuery(), delta);
-                assertEquals("NATIVE scoreQuery", expected, nativeBench.scoreQuery(), delta);
+                if(supportsHeapSegments()) {
+                    assertEquals("LUCENE scoreQuery", expected, lucene.scoreQuery(), delta);
+                    assertEquals("NATIVE scoreQuery", expected, nativeBench.scoreQuery(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if(supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkBenchmarkTests.java
@@ -19,6 +19,8 @@ import org.openjdk.jmh.annotations.Param;
 
 import java.util.Arrays;
 
+import static org.elasticsearch.benchmark.vector.scorer.BenchmarkUtils.supportsHeapSegments;
+
 public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
 
     private final VectorSimilarityType function;
@@ -52,17 +54,25 @@ public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreMultipleSequential();
-                assertArrayEquals("LUCENE sequential", expected, lucene.scoreMultipleSequential(), delta);
-                assertArrayEquals("NATIVE sequential", expected, nativeBench.scoreMultipleSequential(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE sequential", expected, lucene.scoreMultipleSequential(), delta);
+                    assertArrayEquals("NATIVE sequential", expected, nativeBench.scoreMultipleSequential(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
@@ -71,17 +81,25 @@ public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreMultipleRandom();
-                assertArrayEquals("LUCENE random", expected, lucene.scoreMultipleRandom(), delta);
-                assertArrayEquals("NATIVE random", expected, nativeBench.scoreMultipleRandom(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE random", expected, lucene.scoreMultipleRandom(), delta);
+                    assertArrayEquals("NATIVE random", expected, nativeBench.scoreMultipleRandom(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
@@ -90,17 +108,25 @@ public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreQueryMultipleRandom();
-                assertArrayEquals("LUCENE queryRandom", expected, lucene.scoreQueryMultipleRandom(), delta);
-                assertArrayEquals("NATIVE queryRandom", expected, nativeBench.scoreQueryMultipleRandom(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE queryRandom", expected, lucene.scoreQueryMultipleRandom(), delta);
+                    assertArrayEquals("NATIVE queryRandom", expected, nativeBench.scoreQueryMultipleRandom(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
@@ -109,17 +135,25 @@ public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreMultipleSequentialBulk();
-                assertArrayEquals("LUCENE sequentialBulk", expected, lucene.scoreMultipleSequentialBulk(), delta);
-                assertArrayEquals("NATIVE sequentialBulk", expected, nativeBench.scoreMultipleSequentialBulk(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE sequentialBulk", expected, lucene.scoreMultipleSequentialBulk(), delta);
+                    assertArrayEquals("NATIVE sequentialBulk", expected, nativeBench.scoreMultipleSequentialBulk(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
@@ -128,36 +162,53 @@ public class VectorScorerInt4BulkBenchmarkTests extends ESTestCase {
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreMultipleRandomBulk();
-                assertArrayEquals("LUCENE randomBulk", expected, lucene.scoreMultipleRandomBulk(), delta);
-                assertArrayEquals("NATIVE randomBulk", expected, nativeBench.scoreMultipleRandomBulk(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE randomBulk", expected, lucene.scoreMultipleRandomBulk(), delta);
+                    assertArrayEquals("NATIVE randomBulk", expected, nativeBench.scoreMultipleRandomBulk(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }
 
     public void testQueryRandomBulk() throws Exception {
+
         for (int i = 0; i < 100; i++) {
             var vectorData = new VectorScorerInt4BulkBenchmark.VectorData(dims, 1000, 200);
             var scalar = createBench(VectorImplementation.SCALAR, vectorData);
-            var lucene = createBench(VectorImplementation.LUCENE, vectorData);
-            var nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            VectorScorerInt4BulkBenchmark lucene = null;
+            VectorScorerInt4BulkBenchmark nativeBench = null;
+            if (supportsHeapSegments()) {
+                lucene = createBench(VectorImplementation.LUCENE, vectorData);
+                nativeBench = createBench(VectorImplementation.NATIVE, vectorData);
+            }
 
             try {
                 float[] expected = scalar.scoreQueryMultipleRandomBulk();
-                assertArrayEquals("LUCENE queryRandomBulk", expected, lucene.scoreQueryMultipleRandomBulk(), delta);
-                assertArrayEquals("NATIVE queryRandomBulk", expected, nativeBench.scoreQueryMultipleRandomBulk(), delta);
+                if (supportsHeapSegments()) {
+                    assertArrayEquals("LUCENE queryRandomBulk", expected, lucene.scoreQueryMultipleRandomBulk(), delta);
+                    assertArrayEquals("NATIVE queryRandomBulk", expected, nativeBench.scoreQueryMultipleRandomBulk(), delta);
+                }
             } finally {
                 scalar.teardown();
-                lucene.teardown();
-                nativeBench.teardown();
+                if (supportsHeapSegments()) {
+                    lucene.teardown();
+                    nativeBench.teardown();
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/145054
Fixes: https://github.com/elastic/elasticsearch/issues/145055
Fixes: https://github.com/elastic/elasticsearch/issues/145056
Fixes: https://github.com/elastic/elasticsearch/issues/145057
Fixes: https://github.com/elastic/elasticsearch/issues/145058
