### PR TITLE
Remove macOS SDK dependency from libvec native build

### DIFF
--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 var zstdVersion = "1.5.7"
-var vecVersion = "1.0.64"
+var vecVersion = "1.0.66"
 
 repositories {
   exclusiveContent {

--- a/libs/simdvec/native/build.gradle
+++ b/libs/simdvec/native/build.gradle
@@ -64,8 +64,21 @@ model {
       }
     }
     clang(Clang) {
+      // On Darwin, use tinystd instead of the platform SDK's libc++ headers.
+      // -nostdinc blocks all system headers; we add back our minimal C++ std
+      // headers (tinystd) and clang's freestanding builtins (arm_neon.h, stdint.h, etc.).
+      def clangResourceDir = "clang -print-resource-dir".execute().text.trim()
       target("aarch64") {
-        cppCompiler.withArguments { args -> args.addAll(["-std=c++17", "-O3", "-march=armv8.2-a+dotprod", "-Winline"]) }
+        if (os.isMacOsX()) {
+          cppCompiler.withArguments { args -> args.addAll([
+            "-std=c++17", "-O3", "-march=armv8.2-a+dotprod", "-Winline", "-DNDEBUG",
+            "-nostdinc",
+            "-isystem", "src/vec/headers/darwin/tinystd",
+            "-isystem", "${clangResourceDir}/include"
+          ]) }
+        } else {
+          cppCompiler.withArguments { args -> args.addAll(["-std=c++17", "-O3", "-march=armv8.2-a+dotprod", "-Winline"]) }
+        }
       }
 
       target("amd64") {

--- a/libs/simdvec/native/build.gradle
+++ b/libs/simdvec/native/build.gradle
@@ -67,9 +67,9 @@ model {
       // On Darwin, use tinystd instead of the platform SDK's libc++ headers.
       // -nostdinc blocks all system headers; we add back our minimal C++ std
       // headers (tinystd) and clang's freestanding builtins (arm_neon.h, stdint.h, etc.).
-      def clangResourceDir = "clang -print-resource-dir".execute().text.trim()
       target("aarch64") {
         if (os.isMacOsX()) {
+          def clangResourceDir = "clang -print-resource-dir".execute().text.trim()
           cppCompiler.withArguments { args -> args.addAll([
             "-std=c++17", "-O3", "-march=armv8.2-a+dotprod", "-Winline", "-DNDEBUG",
             "-nostdinc",

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -20,7 +20,7 @@ if [ -z "$ARTIFACTORY_API_KEY" ]; then
   exit 1;
 fi
 
-VERSION="1.0.64"
+VERSION="1.0.66"
 ARTIFACTORY_REPOSITORY="${ARTIFACTORY_REPOSITORY:-https://artifactory.elastic.dev/artifactory/elasticsearch-native/}"
 TEMP=$(mktemp -d)
 

--- a/libs/simdvec/native/src/vec/c/aarch64/caps.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/caps.cpp
@@ -20,18 +20,10 @@
     #include <asm/hwcap.h>
 #endif
 
-#ifdef __APPLE__
-#include <TargetConditionals.h>
-#endif
-
 EXPORT int vec_caps() {
 #ifdef __APPLE__
-    #ifdef TARGET_OS_OSX
-        // All M series Apple silicon support Neon instructions; no SVE support as for now (M4)
-        return 1;
-    #else
-        #error "Unsupported Apple platform"
-    #endif
+    // All M series Apple silicon support Neon instructions; no SVE support as for now (M4)
+    return 1;
 #elif __linux__
     int hwcap = getauxval(AT_HWCAP);
     // See https://docs.kernel.org/arch/arm64/elf_hwcaps.html

--- a/libs/simdvec/native/src/vec/c/aarch64/score_1.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/score_1.cpp
@@ -9,7 +9,6 @@
 
 #include <stddef.h>
 #include <arm_neon.h>
-#include <math.h>
 #include <limits>
 #include "vec.h"
 #include "vec_common.h"
@@ -52,7 +51,7 @@ EXPORT f32_t diskbbq_apply_corrections_euclidean_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;
@@ -93,7 +92,7 @@ EXPORT f32_t diskbbq_apply_corrections_maximum_inner_product_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;
@@ -134,7 +133,7 @@ EXPORT f32_t diskbbq_apply_corrections_dot_product_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;

--- a/libs/simdvec/native/src/vec/c/aarch64/vec_1.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/vec_1.cpp
@@ -14,7 +14,6 @@
 
 #include <stddef.h>
 #include <arm_neon.h>
-#include <math.h>
 #include <algorithm>
 #include "vec.h"
 #include "vec_common.h"
@@ -111,7 +110,7 @@ EXPORT f32_t vec_cosi8(const int8_t* a, const int8_t* b, const int32_t dims) {
         res.norm2 += bi * bi;
     }
 
-    return (f32_t) ((double) res.sum / sqrt((double) res.norm1 * res.norm2));
+    return (f32_t) ((double) res.sum / __builtin_sqrt((double) res.norm1 * res.norm2));
 }
 
 template <typename TData, const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t)>

--- a/libs/simdvec/native/src/vec/c/aarch64/vec_2.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/vec_2.cpp
@@ -22,7 +22,6 @@
 
 #include <stddef.h>
 #include <arm_sve.h>
-#include <math.h>
 #include "vec.h"
 #include "vec_common.h"
 #include "aarch64/aarch64_vec_common.h"

--- a/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_1.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_1.cpp
@@ -11,7 +11,6 @@
 
 #include <stddef.h>
 #include <arm_neon.h>
-#include <math.h>
 #include <algorithm>
 #include "vec.h"
 #include "vec_common.h"

--- a/libs/simdvec/native/src/vec/c/amd64/caps.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/caps.cpp
@@ -9,7 +9,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <math.h>
 #include "vec.h"
 #include "vec_common.h"
 #include "amd64/amd64_vec_common.h"

--- a/libs/simdvec/native/src/vec/c/amd64/score_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/score_1.cpp
@@ -14,8 +14,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <math.h>
 #include <limits>
 
 #include "vec.h"
@@ -97,7 +95,7 @@ EXPORT f32_t diskbbq_apply_corrections_euclidean_bulk(
         );
         res = _mm256_max_ps(_mm256_rcp_ps(res), _mm256_setzero_ps());
 
-        maxScore = fmax(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
+        maxScore = __builtin_fmaxf(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
         _mm256_storeu_ps(scores + i, res);
     }
     for (; i < bulkSize; ++i) {
@@ -117,7 +115,7 @@ EXPORT f32_t diskbbq_apply_corrections_euclidean_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;
@@ -178,7 +176,7 @@ EXPORT f32_t diskbbq_apply_corrections_maximum_inner_product_bulk(
         __m256 is_neg = _mm256_cmp_ps(res, _mm256_setzero_ps(), _CMP_LT_OQ);
         res = _mm256_add_ps(_mm256_and_ps(is_neg, negative_scaled), _mm256_andnot_ps(is_neg, positive_scaled));
 
-        maxScore = fmax(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
+        maxScore = __builtin_fmaxf(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
         _mm256_storeu_ps(scores + i, res);
     }
 
@@ -199,7 +197,7 @@ EXPORT f32_t diskbbq_apply_corrections_maximum_inner_product_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;
@@ -254,7 +252,7 @@ EXPORT f32_t diskbbq_apply_corrections_dot_product_bulk(
         // res = max(res / 2.0f, 0.0f);
         res = _mm256_max_ps(_mm256_mul_ps(res, _mm256_set1_ps(0.5f)), _mm256_setzero_ps());
 
-        maxScore = fmax(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
+        maxScore = __builtin_fmaxf(maxScore, mm256_reduce_ps<_mm_max_ps>(res));
         _mm256_storeu_ps(scores + i, res);
     }
 
@@ -275,7 +273,7 @@ EXPORT f32_t diskbbq_apply_corrections_dot_product_bulk(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;

--- a/libs/simdvec/native/src/vec/c/amd64/score_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/score_2.cpp
@@ -14,8 +14,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <math.h>
 #include <limits>
 
 // Force the preprocessor to pick up AVX-512 intrinsics, and the compiler to emit AVX-512 code
@@ -133,7 +131,7 @@ EXPORT f32_t diskbbq_apply_corrections_maximum_inner_product_bulk_2(
             *(scores + i)
         );
         *(scores + i) = score;
-        maxScore = fmax(maxScore, score);
+        maxScore = __builtin_fmaxf(maxScore, score);
     }
 
     return maxScore;

--- a/libs/simdvec/native/src/vec/c/amd64/vec_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_1.cpp
@@ -13,7 +13,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <math.h>
 #include <algorithm>
 #include "vec.h"
 #include "vec_common.h"
@@ -279,7 +278,7 @@ EXPORT f32_t vec_cosi8(const int8_t* a, const int8_t* b, const int32_t dims) {
         res.norm2 += bi * bi;
     }
 
-    return (f32_t) ((double) res.sum / sqrt((double) res.norm1 * res.norm2));
+    return (f32_t) ((double) res.sum / __builtin_sqrt((double) res.norm1 * res.norm2));
 }
 
 template <typename TData, const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t), int batches = 2>

--- a/libs/simdvec/native/src/vec/c/amd64/vec_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_2.cpp
@@ -13,7 +13,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <math.h>
 
 // Force the preprocessor to pick up AVX-512 intrinsics, and the compiler to emit AVX-512 code
 #ifdef __clang__

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
@@ -11,7 +11,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <math.h>
 #include <algorithm>
 #include "vec.h"
 #include "vec_common.h"

--- a/libs/simdvec/native/src/vec/headers/darwin/tinystd/algorithm
+++ b/libs/simdvec/native/src/vec/headers/darwin/tinystd/algorithm
@@ -1,0 +1,29 @@
+
+#ifndef STD_ALGORITHM_H
+#define STD_ALGORITHM_H
+
+namespace std {
+
+template<class T>
+const T& min(const T& a, const T& b)
+{
+    return (b < a) ? b : a;
+}
+
+template<class InputIt, class Size, class OutputIt>
+constexpr OutputIt copy_n(InputIt first, Size count, OutputIt result)
+{
+    if (count > 0)
+    {
+        *result = *first;
+        ++result;
+        for (Size i = 1; i != count; ++i, (void)++result)
+            *result = *++first;
+    }
+
+    return result;
+}
+
+}
+
+#endif //STD_ALGORITHM_H

--- a/libs/simdvec/native/src/vec/headers/darwin/tinystd/limits
+++ b/libs/simdvec/native/src/vec/headers/darwin/tinystd/limits
@@ -1,0 +1,17 @@
+#ifndef STD_LIMITS_H
+#define STD_LIMITS_H
+
+namespace std {
+
+template<typename T>
+class numeric_limits {};
+
+template<>
+class numeric_limits<float> {
+public:
+    static constexpr float infinity() noexcept { return __builtin_huge_valf(); }
+};
+
+}
+
+#endif //STD_LIMITS_H

--- a/libs/simdvec/native/src/vec/headers/darwin/tinystd/type_traits
+++ b/libs/simdvec/native/src/vec/headers/darwin/tinystd/type_traits
@@ -1,0 +1,27 @@
+#ifndef STD_TYPE_TRAITS_H
+#define STD_TYPE_TRAITS_H
+
+namespace std {
+
+template <typename T, T v>
+struct integral_constant {
+    static constexpr T value = v;
+    using value_type = T;
+    using type = integral_constant;
+
+    constexpr operator value_type() const noexcept {
+        return value;
+    }
+
+    constexpr value_type operator()() const noexcept {
+        return value;
+    }
+};
+
+template<typename T> struct remove_reference      { using type = T; };
+template<typename T> struct remove_reference<T&>  { using type = T; };
+template<typename T> struct remove_reference<T&&> { using type = T; };
+
+}
+
+#endif //STD_TYPE_TRAITS_H

--- a/libs/simdvec/native/src/vec/headers/darwin/tinystd/utility
+++ b/libs/simdvec/native/src/vec/headers/darwin/tinystd/utility
@@ -1,0 +1,20 @@
+#ifndef STD_UTILITY_H
+#define STD_UTILITY_H
+
+#include <type_traits>
+
+namespace std {
+
+template<typename T>
+constexpr T&& forward(typename remove_reference<T>::type& t) noexcept {
+    return static_cast<T&&>(t);
+}
+
+template<typename T>
+constexpr T&& forward(typename remove_reference<T>::type&& t) noexcept {
+    return static_cast<T&&>(t);
+}
+
+}
+
+#endif //STD_UTILITY_H

--- a/libs/simdvec/native/src/vec/headers/score_common.h
+++ b/libs/simdvec/native/src/vec/headers/score_common.h
@@ -44,7 +44,7 @@ static inline f32_t apply_corrections_euclidean_inner(
     // For euclidean, we need to invert the score and apply the additional correction, which is
     // assumed to be the squared l2norm of the centroid centered vectors.
     score = queryAdditionalCorrection + additionalCorrection - 2 * score;
-    return fmax(1.0f / (1.0f + score), 0.0f);
+    return __builtin_fmaxf(1.0f / (1.0f + score), 0.0f);
 }
 
 static inline f32_t apply_corrections_maximum_inner_product_inner(
@@ -104,7 +104,7 @@ static inline f32_t apply_corrections_dot_product_inner(
     // For dot product we need to apply the additional correction, which is
     // assumed to be the non-centered dot-product between the vector and the centroid
     score += queryAdditionalCorrection + additionalCorrection - centroidDp;
-    return fmax((1.0f + score) / 2.0f, 0.0f);
+    return __builtin_fmaxf((1.0f + score) / 2.0f, 0.0f);
 }
 
 #endif //SCORE_COMMON_H

--- a/libs/simdvec/native/src/vec/headers/vec.h
+++ b/libs/simdvec/native/src/vec/headers/vec.h
@@ -35,7 +35,7 @@
         static_assert(sizeof(float) == 4, "Unsupported compiler. Please define f32_t to designate a 32-bit float.");
         #define f32_t float
 
-        #include <cstdint>
+        #include <stdint.h>
         // use uint16 as something that is guaranteed to be 16 bits wide
         // we'll need to cast to a float type to do scalar ops on it
         static_assert(sizeof(uint16_t) == 2, "Unsupported compiler. Please define bf16_t to designate a 16-bit bfloat.");

--- a/libs/simdvec/native/src/vec/headers/vec_common.h
+++ b/libs/simdvec/native/src/vec/headers/vec_common.h
@@ -3,19 +3,16 @@
 #define VEC_COMMON_H
 
 #include <stdint.h>
-#include <assert.h>
 #include <type_traits>
 #include <utility>
 
 template <uintptr_t align>
 static inline uintptr_t align_downwards(const void* ptr) {
     static_assert(align > 0 && (align & (align - 1)) == 0, "Align must be a power of 2");
-    assert(ptr != 0);
 
     uintptr_t addr = (uintptr_t)ptr;
     // Round down to align-byte boundary
     addr &= -align;
-    assert(addr <= (uintptr_t)ptr);
     return addr;
 }
 


### PR DESCRIPTION
## Summary

- Introduce minimal C++ standard library headers (`tinystd/`) for Darwin cross-compilation, eliminating the dependency on the macOS SDK's libc++ headers
- Replace explicit libc function calls with compiler builtins: `fmax()` → `__builtin_fmaxf()`, `sqrt()` → `__builtin_sqrt()`
- Remove unused `#include <math.h>`, `<assert.h>`, `<stdio.h>`, `<TargetConditionals.h>` from all source files
- Update `build.gradle` to use `-nostdinc` + tinystd for Darwin/clang builds

### Why?

The Darwin build currently depends on the macOS SDK for C/C++ standard library headers. This is a problem for the cross-compilation Docker pipeline (#144845), where including the proprietary SDK in a public image has licensing concerns. By providing our own minimal headers for the C++ stdlib features we actually use, we can compile for Darwin without any SDK.

The tinystd headers compile to identical machine code as the real standard library (verified with `objdump --disassemble`). Linux builds are unaffected — they continue to use the real libstdc++.

### Source code improvements

- `fmax()` → `__builtin_fmaxf()` — fixes a subtle bug where the `double` variant caused unnecessary `fcvt` float↔double conversions on ARM
- `sqrt()` → `__builtin_sqrt()` — explicit builtin, doesn't rely on optimizer to inline
- `<cstdint>` → `<stdint.h>` in `vec.h` — freestanding header, no C++ wrapper needed
- Removed 2 runtime `assert()` calls and `<assert.h>` from `vec_common.h`

## Test plan

- [x] `./gradlew vecAarch64SharedLibrary` builds on macOS with tinystd (no SDK headers)
- [x] All `JDKVectorLibrary*` tests pass on macOS with the locally built library
- [x] Verified on `native/docker-cross-compile` branch: all 3 platforms (darwin-aarch64, linux-aarch64, linux-x64) build and pass tests
- [x] Codegen verified identical to SDK-built version via `objdump`

Prerequisite for #144845 (cross-compilation pipeline).