### PR TITLE
ESQL: Skip COUNT(field) stats pushdown through EVAL/RENAME path

### DIFF
--- a/docs/changelog/145093.yaml
+++ b/docs/changelog/145093.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145093
+summary: Skip COUNT(field) stats pushdown through EVAL/RENAME path
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
@@ -71,6 +71,15 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
         List<? extends NamedExpression> aggregates = aggregateExec.aggregates();
         if (aliasReplacedBy.isEmpty() == false) {
             aggregates = resolveAliases(aggregates, aliasReplacedBy);
+            // When resolving through EVAL/RENAME, only push COUNT(*) — not COUNT(field).
+            // Alias resolution transforms ReferenceAttribute → FieldAttribute, which enables
+            // COUNT(field) pushdown via isSingleValue(). But isSingleValue() is per-shard and
+            // can disagree across shards in INLINESTATS queries where filtering narrows the data
+            // asymmetrically. COUNT(field) on multivalue fields counts values, not documents,
+            // and Lucene count returns document count — producing wrong results.
+            if (hasCountOverField(aggregates)) {
+                return aggregateExec;
+            }
         }
 
         var tuple = pushableStats(aggregateExec.groupings(), aggregates, context);
@@ -109,6 +118,22 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
         }
 
         return plan;
+    }
+
+    /**
+     * Returns true if any aggregate is COUNT(field) — not COUNT(*).
+     * COUNT(field) on multivalue fields is unsafe to push to Lucene count.
+     */
+    private static boolean hasCountOverField(List<? extends NamedExpression> aggregates) {
+        for (int i = 0; i < aggregates.size(); i++) {
+            NamedExpression agg = aggregates.get(i);
+            if (agg instanceof Alias alias && alias.child() instanceof Count count) {
+                if (count.field().foldable() == false) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
When PushStatsToSource resolves aggregates through an intermediate EvalExec or ProjectExec (alias resolution added by #144806), skip pushdown for COUNT(field) — only allow COUNT(*).

## Summary

The isSingleValue() check is per-shard and can disagree across shards in INLINESTATS queries where filtering narrows the data asymmetrically. On one shard, a multivalue field appears single-valued after filtering, so COUNT(field) gets pushed to EsStatsQueryExec (Lucene document count). On another shard it doesn't. Since COUNT(field) on multivalue fields counts values — not documents — the Lucene count produces wrong results.

The direct path (AggregateExec → EsQueryExec without intermediate EVAL/RENAME) is unaffected because it was working before #144806.

- **PushStatsToSource**: When alias resolution is active, skip COUNT(field) pushdown; COUNT(*) still pushes down normally

Developed with AI-assisted tooling