### PR TITLE
Address ignored source read performance issue.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.IOFunction;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.XContentParser;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
@@ -116,7 +118,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
         private final SourceFilter sourceFilter;
         private final Reader<T> reader;
         private final IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat;
-        private final LeafReader leafReader;
+        private final MultiValuedSortedBinaryDocValues ignoredSourceDocValues;
 
         IgnoredSourceRowStrideReader(
             CircuitBreaker breaker,
@@ -125,14 +127,20 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
             Reader<T> reader,
             IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat,
             LeafReader leafReader
-        ) {
+        ) throws IOException {
             breaker.addEstimateBytesAndMaybeBreak(ESTIMATED_SIZE, "load blocks");
             this.breaker = breaker;
             this.fieldName = fieldName;
             this.sourceFilter = sourceFilter;
             this.reader = reader;
             this.ignoredSourceFormat = ignoredSourceFormat;
-            this.leafReader = leafReader;
+            if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
+                this.ignoredSourceDocValues = Objects.requireNonNull(
+                    MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                );
+            } else {
+                this.ignoredSourceDocValues = null;
+            }
         }
 
         @Override
@@ -141,7 +149,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
                 sourceFilter,
                 storedFields.storedFields(),
                 docId,
-                leafReader
+                ignoredSourceDocValues
             );
 
             if (valuesGroupedByParent.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -397,7 +397,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
                 SourceFilter filter,
                 Map<String, List<Object>> storedFields,
                 int docId,
-                LeafReader leafReader
+                MultiValuedSortedBinaryDocValues docValues
             ) {
                 return Map.of();
             }
@@ -419,7 +419,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
                 SourceFilter filter,
                 Map<String, List<Object>> storedFields,
                 int docId,
-                LeafReader leafReader
+                MultiValuedSortedBinaryDocValues docValues
             ) {
                 var ignoredStoredValues = storedFields.get(NAME);
                 if (ignoredStoredValues == null) {
@@ -454,7 +454,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
                 SourceFilter filter,
                 Map<String, List<Object>> storedFields,
                 int docId,
-                LeafReader leafReader
+                MultiValuedSortedBinaryDocValues docValues
             ) {
                 var ignoredStoredValues = storedFields.get(NAME);
                 if (ignoredStoredValues == null) {
@@ -532,10 +532,9 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
                 SourceFilter filter,
                 Map<String, List<Object>> storedFields,
                 int docId,
-                LeafReader leafReader
+                MultiValuedSortedBinaryDocValues docValues
             ) throws IOException {
-                MultiValuedSortedBinaryDocValues docValues = MultiValuedSortedBinaryDocValues.from(leafReader, NAME);
-                if (docValues == null || docValues.advanceExact(docId) == false) {
+                if (docValues.advanceExact(docId) == false) {
                     return Map.of();
                 }
                 Map<String, List<NameValue>> objectsWithIgnoredFields = new HashMap<>();
@@ -574,14 +573,14 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
          * @param filter       optional path filter; filtered paths are excluded from the result
          * @param storedFields pre-loaded stored fields for the document (used by stored-field-based formats)
          * @param docId        the Lucene doc ID within the current leaf
-         * @param leafReader   the leaf reader for the current segment (used by doc-values-based formats)
+         * @param docValues    doc values instance for accessing ignored source (used by doc-values-based formats)
          * @return map from parent field name to list of {@link NameValue}, or an empty map when no entries exist
          */
         public abstract Map<String, List<NameValue>> loadIgnoredFields(
             SourceFilter filter,
             Map<String, List<Object>> storedFields,
             int docId,
-            LeafReader leafReader
+            MultiValuedSortedBinaryDocValues docValues
         ) throws IOException;
 
         public abstract void writeIgnoredFields(Collection<NameValue> ignoredFieldValues);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceFilter;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -193,7 +195,7 @@ public interface SourceLoader {
             private final SyntheticFieldLoader.DocValuesLoader docValuesLoader;
             private final Map<String, SyntheticFieldLoader.StoredFieldLoader> storedFieldLoaders;
             private final IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat;
-            private final LeafReader leafReader;
+            private final MultiValuedSortedBinaryDocValues ignoredSourcedocValues;
 
             private SyntheticLeaf(
                 SourceFilter filter,
@@ -201,7 +203,7 @@ public interface SourceLoader {
                 SyntheticFieldLoader.DocValuesLoader docValuesLoader,
                 IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat,
                 LeafReader leafReader
-            ) {
+            ) throws IOException {
                 this.filter = filter;
                 this.loader = loader;
                 this.docValuesLoader = docValuesLoader;
@@ -209,7 +211,13 @@ public interface SourceLoader {
                     loader.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
                 );
                 this.ignoredSourceFormat = ignoredSourceFormat;
-                this.leafReader = leafReader;
+                if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
+                    this.ignoredSourcedocValues = Objects.requireNonNull(
+                        MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                    );
+                } else {
+                    this.ignoredSourcedocValues = null;
+                }
             }
 
             @Override
@@ -234,7 +242,7 @@ public interface SourceLoader {
                     filter,
                     storedFieldLoader.storedFields(),
                     docId,
-                    leafReader
+                    ignoredSourcedocValues
                 );
 
                 if (objectsWithIgnoredFields.isEmpty() == false) {


### PR DESCRIPTION
With the new DOC_VALUES_IGNORED_SOURCE ignored source format, the binary doc values instance (fetched via MultiValuedSortedBinaryDocValues) gets re-initialized for each docid that needs to read ignored source.

The binary doc values instance keeps the current uncompressed block around, so that subsequent docids can read without having to decompress if the docid needs current block. Because binary doc values instance gets re-initialized each time ignored source gets read for a docid, the binary doc values implementation doesn't get a chance to reuse current decompressed block. With the result that each docid always decompresses a compressed block.

Marking as non-issue, since this bug hasn't been released in a stateful release yet.

See attached flamegraph for how this issue manifests:
[rally.html](https://github.com/user-attachments/files/26301475/rally.html)
