### PR TITLE
Explicitly set a confidence interval in dense vector tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
@@ -1,5 +1,9 @@
 setup:
+  - requires:
+        test_runner_features: [ "allowed_warnings" ]
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version",
+                         "Parameter [confidence_interval] in [index_options] for dense_vector field [another_vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: int4_flat
         body:
@@ -17,6 +21,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_flat
+                  confidence_interval: 0.0
               another_vector:
                 type: dense_vector
                 dims: 4
@@ -307,6 +312,8 @@ setup:
                   type: int4_flat
 ---
 "Test odd dimensions fail indexing":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
   # verify index creation fails
   - do:
       catch: bad_request
@@ -325,6 +332,7 @@ setup:
 
   # verify dynamic dimension fails
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: dynamic_dim_hnsw_quantized
         body:
@@ -348,6 +356,7 @@ setup:
 
   # verify that we can index an even dim vector after the odd dim vector failure
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       index:
         index: dynamic_dim_hnsw_quantized
         body:
@@ -412,9 +421,11 @@ setup:
   - requires:
       cluster_features: ["mapper.dense_vector.rescore_vector"]
       reason: Needs rescore_vector feature
+      test_runner_features: [ "allowed_warnings" ]
   - skip:
       features: "headers"
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: int4_rescore_flat
         body:
@@ -511,7 +522,10 @@ setup:
   - not_exists: int4_flat.mappings.properties.vector.index_options.rescore_vector
 ---
 "Nested flat search":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: int4_flat_nested
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
@@ -24,6 +24,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_flat
+                  confidence_interval: 0.0
 
   - do:
       index:
@@ -335,6 +336,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_hnsw
+                  confidence_interval: 0.0
 
   # verify index fails for odd dim vector
   - do:
@@ -430,6 +432,7 @@ setup:
                   type: int4_flat
                   rescore_vector:
                     oversample: 1.5
+                  confidence_interval: 0.0
 
   - do:
       bulk:
@@ -531,6 +534,7 @@ setup:
                     similarity: l2_norm
                     index_options:
                       type: int4_flat
+                      confidence_interval: 0.0
   - do:
       index:
         index: int4_flat_nested

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat_bfloat16.yml
@@ -1,8 +1,11 @@
 setup:
   - requires:
       cluster_features: [ "mapper.vectors.generic_vector_format" ]
+      test_runner_features: [ "allowed_warnings" ]
       reason: Needs generic vector support
   - do:
+      allowed_warnings: [ "Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version",
+                          "Parameter [confidence_interval] in [index_options] for dense_vector field [another_vector] is deprecated and will be removed in a future version" ]
       indices.create:
         index: int4_flat
         body:
@@ -21,6 +24,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_flat
+                  confidence_interval: 0.0
               another_vector:
                 type: dense_vector
                 element_type: bfloat16
@@ -313,6 +317,8 @@ setup:
                   type: int4_flat
 ---
 "Test odd dimensions fail indexing":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
   # verify index creation fails
   - do:
       catch: bad_request
@@ -332,6 +338,7 @@ setup:
 
   # verify dynamic dimension fails
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: dynamic_dim_hnsw_quantized
         body:
@@ -356,6 +363,7 @@ setup:
 
   # verify that we can index an even dim vector after the odd dim vector failure
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       index:
         index: dynamic_dim_hnsw_quantized
         body:
@@ -411,10 +419,11 @@ setup:
 ---
 "Test index configured rescore vector":
   - requires:
-      test_runner_features: "close_to"
+      test_runner_features: ["close_to", "allowed_warnings"]
   - skip:
       features: "headers"
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: int4_rescore_flat
         body:
@@ -509,7 +518,10 @@ setup:
   - not_exists: int4_flat.mappings.properties.vector.index_options.rescore_vector
 ---
 "Nested flat search":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       indices.create:
         index: int4_flat_nested
         body:
@@ -535,6 +547,7 @@ setup:
                       type: int4_flat
                       confidence_interval: 0.0
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       index:
         index: int4_flat_nested
         id: "1"
@@ -547,6 +560,7 @@ setup:
               vector: [240.0, 300, -3, 1 ]
 
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       index:
         index: int4_flat_nested
         id: "2"
@@ -561,6 +575,7 @@ setup:
               vector: [0, 1.0, 0, 1.8]
 
   - do:
+      allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [vector] is deprecated and will be removed in a future version"]
       index:
         index: int4_flat_nested
         id: "3"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat_bfloat16.yml
@@ -29,6 +29,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_flat
+                  confidence_interval: 0.0
 
   - do:
       index:
@@ -343,6 +344,7 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int4_hnsw
+                  confidence_interval: 0.0
 
   # verify index fails for odd dim vector
   - do:
@@ -431,6 +433,7 @@ setup:
                   type: int4_flat
                   rescore_vector:
                     oversample: 1.5
+                  confidence_interval: 0.0
 
   - do:
       bulk:
@@ -530,6 +533,7 @@ setup:
                     similarity: l2_norm
                     index_options:
                       type: int4_flat
+                      confidence_interval: 0.0
   - do:
       index:
         index: int4_flat_nested


### PR DESCRIPTION
Mixed cluster tests using int4_flat or int4_hnsw index options fail because `confidence_interval` previously [defaulted](https://github.com/elastic/elasticsearch/blob/194133bef06bf9e0b7f8ab1b8c2fc49c86ceb89f/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java#L2134) to 0.0 but is now deprecated. This means when the value is unset versions before 9.4.0 write it out as 0.0 but after 9.4.0 the field is not written. The difference triggers an assertion in the [DocumentMapper](https://github.com/elastic/elasticsearch/blob/5bff441e4ffcb28d8b78783eb71e4e315c3a5178/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java#L77). 

The simple fix is to explicitly add the param into the tests so both versions have the same representation



Closes #144997.