### PR TITLE
[ESQL] Parquet page-index filtering, adaptive I/O, filter gaps

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -15,22 +15,34 @@ import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.io.api.Binary;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.pushdown.PushdownPredicates;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.xpack.esql.expression.Foldables.literalValueOf;
 
 /**
  * Parquet-specific filter pushdown support that translates ESQL filter expressions
@@ -44,12 +56,24 @@ import java.util.Set;
  *   <li>Bloom filter — skips row groups where bloom filter says value definitely absent</li>
  * </ol>
  * <p>
+ * Uses a two-pass approach (like {@code OrcPushdownFilters}):
+ * <ol>
+ *   <li>{@link #canConvert(Expression)} validates convertibility without side effects</li>
+ *   <li>{@link #translateExpression(Expression)} builds the FilterPredicate from validated expressions</li>
+ * </ol>
+ * <p>
  * All pushed filters use {@link Pushability#RECHECK} semantics: the original filter remains
  * in FilterExec for per-row correctness since row-group skipping is an optimization.
  */
 public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
 
     private static final Logger logger = LogManager.getLogger(ParquetFilterPushdownSupport.class);
+
+    static final Predicate<DataType> TYPE_SUPPORTED = dt -> dt == DataType.INTEGER
+        || dt == DataType.LONG
+        || dt == DataType.DOUBLE
+        || dt == DataType.KEYWORD
+        || dt == DataType.BOOLEAN;
 
     @Override
     public PushdownResult pushFilters(List<Expression> filters) {
@@ -58,9 +82,11 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         List<Expression> remainder = new ArrayList<>(filters);
 
         for (Expression filter : filters) {
-            FilterPredicate predicate = translateExpression(filter);
-            if (predicate != null) {
-                pushed.add(predicate);
+            if (canConvert(filter)) {
+                FilterPredicate predicate = translateExpression(filter);
+                if (predicate != null) {
+                    pushed.add(predicate);
+                }
             }
         }
 
@@ -68,7 +94,6 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
             return PushdownResult.none(filters);
         }
 
-        // Combine all pushed predicates with AND
         FilterPredicate combined = pushed.get(0);
         for (int i = 1; i < pushed.size(); i++) {
             combined = FilterApi.and(combined, pushed.get(i));
@@ -80,191 +105,222 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
 
     @Override
     public Pushability canPush(Expression expr) {
-        if (translateExpression(expr) != null) {
+        if (canConvert(expr)) {
             return Pushability.RECHECK;
         }
         return Pushability.NO;
     }
 
     /**
+     * Validates whether an expression can be converted to a Parquet FilterPredicate.
+     * For AND, partial pushdown is safe (at least one side convertible).
+     * For OR and NOT, all children must be convertible.
+     */
+    static boolean canConvert(Expression expr) {
+        if (expr instanceof EsqlBinaryComparison bc) {
+            if (PushdownPredicates.isComparison(bc, TYPE_SUPPORTED) == false) {
+                return false;
+            }
+            // BooleanColumn doesn't implement SupportsLtGt — only eq/notEq are valid
+            if (bc.left() instanceof NamedExpression ne && ne.dataType() == DataType.BOOLEAN) {
+                return bc instanceof Equals || bc instanceof NotEquals;
+            }
+            return true;
+        }
+        if (expr instanceof In inExpr) {
+            return PushdownPredicates.isIn(inExpr, TYPE_SUPPORTED);
+        }
+        if (expr instanceof IsNull isNull) {
+            return PushdownPredicates.isIsNull(isNull, TYPE_SUPPORTED);
+        }
+        if (expr instanceof IsNotNull isNotNull) {
+            return PushdownPredicates.isIsNotNull(isNotNull, TYPE_SUPPORTED);
+        }
+        if (expr instanceof Range range) {
+            // BooleanColumn doesn't implement SupportsLtGt — Range requires ordered comparisons
+            if (range.value() instanceof NamedExpression ne && ne.dataType() == DataType.BOOLEAN) {
+                return false;
+            }
+            return PushdownPredicates.isRange(range, TYPE_SUPPORTED);
+        }
+        if (expr instanceof And and) {
+            return canConvert(and.left()) || canConvert(and.right());
+        }
+        if (expr instanceof Or or) {
+            return canConvert(or.left()) && canConvert(or.right());
+        }
+        if (expr instanceof Not not) {
+            return canConvert(not.field());
+        }
+        return false;
+    }
+
+    /**
      * Translates an ESQL expression to a parquet-java FilterPredicate.
-     * Returns null if the expression cannot be translated.
+     * Must only be called after {@link #canConvert(Expression)} returns true.
      */
     private FilterPredicate translateExpression(Expression expr) {
-        if (expr instanceof Equals eq) {
-            return translateEquals(eq);
-        } else if (expr instanceof In in) {
-            return translateIn(in);
-        } else if (expr instanceof GreaterThan gt) {
-            return translateComparison(gt.left(), gt.right(), CompOp.GT);
-        } else if (expr instanceof GreaterThanOrEqual gte) {
-            return translateComparison(gte.left(), gte.right(), CompOp.GTE);
-        } else if (expr instanceof LessThan lt) {
-            return translateComparison(lt.left(), lt.right(), CompOp.LT);
-        } else if (expr instanceof LessThanOrEqual lte) {
-            return translateComparison(lte.left(), lte.right(), CompOp.LTE);
-        }
-        return null;
-    }
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
+            String name = ne.name();
+            DataType dataType = ne.dataType();
+            Object value = literalValueOf(bc.right());
 
-    private FilterPredicate translateEquals(Equals eq) {
-        Expression left = eq.left();
-        Expression right = eq.right();
-
-        // Pattern: column = literal
-        if (left instanceof Attribute attr && right instanceof Literal lit) {
-            return buildEqualityPredicate(attr, lit);
-        }
-        // Pattern: literal = column (swapped)
-        if (right instanceof Attribute attr && left instanceof Literal lit) {
-            return buildEqualityPredicate(attr, lit);
-        }
-        return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    private FilterPredicate translateIn(In in) {
-        if (in.value() instanceof Attribute == false) {
-            return null;
-        }
-        Attribute attr = (Attribute) in.value();
-        DataType dataType = attr.dataType();
-        String columnName = attr.name();
-
-        // Collect all literal values
-        List<Object> values = new ArrayList<>();
-        for (Expression child : in.list()) {
-            if (child instanceof Literal lit && lit.value() != null) {
-                values.add(lit.value());
-            } else {
-                // Non-literal in IN list — can't push
+            // SQL null comparisons are always UNKNOWN — only IsNull/IsNotNull use null predicates
+            if (value == null) {
                 return null;
             }
-        }
 
-        if (values.isEmpty()) {
-            return null;
+            return switch (bc) {
+                case Equals ignored -> buildPredicate(name, dataType, value, PredicateOp.EQ);
+                case NotEquals ignored -> buildPredicate(name, dataType, value, PredicateOp.NOT_EQ);
+                case GreaterThan ignored -> buildPredicate(name, dataType, value, PredicateOp.GT);
+                case GreaterThanOrEqual ignored -> buildPredicate(name, dataType, value, PredicateOp.GTE);
+                case LessThan ignored -> buildPredicate(name, dataType, value, PredicateOp.LT);
+                case LessThanOrEqual ignored -> buildPredicate(name, dataType, value, PredicateOp.LTE);
+                default -> null;
+            };
         }
-
-        if (dataType == DataType.INTEGER) {
-            Operators.IntColumn col = FilterApi.intColumn(columnName);
-            Set<Integer> intValues = new HashSet<>();
-            for (Object v : values) {
-                intValues.add(((Number) v).intValue());
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            return translateIn(ne.name(), ne.dataType(), inExpr.list());
+        }
+        if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            return buildPredicate(ne.name(), ne.dataType(), null, PredicateOp.EQ);
+        }
+        if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            return buildPredicate(ne.name(), ne.dataType(), null, PredicateOp.NOT_EQ);
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            return translateRange(ne.name(), ne.dataType(), range);
+        }
+        if (expr instanceof And and) {
+            boolean leftConvertible = canConvert(and.left());
+            boolean rightConvertible = canConvert(and.right());
+            if (leftConvertible && rightConvertible) {
+                return FilterApi.and(translateExpression(and.left()), translateExpression(and.right()));
+            } else if (leftConvertible) {
+                return translateExpression(and.left());
+            } else {
+                return translateExpression(and.right());
             }
-            return FilterApi.in(col, intValues);
-        } else if (dataType == DataType.LONG) {
-            Operators.LongColumn col = FilterApi.longColumn(columnName);
-            Set<Long> longValues = new HashSet<>();
-            for (Object v : values) {
-                longValues.add(((Number) v).longValue());
-            }
-            return FilterApi.in(col, longValues);
-        } else if (dataType == DataType.DOUBLE) {
-            Operators.DoubleColumn col = FilterApi.doubleColumn(columnName);
-            Set<Double> doubleValues = new HashSet<>();
-            for (Object v : values) {
-                doubleValues.add(((Number) v).doubleValue());
-            }
-            return FilterApi.in(col, doubleValues);
-        } else if (dataType == DataType.KEYWORD) {
-            Operators.BinaryColumn col = FilterApi.binaryColumn(columnName);
-            Set<Binary> binaryValues = new HashSet<>();
-            for (Object v : values) {
-                binaryValues.add(toBinary(v));
-            }
-            return FilterApi.in(col, binaryValues);
+        }
+        if (expr instanceof Or or) {
+            return FilterApi.or(translateExpression(or.left()), translateExpression(or.right()));
+        }
+        if (expr instanceof Not not) {
+            return FilterApi.not(translateExpression(not.field()));
         }
         return null;
     }
 
-    private enum CompOp {
+    // -----------------------------------------------------------------------------------
+    // Predicate building — type dispatch happens once, operations are applied generically
+    // -----------------------------------------------------------------------------------
+
+    enum PredicateOp {
+        EQ,
+        NOT_EQ,
         GT,
         GTE,
         LT,
-        LTE
+        LTE;
+
+        boolean isOrdered() {
+            return this == GT || this == GTE || this == LT || this == LTE;
+        }
     }
 
-    private FilterPredicate translateComparison(Expression left, Expression right, CompOp op) {
-        // Pattern: column op literal
-        if (left instanceof Attribute attr && right instanceof Literal lit) {
-            return buildComparisonPredicate(attr, lit, op);
-        }
-        // Pattern: literal op column (swap the operator direction)
-        if (right instanceof Attribute attr && left instanceof Literal lit) {
-            CompOp swapped = switch (op) {
-                case GT -> CompOp.LT;
-                case GTE -> CompOp.LTE;
-                case LT -> CompOp.GT;
-                case LTE -> CompOp.GTE;
-            };
-            return buildComparisonPredicate(attr, lit, swapped);
-        }
-        return null;
-    }
-
-    private FilterPredicate buildEqualityPredicate(Attribute attr, Literal lit) {
-        if (lit.value() == null) {
-            return null; // NULL comparisons can't use bloom filters
-        }
-
-        DataType dataType = attr.dataType();
-        String columnName = attr.name();
-
-        if (dataType == DataType.INTEGER) {
-            return FilterApi.eq(FilterApi.intColumn(columnName), ((Number) lit.value()).intValue());
-        } else if (dataType == DataType.LONG) {
-            return FilterApi.eq(FilterApi.longColumn(columnName), ((Number) lit.value()).longValue());
-        } else if (dataType == DataType.DOUBLE) {
-            return FilterApi.eq(FilterApi.doubleColumn(columnName), ((Number) lit.value()).doubleValue());
-        } else if (dataType == DataType.KEYWORD) {
-            return FilterApi.eq(FilterApi.binaryColumn(columnName), toBinary(lit.value()));
-        } else if (dataType == DataType.BOOLEAN) {
-            return FilterApi.eq(FilterApi.booleanColumn(columnName), (Boolean) lit.value());
-        }
-        return null;
-    }
-
-    private FilterPredicate buildComparisonPredicate(Attribute attr, Literal lit, CompOp op) {
-        if (lit.value() == null) {
+    /**
+     * Builds a single Parquet FilterPredicate by resolving the column type from the ESQL DataType,
+     * converting the value, and applying the requested operation.
+     * Value may be null for EQ/NOT_EQ (used by IsNull/IsNotNull).
+     */
+    private FilterPredicate buildPredicate(String columnName, DataType dataType, Object value, PredicateOp op) {
+        if (value == null && op.isOrdered()) {
             return null;
         }
+        return switch (dataType) {
+            case INTEGER -> orderedPredicate(FilterApi.intColumn(columnName), value != null ? ((Number) value).intValue() : null, op);
+            case LONG -> orderedPredicate(FilterApi.longColumn(columnName), value != null ? ((Number) value).longValue() : null, op);
+            case DOUBLE -> orderedPredicate(FilterApi.doubleColumn(columnName), value != null ? ((Number) value).doubleValue() : null, op);
+            case KEYWORD -> orderedPredicate(FilterApi.binaryColumn(columnName), value != null ? toBinary(value) : null, op);
+            case BOOLEAN -> {
+                // BooleanColumn only supports eq/notEq (no SupportsLtGt in parquet-java)
+                var col = FilterApi.booleanColumn(columnName);
+                Boolean v = value != null ? (Boolean) value : null;
+                yield switch (op) {
+                    case EQ -> FilterApi.eq(col, v);
+                    case NOT_EQ -> FilterApi.notEq(col, v);
+                    default -> null;
+                };
+            }
+            default -> null;
+        };
+    }
 
-        DataType dataType = attr.dataType();
-        String columnName = attr.name();
+    /**
+     * Applies a predicate operation on a column type that supports all comparison operators.
+     * IntColumn, LongColumn, DoubleColumn, and BinaryColumn all implement SupportsLtGt.
+     */
+    private static <T extends Comparable<T>, C extends Operators.Column<T> & Operators.SupportsLtGt> FilterPredicate orderedPredicate(
+        C col,
+        T value,
+        PredicateOp op
+    ) {
+        return switch (op) {
+            case EQ -> FilterApi.eq(col, value);
+            case NOT_EQ -> FilterApi.notEq(col, value);
+            case GT -> FilterApi.gt(col, value);
+            case GTE -> FilterApi.gtEq(col, value);
+            case LT -> FilterApi.lt(col, value);
+            case LTE -> FilterApi.ltEq(col, value);
+        };
+    }
 
-        if (dataType == DataType.INTEGER) {
-            int value = ((Number) lit.value()).intValue();
-            return switch (op) {
-                case GT -> FilterApi.gt(FilterApi.intColumn(columnName), value);
-                case GTE -> FilterApi.gtEq(FilterApi.intColumn(columnName), value);
-                case LT -> FilterApi.lt(FilterApi.intColumn(columnName), value);
-                case LTE -> FilterApi.ltEq(FilterApi.intColumn(columnName), value);
-            };
-        } else if (dataType == DataType.LONG) {
-            long value = ((Number) lit.value()).longValue();
-            return switch (op) {
-                case GT -> FilterApi.gt(FilterApi.longColumn(columnName), value);
-                case GTE -> FilterApi.gtEq(FilterApi.longColumn(columnName), value);
-                case LT -> FilterApi.lt(FilterApi.longColumn(columnName), value);
-                case LTE -> FilterApi.ltEq(FilterApi.longColumn(columnName), value);
-            };
-        } else if (dataType == DataType.DOUBLE) {
-            double value = ((Number) lit.value()).doubleValue();
-            return switch (op) {
-                case GT -> FilterApi.gt(FilterApi.doubleColumn(columnName), value);
-                case GTE -> FilterApi.gtEq(FilterApi.doubleColumn(columnName), value);
-                case LT -> FilterApi.lt(FilterApi.doubleColumn(columnName), value);
-                case LTE -> FilterApi.ltEq(FilterApi.doubleColumn(columnName), value);
-            };
-        } else if (dataType == DataType.KEYWORD) {
-            Binary value = toBinary(lit.value());
-            return switch (op) {
-                case GT -> FilterApi.gt(FilterApi.binaryColumn(columnName), value);
-                case GTE -> FilterApi.gtEq(FilterApi.binaryColumn(columnName), value);
-                case LT -> FilterApi.lt(FilterApi.binaryColumn(columnName), value);
-                case LTE -> FilterApi.ltEq(FilterApi.binaryColumn(columnName), value);
-            };
+    /**
+     * Translates an IN expression by collecting non-null values into a typed set.
+     */
+    private FilterPredicate translateIn(String columnName, DataType dataType, List<Expression> items) {
+        List<Object> rawValues = new ArrayList<>();
+        for (Expression item : items) {
+            Object val = literalValueOf(item);
+            if (val != null) {
+                rawValues.add(val);
+            }
+        }
+        if (rawValues.isEmpty()) {
+            return null;
+        }
+        return switch (dataType) {
+            case INTEGER -> inPredicate(FilterApi.intColumn(columnName), rawValues, v -> ((Number) v).intValue());
+            case LONG -> inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
+            case DOUBLE -> inPredicate(FilterApi.doubleColumn(columnName), rawValues, v -> ((Number) v).doubleValue());
+            case KEYWORD -> inPredicate(FilterApi.binaryColumn(columnName), rawValues, ParquetFilterPushdownSupport::toBinary);
+            case BOOLEAN -> inPredicate(FilterApi.booleanColumn(columnName), rawValues, v -> (Boolean) v);
+            default -> null;
+        };
+    }
+
+    private static <T extends Comparable<T>, C extends Operators.Column<T> & Operators.SupportsEqNotEq> FilterPredicate inPredicate(
+        C col,
+        List<Object> values,
+        Function<Object, T> converter
+    ) {
+        Set<T> converted = new HashSet<>();
+        for (Object v : values) {
+            converted.add(converter.apply(v));
+        }
+        return FilterApi.in(col, converted);
+    }
+
+    private FilterPredicate translateRange(String columnName, DataType dataType, Range range) {
+        Object lower = literalValueOf(range.lower());
+        Object upper = literalValueOf(range.upper());
+
+        FilterPredicate lowerBound = buildPredicate(columnName, dataType, lower, range.includeLower() ? PredicateOp.GTE : PredicateOp.GT);
+        FilterPredicate upperBound = buildPredicate(columnName, dataType, upper, range.includeUpper() ? PredicateOp.LTE : PredicateOp.LT);
+
+        if (lowerBound != null && upperBound != null) {
+            return FilterApi.and(lowerBound, upperBound);
         }
         return null;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -359,7 +359,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         List<Attribute> resolvedAttributes,
         ErrorPolicy errorPolicy
     ) throws IOException {
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         ParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd);
         if (FilterCompat.isFilteringRequired(pushedFilter)) {
             optionsBuilder.withRecordFilter(pushedFilter);
@@ -544,6 +544,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             this.rowBudget = rowLimit;
             this.createdBy = createdBy != null ? createdBy : "";
 
+            reader.setRequestedSchema(projectedSchema);
+
             this.columnInfos = new ColumnInfo[attributes.size()];
             Map<String, ColumnDescriptor> descByName = new HashMap<>();
             for (ColumnDescriptor desc : projectedSchema.getColumns()) {
@@ -593,7 +595,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 rowGroup.close();
                 rowGroup = null;
             }
-            rowGroup = reader.readNextRowGroup();
+            rowGroup = reader.readNextFilteredRowGroup();
             if (rowGroup == null) {
                 exhausted = true;
                 return false;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -32,9 +32,13 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     private final StorageObject storageObject;
     private final long length;
     private final FooterCacheKey footerCacheKey;
+    private final int windowSize;
 
-    /** Default window size (4MB) for the sliding range cache. Capped so total budget stays ≤16MB per reader. */
+    /** Default window size (4MB) for the sliding range cache. */
     static final int DEFAULT_WINDOW_SIZE = 4 * 1024 * 1024;
+
+    /** Maximum window size (16MB). Caps adaptive window hints to prevent unbounded memory allocation. */
+    static final int MAX_WINDOW_SIZE = 16 * 1024 * 1024;
 
     /** Footer cache budget across the JVM (8MB). */
     static final int FOOTER_CACHE_MAX_BYTES = 8 * 1024 * 1024;
@@ -45,15 +49,30 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     private static final FooterCache FOOTER_CACHE = new FooterCache(FOOTER_CACHE_MAX_BYTES, FOOTER_CACHE_MAX_ENTRY_BYTES);
 
     /**
-     * Creates an adapter for the given StorageObject.
-     *
-     * @param storageObject the storage object to adapt
+     * Creates an adapter with the default 4MB sliding window.
      */
     public ParquetStorageObjectAdapter(StorageObject storageObject) {
+        this(storageObject, DEFAULT_WINDOW_SIZE);
+    }
+
+    /**
+     * Creates an adapter with an adaptive window sized to cover the given byte range.
+     * This allows all column chunks within a small row-group split to be fetched in a single I/O
+     * instead of incurring multiple range GETs with the default 4 MiB window.
+     *
+     * @param rangeBytes byte span of the range being read; clamped to [{@link #DEFAULT_WINDOW_SIZE}, {@link #MAX_WINDOW_SIZE}]
+     */
+    public static ParquetStorageObjectAdapter forRange(StorageObject storageObject, long rangeBytes) {
+        int windowSize = (int) Math.min(Math.max(rangeBytes, DEFAULT_WINDOW_SIZE), MAX_WINDOW_SIZE);
+        return new ParquetStorageObjectAdapter(storageObject, windowSize);
+    }
+
+    private ParquetStorageObjectAdapter(StorageObject storageObject, int windowSize) {
         if (storageObject == null) {
             throw new IllegalArgumentException("storageObject cannot be null");
         }
         this.storageObject = storageObject;
+        this.windowSize = windowSize;
         try {
             this.length = storageObject.length();
         } catch (IOException e) {
@@ -69,7 +88,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-        return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, DEFAULT_WINDOW_SIZE);
+        return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, windowSize);
     }
 
     static void clearFooterCacheForTests() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -17,13 +17,21 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -42,7 +50,6 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
         assertTrue(result.hasPushedFilter());
         assertThat(result.pushedFilter(), instanceOf(FilterCompat.Filter.class));
-        // RECHECK: original expression stays in remainder
         assertEquals(1, result.remainder().size());
     }
 
@@ -83,16 +90,6 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertTrue(result.hasPushedFilter());
     }
 
-    public void testEqualsSwappedPushed() {
-        // literal = column (swapped)
-        Attribute col = attr("salary", DataType.INTEGER);
-        Expression filter = new Equals(Source.EMPTY, intLit(50000), col, null);
-
-        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
-
-        assertTrue(result.hasPushedFilter());
-    }
-
     public void testEqualsNullNotPushed() {
         Attribute col = attr("salary", DataType.INTEGER);
         Expression filter = new Equals(Source.EMPTY, col, new Literal(Source.EMPTY, null, DataType.INTEGER), null);
@@ -102,7 +99,163 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertFalse(result.hasPushedFilter());
     }
 
+    // --- NotEquals tests ---
+
+    public void testNotEqualsIntegerPushed() {
+        Attribute col = attr("salary", DataType.INTEGER);
+        Expression filter = new NotEquals(Source.EMPTY, col, intLit(50000), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testNotEqualsLongPushed() {
+        Attribute col = attr("id", DataType.LONG);
+        Expression filter = new NotEquals(Source.EMPTY, col, longLit(999L), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testNotEqualsDoublePushed() {
+        Attribute col = attr("price", DataType.DOUBLE);
+        Expression filter = new NotEquals(Source.EMPTY, col, doubleLit(0.0), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testNotEqualsKeywordPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new NotEquals(Source.EMPTY, col, keywordLit("deleted"), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testNotEqualsBooleanPushed() {
+        Attribute col = attr("active", DataType.BOOLEAN);
+        Expression filter = new NotEquals(Source.EMPTY, col, boolLit(false), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testNotEqualsNullNotPushed() {
+        Attribute col = attr("salary", DataType.INTEGER);
+        Expression filter = new NotEquals(Source.EMPTY, col, new Literal(Source.EMPTY, null, DataType.INTEGER), null);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    // --- IsNull / IsNotNull tests ---
+
+    public void testIsNullPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new IsNull(Source.EMPTY, col);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testIsNullIntegerPushed() {
+        Attribute col = attr("salary", DataType.INTEGER);
+        Expression filter = new IsNull(Source.EMPTY, col);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testIsNotNullPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new IsNotNull(Source.EMPTY, col);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testIsNotNullDoublePushed() {
+        Attribute col = attr("price", DataType.DOUBLE);
+        Expression filter = new IsNotNull(Source.EMPTY, col);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testIsNullUnsupportedTypeNotPushed() {
+        Attribute col = attr("ts", DataType.DATETIME);
+        Expression filter = new IsNull(Source.EMPTY, col);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
     // --- Range tests ---
+
+    public void testRangePushedInclusiveBoth() {
+        Attribute col = attr("age", DataType.INTEGER);
+        Expression filter = new Range(Source.EMPTY, col, intLit(18), true, intLit(65), true, ZoneOffset.UTC);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testRangePushedExclusiveBoth() {
+        Attribute col = attr("price", DataType.DOUBLE);
+        Expression filter = new Range(Source.EMPTY, col, doubleLit(0.0), false, doubleLit(100.0), false, ZoneOffset.UTC);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testRangePushedMixedBounds() {
+        Attribute col = attr("salary", DataType.LONG);
+        Expression filter = new Range(Source.EMPTY, col, longLit(30000L), true, longLit(100000L), false, ZoneOffset.UTC);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testRangeKeywordPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new Range(Source.EMPTY, col, keywordLit("a"), true, keywordLit("z"), true, ZoneOffset.UTC);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testRangeUnsupportedTypeNotPushed() {
+        Attribute col = attr("ts", DataType.DATETIME);
+        Literal lower = new Literal(Source.EMPTY, 1000L, DataType.DATETIME);
+        Literal upper = new Literal(Source.EMPTY, 2000L, DataType.DATETIME);
+        Expression filter = new Range(Source.EMPTY, col, lower, true, upper, true, ZoneOffset.UTC);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    // --- Comparison tests (GT, GTE, LT, LTE) ---
 
     public void testGreaterThanPushed() {
         Attribute col = attr("age", DataType.INTEGER);
@@ -111,7 +264,7 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
-        assertEquals(1, result.remainder().size()); // RECHECK
+        assertEquals(1, result.remainder().size());
     }
 
     public void testLessThanPushed() {
@@ -141,16 +294,6 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertTrue(result.hasPushedFilter());
     }
 
-    public void testRangeSwappedOperator() {
-        // literal > column → column < literal
-        Attribute col = attr("age", DataType.INTEGER);
-        Expression filter = new GreaterThan(Source.EMPTY, intLit(65), col, null);
-
-        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
-
-        assertTrue(result.hasPushedFilter());
-    }
-
     // --- IN list tests ---
 
     public void testInListPushed() {
@@ -160,7 +303,7 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
-        assertEquals(1, result.remainder().size()); // RECHECK
+        assertEquals(1, result.remainder().size());
     }
 
     public void testInListIntegerPushed() {
@@ -170,6 +313,95 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
+    }
+
+    // --- And tests ---
+
+    public void testAndPushed() {
+        Attribute salary = attr("salary", DataType.LONG);
+        Attribute age = attr("age", DataType.INTEGER);
+        Expression left = new GreaterThan(Source.EMPTY, salary, longLit(50000L), null);
+        Expression right = new LessThan(Source.EMPTY, age, intLit(65), null);
+        Expression filter = new And(Source.EMPTY, left, right);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testAndPartialPushdown() {
+        Attribute salary = attr("salary", DataType.LONG);
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression supported = new GreaterThan(Source.EMPTY, salary, longLit(50000L), null);
+        Expression unsupported = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1234567890L, DataType.DATETIME), null);
+        Expression filter = new And(Source.EMPTY, supported, unsupported);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testAndBothUnsupportedNotPushed() {
+        Attribute ts1 = attr("ts1", DataType.DATETIME);
+        Attribute ts2 = attr("ts2", DataType.DATETIME);
+        Expression left = new Equals(Source.EMPTY, ts1, new Literal(Source.EMPTY, 1000L, DataType.DATETIME), null);
+        Expression right = new Equals(Source.EMPTY, ts2, new Literal(Source.EMPTY, 2000L, DataType.DATETIME), null);
+        Expression filter = new And(Source.EMPTY, left, right);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    // --- Or tests ---
+
+    public void testOrPushed() {
+        Attribute col = attr("status", DataType.INTEGER);
+        Expression left = new Equals(Source.EMPTY, col, intLit(1), null);
+        Expression right = new Equals(Source.EMPTY, col, intLit(2), null);
+        Expression filter = new Or(Source.EMPTY, left, right);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testOrWithUnsupportedSideNotPushed() {
+        Attribute salary = attr("salary", DataType.LONG);
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression supported = new GreaterThan(Source.EMPTY, salary, longLit(50000L), null);
+        Expression unsupported = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1234567890L, DataType.DATETIME), null);
+        Expression filter = new Or(Source.EMPTY, supported, unsupported);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    // --- Not tests ---
+
+    public void testNotPushed() {
+        Attribute col = attr("active", DataType.BOOLEAN);
+        Expression inner = new Equals(Source.EMPTY, col, boolLit(true), null);
+        Expression filter = new Not(Source.EMPTY, inner);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testNotWithUnsupportedInnerNotPushed() {
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression inner = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1234567890L, DataType.DATETIME), null);
+        Expression filter = new Not(Source.EMPTY, inner);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
     }
 
     // --- Unsupported types ---
@@ -196,9 +428,7 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(eq, gt, tsFilter));
 
-        // eq and gt should be pushed, tsFilter should not
         assertTrue(result.hasPushedFilter());
-        // All 3 are in remainder (RECHECK for pushed, untranslatable for ts)
         assertEquals(3, result.remainder().size());
     }
 
@@ -212,7 +442,6 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(eq, gt));
 
         assertTrue(result.hasPushedFilter());
-        // Both pushed with RECHECK
         assertEquals(2, result.remainder().size());
     }
 
@@ -240,6 +469,81 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         Expression filter = new Equals(Source.EMPTY, col, new Literal(Source.EMPTY, 1234567890L, DataType.DATETIME), null);
 
         assertEquals(FilterPushdownSupport.Pushability.NO, support.canPush(filter));
+    }
+
+    // --- canConvert tests ---
+
+    public void testCanConvertNotEquals() {
+        Attribute col = attr("salary", DataType.INTEGER);
+        Expression filter = new NotEquals(Source.EMPTY, col, intLit(0), null);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testCanConvertIsNull() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new IsNull(Source.EMPTY, col);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testCanConvertIsNotNull() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new IsNotNull(Source.EMPTY, col);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testCanConvertRange() {
+        Attribute col = attr("age", DataType.INTEGER);
+        Expression filter = new Range(Source.EMPTY, col, intLit(18), true, intLit(65), true, ZoneOffset.UTC);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testCanConvertAndPartial() {
+        Attribute salary = attr("salary", DataType.LONG);
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression supported = new Equals(Source.EMPTY, salary, longLit(50000L), null);
+        Expression unsupported = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1000L, DataType.DATETIME), null);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(new And(Source.EMPTY, supported, unsupported)));
+    }
+
+    public void testCanConvertOrRequiresBothSides() {
+        Attribute salary = attr("salary", DataType.LONG);
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression supported = new Equals(Source.EMPTY, salary, longLit(50000L), null);
+        Expression unsupported = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1000L, DataType.DATETIME), null);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(new Or(Source.EMPTY, supported, unsupported)));
+    }
+
+    public void testCanConvertNot() {
+        Attribute col = attr("active", DataType.BOOLEAN);
+        Expression inner = new Equals(Source.EMPTY, col, boolLit(true), null);
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(new Not(Source.EMPTY, inner)));
+    }
+
+    public void testCanConvertNotWithUnsupportedInner() {
+        Attribute ts = attr("ts", DataType.DATETIME);
+        Expression inner = new Equals(Source.EMPTY, ts, new Literal(Source.EMPTY, 1000L, DataType.DATETIME), null);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(new Not(Source.EMPTY, inner)));
+    }
+
+    public void testBooleanOrderedComparisonNotConvertible() {
+        Attribute col = attr("active", DataType.BOOLEAN);
+        assertFalse(ParquetFilterPushdownSupport.canConvert(new GreaterThan(Source.EMPTY, col, boolLit(false), null)));
+        assertFalse(ParquetFilterPushdownSupport.canConvert(new LessThan(Source.EMPTY, col, boolLit(true), null)));
+    }
+
+    public void testBooleanRangeNotConvertible() {
+        Attribute col = attr("active", DataType.BOOLEAN);
+        Expression filter = new Range(Source.EMPTY, col, boolLit(false), true, boolLit(true), true, ZoneOffset.UTC);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -601,6 +601,171 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         assertEquals(2, rangeReadCount[0]);
     }
 
+    // --- Adaptive window tests ---
+
+    public void testDefaultWindowUnchanged() throws IOException {
+        byte[] data = new byte[100];
+        randomBytes(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
+
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            assertNotNull(stream);
+            assertEquals(0, stream.getPos());
+        }
+    }
+
+    public void testAdaptiveWindowSmallHint() throws IOException {
+        byte[] data = new byte[100];
+        randomBytes(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
+
+        long rangeBytes = 8 * 1024 * 1024L; // 8 MiB
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, rangeBytes);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            assertNotNull(stream);
+            byte[] buf = new byte[data.length];
+            stream.readFully(buf);
+            assertArrayEquals(data, buf);
+        }
+    }
+
+    public void testAdaptiveWindowCappedAtMax() throws IOException {
+        int size = ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 123;
+        byte[] data = new byte[size];
+        randomBytes(data);
+        final int[] maxRequestedLength = { 0 };
+
+        StorageObject measuringStorageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                maxRequestedLength[0] = Math.max(maxRequestedLength[0], (int) length);
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.ofEpochMilli(0);
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+
+        long hugeRange = 64 * 1024 * 1024L; // 64 MiB — should be capped to MAX_WINDOW_SIZE
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(measuringStorageObject, hugeRange);
+
+        byte[] buf = new byte[size];
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.readFully(buf);
+        }
+        assertArrayEquals(data, buf);
+        assertTrue(
+            "Requested range length should not exceed MAX_WINDOW_SIZE, got " + maxRequestedLength[0],
+            maxRequestedLength[0] <= ParquetStorageObjectAdapter.MAX_WINDOW_SIZE
+        );
+    }
+
+    public void testAdaptiveWindowFloorAtDefault() throws IOException {
+        byte[] data = new byte[100];
+        randomBytes(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
+
+        long tinyRange = 1024L; // 1 KiB — should be floored to DEFAULT_WINDOW_SIZE
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, tinyRange);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            byte[] buf = new byte[data.length];
+            stream.readFully(buf);
+            assertArrayEquals(data, buf);
+        }
+    }
+
+    public void testAdaptiveWindowReducesRangeRequests() throws IOException {
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        int size = 6 * 1024 * 1024; // 6 MiB
+        byte[] data = new byte[size];
+        randomBytes(data);
+        final int[] rangeReadCount = { 0 };
+
+        StorageObject countingStorageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount[0]++;
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.ofEpochMilli(42);
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test-adaptive.parquet");
+            }
+        };
+
+        // With default 4 MiB window, reading 6 MiB requires 2 range requests
+        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(countingStorageObject);
+        byte[] buf = new byte[size];
+        try (SeekableInputStream stream = defaultAdapter.newStream()) {
+            stream.readFully(buf);
+        }
+        int defaultReads = rangeReadCount[0];
+
+        // With 8 MiB adaptive window, reading 6 MiB requires 1 range request
+        rangeReadCount[0] = 0;
+        ParquetStorageObjectAdapter adaptiveAdapter = ParquetStorageObjectAdapter.forRange(countingStorageObject, 8 * 1024 * 1024L);
+        try (SeekableInputStream stream = adaptiveAdapter.newStream()) {
+            stream.readFully(buf);
+        }
+        int adaptiveReads = rangeReadCount[0];
+
+        assertTrue(
+            "Adaptive window should use fewer range reads (" + adaptiveReads + ") than default (" + defaultReads + ")",
+            adaptiveReads < defaultReads
+        );
+    }
+
     private void randomBytes(byte[] data) {
         random().nextBytes(data);
     }


### PR DESCRIPTION
Switch ParquetColumnIterator from readNextRowGroup() to
readNextFilteredRowGroup() so parquet-java uses ColumnIndex and
OffsetIndex to skip non-matching pages within row groups.

Add adaptive window sizing to ParquetStorageObjectAdapter: when
readRange() knows the split size, the sliding window is sized to
cover all column chunks in a single I/O instead of the fixed 4 MiB
default. Capped at 16 MiB.

Refactor ParquetFilterPushdownSupport to use PushdownPredicates
for two-pass canConvert/translateExpression validation and add
NotEquals, IsNull, IsNotNull, Range, And, Or, Not expressions.
Consolidate type dispatch into generic buildPredicate/orderedPredicate
helpers with a PredicateOp enum.

Developed with AI-assisted tooling