### PR TITLE
feat(tsdb): add ES94 codec format, entry factory and test hierarchy

### DIFF
--- a/docs/plans/2026-03-20-tsdb-codec-modularity-design.md
+++ b/docs/plans/2026-03-20-tsdb-codec-modularity-design.md
@@ -1,0 +1,244 @@
+# TSDB Doc Values Codec: Modular Architecture Design
+
+## 1. Introduction
+
+The ES819 TSDB doc values codec is a monolithic implementation: a single consumer
+class (~1300 lines) owns the full write path for all field types, and a single
+producer class (~2900 lines) owns the full read path. Introducing a new codec
+version (ES94) requires duplicating or modifying large sections of these classes,
+even when the change is limited to one concern (e.g., numeric block encoding).
+
+This document describes a modular architecture where the base classes define the
+structure and order in which sections are written and read, while each codec
+version provides its own encoding and decoding for each section via dependency
+injection. The refactoring PR (#144324) is the first step toward this architecture.
+
+## 2. Current State
+
+### What the refactoring PR (#144324) does
+
+Extracts shared wire-format logic from ES819 into abstract base classes:
+
+- `AbstractTSDBDocValuesConsumer` orchestrates the write path for all field types
+- `AbstractTSDBDocValuesProducer` orchestrates the read path and metadata parsing
+- `NumericFieldWriter` and `NumericFieldReader` interfaces let each codec own its
+  numeric encoding end-to-end (entry metadata, block encoding, ordinal encoding)
+- `DocOffsetsCodec` is injected via constructor instead of an abstract method
+- Shared segment write state bundled into a context record
+- `TSDBDocValuesFormatConfig` groups all format parameters into sub-records
+
+### What ES94 changes vs ES819
+
+ES94 replaces the monolithic `TSDBDocValuesEncoder` with a composable pipeline of
+encoding stages (delta, offset, GCD, bit-pack) for numeric fields. It writes a
+self-describing `FieldDescriptor` to metadata so the decoder can reconstruct the
+pipeline without compile-time knowledge. Non-numeric field types (binary, sorted,
+sorted-set) remain identical to ES819.
+
+## 3. Target Architecture
+
+### Principle
+
+The base class defines **what** gets written and in **what order**. Each codec
+defines **how** each section is encoded and decoded. The format class is the
+composition root that wires codec-specific factory implementations to the base
+class via constructor injection.
+
+This follows Lucene's existing separation: `DocValuesConsumer` (write) and
+`DocValuesProducer` (read) are independent. Each side receives only the
+dependencies it needs. Writer factories are injected into the consumer,
+reader factories into the producer.
+
+### Why factories, not instances
+
+Section writers and readers are created per field and hold mutable per-field state
+(encoding contexts, block decoders, ordinal encoders). The base class controls
+their lifecycle: when to create them, how many instances are needed, and when
+they are done. Injecting factories gives the base class this control while letting
+the codec define what gets created.
+
+On the write side, a `NumericFieldWriterFactory` creates a writer per field,
+each owning its own encoding state. On the read side, a `NumericFieldReaderFactory`
+creates a reader per field, each owning its own decoding state. The base class
+calls the factory when it needs an instance, and the codec never needs to know
+about field lifecycle details.
+
+### Wire format sections
+
+A TSDB doc values segment consists of these sections, each a candidate for
+codec-specific encoding:
+
+| Section | Description | Pluggable today? |
+|---|---|---|
+| Numeric blocks | Block-encoded numeric values | Yes (NumericFieldWriter/Reader) |
+| Numeric ordinals | Ordinal encoding for sorted fields | Yes (NumericFieldWriter/Reader) |
+| Numeric entry header | Per-field metadata (stats, offsets, codec header) | Yes (NumericFieldWriter/Reader) |
+| Skip index | Multi-level min/max tree for range skipping | No (hardcoded in base) |
+| DISI | Document-level presence bitset | No (hardcoded IndexedDISI) |
+| Binary data | Binary field values with optional compression | No (hardcoded in base) |
+| Binary block compression | Per-block compression of binary data | Partially (mode configurable) |
+| Doc offsets | Document offset encoding in binary blocks | Yes (DocOffsetsCodec injected) |
+| Terms dict | LZ4-compressed term dictionary for sorted fields | No (hardcoded LZ4 in base) |
+| Terms dict reverse index | Reverse lookup structure for terms | No (hardcoded in base) |
+| DirectMonotonic index | Block-to-offset index for numeric values | No (Lucene fixed) |
+| Ordinal range encoding | Compact encoding for low-cardinality ordinals | No (hardcoded in base) |
+
+### Composition model
+
+The format class is the composition root. It wires codec-specific factories into
+the base classes. Each factory creates per-field instances on demand. Sections that
+a codec does not customize use default factories matching the current ES819 behavior.
+
+```
+TSDBDocValuesFormat (codec-specific)
+    |
+    +-- fieldsConsumer(state) --> AbstractTSDBDocValuesConsumer(
+    |       config,
+    |       numericFieldWriterFactory,   // codec-specific or default
+    |       binaryFieldWriterFactory,    // codec-specific or default
+    |       termsDictWriterFactory,      // codec-specific or default
+    |       skipIndexWriterFactory,      // codec-specific or default
+    |       disiWriterFactory,           // codec-specific or default
+    |       docOffsetsEncoder            // codec-specific or default
+    |   )
+    |
+    +-- fieldsProducer(state) --> AbstractTSDBDocValuesProducer(
+            config,
+            numericFieldReaderFactory,   // codec-specific or default
+            binaryFieldReaderFactory,    // codec-specific or default
+            termsDictReaderFactory,      // codec-specific or default
+            skipIndexReaderFactory,      // codec-specific or default
+            disiReaderFactory,           // codec-specific or default
+            docOffsetsDecoder,           // codec-specific or default
+            entryFactory                 // codec-specific or default
+        )
+```
+
+The base class orchestrates field dispatch, type tags, and section ordering. It
+calls each factory to obtain a per-field writer or reader, then delegates encoding
+and decoding to it. The base class never touches encoding logic directly.
+
+The existing optimized merge path (`XDocValuesConsumer` merge methods with
+pre-computed `MergeStats`) remains in the base class since merge orchestration
+is format-agnostic. The merge path passes `MergeStats` through
+`TsdbDocValuesProducer` into the codec's writer, which uses them to skip
+stats computation and fuse DISI accumulation into the block loop.
+
+## 4. End State: What a New Codec Looks Like
+
+When the architecture is fully realized, introducing a new codec version requires
+no changes to the base classes. The codec provides a format class that wires its
+specific factories.
+
+A hypothetical codec that changes numeric encoding and binary compression:
+
+```java
+public class CustomTSDBDocValuesFormat extends DocValuesFormat {
+
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) {
+        return new AbstractTSDBDocValuesConsumer(
+            state, CUSTOM_CONFIG,
+            ctx -> new CustomNumericFieldWriter(ctx),     // custom numeric encoder
+            field -> new CustomBinaryFieldWriter(field),  // custom binary compressor
+            TermsDictWriterFactory.DEFAULT,                // reuse default terms dict
+            SkipIndexWriterFactory.DEFAULT,                // reuse default skip index
+            DISIWriterFactory.DEFAULT,                     // reuse default DISI
+            DocOffsetsCodec.GROUPED_VINT.getEncoder()      // reuse default doc offsets
+        );
+    }
+
+    public DocValuesProducer fieldsProducer(SegmentReadState state) {
+        return new AbstractTSDBDocValuesProducer(
+            state, CUSTOM_CONFIG,
+            (entry, bs) -> new CustomNumericFieldReader(entry, bs),
+            entry -> new CustomBinaryFieldReader(entry),
+            TermsDictReaderFactory.DEFAULT,
+            SkipIndexReaderFactory.DEFAULT,
+            DISIReaderFactory.DEFAULT,
+            DocOffsetsCodec.GROUPED_VINT.getDecoder(),
+            CustomEntryFactory.INSTANCE
+        );
+    }
+}
+```
+
+What the codec author provides:
+- Format class: wiring (the composition root)
+- Custom writer and reader implementations for sections that change
+- Custom entry factory if codec-specific metadata fields are needed
+
+What the codec author does NOT touch:
+- `AbstractTSDBDocValuesConsumer` / `AbstractTSDBDocValuesProducer`
+- Default factories for sections that are unchanged
+- Wire format ordering, field dispatch, type tags, merge orchestration
+
+A codec that only changes numeric encoding (like ES94) provides a writer factory
+and a reader factory. One that customizes every section provides more, but most
+codecs only need to provide factories for the sections they change.
+
+Each section is independently testable: unit test a writer by feeding it values
+and verifying the output bytes, without constructing a full segment.
+
+## 5. Incremental Path
+
+Each step is self-contained, delivers value, and does not require subsequent steps.
+
+**Step 1 (done, PR #144324): Numeric read/write abstraction**
+- `NumericFieldWriter` / `NumericFieldReader` interfaces
+- `DocOffsetsCodec` injected via constructor
+- `NumericWriteContext` for shared write state
+- ES819 as the first implementation
+
+**Step 2 (ES94 format PR): Pipeline codec + entry factory**
+- `EntryFactory` for codec-specific entry subclasses
+- ES94 consumer/producer with pipeline encoding
+- `FieldDescriptor` for self-describing wire format
+
+**Step 3: Binary, sorted, sorted-set pluggability**
+- `BinaryFieldWriterFactory` / `BinaryFieldReaderFactory`
+- `TermsDictWriterFactory` / `TermsDictReaderFactory`
+- Extract binary compression and terms dict encoding from base class
+- Enables future codecs to introduce SORTED/BINARY/SORTED_SET pipelines
+
+**Step 4: Skip index, DISI, ordinal range pluggability**
+- `SkipIndexWriterFactory` / `SkipIndexReaderFactory`
+- `DISIWriterFactory` / `DISIReaderFactory`
+- `OrdinalRangeWriterFactory` / `OrdinalRangeReaderFactory`
+- Enables format-specific skip index structures and DISI encodings
+- Unlocks merge optimizations (raw block copy, skip index bulk merge)
+
+## 6. Benefits and Opportunities
+
+**Codec evolution without base class changes.** New codec versions are introduced
+by wiring factory implementations in a format class. The base classes are stable
+infrastructure that rarely changes.
+
+**Per-field adaptive compression.** With pluggable writer factories, a pipeline
+resolver could select a different encoding strategy per field based on data
+profiling: delta + bit-pack for monotonic timestamps, ALP for low-precision
+floats, FPC/Chimp/Gorilla for high-entropy doubles. The factory creates a writer
+with the selected pipeline, persisted in the field descriptor.
+
+**Pluggable compression for every section.** Dictionary-based binary compression,
+columnar binary encoding, custom skip index structures (storing sum/count per
+interval for pre-aggregation), tiered DISI encoding (roaring bitmaps, run-length
+encoding, or skipping DISI for known-dense fields) all become possible by
+providing a custom factory for the relevant section.
+
+**Merge-time optimizations.** Clean section boundaries enable raw block copy during
+same-codec merges and skip index bulk merge. A dedicated merge strategy operating
+above the writer/reader level can drive per-segment raw copy for compatible
+sections.
+
+**Independent testability.** Each section can be unit tested in isolation by
+testing the writer/reader created by a factory, without constructing full segments.
+
+**Backward compatibility by design.** The read path resolves codecs via SPI using
+the codec name stored in segment metadata. Adding a new codec does not affect
+reading of older segments. Version gating lives in the format class at injection
+time, not scattered through the base class.
+
+**Format experimentation without risk.** Behind a feature flag, a new codec version
+can experiment with a different encoding for one section while reusing default
+factories for everything else. The blast radius is limited to the factory being
+changed.

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,24 @@
+## Summary
+
+Introduces the `ES94` TSDB doc values format as a drop-in replacement for `ES819`. The only difference is that numeric encoding uses a composable pipeline of stages (`delta>offset>gcd>bitpack`) via the pipeline framework from [#143589](https://github.com/elastic/elasticsearch/pull/143589) and [#143934](https://github.com/elastic/elasticsearch/pull/143934), instead of the monolithic `TSDBDocValuesEncoder`. All non-numeric field types (binary, sorted, sorted-set) are handled identically to ES819 by the shared abstract base classes from [#144324](https://github.com/elastic/elasticsearch/pull/144324).
+
+The ES94 codec is not wired into `PerFieldFormatSupplier` yet — no index will use it until the wiring and gating PR lands. This PR focuses on the format implementation, entry factory refactoring, and test infrastructure.
+
+### What's included
+
+**ES94 format**: `ES94TSDBDocValuesFormat`, `ES94TSDBDocValuesConsumer`, `ES94TSDBDocValuesProducer` with the same configuration surface as ES819 (optimized merge, binary compression, block sizes, prefix partitions). Each numeric field writes a self-describing `FieldDescriptor` so decoders reconstruct themselves from segment metadata.
+
+**Pipeline encode/decode**: `NumericEncodePipeline`, `NumericDecodePipeline`, `NumericBlockEncoder`/`NumericBlockDecoder`, `NumericCodecFactory`, `StageFactory`, `TransformEncoder`/`TransformDecoder` — the runtime that connects the pipeline framework to the doc values consumer/producer.
+
+**Entry factory**: `EntryFactory` interface with default methods for all entry types. Each codec provides its own factory returning codec-specific entry subclasses. `PrefixPartitionedEntry` now encapsulates its own partition reading and access, eliminating `instanceof` checks from the base class.
+
+**Test restructuring**: Shared TSDB tests extracted into `AbstractTSDBDocValuesFormatTestCase` extending Lucene's `BaseDocValuesFormatTestCase` directly. Both `ES819TSDBDocValuesFormatTests` and `ES94TSDBDocValuesFormatTests` extend this base independently — no codec test depends on another. Adding a new codec version (e.g. ES95) requires only implementing `getCodec()` and `createDocValuesFormat()` to inherit ~158 tests covering all doc value types, merge paths, block loaders, prefix partitions, and cross-format compatibility.
+
+### Testing
+
+```
+./gradlew :server:test --tests "*ES94TSDBDocValuesFormatTests*"
+./gradlew :server:test --tests "*ES819TSDBDocValuesFormatTests*"
+./gradlew :server:test --tests "*ES87TSDBDocValuesFormatTests*"
+./gradlew :server:test --tests "*PrefixPartitionTests*"
+```

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -79,6 +79,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     private static final int DEFAULT_NUMERIC_BLOCK_SHIFT = 7;
     private final TSDBDocValuesFormatConfig formatConfig;
     private final DocOffsetsCodec.Decoder docOffsetsDecoder;
+    private final EntryFactory entryFactory;
 
     @SuppressWarnings("this-escape")
     protected AbstractTSDBDocValuesProducer(
@@ -88,9 +89,11 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         final String metaCodec,
         final String metaExtension,
         final TSDBDocValuesFormatConfig formatConfig,
-        final DocOffsetsCodec.Decoder docOffsetsDecoder
+        final DocOffsetsCodec.Decoder docOffsetsDecoder,
+        final EntryFactory entryFactory
     ) throws IOException {
         this.docOffsetsDecoder = docOffsetsDecoder;
+        this.entryFactory = entryFactory;
         this.numerics = new IntObjectHashMap<>();
         this.binaries = new IntObjectHashMap<>();
         this.sorted = new IntObjectHashMap<>();
@@ -170,6 +173,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     protected AbstractTSDBDocValuesProducer(final AbstractTSDBDocValuesProducer original) {
         this.docOffsetsDecoder = original.docOffsetsDecoder;
+        this.entryFactory = original.entryFactory;
         this.numerics = original.numerics;
         this.binaries = original.binaries;
         this.sorted = original.sorted;
@@ -1324,20 +1328,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
         @Override
         public int prefixPartitionBits() {
-            if (entry instanceof PrefixPartitionedEntry partition) {
-                return partition.partitionNumBits;
-            }
-            return 0;
+            return entry.prefixPartitionBits();
         }
 
         @Override
         public PrefixPartitions prefixPartitions(PrefixPartitions reused) throws IOException {
-            if (entry instanceof PrefixPartitionedEntry partitioned) {
-                var slice = data.slice("partitioning", partitioned.partitionStartPointer, partitioned.partitionDataLength);
-                return PrefixedPartitionsReader.prefixPartitions(slice, reused);
-            } else {
-                return null;
-            }
+            return entry.prefixPartitions(data, reused);
         }
     }
 
@@ -1960,7 +1956,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private NumericEntry readNumeric(IndexInput meta, int numericBlockShift) throws IOException {
-        final NumericEntry entry = new NumericEntry();
+        final NumericEntry entry = entryFactory.createNumericEntry();
         readNumeric(meta, entry, numericBlockShift);
         return entry;
     }
@@ -1988,7 +1984,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         } else {
             compression = BinaryDVCompressionMode.NO_COMPRESS;
         }
-        final BinaryEntry entry = new BinaryEntry(compression);
+        final BinaryEntry entry = entryFactory.createBinaryEntry(compression);
 
         entry.dataOffset = meta.readLong();
         entry.dataLength = meta.readLong();
@@ -2030,7 +2026,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private SortedNumericEntry readSortedNumeric(IndexInput meta, int numericBlockShift) throws IOException {
-        final SortedNumericEntry entry = new SortedNumericEntry();
+        final SortedNumericEntry entry = entryFactory.createSortedNumericEntry();
         readSortedNumeric(meta, entry, numericBlockShift);
         return entry;
     }
@@ -2048,20 +2044,14 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     private SortedEntry readSorted(int version, IndexInput meta, int numericBlockShift, int termsDictBlockLz4Shift, boolean primarySorted)
         throws IOException {
-        SortedEntry entry = new SortedEntry();
-        entry.ordsEntry = new NumericEntry();
-        entry.termsDictEntry = new TermsDictEntry();
+        SortedEntry entry = entryFactory.createSortedEntry();
+        entry.ordsEntry = entryFactory.createNumericEntry();
+        entry.termsDictEntry = entryFactory.createTermsDictEntry();
         if (version >= formatConfig.versionPrefixPartitions()) {
             readTermDict(meta, entry.termsDictEntry, termsDictBlockLz4Shift);
             readNumeric(meta, entry.ordsEntry, numericBlockShift);
             if (primarySorted && meta.readByte() == 1) {
-                PrefixPartitionedEntry partitioned = new PrefixPartitionedEntry();
-                partitioned.ordsEntry = entry.ordsEntry;
-                partitioned.termsDictEntry = entry.termsDictEntry;
-                partitioned.partitionNumBits = meta.readByte();
-                partitioned.partitionStartPointer = meta.readLong();
-                partitioned.partitionDataLength = meta.readVLong();
-                return partitioned;
+                entry.readMeta(meta);
             }
         } else {
             readNumeric(meta, entry.ordsEntry, numericBlockShift);
@@ -2077,7 +2067,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         int termsDictBlockLz4Shift,
         boolean primarySorted
     ) throws IOException {
-        SortedSetEntry entry = new SortedSetEntry();
+        SortedSetEntry entry = entryFactory.createSortedSetEntry();
         byte multiValued = meta.readByte();
         switch (multiValued) {
             case 0: // singlevalued
@@ -2088,9 +2078,9 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             default:
                 throw new CorruptIndexException("Invalid multiValued flag: " + multiValued, meta);
         }
-        entry.ordsEntry = new SortedNumericEntry();
+        entry.ordsEntry = entryFactory.createSortedNumericEntry();
         readSortedNumeric(meta, entry.ordsEntry, numericBlockShift);
-        entry.termsDictEntry = new TermsDictEntry();
+        entry.termsDictEntry = entryFactory.createTermsDictEntry();
         readTermDict(meta, entry.termsDictEntry, termsDictBlockLz4Shift);
         return entry;
     }
@@ -2685,6 +2675,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     private record DocValuesSkipperEntry(long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {}
 
+    /** Numeric field entry holding block index, value offsets, and DISI metadata. */
     public static class NumericEntry {
         public long docsWithFieldOffset;
         public long docsWithFieldLength;
@@ -2701,7 +2692,8 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         public NumericFieldReader fieldReader;
     }
 
-    static class BinaryEntry {
+    /** Binary field entry holding data offsets, compression mode, and address metadata. */
+    public static class BinaryEntry {
         final BinaryDVCompressionMode compression;
 
         long dataOffset;
@@ -2728,30 +2720,75 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
+    /** Sorted-numeric field entry extending {@link NumericEntry} with per-document value count addresses. */
     public static class SortedNumericEntry extends NumericEntry {
         public DirectMonotonicReader.Meta addressesMeta;
         public long addressesOffset;
         public long addressesLength;
     }
 
-    static class SortedEntry {
+    /**
+     * Sorted field entry holding ordinal and terms dictionary metadata.
+     * Subclasses may override {@link #readMeta}, {@link #prefixPartitionBits},
+     * and {@link #prefixPartitions} to encapsulate codec-specific behavior.
+     */
+    public static class SortedEntry {
         NumericEntry ordsEntry;
         TermsDictEntry termsDictEntry;
+
+        /** Reads codec-specific sorted metadata from the meta stream. */
+        void readMeta(IndexInput meta) throws IOException {}
+
+        /** @return partition bit count, 0 if not partitioned */
+        int prefixPartitionBits() {
+            return 0;
+        }
+
+        /** @return prefix partitions, null if not partitioned */
+        PartitionedDocValues.PrefixPartitions prefixPartitions(IndexInput data, PartitionedDocValues.PrefixPartitions reused)
+            throws IOException {
+            return null;
+        }
     }
 
-    static class PrefixPartitionedEntry extends SortedEntry {
-        int partitionNumBits;
-        long partitionStartPointer;
-        long partitionDataLength;
+    /**
+     * ES819 sorted entry carrying prefix partition metadata. Encapsulates
+     * reading and access to partition data as an implementation detail.
+     */
+    public static class PrefixPartitionedEntry extends SortedEntry {
+        private int partitionNumBits;
+        private long partitionStartPointer;
+        private long partitionDataLength;
+
+        @Override
+        void readMeta(IndexInput meta) throws IOException {
+            partitionNumBits = meta.readByte();
+            partitionStartPointer = meta.readLong();
+            partitionDataLength = meta.readVLong();
+        }
+
+        @Override
+        int prefixPartitionBits() {
+            return partitionNumBits;
+        }
+
+        @Override
+        PartitionedDocValues.PrefixPartitions prefixPartitions(IndexInput data, PartitionedDocValues.PrefixPartitions reused)
+            throws IOException {
+            IndexInput slice = data.slice("partitioning", partitionStartPointer, partitionDataLength);
+            return PrefixedPartitionsReader.prefixPartitions(slice, reused);
+        }
     }
 
-    static class SortedSetEntry {
+    /** Sorted-set field entry holding either a single-valued {@link SortedEntry} or multi-valued ordinals. */
+    public static class SortedSetEntry {
         SortedEntry singleValueEntry;
         SortedNumericEntry ordsEntry;
         TermsDictEntry termsDictEntry;
     }
 
-    static class TermsDictEntry {
+    /** Terms dictionary entry holding term data offsets, address metadata, and reverse index pointers. */
+    public static class TermsDictEntry {
         long termsDictSize;
         DirectMonotonicReader.Meta termsAddressesMeta;
         int maxTermLength;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/EntryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/EntryFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.BinaryEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.NumericEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedNumericEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedSetEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.TermsDictEntry;
+
+/**
+ * Factory for creating entry instances during segment metadata reading.
+ * Each codec version provides its own factory to return codec-specific
+ * subclasses of the base entry types. All methods have default implementations
+ * returning base types; codecs override only the entries they need.
+ */
+public interface EntryFactory {
+
+    /** Creates a numeric entry. */
+    default NumericEntry createNumericEntry() {
+        return new NumericEntry();
+    }
+
+    /** Creates a sorted-numeric entry. */
+    default SortedNumericEntry createSortedNumericEntry() {
+        return new SortedNumericEntry();
+    }
+
+    /** Creates a sorted entry. */
+    default SortedEntry createSortedEntry() {
+        return new SortedEntry();
+    }
+
+    /** Creates a sorted-set entry. */
+    default SortedSetEntry createSortedSetEntry() {
+        return new SortedSetEntry();
+    }
+
+    /** Creates a terms dictionary entry. */
+    default TermsDictEntry createTermsDictEntry() {
+        return new TermsDictEntry();
+    }
+
+    /** Creates a binary entry with the given compression mode. */
+    default BinaryEntry createBinaryEntry(BinaryDVCompressionMode compression) {
+        return new BinaryEntry(compression);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819NumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819NumericEntry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+
+/**
+ * ES819 numeric entry. Currently identical to the base type; exists so that
+ * the ES819 {@link org.elasticsearch.index.codec.tsdb.EntryFactory} returns
+ * a codec-specific type for every entry kind.
+ */
+final class ES819NumericEntry extends AbstractTSDBDocValuesProducer.NumericEntry {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819SortedNumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819SortedNumericEntry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+
+/**
+ * ES819 sorted-numeric entry. Currently identical to the base type; exists so
+ * that the ES819 {@link org.elasticsearch.index.codec.tsdb.EntryFactory} returns
+ * a codec-specific type for every entry kind.
+ */
+final class ES819SortedNumericEntry extends AbstractTSDBDocValuesProducer.SortedNumericEntry {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94NumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94NumericEntry.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es94;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+
+/**
+ * ES94 numeric entry carrying a {@link PipelineDescriptor} that describes
+ * the encoding pipeline used for this field. The descriptor is read from
+ * segment metadata and used to reconstruct the decoder at iteration time.
+ */
+final class ES94NumericEntry extends AbstractTSDBDocValuesProducer.NumericEntry implements PipelineDescriptorEntry {
+
+    private PipelineDescriptor pipelineDescriptor;
+
+    @Override
+    public PipelineDescriptor pipelineDescriptor() {
+        return pipelineDescriptor;
+    }
+
+    @Override
+    public void pipelineDescriptor(PipelineDescriptor pipelineDescriptor) {
+        this.pipelineDescriptor = pipelineDescriptor;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94SortedNumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94SortedNumericEntry.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es94;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+
+/**
+ * ES94 sorted-numeric entry carrying a {@link PipelineDescriptor} that describes
+ * the encoding pipeline used for this field. The descriptor is read from
+ * segment metadata and used to reconstruct the decoder at iteration time.
+ */
+final class ES94SortedNumericEntry extends AbstractTSDBDocValuesProducer.SortedNumericEntry implements PipelineDescriptorEntry {
+
+    private PipelineDescriptor pipelineDescriptor;
+
+    @Override
+    public PipelineDescriptor pipelineDescriptor() {
+        return pipelineDescriptor;
+    }
+
+    @Override
+    public void pipelineDescriptor(PipelineDescriptor pipelineDescriptor) {
+        this.pipelineDescriptor = pipelineDescriptor;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesConsumer.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es94;
+
+import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.packed.DirectMonotonicWriter;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesConsumer;
+import org.elasticsearch.index.codec.tsdb.DISIAccumulator;
+import org.elasticsearch.index.codec.tsdb.DocOffsetsCodec;
+import org.elasticsearch.index.codec.tsdb.NumericFieldWriter;
+import org.elasticsearch.index.codec.tsdb.NumericFieldWriter.OffsetsConsumer;
+import org.elasticsearch.index.codec.tsdb.NumericWriteContext;
+import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
+import org.elasticsearch.index.codec.tsdb.SortedFieldObserverFactory;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
+import org.elasticsearch.index.codec.tsdb.TsdbDocValuesProducer;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockEncoder;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * ES94 doc values consumer. Uses a {@link NumericEncoder} for numeric block
+ * encoding and writes a {@link FieldDescriptor} to metadata for self-describing
+ * format evolution. Ordinal encoding delegates to {@link TSDBDocValuesEncoder}
+ * for feature parity with ES819.
+ */
+final class ES94TSDBDocValuesConsumer extends AbstractTSDBDocValuesConsumer {
+
+    private final NumericEncoder numericEncoder;
+
+    ES94TSDBDocValuesConsumer(
+        final SegmentWriteState state,
+        boolean enableOptimizedMerge,
+        final String dataCodec,
+        final String dataExtension,
+        final String metaCodec,
+        final String metaExtension,
+        final TSDBDocValuesFormatConfig formatConfig,
+        final DocOffsetsCodec.Encoder docOffsetsEncoder,
+        final SortedFieldObserverFactory sortedFieldObserverFactory,
+        final NumericEncoder numericEncoder
+    ) throws IOException {
+        super(
+            state,
+            enableOptimizedMerge,
+            dataCodec,
+            dataExtension,
+            metaCodec,
+            metaExtension,
+            formatConfig,
+            docOffsetsEncoder,
+            sortedFieldObserverFactory
+        );
+        this.numericEncoder = numericEncoder;
+    }
+
+    @Override
+    protected NumericFieldWriter createNumericFieldWriter(final NumericWriteContext ctx) {
+        return new ES94NumericFieldWriter(ctx, numericEncoder);
+    }
+
+    private static final class ES94NumericFieldWriter implements NumericFieldWriter {
+
+        private final NumericWriteContext ctx;
+        private final NumericEncoder numericEncoder;
+
+        ES94NumericFieldWriter(final NumericWriteContext ctx, final NumericEncoder numericEncoder) {
+            this.ctx = ctx;
+            this.numericEncoder = numericEncoder;
+        }
+
+        @Override
+        public Encoder encoder() {
+            final NumericBlockEncoder blockEncoder = numericEncoder.newBlockEncoder();
+            final TSDBDocValuesEncoder ordinalEncoder = new TSDBDocValuesEncoder(ctx.blockSize());
+            return new Encoder() {
+                @Override
+                public void encodeBlock(final long[] values, int blockSize, final IndexOutput data) throws IOException {
+                    blockEncoder.encode(values, blockSize, data);
+                }
+
+                @Override
+                public void encodeOrdinals(final long[] values, final IndexOutput data, int bitsPerOrd) throws IOException {
+                    ordinalEncoder.encodeOrdinals(values, data, bitsPerOrd);
+                }
+            };
+        }
+
+        @Override
+        public long[] writeField(
+            final FieldInfo field,
+            final TsdbDocValuesProducer valuesSource,
+            long maxOrd,
+            final OffsetsConsumer offsetsConsumer,
+            final SortedFieldObserver sortedFieldObserver
+        ) throws IOException {
+            final Encoder blockEncoder = encoder();
+            final IndexOutput meta = ctx.meta();
+            final IndexOutput data = ctx.data();
+            final int blockSize = ctx.blockSize();
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            final int maxDoc = ctx.maxDoc();
+            final TSDBDocValuesFormatConfig formatConfig = ctx.formatConfig();
+
+            int numDocsWithValue = 0;
+            long numValues = 0;
+
+            SortedNumericDocValues values;
+            if (valuesSource.mergeStats.supported()) {
+                numDocsWithValue = valuesSource.mergeStats.sumNumDocsWithField();
+                numValues = valuesSource.mergeStats.sumNumValues();
+            } else {
+                values = valuesSource.getSortedNumeric(field);
+                for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                    numDocsWithValue++;
+                    numValues += values.docValueCount();
+                }
+            }
+
+            meta.writeLong(numValues);
+            meta.writeInt(numDocsWithValue);
+
+            DISIAccumulator disiAccumulator = null;
+            try {
+                if (numValues > 0) {
+                    assert numDocsWithValue > 0;
+                    final ByteBuffersDataOutput indexOut = new ByteBuffersDataOutput();
+                    DirectMonotonicWriter indexWriter = null;
+
+                    final long valuesDataOffset = data.getFilePointer();
+                    if (maxOrd == 1) {
+                        meta.writeInt(INDEX_SINGLE_ORDINAL);
+                        if (sortedFieldObserver != null) {
+                            sortedFieldObserver.onDoc(0, 0);
+                        }
+                    } else if (shouldEncodeOrdinalRange(ctx, field, maxOrd, numDocsWithValue, numValues)) {
+                        assert offsetsConsumer == null;
+                        meta.writeInt(INDEX_ORDINAL_RANGE);
+                        meta.writeVInt(Math.toIntExact(maxOrd));
+                        meta.writeByte((byte) formatConfig.ordinalRangeBlockShift());
+                        values = valuesSource.getSortedNumeric(field);
+                        if (valuesSource.mergeStats.supported() && numDocsWithValue < maxDoc) {
+                            disiAccumulator = new DISIAccumulator(ctx.dir(), ctx.ioContext(), data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                        }
+                        final DirectMonotonicWriter startDocs = DirectMonotonicWriter.getInstance(
+                            meta,
+                            data,
+                            maxOrd + 1,
+                            formatConfig.ordinalRangeBlockShift()
+                        );
+                        long lastOrd = 0;
+                        startDocs.add(0);
+                        if (sortedFieldObserver != null) {
+                            sortedFieldObserver.onDoc(0, lastOrd);
+                        }
+                        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                            if (disiAccumulator != null) {
+                                disiAccumulator.addDocId(doc);
+                            }
+                            final long nextOrd = values.nextValue();
+                            if (nextOrd != lastOrd) {
+                                lastOrd = nextOrd;
+                                startDocs.add(doc);
+                                if (sortedFieldObserver != null) {
+                                    sortedFieldObserver.onDoc(doc, nextOrd);
+                                }
+                            }
+                        }
+                        startDocs.add(maxDoc);
+                        startDocs.finish();
+                    } else {
+                        indexWriter = DirectMonotonicWriter.getInstance(
+                            meta,
+                            new ByteBuffersIndexOutput(indexOut, "temp-dv-index", "temp-dv-index"),
+                            1L + ((numValues - 1) >>> blockShift),
+                            formatConfig.directMonotonicBlockShift()
+                        );
+                        meta.writeInt(formatConfig.directMonotonicBlockShift());
+                        FieldDescriptor.write(meta, numericEncoder.descriptor());
+                        final long[] buffer = new long[blockSize];
+                        int bufferSize = 0;
+                        final boolean useOrdinals = maxOrd >= 0;
+                        values = valuesSource.getSortedNumeric(field);
+                        final int bitsPerOrd = useOrdinals ? PackedInts.bitsRequired(maxOrd - 1) : -1;
+                        if (valuesSource.mergeStats.supported() && numDocsWithValue < maxDoc) {
+                            disiAccumulator = new DISIAccumulator(ctx.dir(), ctx.ioContext(), data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                        }
+                        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                            if (disiAccumulator != null) {
+                                disiAccumulator.addDocId(doc);
+                            }
+                            final int count = values.docValueCount();
+                            if (offsetsConsumer != null) {
+                                offsetsConsumer.accept(count);
+                            }
+                            for (int i = 0; i < count; ++i) {
+                                final long v = values.nextValue();
+                                if (sortedFieldObserver != null) {
+                                    sortedFieldObserver.onDoc(doc, v);
+                                }
+                                buffer[bufferSize++] = v;
+                                if (bufferSize == blockSize) {
+                                    indexWriter.add(data.getFilePointer() - valuesDataOffset);
+                                    if (useOrdinals) {
+                                        blockEncoder.encodeOrdinals(buffer, data, bitsPerOrd);
+                                    } else {
+                                        blockEncoder.encodeBlock(buffer, blockSize, data);
+                                    }
+                                    bufferSize = 0;
+                                }
+                            }
+                        }
+                        if (bufferSize > 0) {
+                            indexWriter.add(data.getFilePointer() - valuesDataOffset);
+                            Arrays.fill(buffer, bufferSize, blockSize, 0L);
+                            if (useOrdinals) {
+                                blockEncoder.encodeOrdinals(buffer, data, bitsPerOrd);
+                            } else {
+                                blockEncoder.encodeBlock(buffer, blockSize, data);
+                            }
+                        }
+                    }
+
+                    final long valuesDataLength = data.getFilePointer() - valuesDataOffset;
+                    if (indexWriter != null) {
+                        indexWriter.finish();
+                    }
+                    final long indexDataOffset = data.getFilePointer();
+                    data.copyBytes(indexOut.toDataInput(), indexOut.size());
+                    meta.writeLong(indexDataOffset);
+                    meta.writeLong(data.getFilePointer() - indexDataOffset);
+
+                    meta.writeLong(valuesDataOffset);
+                    meta.writeLong(valuesDataLength);
+                }
+
+                writeDISI(meta, data, ctx, valuesSource, field, maxOrd, numDocsWithValue, disiAccumulator);
+            } finally {
+                IOUtils.close(disiAccumulator);
+            }
+
+            return new long[] { numDocsWithValue, numValues };
+        }
+
+        private static boolean shouldEncodeOrdinalRange(
+            final NumericWriteContext ctx,
+            final FieldInfo field,
+            long maxOrd,
+            int numDocsWithValue,
+            long numValues
+        ) {
+            return ctx.maxDoc() > 1
+                && field.number == ctx.primarySortFieldNumber()
+                && numDocsWithValue == numValues
+                && (numDocsWithValue / maxOrd) >= ctx.formatConfig().minDocsPerOrdinalForRangeEncoding();
+        }
+
+        private static void writeDISI(
+            final IndexOutput meta,
+            final IndexOutput data,
+            final NumericWriteContext ctx,
+            final TsdbDocValuesProducer valuesSource,
+            final FieldInfo field,
+            long maxOrd,
+            int numDocsWithValue,
+            final DISIAccumulator disiAccumulator
+        ) throws IOException {
+            if (numDocsWithValue == 0) {
+                meta.writeLong(-2);
+                meta.writeLong(0L);
+                meta.writeShort((short) -1);
+                meta.writeByte((byte) -1);
+            } else if (numDocsWithValue == ctx.maxDoc()) {
+                meta.writeLong(-1);
+                meta.writeLong(0L);
+                meta.writeShort((short) -1);
+                meta.writeByte((byte) -1);
+            } else {
+                long offset = data.getFilePointer();
+                meta.writeLong(offset);
+                final short jumpTableEntryCount;
+                if (maxOrd != 1 && disiAccumulator != null) {
+                    jumpTableEntryCount = disiAccumulator.build(data);
+                } else {
+                    final SortedNumericDocValues values = valuesSource.getSortedNumeric(field);
+                    jumpTableEntryCount = IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                }
+                meta.writeLong(data.getFilePointer() - offset);
+                meta.writeShort(jumpTableEntryCount);
+                meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesFormat.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es94;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+import org.elasticsearch.index.codec.tsdb.BinaryDVCompressionMode;
+import org.elasticsearch.index.codec.tsdb.DocOffsetsCodec;
+import org.elasticsearch.index.codec.tsdb.PrefixedPartitionsWriter;
+import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
+import org.elasticsearch.index.codec.tsdb.SortedFieldObserverFactory;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.BinaryConfig;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.NumericConfig;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.SkipIndexConfig;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.TermsDictConfig;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.VersionConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecFactory;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder;
+
+import java.io.IOException;
+
+/**
+ * ES94 TSDB doc values format. Functionally equivalent to ES819 for all doc
+ * value types, with the sole difference that numeric fields are encoded via a
+ * composable pipeline of stages ({@code delta>offset>gcd>bitpack}) instead of
+ * the monolithic {@code TSDBDocValuesEncoder}. Each numeric field writes a
+ * self-describing {@link org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor}
+ * so decoders need no implicit format knowledge.
+ *
+ * <p>Non-numeric field types (binary, sorted, sorted-set) are handled identically
+ * to ES819 by the shared abstract base classes.
+ */
+public class ES94TSDBDocValuesFormat extends DocValuesFormat {
+
+    static final String CODEC_NAME = "ES94TSDB";
+    static final String DATA_CODEC = "ES94TSDBDocValuesData";
+    static final String DATA_EXTENSION = "dvd";
+    static final String META_CODEC = "ES94TSDBDocValuesMetadata";
+    static final String META_EXTENSION = "dvm";
+
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = 0;
+
+    static final int NUMERIC_BLOCK_SHIFT = 7;
+    static final int NUMERIC_LARGE_BLOCK_SHIFT = 9;
+    static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+    static final int ORDINAL_RANGE_ENCODING_BLOCK_SHIFT = 12;
+    static final int ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL = 512;
+    static final int DEFAULT_SKIP_INDEX_INTERVAL_SIZE = 4096;
+    static final int SKIP_INDEX_LEVEL_SHIFT = 3;
+    static final int SKIP_INDEX_MAX_LEVEL = 4;
+
+    static final int TERMS_DICT_BLOCK_LZ4_SHIFT = 6;
+    static final int TERMS_DICT_BLOCK_LZ4_SIZE = 1 << TERMS_DICT_BLOCK_LZ4_SHIFT;
+    static final int TERMS_DICT_BLOCK_LZ4_MASK = TERMS_DICT_BLOCK_LZ4_SIZE - 1;
+    static final int TERMS_DICT_REVERSE_INDEX_SHIFT = 10;
+    static final int TERMS_DICT_REVERSE_INDEX_SIZE = 1 << TERMS_DICT_REVERSE_INDEX_SHIFT;
+    static final int TERMS_DICT_REVERSE_INDEX_MASK = TERMS_DICT_REVERSE_INDEX_SIZE - 1;
+
+    static final int BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT = 128 * 1024;
+    static final int BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT = 1024;
+
+    static final VersionConfig VERSION_CONFIG = new VersionConfig(
+        VERSION_START,
+        VERSION_CURRENT,
+        VERSION_START,
+        VERSION_START,
+        VERSION_START
+    );
+
+    static final TermsDictConfig TERMS_DICT_CONFIG = new TermsDictConfig(
+        TERMS_DICT_BLOCK_LZ4_MASK,
+        TERMS_DICT_BLOCK_LZ4_SHIFT,
+        TERMS_DICT_REVERSE_INDEX_SHIFT,
+        TERMS_DICT_REVERSE_INDEX_MASK
+    );
+
+    static final NumericCodecFactory NUMERIC_CODEC_FACTORY = NumericCodecFactory.DEFAULT;
+
+    final boolean enableOptimizedMerge;
+    final DocOffsetsCodec docOffsetsCodec;
+    final TSDBDocValuesFormatConfig formatConfig;
+    final NumericEncoder numericEncoder;
+
+    public ES94TSDBDocValuesFormat() {
+        this(NUMERIC_BLOCK_SHIFT);
+    }
+
+    public ES94TSDBDocValuesFormat(int numericBlockShift) {
+        this(
+            DEFAULT_SKIP_INDEX_INTERVAL_SIZE,
+            ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL,
+            true,
+            BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+            true,
+            numericBlockShift
+        );
+    }
+
+    public ES94TSDBDocValuesFormat(
+        int skipIndexIntervalSize,
+        int minDocsPerOrdinalForRangeEncoding,
+        boolean enableOptimizedMerge,
+        BinaryDVCompressionMode binaryDVCompressionMode,
+        boolean enablePerBlockCompression,
+        int numericBlockShift
+    ) {
+        this(
+            skipIndexIntervalSize,
+            minDocsPerOrdinalForRangeEncoding,
+            enableOptimizedMerge,
+            binaryDVCompressionMode,
+            enablePerBlockCompression,
+            numericBlockShift,
+            DocOffsetsCodec.GROUPED_VINT,
+            BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT,
+            BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT,
+            false
+        );
+    }
+
+    public ES94TSDBDocValuesFormat(
+        int skipIndexIntervalSize,
+        int minDocsPerOrdinalForRangeEncoding,
+        boolean enableOptimizedMerge,
+        BinaryDVCompressionMode binaryDVCompressionMode,
+        boolean enablePerBlockCompression,
+        int numericBlockShift,
+        DocOffsetsCodec docOffsetsCodec,
+        int blockBytesThreshold,
+        int blockCountThreshold,
+        boolean writePrefixPartitions
+    ) {
+        super(CODEC_NAME);
+        assert numericBlockShift == NUMERIC_BLOCK_SHIFT || numericBlockShift == NUMERIC_LARGE_BLOCK_SHIFT : numericBlockShift;
+        if (skipIndexIntervalSize < 2) {
+            throw new IllegalArgumentException("skipIndexIntervalSize must be > 1, got [" + skipIndexIntervalSize + "]");
+        }
+        this.enableOptimizedMerge = enableOptimizedMerge;
+        this.docOffsetsCodec = docOffsetsCodec;
+        final PipelineConfig pipelineConfig = PipelineConfig.forLongs(1 << numericBlockShift).delta().offset().gcd().bitPack();
+        this.numericEncoder = NUMERIC_CODEC_FACTORY.createEncoder(pipelineConfig);
+        this.formatConfig = new TSDBDocValuesFormatConfig(
+            VERSION_CONFIG,
+            TERMS_DICT_CONFIG,
+            new SkipIndexConfig(SKIP_INDEX_LEVEL_SHIFT, SKIP_INDEX_MAX_LEVEL, skipIndexIntervalSize),
+            new NumericConfig(numericBlockShift, ORDINAL_RANGE_ENCODING_BLOCK_SHIFT, minDocsPerOrdinalForRangeEncoding),
+            new BinaryConfig(blockBytesThreshold, blockCountThreshold, enablePerBlockCompression, binaryDVCompressionMode),
+            DIRECT_MONOTONIC_BLOCK_SHIFT,
+            writePrefixPartitions
+        );
+    }
+
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        return new ES94TSDBDocValuesConsumer(
+            state,
+            enableOptimizedMerge,
+            DATA_CODEC,
+            DATA_EXTENSION,
+            META_CODEC,
+            META_EXTENSION,
+            formatConfig,
+            docOffsetsCodec.getEncoder(),
+            formatConfig.writePrefixPartitions()
+                ? field -> field.number == AbstractTSDBDocValuesProducer.primarySortFieldNumber(state.segmentInfo, state.fieldInfos)
+                    ? new PrefixedPartitionsWriter()
+                    : SortedFieldObserver.NOOP
+                : SortedFieldObserverFactory.NOOP,
+            numericEncoder
+        );
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new ES94TSDBDocValuesProducer(
+            state,
+            DATA_CODEC,
+            DATA_EXTENSION,
+            META_CODEC,
+            META_EXTENSION,
+            formatConfig,
+            docOffsetsCodec.getDecoder(),
+            NUMERIC_CODEC_FACTORY
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesProducer.java
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.index.codec.tsdb.es819;
+package org.elasticsearch.index.codec.tsdb.es94;
 
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.DataInput;
@@ -20,25 +20,30 @@ import org.elasticsearch.index.codec.tsdb.EntryFactory;
 import org.elasticsearch.index.codec.tsdb.NumericFieldReader;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockDecoder;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecFactory;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecoder;
 
 import java.io.IOException;
 
 /**
- * ES819 doc values producer. Delegates all shared wire-format reading logic to
- * {@link AbstractTSDBDocValuesProducer} and provides the ES819-specific numeric
- * decoding strategy via {@link TSDBDocValuesEncoder}.
+ * ES94 doc values producer. Reads a {@link FieldDescriptor} from metadata to
+ * reconstruct a {@link NumericDecoder} for each field, making the format
+ * self-describing. Ordinal decoding delegates to {@link TSDBDocValuesEncoder}
+ * for feature parity with ES819.
  */
-final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
+final class ES94TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
 
     private static final EntryFactory ENTRY_FACTORY = new EntryFactory() {
         @Override
         public NumericEntry createNumericEntry() {
-            return new ES819NumericEntry();
+            return new ES94NumericEntry();
         }
 
         @Override
         public SortedNumericEntry createSortedNumericEntry() {
-            return new ES819SortedNumericEntry();
+            return new ES94SortedNumericEntry();
         }
 
         @Override
@@ -47,24 +52,30 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
         }
     };
 
-    ES819TSDBDocValuesProducer(
+    private final NumericCodecFactory numericCodecFactory;
+
+    ES94TSDBDocValuesProducer(
         final SegmentReadState state,
         final String dataCodec,
         final String dataExtension,
         final String metaCodec,
         final String metaExtension,
         final TSDBDocValuesFormatConfig formatConfig,
-        final DocOffsetsCodec.Decoder docOffsetsDecoder
+        final DocOffsetsCodec.Decoder docOffsetsDecoder,
+        final NumericCodecFactory numericCodecFactory
     ) throws IOException {
         super(state, dataCodec, dataExtension, metaCodec, metaExtension, formatConfig, docOffsetsDecoder, ENTRY_FACTORY);
+        this.numericCodecFactory = numericCodecFactory;
     }
 
-    private ES819TSDBDocValuesProducer(final ES819TSDBDocValuesProducer original) {
+    private ES94TSDBDocValuesProducer(final ES94TSDBDocValuesProducer original) {
         super(original);
+        this.numericCodecFactory = original.numericCodecFactory;
     }
 
     @Override
     protected NumericFieldReader createNumericFieldReader(final NumericEntry entry, int numericBlockSize) {
+        final PipelineDescriptorEntry pipelineEntry = (PipelineDescriptorEntry) entry;
         return new NumericFieldReader() {
             @Override
             public void readField(final IndexInput meta, final NumericEntry e, int numericBlockShift) throws IOException {
@@ -79,6 +90,7 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
                         final int blockShift = meta.readByte();
                         e.sortedOrdinals = DirectMonotonicReader.loadMeta(meta, numOrds + 1, blockShift);
                     } else {
+                        pipelineEntry.pipelineDescriptor(FieldDescriptor.read(meta));
                         e.indexMeta = DirectMonotonicReader.loadMeta(meta, 1 + ((e.numValues - 1) >>> numericBlockShift), indexBlockShift);
                     }
                     e.indexOffset = meta.readLong();
@@ -94,16 +106,22 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
 
             @Override
             public Decoder decoder() {
-                final TSDBDocValuesEncoder decoder = new TSDBDocValuesEncoder(numericBlockSize);
+                final TSDBDocValuesEncoder ordinalDecoder = new TSDBDocValuesEncoder(numericBlockSize);
                 return new Decoder() {
+                    private NumericBlockDecoder blockDecoder;
+
                     @Override
                     public void decodeBlock(final DataInput input, final long[] values, int count) throws IOException {
-                        decoder.decode(input, values);
+                        if (blockDecoder == null) {
+                            final NumericDecoder decoder = numericCodecFactory.createDecoder(pipelineEntry.pipelineDescriptor());
+                            blockDecoder = decoder.newBlockDecoder();
+                        }
+                        blockDecoder.decode(values, count, input);
                     }
 
                     @Override
                     public void decodeOrdinals(final DataInput input, final long[] values, int bitsPerOrd) throws IOException {
-                        decoder.decodeOrdinals(input, values, bitsPerOrd);
+                        ordinalDecoder.decodeOrdinals(input, values, bitsPerOrd);
                     }
                 };
             }
@@ -112,6 +130,6 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
 
     @Override
     protected AbstractTSDBDocValuesProducer createMergeInstance() {
-        return new ES819TSDBDocValuesProducer(this);
+        return new ES94TSDBDocValuesProducer(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/PipelineDescriptorEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es94/PipelineDescriptorEntry.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es94;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+
+/**
+ * Implemented by ES94 numeric entry types to provide typed access to the
+ * {@link PipelineDescriptor} read from segment metadata.
+ */
+interface PipelineDescriptorEntry {
+
+    PipelineDescriptor pipelineDescriptor();
+
+    void pipelineDescriptor(PipelineDescriptor pipelineDescriptor);
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+
+import java.io.IOException;
+
+/**
+ * Per-field block decoder owning a mutable {@link DecodingContext}.
+ *
+ * <p>NOT thread-safe. Each instance owns a {@link DecodingContext} with mutable
+ * per-block state. Callers that may run concurrently must each hold their own
+ * decoder instance, obtained via {@link NumericDecoder#newBlockDecoder()}.
+ */
+public final class NumericBlockDecoder {
+
+    private final NumericDecodePipeline pipeline;
+    private final DecodingContext decodingContext;
+
+    NumericBlockDecoder(final NumericDecodePipeline pipeline) {
+        this.pipeline = pipeline;
+        this.decodingContext = new DecodingContext(pipeline.blockSize(), pipeline.size());
+    }
+
+    /**
+     * Decodes a block of values by reading the payload and reversing transforms.
+     *
+     * @param values the output array to populate
+     * @param count  the expected number of values
+     * @param in     the data input to read from
+     * @throws IOException if an I/O error occurs
+     */
+    public void decode(final long[] values, int count, final DataInput in) throws IOException {
+        decodingContext.clear();
+        pipeline.decode(values, count, in, decodingContext);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockEncoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+
+import java.io.IOException;
+
+/**
+ * Per-field block encoder owning a mutable {@link EncodingContext}.
+ *
+ * <p>NOT thread-safe. Each instance owns an {@link EncodingContext} with mutable
+ * per-block state. Callers that may run concurrently must each hold their own
+ * encoder instance, obtained via {@link NumericEncoder#newBlockEncoder()}.
+ */
+public final class NumericBlockEncoder {
+
+    private final NumericEncodePipeline pipeline;
+    private final EncodingContext encodingContext;
+
+    NumericBlockEncoder(final NumericEncodePipeline pipeline) {
+        this.pipeline = pipeline;
+        this.encodingContext = new EncodingContext(pipeline.blockSize(), pipeline.size());
+    }
+
+    /**
+     * Encodes a block of values through the pipeline.
+     *
+     * @param values     the values to encode (modified in-place by transform stages)
+     * @param valueCount the number of valid values
+     * @param out        the data output to write the encoded block to
+     * @throws IOException if an I/O error occurs
+     */
+    public void encode(final long[] values, int valueCount, final DataOutput out) throws IOException {
+        encodingContext.clear();
+        pipeline.encode(values, valueCount, out, encodingContext);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+
+/**
+ * Factory for creating encoder/decoder instances from pipeline configurations.
+ * The consumer calls {@link #createEncoder} with a {@link PipelineConfig}.
+ * The producer calls {@link #createDecoder} with a {@link PipelineDescriptor}.
+ */
+public interface NumericCodecFactory {
+
+    /** Default factory that delegates to {@link NumericEncoder#fromConfig} and {@link NumericDecoder#fromDescriptor}. */
+    NumericCodecFactory DEFAULT = new NumericCodecFactory() {
+        @Override
+        public NumericEncoder createEncoder(PipelineConfig config) {
+            return NumericEncoder.fromConfig(config);
+        }
+
+        @Override
+        public NumericDecoder createDecoder(PipelineDescriptor descriptor) {
+            return NumericDecoder.fromDescriptor(descriptor);
+        }
+    };
+
+    /** Creates an encoder from the given pipeline configuration. */
+    NumericEncoder createEncoder(PipelineConfig config);
+
+    /** Creates a decoder from the given pipeline descriptor. */
+    NumericDecoder createDecoder(PipelineDescriptor descriptor);
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecStage.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecStage.java
@@ -17,4 +17,4 @@ package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
  * deltas, removing offsets, or factoring out a GCD) so that the terminal payload
  * stage can pack them into fewer bits.
  */
-public interface NumericCodecStage extends NumericEncoder, NumericDecoder {}
+public interface NumericCodecStage extends TransformEncoder, TransformDecoder {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.BlockFormat;
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Immutable decoding pipeline: reads payload then reverses transform stages.
+ *
+ * <p>Reconstructed from a {@link PipelineDescriptor} read from segment metadata,
+ * making the format self-describing. The decoder does not need to know the
+ * pipeline configuration at compile time.
+ *
+ * <p>Instances are immutable and thread-safe. Mutable per-block state lives in
+ * {@link DecodingContext}, which must be provided by the caller.
+ */
+public final class NumericDecodePipeline {
+
+    private final NumericCodecStage[] transformStages;
+    private final PayloadCodecStage payloadStage;
+    private final int blockSize;
+    private final int payloadPosition;
+
+    NumericDecodePipeline(final NumericCodecStage[] transformStages, final PayloadCodecStage payloadStage, int blockSize) {
+        this.transformStages = transformStages;
+        this.payloadStage = payloadStage;
+        this.blockSize = blockSize;
+        this.payloadPosition = transformStages.length;
+    }
+
+    /**
+     * Reconstructs a decode pipeline from a persisted descriptor.
+     *
+     * @param descriptor the pipeline descriptor read from segment metadata
+     * @return the decode pipeline
+     */
+    public static NumericDecodePipeline fromDescriptor(final PipelineDescriptor descriptor) {
+        final int blockSize = descriptor.blockSize();
+        final int stageCount = descriptor.pipelineLength();
+        final List<NumericCodecStage> transforms = new ArrayList<>();
+
+        for (int i = 0; i < stageCount - 1; i++) {
+            final StageSpec spec = StageFactory.specFromStageId(StageId.fromId(descriptor.stageIdAt(i)));
+            transforms.add(StageFactory.newTransformStage(spec));
+        }
+        final StageSpec payloadSpec = StageFactory.specFromStageId(StageId.fromId(descriptor.stageIdAt(stageCount - 1)));
+        final PayloadCodecStage payloadStage = StageFactory.newPayloadStage(payloadSpec, blockSize);
+
+        return new NumericDecodePipeline(transforms.toArray(NumericCodecStage[]::new), payloadStage, blockSize);
+    }
+
+    /**
+     * Decodes a block of values by reading the payload and reversing transforms.
+     *
+     * @param values  the output array to populate
+     * @param count   the expected number of values
+     * @param in      the data input to read from
+     * @param context the mutable per-block decoding context
+     * @throws IOException if an I/O error occurs
+     */
+    public void decode(final long[] values, int count, final DataInput in, final DecodingContext context) throws IOException {
+        context.setDataInput(in);
+        BlockFormat.readBlock(in, values, payloadStage, context, payloadPosition);
+        for (int i = transformStages.length - 1; i >= 0; i--) {
+            if (context.isStageApplied(i)) {
+                transformStages[i].decode(values, count, context);
+            }
+        }
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return blockSize;
+    }
+
+    /** Returns the total number of stages (transforms + payload). */
+    public int size() {
+        return transformStages.length + 1;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecoder.java
@@ -9,33 +9,47 @@
 
 package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
 
-import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
-
-import java.io.IOException;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 /**
- * Reverses an in-place transformation as a non-terminal stage of the decode pipeline.
+ * Read-path coordinator: owns a {@link NumericDecodePipeline} and produces
+ * {@link NumericBlockDecoder} instances for decoding blocks of values.
  *
- * <p>Unlike {@link PayloadDecoder}, transform decoders do not read from a
- * {@link org.apache.lucene.store.DataInput} directly. They read metadata written
- * by the corresponding {@link NumericEncoder} via {@link DecodingContext#metadata()}.
+ * <p>Instances are immutable and thread-safe. Per-field mutable state lives in
+ * {@link NumericBlockDecoder}, which callers obtain via {@link #newBlockDecoder()}.
+ *
+ * <p>Created via {@link #fromDescriptor} or via {@link NumericCodecFactory#createDecoder}.
  */
-public interface NumericDecoder {
+public final class NumericDecoder {
+
+    private final NumericDecodePipeline pipeline;
+
+    NumericDecoder(final NumericDecodePipeline pipeline) {
+        this.pipeline = pipeline;
+    }
 
     /**
-     * Returns the unique stage identifier.
+     * Reconstructs a decoder from a persisted descriptor.
+     * Use {@link NumericCodecFactory#createDecoder} as the public entry point.
      *
-     * @return the stage ID byte
+     * @param descriptor the pipeline descriptor read from segment metadata
+     * @return the decoder
      */
-    byte id();
+    static NumericDecoder fromDescriptor(final PipelineDescriptor descriptor) {
+        return new NumericDecoder(NumericDecodePipeline.fromDescriptor(descriptor));
+    }
 
     /**
-     * Reverses the transformation on values in-place using metadata from the context.
+     * Creates a new block decoder with its own mutable decoding context.
      *
-     * @param values     the values to reverse-transform in-place
-     * @param valueCount the number of valid values in the array
-     * @param context    the decoding context for reading stage metadata
-     * @throws IOException if an I/O error occurs while reading metadata
+     * @return a fresh block decoder
      */
-    void decode(long[] values, int valueCount, DecodingContext context) throws IOException;
+    public NumericBlockDecoder newBlockDecoder() {
+        return new NumericBlockDecoder(pipeline);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.BlockFormat;
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Immutable encoding pipeline: transform stages followed by a terminal payload stage.
+ *
+ * <p>Transform stages run in forward order, modifying values in-place to reduce
+ * dynamic range. The payload stage serializes the result. Each stage decides
+ * per-block whether to apply itself, recorded in a position bitmap for decoding.
+ *
+ * <p>Instances are immutable and thread-safe. Mutable per-block state lives in
+ * {@link EncodingContext}, which must be provided by the caller.
+ */
+public final class NumericEncodePipeline {
+
+    private final NumericCodecStage[] transformStages;
+    private final PayloadCodecStage payloadStage;
+    private final PipelineDescriptor descriptor;
+    private final int blockSize;
+    private final int payloadPosition;
+
+    NumericEncodePipeline(
+        final NumericCodecStage[] transformStages,
+        final PayloadCodecStage payloadStage,
+        int blockSize,
+        final PipelineDescriptor descriptor
+    ) {
+        this.transformStages = transformStages;
+        this.payloadStage = payloadStage;
+        this.blockSize = blockSize;
+        this.payloadPosition = transformStages.length;
+        this.descriptor = descriptor;
+    }
+
+    /**
+     * Builds an encode pipeline from a pipeline configuration.
+     *
+     * @param config the pipeline configuration
+     * @return the encode pipeline
+     * @throws IllegalStateException if the pipeline has no payload stage
+     */
+    public static NumericEncodePipeline fromConfig(final PipelineConfig config) {
+        final int blockSize = config.blockSize();
+        final List<StageSpec> specs = config.specs();
+        final List<NumericCodecStage> transforms = new ArrayList<>();
+        PayloadCodecStage payload = null;
+
+        for (final StageSpec spec : specs) {
+            if (spec instanceof StageSpec.PayloadSpec) {
+                if (payload != null) {
+                    throw new IllegalStateException("Pipeline must have exactly one payload stage");
+                }
+                payload = StageFactory.newPayloadStage(spec, blockSize);
+            } else {
+                transforms.add(StageFactory.newTransformStage(spec));
+            }
+        }
+
+        if (payload == null) {
+            throw new IllegalStateException("Pipeline must end with a payload stage");
+        }
+
+        final byte[] ids = new byte[specs.size()];
+        for (int i = 0; i < specs.size(); i++) {
+            ids[i] = specs.get(i).stageId().id;
+        }
+        final PipelineDescriptor descriptor = new PipelineDescriptor(ids, blockSize, config.dataType());
+
+        return new NumericEncodePipeline(transforms.toArray(NumericCodecStage[]::new), payload, blockSize, descriptor);
+    }
+
+    /**
+     * Encodes a block of values through the pipeline.
+     *
+     * @param values     the values to encode (modified in-place by transform stages)
+     * @param valueCount the number of valid values
+     * @param out        the data output to write the encoded block to
+     * @param context    the mutable per-block encoding context
+     * @throws IOException if an I/O error occurs
+     */
+    public void encode(final long[] values, int valueCount, final DataOutput out, final EncodingContext context) throws IOException {
+        context.setValueCount(valueCount);
+
+        for (int i = 0; i < transformStages.length; i++) {
+            context.setCurrentPosition(i);
+            transformStages[i].encode(values, context.valueCount(), context);
+        }
+
+        context.setCurrentPosition(payloadPosition);
+        context.applyStage(payloadPosition);
+
+        BlockFormat.writeBlock(out, values, payloadStage, context);
+    }
+
+    /** Returns the pipeline descriptor for persistence via {@link org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor}. */
+    public PipelineDescriptor descriptor() {
+        return descriptor;
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return blockSize;
+    }
+
+    /** Returns the total number of stages (transforms + payload). */
+    public int size() {
+        return transformStages.length + 1;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncoder.java
@@ -9,35 +9,53 @@
 
 package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
 
-import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 /**
- * Transforms values in-place as a non-terminal stage of the encode pipeline.
+ * Write-path coordinator: owns a {@link NumericEncodePipeline} and produces
+ * {@link NumericBlockEncoder} instances for encoding blocks of values.
  *
- * <p>Unlike {@link PayloadEncoder}, transform stages do not write to a
- * {@link org.apache.lucene.store.DataOutput}. They modify the {@code long[]}
- * array in-place and record any metadata needed for decoding via
- * {@link EncodingContext#metadata()}.
+ * <p>Instances are immutable and thread-safe. Per-field mutable state lives in
+ * {@link NumericBlockEncoder}, which callers obtain via {@link #newBlockEncoder()}.
+ *
+ * <p>Created via {@link #fromConfig} or via {@link NumericCodecFactory#createEncoder}.
  */
-public interface NumericEncoder {
+public final class NumericEncoder {
+
+    private final NumericEncodePipeline pipeline;
+
+    NumericEncoder(final NumericEncodePipeline pipeline) {
+        this.pipeline = pipeline;
+    }
 
     /**
-     * Returns the unique stage identifier.
+     * Builds an encoder from a pipeline configuration.
+     * Use {@link NumericCodecFactory#createEncoder} as the public entry point.
      *
-     * @return the stage ID byte
+     * @param config the pipeline configuration
+     * @return the encoder
      */
-    byte id();
+    static NumericEncoder fromConfig(final PipelineConfig config) {
+        return new NumericEncoder(NumericEncodePipeline.fromConfig(config));
+    }
 
     /**
-     * Transforms values in-place and writes any metadata to the context.
+     * Creates a new block encoder with its own mutable encoding context.
      *
-     * <p>If the stage determines that the transformation would not be effective,
-     * it may return without modifying the values or writing metadata. The pipeline
-     * checks {@link EncodingContext#isStageApplied(int)} to detect this.
-     *
-     * @param values     the values to transform in-place
-     * @param valueCount the number of valid values in the array
-     * @param context    the encoding context for metadata and stage tracking
+     * @return a fresh block encoder
      */
-    void encode(long[] values, int valueCount, EncodingContext context);
+    public NumericBlockEncoder newBlockEncoder() {
+        return new NumericBlockEncoder(pipeline);
+    }
+
+    /** Returns the pipeline descriptor for persistence via {@link org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor}. */
+    public PipelineDescriptor descriptor() {
+        return pipeline.descriptor();
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadDecoder.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 /**
  * Deserializes bytes back to values as the terminal stage of the decode pipeline.
  *
- * <p>Unlike {@link NumericDecoder}, payload stages read directly from a
+ * <p>Unlike {@link TransformDecoder}, payload stages read directly from a
  * {@link org.apache.lucene.store.DataInput} rather than reading metadata from the context.
  */
 public interface PayloadDecoder {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadEncoder.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 /**
  * Serializes values to bytes as the terminal stage of the encode pipeline.
  *
- * <p>Unlike {@link NumericEncoder}, payload stages write directly to a
+ * <p>Unlike {@link TransformEncoder}, payload stages write directly to a
  * {@link org.apache.lucene.store.DataOutput} rather than modifying values in-place.
  */
 public interface PayloadEncoder {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.DocValuesForUtil;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.BitPackCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.GcdCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.OffsetCodecStage;
+
+/**
+ * Maps between {@link StageSpec} records and concrete stage instances, and between
+ * persisted {@link StageId} bytes and {@link StageSpec} records.
+ *
+ * <p>The encode path uses {@link #newTransformStage} and {@link #newPayloadStage} to
+ * create stages from a {@link org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig}.
+ * The decode path uses {@link #specFromStageId} to reconstruct specs from the persisted
+ * stage IDs in a {@link org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor}.
+ */
+public final class StageFactory {
+
+    private StageFactory() {}
+
+    /**
+     * Creates a transform stage from a specification.
+     *
+     * @param spec the stage specification
+     * @return the concrete stage instance
+     * @throws IllegalArgumentException if the spec is not a transform stage
+     */
+    static NumericCodecStage newTransformStage(final StageSpec spec) {
+        return switch (spec) {
+            case StageSpec.DeltaStage ignored -> DeltaCodecStage.INSTANCE;
+            case StageSpec.OffsetStage ignored -> OffsetCodecStage.INSTANCE;
+            case StageSpec.GcdStage ignored -> GcdCodecStage.INSTANCE;
+            default -> throw new IllegalArgumentException("Not a transform stage: " + spec);
+        };
+    }
+
+    /**
+     * Creates a payload stage from a specification.
+     *
+     * @param spec      the stage specification
+     * @param blockSize the number of values per block
+     * @return the concrete payload stage instance
+     * @throws IllegalArgumentException if the spec is not a payload stage
+     */
+    static PayloadCodecStage newPayloadStage(final StageSpec spec, int blockSize) {
+        return switch (spec) {
+            case StageSpec.BitPackPayload ignored -> new BitPackCodecStage(new DocValuesForUtil(blockSize));
+            default -> throw new IllegalArgumentException("Not a payload stage: " + spec);
+        };
+    }
+
+    /**
+     * Converts a persisted {@link StageId} back to its corresponding {@link StageSpec}.
+     *
+     * <p>Used on the decode path to reconstruct the pipeline from a
+     * {@link org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor}.
+     *
+     * @param stageId the persisted stage identifier
+     * @return the corresponding stage specification
+     */
+    static StageSpec specFromStageId(final StageId stageId) {
+        return switch (stageId) {
+            case DELTA_STAGE -> new StageSpec.DeltaStage();
+            case OFFSET_STAGE -> new StageSpec.OffsetStage();
+            case GCD_STAGE -> new StageSpec.GcdStage();
+            case BITPACK_PAYLOAD -> new StageSpec.BitPackPayload();
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformDecoder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+
+import java.io.IOException;
+
+/**
+ * Reverses an in-place transformation as a non-terminal stage of the decode pipeline.
+ *
+ * <p>Unlike {@link PayloadDecoder}, transform decoders do not read from a
+ * {@link org.apache.lucene.store.DataInput} directly. They read metadata written
+ * by the corresponding {@link TransformEncoder} via {@link DecodingContext#metadata()}.
+ */
+public interface TransformDecoder {
+
+    /**
+     * Returns the unique stage identifier.
+     *
+     * @return the stage ID byte
+     */
+    byte id();
+
+    /**
+     * Reverses the transformation on values in-place using metadata from the context.
+     *
+     * @param values     the values to reverse-transform in-place
+     * @param valueCount the number of valid values in the array
+     * @param context    the decoding context for reading stage metadata
+     * @throws IOException if an I/O error occurs while reading metadata
+     */
+    void decode(long[] values, int valueCount, DecodingContext context) throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+
+/**
+ * Transforms values in-place as a non-terminal stage of the encode pipeline.
+ *
+ * <p>Unlike {@link PayloadEncoder}, transform stages do not write to a
+ * {@link org.apache.lucene.store.DataOutput}. They modify the {@code long[]}
+ * array in-place and record any metadata needed for decoding via
+ * {@link EncodingContext#metadata()}.
+ */
+public interface TransformEncoder {
+
+    /**
+     * Returns the unique stage identifier.
+     *
+     * @return the stage ID byte
+     */
+    byte id();
+
+    /**
+     * Transforms values in-place and writes any metadata to the context.
+     *
+     * <p>If the stage determines that the transformation would not be effective,
+     * it may return without modifying the values or writing metadata. The pipeline
+     * checks {@link EncodingContext#isStageApplied(int)} to detect this.
+     *
+     * @param values     the values to transform in-place
+     * @param valueCount the number of valid values in the array
+     * @param context    the encoding context for metadata and stage tracking
+     */
+    void encode(long[] values, int valueCount, EncodingContext context);
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/package-info.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/package-info.java
@@ -8,13 +8,13 @@
  */
 
 /**
- * Encoder/decoder contracts for numeric pipeline stages.
+ * Encoder/decoder contracts and pipeline orchestration for numeric pipeline stages.
  *
  * <p>This package defines two families of stage contracts:
  * <ul>
  *   <li><strong>Transform stages</strong>:
- *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder} and
- *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecoder}
+ *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.TransformEncoder} and
+ *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.TransformDecoder}
  *       (combined as {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecStage})
  *       modify {@code long[]} values in-place and exchange metadata through the
  *       encoding/decoding context. Concrete implementations live in the
@@ -26,6 +26,14 @@
  *       serialize transformed values to bytes and read them back as the terminal
  *       pipeline step.</li>
  * </ul>
+ *
+ * <p>Pipeline orchestration is provided by {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncodePipeline}
+ * (write path) and {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecodePipeline} (read path).
+ * The high-level API is exposed via {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder}
+ * and {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecoder}, which produce per-field
+ * {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockEncoder} and
+ * {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockDecoder} instances owning
+ * mutable per-block context.
  *
  * <p>Each stage implementation corresponds to a
  * {@link org.elasticsearch.index.codec.tsdb.pipeline.StageSpec} and is identified by a

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
@@ -1,4 +1,5 @@
 org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat
 org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat
 org.elasticsearch.index.codec.tsdb.es819.ES819Version3TSDBDocValuesFormat
+org.elasticsearch.index.codec.tsdb.es94.ES94TSDBDocValuesFormat
 org.elasticsearch.index.codec.bloomfilter.ES94BloomFilterDocValuesFormat

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -635,16 +635,12 @@ public class CancellableTasksTests extends TaskManagerTestCase {
         final Thread reader = new Thread(() -> {
             safeAwait(start);
             while (task.isCancelled() == false) {
-                assertThat(
-                    "toString should consistently render status and reason",
-                    task.toString(),
-                    anyOf(endsWith("reason='null', isCancelled=false}"), endsWith("reason='test-reason', isCancelled=true}"))
-                );
+                Thread.onSpinWait();
             }
             assertThat(
-                "toString should consistently render status and reason when task is cancelled",
+                "toString should consistently render status and reason",
                 task.toString(),
-                endsWith("reason='test-reason', isCancelled=true}")
+                anyOf(endsWith("reason='null', isCancelled=false}"), endsWith("reason='test-reason', isCancelled=true}"))
             );
         });
         reader.start();

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -74,7 +74,6 @@ public final class MockSearchPhaseContext extends AbstractSearchAsyncAction<Sear
             new SearchRequest(),
             ActionListener.noop(),
             List.of(),
-            Collections.emptyMap(),
             null,
             ClusterState.EMPTY_STATE,
             new SearchTask(0, "n/a", "n/a", () -> "test", null, Collections.emptyMap()),
@@ -129,12 +128,11 @@ public final class MockSearchPhaseContext extends AbstractSearchAsyncAction<Sear
 
     @Override
     public void sendSearchResponse(SearchResponseSections internalSearchResponse, AtomicArray<SearchPhaseResult> queryResults) {
-        boolean isMultiShard = getNumShards() > 1;
         String scrollId = getRequest().scroll() != null
-            ? TransportSearchHelper.buildScrollId(queryResults, bigArrays.bytesRefRecycler(), isMultiShard)
+            ? TransportSearchHelper.buildScrollId(queryResults, bigArrays.bytesRefRecycler())
             : null;
         BytesReference searchContextId = getRequest().pointInTimeBuilder() != null
-            ? new BytesArray(TransportSearchHelper.buildScrollId(queryResults, bigArrays.bytesRefRecycler(), isMultiShard))
+            ? new BytesArray(TransportSearchHelper.buildScrollId(queryResults, bigArrays.bytesRefRecycler()))
             : null;
         var existing = searchResponse.getAndSet(
             new SearchResponse(

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesFormatTestCase.java
@@ -1,0 +1,2914 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.LogByteSizeMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.codec.Elasticsearch900Lucene101Codec;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.BaseDenseNumericValues;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.BaseSortedDocValues;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.TSDBBinaryDocValues;
+import org.elasticsearch.index.mapper.BinaryFieldMapper.CustomBinaryDocValuesField;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.BlockLoader.OptionalColumnAtATimeReader;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
+import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.test.ESTestCase.between;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.ESTestCase.randomUnicodeOfCodepointLengthBetween;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public abstract class AbstractTSDBDocValuesFormatTestCase extends BaseDocValuesFormatTestCase {
+
+    static final int NUMERIC_BLOCK_SHIFT = 7;
+    static final int NUMERIC_LARGE_BLOCK_SHIFT = 9;
+    static final int BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT = 128 * 1024;
+    static final int BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT = 1024;
+
+    private static final int NUM_DOCS = 10;
+
+    static {
+        LogConfigurator.loadLog4jPlugins();
+        LogConfigurator.configureESLogging();
+    }
+
+    protected abstract DocValuesFormat createDocValuesFormat(
+        int skipIndexIntervalSize,
+        int minDocsPerOrdinalForRangeEncoding,
+        boolean enableOptimizedMerge,
+        BinaryDVCompressionMode binaryDVCompressionMode,
+        boolean enablePerBlockCompression,
+        int numericBlockShift,
+        boolean writePrefixPartitions
+    );
+
+    public void testSortedDocValuesSingleUniqueValue() throws IOException {
+        try (Directory directory = newDirectory()) {
+            Analyzer analyzer = new MockAnalyzer(random());
+            IndexWriterConfig conf = newIndexWriterConfig(analyzer);
+            conf.setCodec(getCodec());
+            conf.setMergePolicy(newLogMergePolicy());
+            try (RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf)) {
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedDocValuesField("field", newBytesRef("value")));
+                    doc.add(new SortedDocValuesField("field" + i, newBytesRef("value" + i)));
+                    iwriter.addDocument(doc);
+                }
+                iwriter.forceMerge(1);
+            }
+            try (IndexReader ireader = maybeWrapWithMergingReader(DirectoryReader.open(directory))) {
+                assert ireader.leaves().size() == 1;
+                SortedDocValues field = ireader.leaves().get(0).reader().getSortedDocValues("field");
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    assertEquals(i, field.nextDoc());
+                    assertEquals(0, field.ordValue());
+                    BytesRef scratch = field.lookupOrd(0);
+                    assertEquals("value", scratch.utf8ToString());
+                }
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, field.nextDoc());
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    SortedDocValues fieldN = ireader.leaves().get(0).reader().getSortedDocValues("field" + i);
+                    assertEquals(i, fieldN.nextDoc());
+                    assertEquals(0, fieldN.ordValue());
+                    BytesRef scratch = fieldN.lookupOrd(0);
+                    assertEquals("value" + i, scratch.utf8ToString());
+                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, fieldN.nextDoc());
+                }
+            }
+        }
+    }
+
+    public void testSortedSetDocValuesSingleUniqueValue() throws IOException {
+        try (Directory directory = newDirectory()) {
+            Analyzer analyzer = new MockAnalyzer(random());
+            IndexWriterConfig conf = newIndexWriterConfig(analyzer);
+            conf.setCodec(getCodec());
+            conf.setMergePolicy(newLogMergePolicy());
+            try (RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf)) {
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedSetDocValuesField("field", newBytesRef("value")));
+                    doc.add(new SortedSetDocValuesField("field" + i, newBytesRef("value" + i)));
+                    iwriter.addDocument(doc);
+                }
+                iwriter.forceMerge(1);
+            }
+
+            try (IndexReader ireader = maybeWrapWithMergingReader(DirectoryReader.open(directory))) {
+                assert ireader.leaves().size() == 1;
+                var field = ireader.leaves().get(0).reader().getSortedSetDocValues("field");
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    assertEquals(i, field.nextDoc());
+                    assertEquals(1, field.docValueCount());
+                    assertEquals(0, field.nextOrd());
+                    BytesRef scratch = field.lookupOrd(0);
+                    assertEquals("value", scratch.utf8ToString());
+                }
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, field.nextDoc());
+                for (int i = 0; i < NUM_DOCS; i++) {
+                    var fieldN = ireader.leaves().get(0).reader().getSortedSetDocValues("field" + i);
+                    assertEquals(i, fieldN.nextDoc());
+                    assertEquals(1, fieldN.docValueCount());
+                    assertEquals(0, fieldN.nextOrd());
+                    BytesRef scratch = fieldN.lookupOrd(0);
+                    assertEquals("value" + i, scratch.utf8ToString());
+                    assertEquals(DocIdSetIterator.NO_MORE_DOCS, fieldN.nextDoc());
+                }
+            }
+        }
+    }
+
+    public void testOneDocManyValues() throws Exception {
+        IndexWriterConfig config = new IndexWriterConfig();
+        config.setCodec(getCodec());
+        try (Directory dir = newDirectory(); IndexWriter writer = new IndexWriter(dir, config)) {
+            // requires two blocks (use 128, which is 1 << NUMERIC_BLOCK_SHIFT)
+            int numValues = 128 + random().nextInt(128 * 4);
+            Document d = new Document();
+            for (int i = 0; i < numValues; i++) {
+                d.add(new SortedSetDocValuesField("dv", new BytesRef("v-" + i)));
+            }
+            writer.addDocument(d);
+            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                LeafReaderContext leaf = reader.leaves().get(0);
+                SortedSetDocValues dv = leaf.reader().getSortedSetDocValues("dv");
+                for (int i = 0; i < 3; i++) {
+                    assertTrue(dv.advanceExact(0));
+                    assertThat(dv.docValueCount(), equalTo(numValues));
+                    for (int v = 0; v < dv.docValueCount(); v++) {
+                        assertThat(dv.nextOrd(), greaterThanOrEqualTo(0L));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testManyDocsWithManyValues() throws Exception {
+        final int numDocs = 10 + random().nextInt(20);
+        final Map<String, List<String>> sortedSet = new HashMap<>(); // key -> doc-values
+        final Map<String, long[]> sortedNumbers = new HashMap<>(); // key -> numbers
+        try (Directory directory = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig();
+            conf.setCodec(getCodec());
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory, conf)) {
+                for (int i = 0; i < numDocs; i++) {
+                    Document doc = new Document();
+                    String key = "k-" + i;
+                    doc.add(new StringField("key", new BytesRef(key), Field.Store.YES));
+                    int numValues = random().nextInt(600);
+                    List<String> binary = new ArrayList<>();
+                    for (int v = 0; v < numValues; v++) {
+                        String dv = "v-" + random().nextInt(3) + ":" + v;
+                        binary.add(dv);
+                        doc.add(new SortedSetDocValuesField("binary", new BytesRef(dv)));
+                    }
+                    sortedSet.put(key, binary.stream().sorted().toList());
+                    numValues = random().nextInt(600);
+                    long[] numbers = new long[numValues];
+                    for (int v = 0; v < numValues; v++) {
+                        numbers[v] = random().nextInt(10) * 1000 + v;
+                        doc.add(new SortedNumericDocValuesField("numbers", numbers[v]));
+                    }
+                    Arrays.sort(numbers);
+                    sortedNumbers.put(key, numbers);
+                    writer.addDocument(doc);
+                }
+                writer.commit();
+            }
+            try (IndexReader reader = maybeWrapWithMergingReader(DirectoryReader.open(directory))) {
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    StoredFields storedFields = leaf.reader().storedFields();
+                    int iters = 1 + random().nextInt(5);
+                    for (int i = 0; i < iters; i++) {
+                        // check with binary
+                        SortedSetDocValues binaryDV = leaf.reader().getSortedSetDocValues("binary");
+                        int doc = random().nextInt(leaf.reader().maxDoc());
+                        while ((doc = binaryDV.advance(doc)) != DocIdSetIterator.NO_MORE_DOCS) {
+                            String key = storedFields.document(doc).getBinaryValue("key").utf8ToString();
+                            List<String> expected = sortedSet.get(key);
+                            List<String> actual = new ArrayList<>();
+                            for (int v = 0; v < binaryDV.docValueCount(); v++) {
+                                long ord = binaryDV.nextOrd();
+                                actual.add(binaryDV.lookupOrd(ord).utf8ToString());
+                            }
+                            assertEquals(expected, actual);
+                            int repeats = random().nextInt(3);
+                            for (int r = 0; r < repeats; r++) {
+                                assertTrue(binaryDV.advanceExact(doc));
+                                actual.clear();
+                                for (int v = 0; v < binaryDV.docValueCount(); v++) {
+                                    long ord = binaryDV.nextOrd();
+                                    actual.add(binaryDV.lookupOrd(ord).utf8ToString());
+                                }
+                                assertEquals(expected, actual);
+                            }
+                            doc++;
+                            doc += random().nextInt(3);
+                        }
+                        // check with numbers
+                        doc = random().nextInt(leaf.reader().maxDoc());
+                        SortedNumericDocValues numbersDV = leaf.reader().getSortedNumericDocValues("numbers");
+                        while ((doc = numbersDV.advance(doc)) != DocIdSetIterator.NO_MORE_DOCS) {
+                            String key = storedFields.document(doc).getBinaryValue("key").utf8ToString();
+                            long[] expected = sortedNumbers.get(key);
+                            long[] actual = new long[expected.length];
+                            for (int v = 0; v < numbersDV.docValueCount(); v++) {
+                                actual[v] = numbersDV.nextValue();
+                            }
+                            assertArrayEquals(expected, actual);
+                            int repeats = random().nextInt(3);
+                            for (int r = 0; r < repeats; r++) {
+                                assertTrue(numbersDV.advanceExact(doc));
+                                actual = new long[expected.length];
+                                for (int v = 0; v < numbersDV.docValueCount(); v++) {
+                                    actual[v] = numbersDV.nextValue();
+                                }
+                                assertArrayEquals(expected, actual);
+                            }
+                            doc++;
+                            doc += random().nextInt(3);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void doTestSortedNumericsVsStoredFieldsPatched(LongSupplier counts, LongSupplier values) throws Exception {
+        assumeFalse(
+            "Remove this method and the overrides that call it; the upstream Lucene bug has been fixed in 10.5",
+            IndexVersion.current().luceneVersion().onOrAfter(org.apache.lucene.util.Version.fromBits(10, 5, 0))
+        );
+        Directory dir = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, conf);
+
+        int numDocs = atLeast(300);
+        assert numDocs > 256;
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+
+            int valueCount = (int) counts.getAsLong();
+            long[] valueArray = new long[valueCount];
+            for (int j = 0; j < valueCount; j++) {
+                long value = values.getAsLong();
+                valueArray[j] = value;
+                doc.add(new SortedNumericDocValuesField("dv", value));
+            }
+            Arrays.sort(valueArray);
+            for (int j = 0; j < valueCount; j++) {
+                doc.add(new StoredField("stored", Long.toString(valueArray[j])));
+            }
+            writer.addDocument(doc);
+            if (random().nextInt(31) == 0) {
+                writer.commit();
+            }
+        }
+
+        // delete some docs
+        int numDeletions = random().nextInt(numDocs / 10);
+        for (int i = 0; i < numDeletions; i++) {
+            int id = random().nextInt(numDocs);
+            writer.deleteDocuments(new Term("id", Integer.toString(id)));
+        }
+        writer.commit();
+        try (DirectoryReader reader = maybeWrapWithMergingReader(DirectoryReader.open(dir))) {
+            TestUtil.checkReader(reader);
+            compareStoredFieldWithSortedNumericsDV(reader, "stored", "dv");
+        }
+        writer.forceMerge(numDocs / 256);
+        try (DirectoryReader reader = maybeWrapWithMergingReader(DirectoryReader.open(dir))) {
+            TestUtil.checkReader(reader);
+            compareStoredFieldWithSortedNumericsDV(reader, "stored", "dv");
+        }
+        IOUtils.close(writer, dir);
+    }
+
+    @Override
+    public void testSortedNumericsSingleValuedVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedNumericsVsStoredFieldsPatched(() -> 1, random()::nextLong);
+        }
+    }
+
+    @Override
+    public void testSortedNumericsSingleValuedMissingVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedNumericsVsStoredFieldsPatched(() -> random().nextBoolean() ? 0 : 1, random()::nextLong);
+        }
+    }
+
+    @Override
+    public void testSortedNumericsMultipleValuesVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedNumericsVsStoredFieldsPatched(() -> TestUtil.nextLong(random(), 0, 50), random()::nextLong);
+        }
+    }
+
+    @Override
+    public void testSortedNumericsFewUniqueSetsVsStoredFields() throws Exception {
+        final long[] uniqueValues = new long[TestUtil.nextInt(random(), 2, 6)];
+        for (int i = 0; i < uniqueValues.length; ++i) {
+            uniqueValues[i] = random().nextLong();
+        }
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedNumericsVsStoredFieldsPatched(
+                () -> TestUtil.nextLong(random(), 0, 6),
+                () -> uniqueValues[random().nextInt(uniqueValues.length)]
+            );
+        }
+    }
+
+    public void testBlockWiseBinary() throws Exception {
+        boolean sparse = randomBoolean();
+        int numBlocksBound = 10;
+        int numNonNullValues = randomIntBetween(0, numBlocksBound * BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT);
+
+        List<String> binaryValues = new ArrayList<>();
+        int numNonNull = 0;
+        while (numNonNull < numNonNullValues) {
+            if (sparse && randomBoolean()) {
+                binaryValues.add(null);
+            } else {
+                final String value = randomAlphaOfLengthBetween(0, 50);
+                binaryValues.add(value);
+                numNonNull++;
+            }
+        }
+
+        assertBinaryValues(binaryValues);
+    }
+
+    public void testBlockWiseBinarySmallValues() throws Exception {
+        boolean sparse = randomBoolean();
+        int numBlocksBound = 5;
+        int numNonNullValues = randomIntBetween(0, numBlocksBound * BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT);
+
+        List<String> binaryValues = new ArrayList<>();
+        int numNonNull = 0;
+        while (numNonNull < numNonNullValues) {
+            if (sparse && randomBoolean()) {
+                binaryValues.add(null);
+            } else {
+                final String value = randomAlphaOfLengthBetween(0, 2);
+                binaryValues.add(value);
+                numNonNull++;
+            }
+        }
+
+        assertBinaryValues(binaryValues);
+    }
+
+    public void testBlockWiseBinaryWithEmptySequences() throws Exception {
+        List<String> binaryValues = new ArrayList<>();
+        int numSequences = 10;
+        for (int i = 0; i < numSequences; i++) {
+            int numInSequence = randomIntBetween(0, 3 * BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT);
+            boolean emptySequence = randomBoolean();
+            for (int j = 0; j < numInSequence; j++) {
+                binaryValues.add(emptySequence ? "" : randomAlphaOfLengthBetween(0, 5));
+            }
+        }
+        assertBinaryValues(binaryValues);
+    }
+
+    public void testBlockWiseBinaryLargeValues() throws Exception {
+        boolean sparse = randomBoolean();
+        int numBlocksBound = 5;
+        int binaryDataSize = randomIntBetween(0, numBlocksBound * BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT);
+        List<String> binaryValues = new ArrayList<>();
+        int totalSize = 0;
+        while (totalSize < binaryDataSize) {
+            if (sparse && randomBoolean()) {
+                binaryValues.add(null);
+            } else {
+                final String value = randomAlphaOfLengthBetween(
+                    BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT / 2,
+                    2 * BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT
+                );
+                binaryValues.add(value);
+                totalSize += value.length();
+            }
+        }
+
+        assertBinaryValues(binaryValues);
+    }
+
+    public void assertBinaryValues(List<String> binaryValues) throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+        String binaryField = "binary_field";
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+
+            int numDocs = binaryValues.size();
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = baseTimestamp + (1000L * i);
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef("host-1")));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+
+                String binaryValue = binaryValues.get(i);
+                if (binaryValue != null) {
+                    d.add(new BinaryDocValuesField(binaryField, new BytesRef(binaryValue)));
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var binaryDV = leaf.getBinaryDocValues(binaryField);
+                assertNotNull(binaryDV);
+                for (int i = 0; i < numDocs; i++) {
+                    String expected = binaryValues.removeLast();
+                    if (expected == null) {
+                        assertFalse(binaryDV.advanceExact(i));
+                    } else {
+                        assertTrue(binaryDV.advanceExact(i));
+                        assertEquals(expected, binaryDV.binaryValue().utf8ToString());
+                    }
+                }
+            }
+        }
+    }
+
+    public void testForceMergeDenseCase() throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long counter1 = 0;
+            long counter2 = 10_000_000;
+            long[] gauge1Values = new long[] { 2, 4, 6, 8, 10, 12, 14, 16 };
+            long[] gauge2Values = new long[] { -2, -4, -6, -8, -10, -12, -14, -16 };
+            String[] tags = new String[] { "tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_6", "tag_7", "tag_8" };
+
+            int numDocs = 256 + random().nextInt(1024);
+            int numHosts = numDocs / 20;
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+
+                int batchIndex = i / numHosts;
+                String hostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                long timestamp = baseTimestamp + (1000L * i);
+
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+                d.add(new NumericDocValuesField("counter_1", counter1++));
+                d.add(new SortedNumericDocValuesField("counter_2", counter2++));
+                d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[i % gauge1Values.length]));
+
+                int numGauge2 = 1 + random().nextInt(8);
+                for (int j = 0; j < numGauge2; j++) {
+                    d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[(i + j) % gauge2Values.length]));
+                }
+
+                int numTags = 1 + random().nextInt(8);
+                for (int j = 0; j < numTags; j++) {
+                    d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[(i + j) % tags.length])));
+                }
+
+                d.add(new BinaryDocValuesField("tags_as_bytes", new BytesRef(tags[i % tags.length])));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+
+            iw.forceMerge(1);
+
+            // For asserting using binary search later on:
+            Arrays.sort(gauge2Values);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                var counterOneDV = leaf.getNumericDocValues("counter_1");
+                assertNotNull(counterOneDV);
+                var counterTwoDV = leaf.getSortedNumericDocValues("counter_2");
+                assertNotNull(counterTwoDV);
+                var gaugeOneDV = leaf.getSortedNumericDocValues("gauge_1");
+                assertNotNull(gaugeOneDV);
+                var gaugeTwoDV = leaf.getSortedNumericDocValues("gauge_2");
+                assertNotNull(gaugeTwoDV);
+                var tagsDV = leaf.getSortedSetDocValues("tags");
+                assertNotNull(tagsDV);
+                var tagBytesDV = leaf.getBinaryDocValues("tags_as_bytes");
+                assertNotNull(tagBytesDV);
+                for (int i = 0; i < numDocs; i++) {
+                    assertEquals(i, hostNameDV.nextDoc());
+                    int batchIndex = i / numHosts;
+                    assertEquals(batchIndex, hostNameDV.ordValue());
+                    String expectedHostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                    assertEquals(expectedHostName, hostNameDV.lookupOrd(hostNameDV.ordValue()).utf8ToString());
+
+                    assertEquals(i, timestampDV.nextDoc());
+                    long timestamp = timestampDV.longValue();
+                    long lowerBound = baseTimestamp;
+                    long upperBound = baseTimestamp + (1000L * numDocs);
+                    assertTrue(
+                        "unexpected timestamp [" + timestamp + "], expected between [" + lowerBound + "] and [" + upperBound + "]",
+                        timestamp >= lowerBound && timestamp < upperBound
+                    );
+
+                    assertEquals(i, counterOneDV.nextDoc());
+                    long counterOneValue = counterOneDV.longValue();
+                    assertTrue("unexpected counter [" + counterOneValue + "]", counterOneValue >= 0 && counterOneValue < counter1);
+
+                    assertEquals(i, counterTwoDV.nextDoc());
+                    assertEquals(1, counterTwoDV.docValueCount());
+                    long counterTwoValue = counterTwoDV.nextValue();
+                    assertTrue("unexpected counter [" + counterTwoValue + "]", counterTwoValue > 0 && counterTwoValue <= counter2);
+
+                    assertEquals(i, gaugeOneDV.nextDoc());
+                    assertEquals(1, gaugeOneDV.docValueCount());
+                    long gaugeOneValue = gaugeOneDV.nextValue();
+                    assertTrue("unexpected gauge [" + gaugeOneValue + "]", Arrays.binarySearch(gauge1Values, gaugeOneValue) >= 0);
+
+                    assertEquals(i, gaugeTwoDV.nextDoc());
+                    for (int j = 0; j < gaugeTwoDV.docValueCount(); j++) {
+                        long gaugeTwoValue = gaugeTwoDV.nextValue();
+                        assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                    }
+
+                    assertEquals(i, tagsDV.nextDoc());
+                    for (int j = 0; j < tagsDV.docValueCount(); j++) {
+                        long ordinal = tagsDV.nextOrd();
+                        String actualTag = tagsDV.lookupOrd(ordinal).utf8ToString();
+                        assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
+                    }
+
+                    assertEquals(i, tagBytesDV.nextDoc());
+                    BytesRef tagBytesValue = tagBytesDV.binaryValue();
+                    assertTrue("unexpected bytes " + tagBytesValue, Arrays.binarySearch(tags, tagBytesValue.utf8ToString()) >= 0);
+                }
+            }
+        }
+    }
+
+    public void testTwoSegmentsTwoDifferentFields() throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long timestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long counter1 = 0;
+            long counter2 = 10_000_000;
+
+            {
+                var d = new Document();
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef("host-001")));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp - 1));
+                d.add(new NumericDocValuesField("counter_1", counter1));
+                d.add(new SortedNumericDocValuesField("gauge_1", 2));
+                d.add(new BinaryDocValuesField("binary_1", new BytesRef("foo")));
+                iw.addDocument(d);
+                iw.commit();
+            }
+            {
+                var d = new Document();
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef("host-001")));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+                d.add(new SortedNumericDocValuesField("counter_2", counter2));
+                d.add(new SortedNumericDocValuesField("gauge_2", -2));
+                d.add(new BinaryDocValuesField("binary_2", new BytesRef("bar")));
+                iw.addDocument(d);
+                iw.commit();
+            }
+
+            iw.forceMerge(1);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(2, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                var counterOneDV = leaf.getNumericDocValues("counter_1");
+                assertNotNull(counterOneDV);
+                var counterTwoDV = leaf.getSortedNumericDocValues("counter_2");
+                assertNotNull(counterTwoDV);
+                var gaugeOneDV = leaf.getSortedNumericDocValues("gauge_1");
+                assertNotNull(gaugeOneDV);
+                var gaugeTwoDV = leaf.getSortedNumericDocValues("gauge_2");
+                assertNotNull(gaugeTwoDV);
+                var binaryOneDV = leaf.getBinaryDocValues("binary_1");
+                assertNotNull(binaryOneDV);
+                var binaryTwoDv = leaf.getBinaryDocValues("binary_2");
+                assertNotNull(binaryTwoDv);
+                for (int i = 0; i < 2; i++) {
+                    assertEquals(i, hostNameDV.nextDoc());
+                    assertEquals("host-001", hostNameDV.lookupOrd(hostNameDV.ordValue()).utf8ToString());
+
+                    assertEquals(i, timestampDV.nextDoc());
+                    long actualTimestamp = timestampDV.longValue();
+                    assertTrue(actualTimestamp == timestamp || actualTimestamp == timestamp - 1);
+
+                    if (counterOneDV.advanceExact(i)) {
+                        long counterOneValue = counterOneDV.longValue();
+                        assertEquals(counter1, counterOneValue);
+                    }
+
+                    if (counterTwoDV.advanceExact(i)) {
+                        assertEquals(1, counterTwoDV.docValueCount());
+                        long counterTwoValue = counterTwoDV.nextValue();
+                        assertEquals(counter2, counterTwoValue);
+                    }
+
+                    if (gaugeOneDV.advanceExact(i)) {
+                        assertEquals(1, gaugeOneDV.docValueCount());
+                        long gaugeOneValue = gaugeOneDV.nextValue();
+                        assertEquals(2, gaugeOneValue);
+                    }
+
+                    if (gaugeTwoDV.advanceExact(i)) {
+                        assertEquals(1, gaugeTwoDV.docValueCount());
+                        long gaugeTwoValue = gaugeTwoDV.nextValue();
+                        assertEquals(-2, gaugeTwoValue);
+                    }
+
+                    if (binaryOneDV.advanceExact(i)) {
+                        BytesRef binaryOneValue = binaryOneDV.binaryValue();
+                        assertEquals(new BytesRef("foo"), binaryOneValue);
+                    }
+
+                    if (binaryTwoDv.advanceExact(i)) {
+                        BytesRef binaryTwoValue = binaryTwoDv.binaryValue();
+                        assertEquals(new BytesRef("bar"), binaryTwoValue);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testForceMergeSparseCase() throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long counter1 = 0;
+            long counter2 = 10_000_000;
+            long[] gauge1Values = new long[] { 2, 4, 6, 8, 10, 12, 14, 16 };
+            long[] gauge2Values = new long[] { -2, -4, -6, -8, -10, -12, -14, -16 };
+            String[] tags = new String[] { "tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_6", "tag_7", "tag_8" };
+
+            int numDocs = 256 + random().nextInt(1024);
+            int numHosts = numDocs / 20;
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+
+                int batchIndex = i / numHosts;
+                String hostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                long timestamp = baseTimestamp + (1000L * i);
+
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+
+                if (random().nextBoolean()) {
+                    d.add(new NumericDocValuesField("counter_1", counter1++));
+                }
+                if (random().nextBoolean()) {
+                    d.add(new SortedNumericDocValuesField("counter_2", counter2++));
+                }
+                if (random().nextBoolean()) {
+                    d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[i % gauge1Values.length]));
+                }
+                if (random().nextBoolean()) {
+                    int numGauge2 = 1 + random().nextInt(8);
+                    for (int j = 0; j < numGauge2; j++) {
+                        d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[(i + j) % gauge2Values.length]));
+                    }
+                }
+                if (random().nextBoolean()) {
+                    int numTags = 1 + random().nextInt(8);
+                    for (int j = 0; j < numTags; j++) {
+                        d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[j])));
+                    }
+                }
+                if (random().nextBoolean()) {
+                    int randomIndex = random().nextInt(tags.length);
+                    d.add(new SortedDocValuesField("other_tag", new BytesRef(tags[randomIndex])));
+                }
+                if (random().nextBoolean()) {
+                    int randomIndex = random().nextInt(tags.length);
+                    d.add(new BinaryDocValuesField("tags_as_bytes", new BytesRef(tags[randomIndex])));
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+
+            iw.forceMerge(1);
+
+            // For asserting using binary search later on:
+            Arrays.sort(gauge2Values);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                var counterOneDV = leaf.getNumericDocValues("counter_1");
+                assertNotNull(counterOneDV);
+                var counterTwoDV = leaf.getSortedNumericDocValues("counter_2");
+                assertNotNull(counterTwoDV);
+                var gaugeOneDV = leaf.getSortedNumericDocValues("gauge_1");
+                assertNotNull(gaugeOneDV);
+                var gaugeTwoDV = leaf.getSortedNumericDocValues("gauge_2");
+                assertNotNull(gaugeTwoDV);
+                var tagsDV = leaf.getSortedSetDocValues("tags");
+                assertNotNull(tagsDV);
+                var otherTagDV = leaf.getSortedDocValues("other_tag");
+                assertNotNull(otherTagDV);
+                var tagBytesDV = leaf.getBinaryDocValues("tags_as_bytes");
+                assertNotNull(tagBytesDV);
+                for (int i = 0; i < numDocs; i++) {
+                    assertEquals(i, hostNameDV.nextDoc());
+                    int batchIndex = i / numHosts;
+                    assertEquals(batchIndex, hostNameDV.ordValue());
+                    String expectedHostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                    assertEquals(expectedHostName, hostNameDV.lookupOrd(hostNameDV.ordValue()).utf8ToString());
+
+                    assertEquals(i, timestampDV.nextDoc());
+                    long timestamp = timestampDV.longValue();
+                    long lowerBound = baseTimestamp;
+                    long upperBound = baseTimestamp + (1000L * numDocs);
+                    assertTrue(
+                        "unexpected timestamp [" + timestamp + "], expected between [" + lowerBound + "] and [" + upperBound + "]",
+                        timestamp >= lowerBound && timestamp < upperBound
+                    );
+
+                    if (counterOneDV.advanceExact(i)) {
+                        long counterOneValue = counterOneDV.longValue();
+                        assertTrue("unexpected counter [" + counterOneValue + "]", counterOneValue >= 0 && counterOneValue < counter1);
+                    }
+
+                    if (counterTwoDV.advanceExact(i)) {
+                        assertEquals(1, counterTwoDV.docValueCount());
+                        long counterTwoValue = counterTwoDV.nextValue();
+                        assertTrue("unexpected counter [" + counterTwoValue + "]", counterTwoValue > 0 && counterTwoValue <= counter2);
+                    }
+
+                    if (gaugeOneDV.advanceExact(i)) {
+                        assertEquals(1, gaugeOneDV.docValueCount());
+                        long gaugeOneValue = gaugeOneDV.nextValue();
+                        assertTrue("unexpected gauge [" + gaugeOneValue + "]", Arrays.binarySearch(gauge1Values, gaugeOneValue) >= 0);
+                    }
+
+                    if (gaugeTwoDV.advanceExact(i)) {
+                        for (int j = 0; j < gaugeTwoDV.docValueCount(); j++) {
+                            long gaugeTwoValue = gaugeTwoDV.nextValue();
+                            assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                        }
+                    }
+
+                    if (tagsDV.advanceExact(i)) {
+                        for (int j = 0; j < tagsDV.docValueCount(); j++) {
+                            long ordinal = tagsDV.nextOrd();
+                            String actualTag = tagsDV.lookupOrd(ordinal).utf8ToString();
+                            assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
+                        }
+                    }
+                    if (otherTagDV.advanceExact(i)) {
+                        int ordinal = otherTagDV.ordValue();
+                        String actualTag = otherTagDV.lookupOrd(ordinal).utf8ToString();
+                        assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
+                    }
+
+                    if (tagBytesDV.advanceExact(i)) {
+                        BytesRef tagBytesValue = tagBytesDV.binaryValue();
+                        assertTrue("unexpected bytes " + tagBytesValue, Arrays.binarySearch(tags, tagBytesValue.utf8ToString()) >= 0);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testWithNoValueMultiValue() throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+        int numRounds = 32 + random().nextInt(32);
+        int numDocsPerRound = 64 + random().nextInt(64);
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long[] gauge1Values = new long[] { 2, 4, 6, 8, 10, 12, 14, 16 };
+            String[] tags = new String[] { "tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_6", "tag_7", "tag_8" };
+            {
+                long timestamp = baseTimestamp;
+                for (int i = 0; i < numRounds; i++) {
+                    int r = random().nextInt(10);
+                    for (int j = 0; j < numDocsPerRound; j++) {
+                        var d = new Document();
+                        String hostName = String.format(Locale.ROOT, "host-%03d", numRounds - i);
+                        d.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
+                        d.add(new SortedNumericDocValuesField(timestampField, timestamp++));
+
+                        if (r % 10 == 5) {
+                            // sometimes no values
+                        } else if (r % 10 > 5) {
+                            d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[j % gauge1Values.length]));
+                            d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[j % tags.length])));
+                        } else {
+                            int numValues = 2 + random().nextInt(4);
+                            for (int k = 0; k < numValues; k++) {
+                                d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[(j + k) % gauge1Values.length]));
+                                d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[(j + k) % tags.length])));
+                            }
+                        }
+                        iw.addDocument(d);
+                    }
+                    iw.commit();
+                }
+                iw.forceMerge(1);
+            }
+
+            int numDocs = numRounds * numDocsPerRound;
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                var gaugeOneDV = leaf.getSortedNumericDocValues("gauge_1");
+                assertNotNull(gaugeOneDV);
+                var tagsDV = leaf.getSortedSetDocValues("tags");
+                assertNotNull(tagsDV);
+                for (int i = 0; i < numDocs; i++) {
+                    assertEquals(i, hostNameDV.nextDoc());
+                    String actualHostName = hostNameDV.lookupOrd(hostNameDV.ordValue()).utf8ToString();
+                    assertTrue("unexpected host name:" + actualHostName, actualHostName.startsWith("host-"));
+
+                    assertEquals(i, timestampDV.nextDoc());
+                    long timestamp = timestampDV.longValue();
+                    long lowerBound = baseTimestamp;
+                    long upperBound = baseTimestamp + numDocs;
+                    assertTrue(
+                        "unexpected timestamp [" + timestamp + "], expected between [" + lowerBound + "] and [" + upperBound + "]",
+                        timestamp >= lowerBound && timestamp < upperBound
+                    );
+                    if (gaugeOneDV.advanceExact(i)) {
+                        for (int j = 0; j < gaugeOneDV.docValueCount(); j++) {
+                            long value = gaugeOneDV.nextValue();
+                            assertTrue("unexpected gauge [" + value + "]", Arrays.binarySearch(gauge1Values, value) >= 0);
+                        }
+                    }
+                    if (tagsDV.advanceExact(i)) {
+                        for (int j = 0; j < tagsDV.docValueCount(); j++) {
+                            long ordinal = tagsDV.nextOrd();
+                            String actualTag = tagsDV.lookupOrd(ordinal).utf8ToString();
+                            assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalLengthReaderDenseToLengthValues() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFixedLength = randomIntBetween(0, 100);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            List<BytesRef> binaryVariableValues = new ArrayList<>();
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+
+                binaryVariableValues.add(new BytesRef(randomAlphaOfLength(between(0, 100))));
+                d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                d.add(new BinaryDocValuesField(binaryVariableField, binaryVariableValues.getLast()));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000L;
+                }
+            }
+            iw.commit();
+
+            try (var reader = DirectoryReader.open(iw)) {
+                for (var leaf : reader.leaves()) {
+                    var binaryFixedDV = getTSDBBinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leaf.reader(), binaryVariableField);
+
+                    NumericDocValues fixedLengthReader = binaryFixedDV.toLengthValues();
+                    NumericDocValues variableLengthReader = binaryVariableDV.toLengthValues();
+
+                    int maxDoc = leaf.reader().maxDoc();
+                    for (int i = 0; i < maxDoc; i++) {
+                        assertTrue(fixedLengthReader.advanceExact(i));
+                        assertEquals(binaryFixedLength, fixedLengthReader.longValue());
+
+                        assertTrue(variableLengthReader.advanceExact(i));
+                        assertEquals(binaryVariableValues.removeLast().length, variableLengthReader.longValue());
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalLengthReaderSparseToLengthValues() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFixedLength = randomIntBetween(0, 100);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            List<BytesRef> binaryVariableValues = new ArrayList<>();
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+
+                if (randomBoolean()) {
+                    binaryVariableValues.add(new BytesRef(randomAlphaOfLength(between(0, 100))));
+                    d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                    d.add(new BinaryDocValuesField(binaryVariableField, binaryVariableValues.getLast()));
+                } else {
+                    binaryVariableValues.add(null);
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000L;
+                }
+            }
+            iw.commit();
+
+            try (var reader = DirectoryReader.open(iw)) {
+                for (var leaf : reader.leaves()) {
+                    var binaryFixedDV = getTSDBBinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leaf.reader(), binaryVariableField);
+
+                    int maxDoc = leaf.reader().maxDoc();
+                    // No docs in this segment had these fields, so doc values are null
+                    if (binaryFixedDV == null) {
+                        assertNull(binaryVariableDV);
+                        for (int i = 0; i < maxDoc; i++) {
+                            assertNull(binaryVariableValues.removeLast());
+                        }
+                        continue;
+                    }
+
+                    NumericDocValues fixedLengthReader = binaryFixedDV.toLengthValues();
+                    NumericDocValues variableLengthReader = binaryVariableDV.toLengthValues();
+
+                    for (int i = 0; i < maxDoc; i++) {
+                        BytesRef expectedVariableLength = binaryVariableValues.removeLast();
+                        if (expectedVariableLength == null) {
+                            assertFalse(fixedLengthReader.advanceExact(i));
+                            assertFalse(variableLengthReader.advanceExact(i));
+                        } else {
+                            assertTrue(fixedLengthReader.advanceExact(i));
+                            assertEquals(binaryFixedLength, fixedLengthReader.longValue());
+
+                            assertTrue(variableLengthReader.advanceExact(i));
+                            assertEquals(expectedVariableLength.length, variableLengthReader.longValue());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalLengthReaderDense() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFixedLength = randomIntBetween(0, 100);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            List<BytesRef> binaryVariableValues = new ArrayList<>();
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+
+                binaryVariableValues.add(new BytesRef(randomAlphaOfLength(between(0, 100))));
+                d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                d.add(new BinaryDocValuesField(binaryVariableField, binaryVariableValues.getLast()));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000L;
+                }
+            }
+            iw.commit();
+
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                for (var leaf : reader.leaves()) {
+                    var binaryFixedDV = getTSDBBinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leaf.reader(), binaryVariableField);
+
+                    int maxDoc = leaf.reader().maxDoc();
+                    for (int i = 0; i < maxDoc;) {
+                        int size = Math.max(1, random().nextInt(0, maxDoc - i));
+                        var docs = TestBlock.docs(IntStream.range(i, i + size).toArray());
+                        {
+                            var block = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, 0, random().nextBoolean());
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+
+                            for (int j = 0; j < block.size(); j++) {
+                                var actual = (int) block.get(j);
+                                assertEquals(binaryFixedLength, actual);
+                            }
+                        }
+                        {
+                            var block = (TestBlock) binaryVariableDV.tryReadLength(factory, docs, 0, random().nextBoolean());
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                var actual = (int) block.get(j);
+                                var expected = binaryVariableValues.removeLast().length;
+                                assertEquals(expected, actual);
+                            }
+                        }
+
+                        i += size;
+                    }
+                }
+            }
+
+            // Now bulk reader from one big segment and use random offset:
+            iw.forceMerge(1);
+            try (var reader = DirectoryReader.open(iw)) {
+                int randomOffset = random().nextInt(numDocs / 4);
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+                int maxDoc = leafReader.maxDoc();
+                int size = maxDoc - randomOffset;
+
+                {
+                    var binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+                    var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
+
+                    var expectedBinaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, randomOffset, false);
+                    assertLengthDenseBlock(fixedBinaryBlock, size, randomOffset, docs, expectedBinaryFixedDV);
+
+                    var variableBinaryBlock = (TestBlock) binaryVariableDV.tryReadLength(factory, docs, randomOffset, false);
+                    assertLengthDenseBlock(variableBinaryBlock, size, randomOffset, docs, expectedBinaryVariableDV);
+                }
+
+                {
+                    var docs = TestBlock.docs(IntStream.range(0, maxDoc).filter(docId -> docId == 0 || docId % 64 != 0).toArray());
+                    size = docs.count();
+
+                    var binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var expectedBinaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, 0, false);
+                    assertLengthDenseBlock(fixedBinaryBlock, size, 0, docs, expectedBinaryFixedDV);
+
+                    var variableBinaryBlock = (TestBlock) binaryVariableDV.tryReadLength(factory, docs, 0, false);
+                    assertLengthDenseBlock(variableBinaryBlock, size, 0, docs, expectedBinaryVariableDV);
+                }
+            }
+        }
+    }
+
+    public void testOptionalLengthReaderSparse() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFixedLength = randomIntBetween(0, 100);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            List<BytesRef> binaryVariableValues = new ArrayList<>();
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+
+                if (randomBoolean()) {
+                    binaryVariableValues.add(new BytesRef(randomAlphaOfLength(between(0, 100))));
+                    d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                    d.add(new BinaryDocValuesField(binaryVariableField, binaryVariableValues.getLast()));
+                } else {
+                    binaryVariableValues.add(null);
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000L;
+                }
+            }
+            iw.commit();
+
+            var factory = TestBlock.factory();
+            iw.forceMerge(1);
+            try (var reader = DirectoryReader.open(iw)) {
+                int randomOffset = random().nextInt(numDocs / 4);
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+                int maxDoc = leafReader.maxDoc();
+                int size = maxDoc - randomOffset;
+
+                {
+                    var binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+                    var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
+
+                    var expectedBinaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, randomOffset, false);
+                    assertLengthSparseBlock(fixedBinaryBlock, size, randomOffset, docs, expectedBinaryFixedDV);
+
+                    var variableBinaryBlock = (TestBlock) binaryVariableDV.tryReadLength(factory, docs, randomOffset, false);
+                    assertLengthSparseBlock(variableBinaryBlock, size, randomOffset, docs, expectedBinaryVariableDV);
+                }
+
+                {
+                    var docs = TestBlock.docs(IntStream.range(0, maxDoc).filter(docId -> docId == 0 || docId % 64 != 0).toArray());
+                    size = docs.count();
+
+                    var binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var expectedBinaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    var expectedBinaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                    var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryReadLength(factory, docs, 0, false);
+                    assertLengthSparseBlock(fixedBinaryBlock, size, 0, docs, expectedBinaryFixedDV);
+
+                    var variableBinaryBlock = (TestBlock) binaryVariableDV.tryReadLength(factory, docs, 0, false);
+                    assertLengthSparseBlock(variableBinaryBlock, size, 0, docs, expectedBinaryVariableDV);
+                }
+            }
+        }
+    }
+
+    private void assertLengthSparseBlock(
+        TestBlock block,
+        int size,
+        int randomOffset,
+        BlockLoader.Docs docs,
+        BinaryDocValues expectedBytesRefs
+    ) throws IOException {
+        assertNotNull(block);
+        assertEquals(size, block.size());
+        for (int j = 0; j < block.size(); j++) {
+            var actual = block.get(j);
+            if (expectedBytesRefs.advanceExact(docs.get(randomOffset + j))) {
+                var expected = expectedBytesRefs.binaryValue().length;
+                assertEquals(expected, actual);
+            } else {
+                assertNull(actual);
+            }
+        }
+    }
+
+    private void assertLengthDenseBlock(
+        TestBlock block,
+        int size,
+        int randomOffset,
+        BlockLoader.Docs docs,
+        BinaryDocValues expectedBytesRefs
+    ) throws IOException {
+        assertNotNull(block);
+        assertEquals(size, block.size());
+        for (int j = 0; j < block.size(); j++) {
+            var actual = block.get(j);
+            assert (expectedBytesRefs.advanceExact(docs.get(randomOffset + j)));
+            var expected = expectedBytesRefs.binaryValue().length;
+            assertEquals(expected, actual);
+        }
+    }
+
+    public void testOptionalColumnAtATimeReader() throws Exception {
+        final String counterField = "counter";
+        final String counterFieldAsString = "counter_as_string";
+        final String timestampField = "@timestamp";
+        final String gaugeField = "gauge";
+        final boolean useCustomBinaryFormat = randomBoolean();
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFieldMaxLength = randomIntBetween(1, 20);
+        long currentTimestamp = 1704067200000L;
+        long currentCounter = 10_000_000;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long[] gauge1Values = new long[] { 2, 4, 6, 8, 10, 12, 14, 16 };
+            List<BytesRef> binaryFixedValues = new ArrayList<>();
+            Set<BytesRef> uniqueBinaryFixedValues = new HashSet<>();
+            List<BytesRef> binaryVariableValues = new ArrayList<>();
+            Set<BytesRef> uniqueBinaryVariableValues = new HashSet<>();
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                binaryFixedValues.add(new BytesRef(randomAlphaOfLength(binaryFieldMaxLength)));
+                uniqueBinaryFixedValues.add(binaryFixedValues.getLast());
+                binaryVariableValues.add(new BytesRef(randomAlphaOfLength(between(0, binaryFieldMaxLength))));
+                uniqueBinaryVariableValues.add(binaryVariableValues.getLast());
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+                d.add(new SortedNumericDocValuesField(counterField, currentCounter));
+                d.add(new SortedSetDocValuesField(counterFieldAsString, new BytesRef(Long.toString(currentCounter))));
+                d.add(new SortedNumericDocValuesField(gaugeField, gauge1Values[i % gauge1Values.length]));
+                if (useCustomBinaryFormat) {
+                    byte[] bytes = binaryFixedValues.getLast().utf8ToString().getBytes(StandardCharsets.UTF_8);
+                    d.add(new CustomBinaryDocValuesField(binaryFixedField, bytes));
+                } else {
+                    d.add(new BinaryDocValuesField(binaryFixedField, binaryFixedValues.getLast()));
+                }
+                if (useCustomBinaryFormat) {
+                    byte[] bytes = binaryVariableValues.getLast().utf8ToString().getBytes(StandardCharsets.UTF_8);
+                    d.add(new CustomBinaryDocValuesField(binaryVariableField, bytes));
+                } else {
+                    d.add(new BinaryDocValuesField(binaryVariableField, binaryVariableValues.getLast()));
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000L;
+                    currentCounter++;
+                }
+            }
+            iw.commit();
+            var factory = TestBlock.factory();
+            final long lastIndexedTimestamp = currentTimestamp;
+            final long lastIndexedCounter = currentCounter;
+            try (var reader = DirectoryReader.open(iw)) {
+                int gaugeIndex = numDocs;
+                for (var leaf : reader.leaves()) {
+                    var timestampDV = getBaseDenseNumericValues(leaf.reader(), timestampField);
+                    var counterDV = getBaseDenseNumericValues(leaf.reader(), counterField);
+                    var gaugeDV = getBaseDenseNumericValues(leaf.reader(), gaugeField);
+                    var stringCounterDV = getBaseSortedDocValues(leaf.reader(), counterFieldAsString);
+                    var binaryFixedDV = getTSDBBinaryValues(leaf.reader(), binaryFixedField);
+                    var binaryVariableDV = getTSDBBinaryValues(leaf.reader(), binaryVariableField);
+
+                    int maxDoc = leaf.reader().maxDoc();
+                    for (int i = 0; i < maxDoc;) {
+                        int size = Math.max(1, random().nextInt(0, maxDoc - i));
+                        var docs = TestBlock.docs(IntStream.range(i, i + size).toArray());
+                        int docIdEnd = docs.get(docs.count() - 1);
+
+                        {
+                            var block = (TestBlock) timestampDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                            assertEquals(timestampDV.docID(), docIdEnd);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                long actualTimestamp = (long) block.get(j);
+                                long expectedTimestamp = currentTimestamp;
+                                assertEquals(expectedTimestamp, actualTimestamp);
+                                currentTimestamp -= 1000L;
+                            }
+                        }
+                        {
+                            var block = (TestBlock) counterDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                            assertEquals(counterDV.docID(), docIdEnd);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            var stringBlock = (TestBlock) stringCounterDV.tryRead(
+                                factory,
+                                docs,
+                                0,
+                                random().nextBoolean(),
+                                null,
+                                false,
+                                false
+                            );
+                            assertEquals(stringCounterDV.docID(), docIdEnd);
+                            assertNotNull(stringBlock);
+                            assertEquals(size, stringBlock.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                long expectedCounter = currentCounter;
+                                long actualCounter = (long) block.get(j);
+                                assertEquals(expectedCounter, actualCounter);
+
+                                var expectedStringCounter = Long.toString(actualCounter);
+                                var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                                assertEquals(expectedStringCounter, actualStringCounter);
+
+                                currentCounter--;
+                            }
+                        }
+                        {
+                            var block = (TestBlock) gaugeDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                            assertEquals(gaugeDV.docID(), docIdEnd);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                long actualGauge = (long) block.get(j);
+                                long expectedGauge = gauge1Values[--gaugeIndex % gauge1Values.length];
+                                assertEquals(expectedGauge, actualGauge);
+                            }
+                        }
+                        {
+                            var block = (TestBlock) binaryFixedDV.tryRead(
+                                factory,
+                                docs,
+                                0,
+                                random().nextBoolean(),
+                                null,
+                                false,
+                                useCustomBinaryFormat
+                            );
+                            assertEquals(binaryFixedDV.docID(), docIdEnd);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                var actual = (BytesRef) block.get(j);
+                                var expected = binaryFixedValues.removeLast();
+                                assertEquals(expected, actual);
+                            }
+                        }
+                        {
+                            var block = (TestBlock) binaryVariableDV.tryRead(
+                                factory,
+                                docs,
+                                0,
+                                random().nextBoolean(),
+                                null,
+                                false,
+                                useCustomBinaryFormat
+                            );
+                            assertEquals(binaryVariableDV.docID(), docIdEnd);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                var actual = (BytesRef) block.get(j);
+                                var expected = binaryVariableValues.removeLast();
+                                assertEquals(expected, actual);
+                            }
+                        }
+
+                        i += size;
+                    }
+                }
+            }
+
+            // Now bulk reader from one big segment and use random offset:
+            iw.forceMerge(1);
+            var blockFactory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                int randomOffset = random().nextInt(numDocs / 4);
+                currentTimestamp = lastIndexedTimestamp - (randomOffset * 1000L);
+                currentCounter = lastIndexedCounter - randomOffset;
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+                int maxDoc = leafReader.maxDoc();
+                int size = maxDoc - randomOffset;
+                int gaugeIndex = size;
+
+                var timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
+                var counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                var gaugeDV = getBaseDenseNumericValues(leafReader, gaugeField);
+                var stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
+                var binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                var binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+
+                var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
+                int docIdEnd = docs.get(docs.count() - 1);
+                {
+                    var block = (TestBlock) timestampDV.tryRead(blockFactory, docs, randomOffset, false, null, false, false);
+                    assertEquals(timestampDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+                    for (int j = 0; j < block.size(); j++) {
+                        long actualTimestamp = (long) block.get(j);
+                        long expectedTimestamp = currentTimestamp;
+                        assertEquals(expectedTimestamp, actualTimestamp);
+                        currentTimestamp -= 1000L;
+                    }
+                }
+                {
+                    var block = (TestBlock) counterDV.tryRead(factory, docs, randomOffset, false, null, false, false);
+                    assertEquals(counterDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+
+                    var stringBlock = (TestBlock) stringCounterDV.tryRead(factory, docs, randomOffset, false, null, false, false);
+                    assertEquals(stringCounterDV.docID(), docIdEnd);
+                    assertNotNull(stringBlock);
+                    assertEquals(size, stringBlock.size());
+
+                    for (int j = 0; j < block.size(); j++) {
+                        long actualCounter = (long) block.get(j);
+                        long expectedCounter = currentCounter;
+                        assertEquals(expectedCounter, actualCounter);
+
+                        var expectedStringCounter = Long.toString(actualCounter);
+                        var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                        assertEquals(expectedStringCounter, actualStringCounter);
+
+                        currentCounter--;
+                    }
+                }
+                {
+                    var block = (TestBlock) gaugeDV.tryRead(factory, docs, randomOffset, false, null, false, false);
+                    assertEquals(gaugeDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+                    for (int j = 0; j < block.size(); j++) {
+                        long actualGauge = (long) block.get(j);
+                        long expectedGauge = gauge1Values[--gaugeIndex % gauge1Values.length];
+                        assertEquals(expectedGauge, actualGauge);
+                    }
+                }
+                {
+                    var block = (TestBlock) binaryFixedDV.tryRead(factory, docs, randomOffset, false, null, false, useCustomBinaryFormat);
+                    assertEquals(binaryFixedDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+                    for (int j = 0; j < block.size(); j++) {
+                        var actual = (BytesRef) block.get(j);
+                        assertTrue("unexpected value [" + actual.utf8ToString() + "]", uniqueBinaryFixedValues.contains(actual));
+                    }
+                }
+                {
+                    var block = (TestBlock) binaryVariableDV.tryRead(
+                        factory,
+                        docs,
+                        randomOffset,
+                        false,
+                        null,
+                        false,
+                        useCustomBinaryFormat
+                    );
+                    assertEquals(binaryVariableDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+                    for (int j = 0; j < block.size(); j++) {
+                        var actual = (BytesRef) block.get(j);
+                        assertTrue("unexpected value [" + actual.utf8ToString() + "]", uniqueBinaryVariableValues.contains(actual));
+                    }
+                }
+
+                // And finally docs with gaps:
+                docs = TestBlock.docs(IntStream.range(0, maxDoc).filter(docId -> docId == 0 || docId % 64 != 0).toArray());
+                docIdEnd = docs.get(docs.count() - 1);
+                size = docs.count();
+                // Test against values loaded using normal doc value apis:
+                long[] expectedCounters = new long[size];
+                counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                List<BytesRef> expectedFixedBinaryValues = new ArrayList<>();
+                binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                List<BytesRef> expectedVariableBinaryValues = new ArrayList<>();
+                binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+                final var cdvReader = new CustomBinaryDocValuesReader();
+                for (int i = 0; i < docs.count(); i++) {
+                    int docId = docs.get(i);
+                    counterDV.advanceExact(docId);
+                    expectedCounters[i] = counterDV.longValue();
+                    if (useCustomBinaryFormat) {
+                        binaryFixedDV.advanceExact(docId);
+                        cdvReader.read(binaryFixedDV.binaryValue(), new BytesRefBuilderStub() {
+                            @Override
+                            public BlockLoader.BytesRefBuilder appendBytesRef(BytesRef value) {
+                                expectedFixedBinaryValues.add(BytesRef.deepCopyOf(value));
+                                return this;
+                            }
+                        });
+                        binaryVariableDV.advanceExact(docId);
+                        cdvReader.read(binaryVariableDV.binaryValue(), new BytesRefBuilderStub() {
+                            @Override
+                            public BlockLoader.BytesRefBuilder appendBytesRef(BytesRef value) {
+                                expectedVariableBinaryValues.add(BytesRef.deepCopyOf(value));
+                                return this;
+                            }
+                        });
+                    } else {
+                        binaryFixedDV.advanceExact(docId);
+                        expectedFixedBinaryValues.add(BytesRef.deepCopyOf(binaryFixedDV.binaryValue()));
+                        binaryVariableDV.advanceExact(docId);
+                        expectedVariableBinaryValues.add(BytesRef.deepCopyOf(binaryVariableDV.binaryValue()));
+                    }
+
+                }
+                counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
+                binaryFixedDV = getTSDBBinaryValues(leafReader, binaryFixedField);
+                binaryVariableDV = getTSDBBinaryValues(leafReader, binaryVariableField);
+                {
+                    var block = (TestBlock) counterDV.tryRead(factory, docs, 0, false, null, false, false);
+                    assertEquals(counterDV.docID(), docIdEnd);
+                    assertNotNull(block);
+                    assertEquals(size, block.size());
+
+                    var stringBlock = (TestBlock) stringCounterDV.tryRead(factory, docs, 0, false, null, false, false);
+                    assertEquals(stringCounterDV.docID(), docIdEnd);
+                    assertNotNull(stringBlock);
+                    assertEquals(size, stringBlock.size());
+
+                    var fixedBinaryBlock = (TestBlock) binaryFixedDV.tryRead(factory, docs, 0, false, null, false, useCustomBinaryFormat);
+                    assertEquals(binaryFixedDV.docID(), docIdEnd);
+                    assertNotNull(fixedBinaryBlock);
+                    assertEquals(size, fixedBinaryBlock.size());
+
+                    var variableBinaryBlock = (TestBlock) binaryVariableDV.tryRead(
+                        factory,
+                        docs,
+                        0,
+                        false,
+                        null,
+                        false,
+                        useCustomBinaryFormat
+                    );
+                    assertEquals(binaryVariableDV.docID(), docIdEnd);
+                    assertNotNull(variableBinaryBlock);
+                    assertEquals(size, variableBinaryBlock.size());
+
+                    for (int j = 0; j < block.size(); j++) {
+                        long actualCounter = (long) block.get(j);
+                        long expectedCounter = expectedCounters[j];
+                        assertEquals(expectedCounter, actualCounter);
+
+                        var expectedStringCounter = Long.toString(actualCounter);
+                        var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                        assertEquals(expectedStringCounter, actualStringCounter);
+
+                        var expectedFixedBinary = expectedFixedBinaryValues.get(j);
+                        var actualFixedBinary = (BytesRef) fixedBinaryBlock.get(j);
+                        assertEquals(expectedFixedBinary, actualFixedBinary);
+
+                        var expectedVariableBinary = expectedVariableBinaryValues.get(j);
+                        var actualVariableBinary = (BytesRef) variableBinaryBlock.get(j);
+                        assertEquals(expectedVariableBinary, actualVariableBinary);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalColumnAtATimeReaderReadAsInt() throws Exception {
+        final String counterField = "counter";
+        final String timestampField = "@timestamp";
+        final String gaugeField = "gauge";
+        int currentTimestamp = 17040672;
+        int currentCounter = 10_000_000;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int[] gauge1Values = new int[] { 2, 4, 6, 8, 10, 12, 14, 16 };
+            int numDocs = 256 + random().nextInt(8096);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                long timestamp = currentTimestamp;
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
+                d.add(new SortedNumericDocValuesField(counterField, currentCounter));
+                d.add(new SortedNumericDocValuesField(gaugeField, gauge1Values[i % gauge1Values.length]));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentTimestamp += 1000;
+                    currentCounter++;
+                }
+            }
+            iw.commit();
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                int gaugeIndex = numDocs;
+                for (var leaf : reader.leaves()) {
+                    var timestampDV = getBaseDenseNumericValues(leaf.reader(), timestampField);
+                    var counterDV = getBaseDenseNumericValues(leaf.reader(), counterField);
+                    var gaugeDV = getBaseDenseNumericValues(leaf.reader(), gaugeField);
+                    int maxDoc = leaf.reader().maxDoc();
+                    for (int i = 0; i < maxDoc;) {
+                        int size = Math.max(1, random().nextInt(0, maxDoc - i));
+                        var docs = TestBlock.docs(IntStream.range(i, i + size).toArray());
+
+                        {
+                            var block = (TestBlock) timestampDV.tryRead(factory, docs, 0, random().nextBoolean(), null, true, false);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                int actualTimestamp = (int) block.get(j);
+                                int expectedTimestamp = currentTimestamp;
+                                assertEquals(expectedTimestamp, actualTimestamp);
+                                currentTimestamp -= 1000;
+                            }
+                        }
+                        {
+                            var block = (TestBlock) counterDV.tryRead(factory, docs, 0, random().nextBoolean(), null, true, false);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                int expectedCounter = currentCounter;
+                                int actualCounter = (int) block.get(j);
+                                assertEquals(expectedCounter, actualCounter);
+                                currentCounter--;
+                            }
+                        }
+                        {
+                            var block = (TestBlock) gaugeDV.tryRead(factory, docs, 0, random().nextBoolean(), null, true, false);
+                            assertNotNull(block);
+                            assertEquals(size, block.size());
+                            for (int j = 0; j < block.size(); j++) {
+                                int actualGauge = (int) block.get(j);
+                                int expectedGauge = gauge1Values[--gaugeIndex % gauge1Values.length];
+                                assertEquals(expectedGauge, actualGauge);
+                            }
+                        }
+
+                        i += size;
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalColumnAtATimeReaderBinary() throws Exception {
+        final boolean useCustomBinaryFormat = randomBoolean();
+        final String binaryFieldOne = "binary_1";
+        final String binaryFieldTwo = "binary_2";
+
+        var config = new IndexWriterConfig();
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        config.setCodec(getCodec());
+
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            Set<String> binaryValues = new HashSet<>();
+            int numDocs = 10_000 * randomIntBetween(2, 20);
+
+            int numValues = randomIntBetween(8, 256);
+            for (int i = 0; i < numValues; i++) {
+                binaryValues.add(randomAlphaOfLength(between(128, 256)));
+            }
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                if (useCustomBinaryFormat) {
+                    d.add(new CustomBinaryDocValuesField(binaryFieldOne, randomFrom(binaryValues).getBytes(StandardCharsets.UTF_8)));
+                } else {
+                    d.add(new BinaryDocValuesField(binaryFieldOne, new BytesRef(randomFrom(binaryValues))));
+                }
+
+                int valuesPerDoc = randomIntBetween(2, 8);
+                Set<String> values = new HashSet<>();
+                while (values.size() < valuesPerDoc) {
+                    values.add(randomFrom(binaryValues));
+                }
+                CustomBinaryDocValuesField fieldTwo = null;
+                for (String value : values) {
+                    if (fieldTwo == null) {
+                        fieldTwo = new CustomBinaryDocValuesField(binaryFieldTwo, value.getBytes(StandardCharsets.UTF_8));
+                    } else {
+                        fieldTwo.add(value.getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+                d.add(fieldTwo);
+
+                iw.addDocument(d);
+                if (i % 1000 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                for (var leaf : reader.leaves()) {
+                    int maxDoc = leaf.reader().maxDoc();
+                    var binaryDVField1 = getTSDBBinaryValues(leaf.reader(), binaryFieldOne);
+                    var docs = TestBlock.docs(IntStream.range(between(0, maxDoc - 1), maxDoc).toArray());
+                    var block = (TestBlock) binaryDVField1.tryRead(
+                        factory,
+                        docs,
+                        0,
+                        random().nextBoolean(),
+                        null,
+                        false,
+                        useCustomBinaryFormat
+                    );
+                    assertNotNull(block);
+                    assertTrue(block.size() > 0);
+                    for (int j = 0; j < block.size(); j++) {
+                        var actual = ((BytesRef) block.get(j)).utf8ToString();
+                        assertTrue("actual [" + actual + "] not in generated values", binaryValues.contains(actual));
+                    }
+
+                    var binaryDVField2 = getTSDBBinaryValues(leaf.reader(), binaryFieldTwo);
+                    block = (TestBlock) binaryDVField2.tryRead(factory, docs, 0, random().nextBoolean(), null, false, true);
+                    for (int j = 0; j < block.size(); j++) {
+                        var values = (List<?>) block.get(j);
+                        assertFalse(values.isEmpty());
+                        for (Object value : values) {
+                            var actual = ((BytesRef) value).utf8ToString();
+                            assertTrue("actual [" + actual + "] not in generated values", binaryValues.contains(actual));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testOptionalColumnAtATimeReaderWithSparseDocs() throws Exception {
+        final String counterField = "counter";
+        final String counterAsStringField = "counter_as_string";
+        final String timestampField = "@timestamp";
+        String queryField = "query_field";
+        String temperatureField = "temperature_field";
+        final String binaryFixedField = "binary_variable";
+        final String binaryVariableField = "binary_fixed";
+        final int binaryFieldMaxLength = randomIntBetween(1, 20);
+        boolean denseBinaryData = randomBoolean();
+
+        long currentTimestamp = 1704067200000L;
+        long currentCounter = 10_000_000;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int numDocsPerQValue = 120;
+            int numDocs = numDocsPerQValue * (1 + random().nextInt(40));
+            Long[] temperatureValues = new Long[numDocs];
+            BytesRef[] binaryFixed = new BytesRef[numDocs];
+            BytesRef[] binaryVariable = new BytesRef[numDocs];
+            long q = 1;
+            for (int i = 1; i <= numDocs; i++) {
+                var d = new Document();
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
+                currentTimestamp += 1000L;
+                d.add(new SortedNumericDocValuesField(counterField, currentCounter));
+                d.add(new SortedDocValuesField(counterAsStringField, new BytesRef(Long.toString(currentCounter))));
+                d.add(new SortedNumericDocValuesField(queryField, q));
+
+                if (denseBinaryData || random().nextBoolean()) {
+                    binaryFixed[numDocs - i] = new BytesRef(randomAlphaOfLength(binaryFieldMaxLength));
+                    d.add(new BinaryDocValuesField(binaryFixedField, binaryFixed[numDocs - i]));
+                    binaryVariable[numDocs - i] = new BytesRef(randomAlphaOfLength(between(0, binaryFieldMaxLength)));
+                    d.add(new BinaryDocValuesField(binaryVariableField, binaryVariable[numDocs - i]));
+                }
+
+                if (i % 120 == 0) {
+                    q++;
+                }
+                if (random().nextBoolean()) {
+                    long v = random().nextLong();
+                    temperatureValues[numDocs - i] = v;
+                    d.add(new NumericDocValuesField(temperatureField, v));
+                }
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                if (i < numDocs - 1) {
+                    currentCounter++;
+                }
+            }
+            iw.commit();
+
+            iw.forceMerge(1);
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+
+                for (int query = 1; query < q; query++) {
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    var topDocs = searcher.search(
+                        SortedNumericDocValuesField.newSlowExactQuery(queryField, query),
+                        numDocsPerQValue,
+                        new Sort(SortField.FIELD_DOC),
+                        false
+                    );
+                    assertEquals(numDocsPerQValue, topDocs.totalHits.value());
+                    var timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
+                    long[] expectedTimestamps = new long[numDocsPerQValue];
+                    var counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                    long[] expectedCounters = new long[numDocsPerQValue];
+                    var counterAsStringDV = getBaseSortedDocValues(leafReader, counterAsStringField);
+                    String[] expectedCounterAsStrings = new String[numDocsPerQValue];
+
+                    int[] docIds = new int[numDocsPerQValue];
+                    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                        var scoreDoc = topDocs.scoreDocs[i];
+                        docIds[i] = scoreDoc.doc;
+
+                        assertTrue(timestampDV.advanceExact(scoreDoc.doc));
+                        expectedTimestamps[i] = timestampDV.longValue();
+
+                        assertTrue(counterDV.advanceExact(scoreDoc.doc));
+                        expectedCounters[i] = counterDV.longValue();
+
+                        assertTrue(counterAsStringDV.advanceExact(scoreDoc.doc));
+                        expectedCounterAsStrings[i] = counterAsStringDV.lookupOrd(counterAsStringDV.ordValue()).utf8ToString();
+                    }
+
+                    var docs = TestBlock.docs(docIds);
+                    {
+                        timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
+                        var block = (TestBlock) timestampDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                        assertNotNull(block);
+                        assertEquals(numDocsPerQValue, block.size());
+                        for (int j = 0; j < block.size(); j++) {
+                            long actualTimestamp = (long) block.get(j);
+                            long expectedTimestamp = expectedTimestamps[j];
+                            assertEquals(expectedTimestamp, actualTimestamp);
+                        }
+                    }
+                    {
+                        counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                        var block = (TestBlock) counterDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                        assertNotNull(block);
+                        assertEquals(numDocsPerQValue, block.size());
+                        for (int j = 0; j < block.size(); j++) {
+                            long actualCounter = (long) block.get(j);
+                            long expectedCounter = expectedCounters[j];
+                            assertEquals(expectedCounter, actualCounter);
+                        }
+                    }
+                    {
+                        counterAsStringDV = getBaseSortedDocValues(leafReader, counterAsStringField);
+                        var block = (TestBlock) counterAsStringDV.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                        assertNotNull(block);
+                        assertEquals(numDocsPerQValue, block.size());
+                        for (int j = 0; j < block.size(); j++) {
+                            var actualCounter = ((BytesRef) block.get(j)).utf8ToString();
+                            var expectedCounter = expectedCounterAsStrings[j];
+                            assertEquals(expectedCounter, actualCounter);
+                        }
+                    }
+                }
+
+                BlockLoader.Docs docs;
+                {
+                    int startIndex = ESTestCase.between(0, temperatureValues.length - 1);
+                    int endIndex = ESTestCase.between(startIndex + 1, temperatureValues.length);
+                    List<Integer> testDocs = new ArrayList<>();
+                    for (int i = startIndex; i < endIndex; i++) {
+                        if (temperatureValues[i] != null) {
+                            testDocs.add(i);
+                        }
+                    }
+                    if (testDocs.isEmpty() == false) {
+                        NumericDocValues dv = leafReader.getNumericDocValues(temperatureField);
+                        assertThat(dv, instanceOf(OptionalColumnAtATimeReader.class));
+                        OptionalColumnAtATimeReader directReader = (OptionalColumnAtATimeReader) dv;
+                        docs = TestBlock.docs(testDocs.stream().mapToInt(n -> n).toArray());
+                        assertNull(directReader.tryRead(factory, docs, 0, false, null, false, false));
+                        TestBlock block = (TestBlock) directReader.tryRead(factory, docs, 0, true, null, false, false);
+                        assertNotNull(block);
+                        for (int i = 0; i < testDocs.size(); i++) {
+                            assertThat(block.get(i), equalTo(temperatureValues[testDocs.get(i)]));
+                        }
+                    }
+                    if (testDocs.size() > 2) {
+                        testDocs.remove(ESTestCase.between(1, testDocs.size() - 2));
+                        docs = TestBlock.docs(testDocs.stream().mapToInt(n -> n).toArray());
+                        NumericDocValues dv = leafReader.getNumericDocValues(temperatureField);
+                        OptionalColumnAtATimeReader directReader = (OptionalColumnAtATimeReader) dv;
+                        assertNull(directReader.tryRead(factory, docs, 0, false, null, false, false));
+                        assertNull(directReader.tryRead(factory, docs, 0, true, null, false, false));
+                    }
+                }
+
+                {
+                    List<Integer> testDocs = IntStream.range(0, numDocs - 1).filter(i -> randomBoolean()).boxed().toList();
+                    docs = TestBlock.docs(testDocs.stream().mapToInt(n -> n).toArray());
+                    if (testDocs.isEmpty() == false) {
+                        if (denseBinaryData) {
+                            {
+                                var dv = getTSDBBinaryValues(leafReader, binaryFixedField);
+                                var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                                assertNotNull(block);
+                                for (int i = 0; i < testDocs.size(); i++) {
+                                    assertThat(block.get(i), equalTo(binaryFixed[testDocs.get(i)]));
+                                }
+                            }
+                            {
+                                var dv = getTSDBBinaryValues(leafReader, binaryVariableField);
+                                var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                                assertNotNull(block);
+                                for (int i = 0; i < testDocs.size(); i++) {
+                                    assertThat(block.get(i), equalTo(binaryVariable[testDocs.get(i)]));
+                                }
+                            }
+                        } else {
+                            {
+                                var dv = getTSDBBinaryValues(leafReader, binaryFixedField);
+                                var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                                assertNull(block);
+                            }
+                            {
+                                var dv = getTSDBBinaryValues(leafReader, binaryVariableField);
+                                var block = (TestBlock) dv.tryRead(factory, docs, 0, random().nextBoolean(), null, false, false);
+                                assertNull(block);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testLoadKeywordFieldWithIndexSorts() throws IOException {
+        String primaryField = "sorted_first";
+        String secondField = "sorted_second";
+        String unsortedField = "no_sort";
+        String sparseField = "sparse";
+        var config = new IndexWriterConfig();
+        config.setIndexSort(new Sort(new SortField(primaryField, SortField.Type.STRING, false)));
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        final DocValuesFormat dvFormat = createDocValuesFormat(
+            randomIntBetween(2, 4096),
+            1, // always enable range-encode
+            random().nextBoolean(),
+            randomBinaryCompressionMode(),
+            randomBoolean(),
+            randomNumericBlockSize(),
+            randomBoolean()
+        );
+        var codec = TestUtil.alwaysDocValuesFormat(dvFormat);
+        config.setCodec(codec);
+        Map<Integer, String> hostnames = new HashMap<>();
+        try (Directory dir = newDirectory(); IndexWriter writer = new IndexWriter(dir, config)) {
+            int numDocs = randomIntBetween(100, 5000);
+            for (int i = 0; i < numDocs; i++) {
+                hostnames.put(i, "h" + random().nextInt(10));
+            }
+            List<Integer> ids = new ArrayList<>(hostnames.keySet());
+            Randomness.shuffle(ids);
+            Set<Integer> sparseIds = new HashSet<>(ESTestCase.randomSubsetOf(ESTestCase.between(1, ids.size() / 2), ids));
+            for (Integer id : ids) {
+                var d = new Document();
+                String hostname = hostnames.get(id);
+                d.add(new NumericDocValuesField("id", id));
+                d.add(new SortedDocValuesField(primaryField, new BytesRef(hostname)));
+                d.add(new SortedDocValuesField(secondField, new BytesRef(hostname)));
+                d.add(new SortedDocValuesField(unsortedField, new BytesRef(hostname)));
+                if (sparseIds.contains(id)) {
+                    d.add(new SortedDocValuesField(sparseField, new BytesRef(hostname)));
+                }
+                writer.addDocument(d);
+                if (random().nextInt(100) < 10) {
+                    writer.flush();
+                }
+            }
+            for (int iter = 0; iter < 2; iter++) {
+                var factory = TestBlock.factory();
+                try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        BlockLoader.Docs docs = TestBlock.docs(leaf);
+                        var idReader = ESTestCase.asInstanceOf(OptionalColumnAtATimeReader.class, leaf.reader().getNumericDocValues("id"));
+                        TestBlock idBlock = (TestBlock) idReader.tryRead(factory, docs, 0, false, null, false, false);
+                        assertNotNull(idBlock);
+
+                        {
+                            var reader2 = (BaseSortedDocValues) ESTestCase.asInstanceOf(
+                                OptionalColumnAtATimeReader.class,
+                                leaf.reader().getSortedDocValues(secondField)
+                            );
+                            int randomOffset = ESTestCase.between(0, docs.count() - 1);
+                            TestBlock block;
+                            if (reader2.getValueCount() == 1) {
+                                block = (TestBlock) reader2.tryReadAHead(factory, docs, randomOffset);
+                            } else {
+                                assertNull(reader2.tryReadAHead(factory, docs, randomOffset));
+                                block = (TestBlock) reader2.tryRead(factory, docs, randomOffset, false, null, false, false);
+                            }
+                            assertNotNull(block);
+                            assertThat(block.size(), equalTo(docs.count() - randomOffset));
+                            for (int i = 0; i < block.size(); i++) {
+                                String actualHostName = BytesRefs.toString(block.get(i));
+                                int id = ((Number) idBlock.get(i + randomOffset)).intValue();
+                                String expectedHostName = hostnames.get(id);
+                                assertEquals(expectedHostName, actualHostName);
+                            }
+                        }
+                        {
+                            var reader3 = (BaseSortedDocValues) ESTestCase.asInstanceOf(
+                                OptionalColumnAtATimeReader.class,
+                                leaf.reader().getSortedDocValues(unsortedField)
+                            );
+                            int randomOffset = ESTestCase.between(0, docs.count() - 1);
+                            TestBlock block;
+                            if (reader3.getValueCount() == 1) {
+                                block = (TestBlock) reader3.tryReadAHead(factory, docs, randomOffset);
+                            } else {
+                                assertNull(reader3.tryReadAHead(factory, docs, randomOffset));
+                                block = (TestBlock) reader3.tryRead(factory, docs, randomOffset, false, null, false, false);
+                            }
+                            assertNotNull(reader3);
+                            assertNotNull(block);
+                            assertThat(block.size(), equalTo(docs.count() - randomOffset));
+                            for (int i = 0; i < block.size(); i++) {
+                                String actualHostName = BytesRefs.toString(block.get(i));
+                                int id = ((Number) idBlock.get(i + randomOffset)).intValue();
+                                String expectedHostName = hostnames.get(id);
+                                assertEquals(expectedHostName, actualHostName);
+                            }
+                        }
+                        for (int offset = 0; offset < idBlock.size(); offset += ESTestCase.between(1, numDocs)) {
+                            int start = offset;
+                            var reader1 = (BaseSortedDocValues) ESTestCase.asInstanceOf(
+                                OptionalColumnAtATimeReader.class,
+                                leaf.reader().getSortedDocValues(primaryField)
+                            );
+                            while (start < idBlock.size()) {
+                                int end = start + random().nextInt(idBlock.size() - start);
+                                TestBlock hostBlock = (TestBlock) reader1.tryReadAHead(factory, new BlockLoader.Docs() {
+                                    @Override
+                                    public int count() {
+                                        return end + 1;
+                                    }
+
+                                    @Override
+                                    public int get(int docId) {
+                                        return docId;
+                                    }
+
+                                    @Override
+                                    public boolean mayContainDuplicates() {
+                                        return false;
+                                    }
+                                }, start);
+                                assertNotNull(hostBlock);
+                                assertThat(hostBlock.size(), equalTo(end - start + 1));
+                                for (int i = 0; i < hostBlock.size(); i++) {
+                                    String actualHostName = BytesRefs.toString(hostBlock.get(i));
+                                    assertThat(actualHostName, equalTo(hostnames.get(((Number) idBlock.get(i + start)).intValue())));
+                                }
+                                if (start == idBlock.size() - 1) {
+                                    break;
+                                }
+                                start = end + ESTestCase.between(0, 10);
+                            }
+                        }
+                        writer.forceMerge(1);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testEncodeRangeWithSortedSetPrimarySortField() throws Exception {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, true, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+
+            int numDocs = 512 + random().nextInt(512);
+            int numHosts = numDocs / 20;
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                int batchIndex = i / numHosts;
+                {
+                    String hostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                    d.add(new SortedSetDocValuesField(hostnameField, new BytesRef(hostName)));
+                }
+                {
+                    String hostName = String.format(Locale.ROOT, "host-%03d", batchIndex + 1);
+                    d.add(new SortedSetDocValuesField(hostnameField, new BytesRef(hostName)));
+                }
+                long timestamp = baseTimestamp + (1000L * i);
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedSetDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                for (int i = 0; i < numDocs; i++) {
+                    assertEquals(i, hostNameDV.nextDoc());
+
+                    int batchIndex = i / numHosts;
+                    assertEquals(2, hostNameDV.docValueCount());
+
+                    long firstOrd = hostNameDV.nextOrd();
+                    assertEquals(batchIndex, firstOrd);
+                    String expectedFirstHostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                    String actualFirstHostName = hostNameDV.lookupOrd(firstOrd).utf8ToString();
+                    assertEquals(expectedFirstHostName, actualFirstHostName);
+
+                    batchIndex++;
+                    long secondOrd = hostNameDV.nextOrd();
+                    assertEquals(batchIndex, secondOrd);
+                    String expectedSecondHostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                    String actualSecondHostName = hostNameDV.lookupOrd(secondOrd).utf8ToString();
+                    assertEquals(expectedSecondHostName, actualSecondHostName);
+
+                    assertEquals(i, timestampDV.nextDoc());
+                    long timestamp = timestampDV.longValue();
+                    long lowerBound = baseTimestamp;
+                    long upperBound = baseTimestamp + (1000L * numDocs);
+                    assertTrue(
+                        "unexpected timestamp [" + timestamp + "], expected between [" + lowerBound + "] and [" + upperBound + "]",
+                        timestamp >= lowerBound && timestamp < upperBound
+                    );
+                }
+            }
+        }
+    }
+
+    public void testTryReadReturnsNullWithMayContainDuplicates() throws Exception {
+        final String timestampField = "@timestamp";
+        final String denseNumericField = "dense_numeric";
+        final String binaryFixedField = "binary_fixed";
+        final String binaryVariableField = "binary_variable";
+        final String sortedField = "sorted_field";
+        final int binaryFixedLength = randomIntBetween(1, 20);
+        final int binaryVariableMaxLength = randomIntBetween(1, 20);
+        long currentTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(null, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int numDocs = 256 + random().nextInt(256);
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
+                d.add(new SortedNumericDocValuesField(denseNumericField, random().nextLong()));
+                d.add(new BinaryDocValuesField(binaryFixedField, new BytesRef(randomAlphaOfLength(binaryFixedLength))));
+                d.add(new BinaryDocValuesField(binaryVariableField, new BytesRef(randomAlphaOfLengthBetween(0, binaryVariableMaxLength))));
+                d.add(new SortedDocValuesField(sortedField, new BytesRef(randomAlphaOfLengthBetween(1, 10))));
+                iw.addDocument(d);
+                currentTimestamp += 1000L;
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            var factory = TestBlock.factory();
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                var leafReader = reader.leaves().get(0).reader();
+                int maxDoc = leafReader.maxDoc();
+                var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
+                var docsWithDups = TestBlock.docs(
+                    IntStream.concat(IntStream.range(0, maxDoc), IntStream.of(between(0, maxDoc - 1))).sorted().toArray()
+                );
+
+                {
+                    var dv = getBaseDenseNumericValues(leafReader, denseNumericField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getBaseDenseNumericValues(leafReader, denseNumericField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    var dv = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getTSDBBinaryValues(leafReader, binaryFixedField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    var dv = getTSDBBinaryValues(leafReader, binaryVariableField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getTSDBBinaryValues(leafReader, binaryVariableField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+                {
+                    var dv = getBaseSortedDocValues(leafReader, sortedField);
+                    assertNotNull(dv.tryRead(factory, docs, 0, false, null, false, false));
+                    dv = getBaseSortedDocValues(leafReader, sortedField);
+                    assertNull(dv.tryRead(factory, docsWithDups, 0, false, null, false, false));
+                }
+            }
+        }
+    }
+
+    public void testDocIDEndRun() throws IOException {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        long baseTimestamp = 1704067200000L;
+
+        var config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            long counter1 = 0;
+
+            long[] gauge2Values = new long[] { -2, -4, -6, -8, -10, -12, -14, -16 };
+            String[] tags = new String[] { "tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_6", "tag_7", "tag_8" };
+
+            int gap_frequency = 4500 + random().nextInt(2048);
+            int numDocs = 10000 + random().nextInt(10000);
+            int numHosts = numDocs / 20;
+
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+
+                int batchIndex = i / numHosts;
+                String hostName = String.format(Locale.ROOT, "host-%03d", batchIndex);
+                long timestamp = baseTimestamp + (1000L * i);
+
+                d.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
+                d.add(new SortedNumericDocValuesField(timestampField, timestamp));
+                d.add(new NumericDocValuesField("counter", counter1++));
+                if (i % gap_frequency != 0) {
+                    d.add(new NumericDocValuesField("sparse_counter", counter1));
+                }
+
+                int numGauge2 = 1 + random().nextInt(8);
+                for (int j = 0; j < numGauge2; j++) {
+                    d.add(new SortedNumericDocValuesField("gauge", gauge2Values[(i + j) % gauge2Values.length]));
+                    if (i % gap_frequency != 0) {
+                        d.add(new SortedNumericDocValuesField("sparse_gauge", gauge2Values[(i + j) % gauge2Values.length]));
+                    }
+                }
+
+                d.add(new SortedDocValuesField("tag", new BytesRef(randomFrom(tags))));
+                if (i % gap_frequency != 0) {
+                    d.add(new SortedDocValuesField("sparse_tag", new BytesRef(randomFrom(tags))));
+                }
+
+                int numTags = 1 + random().nextInt(8);
+                for (int j = 0; j < numTags; j++) {
+                    d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[(i + j) % tags.length])));
+                    if (i % gap_frequency != 0) {
+                        d.add(new SortedSetDocValuesField("sparse_tags", new BytesRef(tags[(i + j) % tags.length])));
+                    }
+                }
+
+                d.add(new BinaryDocValuesField("tags_as_bytes", new BytesRef(tags[i % tags.length])));
+                if (i % gap_frequency != 0) {
+                    d.add(new BinaryDocValuesField("sparse_tags_as_bytes", new BytesRef(tags[i % tags.length])));
+                }
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+            }
+            iw.commit();
+
+            iw.forceMerge(1);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leaf = reader.leaves().get(0).reader();
+                var hostNameDV = leaf.getSortedDocValues(hostnameField);
+                assertNotNull(hostNameDV);
+                validateRunEnd(hostNameDV);
+                var timestampDV = DocValues.unwrapSingleton(leaf.getSortedNumericDocValues(timestampField));
+                assertNotNull(timestampDV);
+                validateRunEnd(timestampDV);
+                var counterOneDV = leaf.getNumericDocValues("counter");
+                assertNotNull(counterOneDV);
+                validateRunEnd(counterOneDV);
+                var sparseCounter = leaf.getNumericDocValues("sparse_counter");
+                assertNotNull(sparseCounter);
+                validateRunEnd(sparseCounter);
+                var gaugeOneDV = leaf.getSortedNumericDocValues("gauge");
+                assertNotNull(gaugeOneDV);
+                validateRunEnd(gaugeOneDV);
+                var sparseGaugeDV = leaf.getSortedNumericDocValues("sparse_gauge");
+                assertNotNull(sparseGaugeDV);
+                validateRunEnd(sparseGaugeDV);
+                var tagDV = leaf.getSortedDocValues("tag");
+                assertNotNull(tagDV);
+                validateRunEnd(tagDV);
+                var sparseTagDV = leaf.getSortedDocValues("sparse_tag");
+                assertNotNull(sparseTagDV);
+                validateRunEnd(sparseTagDV);
+                var tagsDV = leaf.getSortedSetDocValues("tags");
+                assertNotNull(tagsDV);
+                validateRunEnd(tagsDV);
+                var sparseTagsDV = leaf.getSortedSetDocValues("sparse_tags");
+                assertNotNull(sparseTagsDV);
+                validateRunEnd(sparseTagsDV);
+                var tagBytesDV = leaf.getBinaryDocValues("tags_as_bytes");
+                assertNotNull(tagBytesDV);
+                validateRunEnd(tagBytesDV);
+                var sparseTagBytesDV = leaf.getBinaryDocValues("sparse_tags_as_bytes");
+                assertNotNull(sparseTagBytesDV);
+                validateRunEnd(sparseTagBytesDV);
+            }
+        }
+    }
+
+    public void testOptionalLengthReaderLengthIterator() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryField = "binary_field";
+        long currentTimestamp = 1704067200000L;
+
+        final int[] possibleLengths = new int[] { 5, 10, 20 };
+        final int targetLength = possibleLengths[randomIntBetween(0, possibleLengths.length - 1)];
+
+        var dvFormat = createDocValuesFormat(
+            ESTestCase.randomIntBetween(2, 4096),
+            ESTestCase.randomIntBetween(1, 512),
+            random().nextBoolean(),
+            randomBoolean() ? BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1 : BinaryDVCompressionMode.NO_COMPRESS,
+            randomBoolean(),
+            NUMERIC_LARGE_BLOCK_SHIFT,
+            randomBoolean()
+        );
+        var compressedCodec = TestUtil.alwaysDocValuesFormat(dvFormat);
+
+        var config = new IndexWriterConfig();
+        config.setIndexSort(new Sort(new SortedNumericSortField(timestampField, SortField.Type.LONG, true)));
+        config.setLeafSorter(DataStream.TIMESERIES_LEAF_READERS_SORTER);
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        config.setCodec(compressedCodec);
+
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int numDocs = 256 + random().nextInt(4096);
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
+
+                int length = possibleLengths[random().nextInt(possibleLengths.length)];
+                d.add(new BinaryDocValuesField(binaryField, new BytesRef(randomAlphaOfLength(length))));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                currentTimestamp += 1000L;
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+
+                Set<Integer> expectedDocIds = new HashSet<>();
+                {
+                    var refDV = getTSDBBinaryValues(leafReader, binaryField);
+                    for (int docId = 0; docId < numDocs; docId++) {
+                        assertTrue(refDV.advanceExact(docId));
+                        if (refDV.binaryValue().length == targetLength) {
+                            expectedDocIds.add(docId);
+                        }
+                    }
+                }
+
+                var binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                DocIdSetIterator lengthIter = binaryDV.tryLengthIterator(targetLength);
+                assertNotNull(lengthIter);
+                assertEquals(-1, lengthIter.docID());
+
+                Set<Integer> actualDocIds = new HashSet<>();
+                int doc;
+                while ((doc = lengthIter.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                    assertTrue("Iterator returned unexpected doc " + doc, expectedDocIds.contains(doc));
+                    actualDocIds.add(doc);
+
+                    int runEnd = lengthIter.docIDRunEnd();
+                    assertTrue("docIDRunEnd (" + runEnd + ") must be > docID (" + doc + ")", runEnd > doc);
+
+                    for (int d = doc; d < runEnd; d++) {
+                        assertTrue("doc " + d + " in run [" + doc + ", " + runEnd + ") should match", expectedDocIds.contains(d));
+                    }
+
+                    for (int d = doc + 1; d < runEnd; d++) {
+                        assertEquals(d, lengthIter.advance(d));
+                        actualDocIds.add(d);
+                        assertEquals("docIDRunEnd should be stable within a run", runEnd, lengthIter.docIDRunEnd());
+                    }
+                }
+
+                assertEquals("Iterator should return exactly the matching docs", expectedDocIds, actualDocIds);
+
+                binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                lengthIter = binaryDV.tryLengthIterator(targetLength);
+                assertNotNull(lengthIter);
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, lengthIter.advance(numDocs));
+
+                binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                lengthIter = binaryDV.tryLengthIterator(9999);
+                assertNotNull(lengthIter);
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, lengthIter.nextDoc());
+            }
+        }
+    }
+
+    public void testContainsIterator() throws Exception {
+        final String timestampField = "@timestamp";
+        final String binaryField = "binary_field";
+        long currentTimestamp = 1704067200000L;
+
+        final String containsTerm = randomUnicodeOfCodepointLengthBetween(1, 10);
+        int numPossibleValues = randomIntBetween(5, 100);
+        final String[] possibleValues = new String[numPossibleValues];
+        for (int i = 0; i < numPossibleValues; i++) {
+            if (randomBoolean()) {
+                String prefix = randomUnicodeOfCodepointLengthBetween(0, 20);
+                String suffix = randomUnicodeOfCodepointLengthBetween(0, 20);
+                possibleValues[i] = prefix + containsTerm + suffix;
+            } else {
+                possibleValues[i] = randomUnicodeOfCodepointLengthBetween(1, 100);
+            }
+        }
+
+        // tryContainsIterator is only implemented for the compressed binary doc values path
+        var dvFormat = createDocValuesFormat(
+            ESTestCase.randomIntBetween(2, 4096),
+            ESTestCase.randomIntBetween(1, 512),
+            random().nextBoolean(),
+            BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+            randomBoolean(),
+            NUMERIC_LARGE_BLOCK_SHIFT,
+            randomBoolean()
+        );
+        var compressedCodec = TestUtil.alwaysDocValuesFormat(dvFormat);
+
+        var config = new IndexWriterConfig();
+        config.setIndexSort(new Sort(new SortedNumericSortField(timestampField, SortField.Type.LONG, true)));
+        config.setLeafSorter(DataStream.TIMESERIES_LEAF_READERS_SORTER);
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        config.setCodec(compressedCodec);
+
+        try (var dir = newDirectory(); var iw = new IndexWriter(dir, config)) {
+            int numDocs = 256 + random().nextInt(4096);
+            for (int i = 0; i < numDocs; i++) {
+                var d = new Document();
+                d.add(SortedNumericDocValuesField.indexedField(timestampField, currentTimestamp));
+
+                String value = possibleValues[random().nextInt(possibleValues.length)];
+                d.add(new BinaryDocValuesField(binaryField, new BytesRef(value)));
+
+                iw.addDocument(d);
+                if (i % 100 == 0) {
+                    iw.commit();
+                }
+                currentTimestamp += 1000L;
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            BytesRef containsTermRef = new BytesRef(containsTerm);
+
+            try (var reader = DirectoryReader.open(iw)) {
+                assertEquals(1, reader.leaves().size());
+                assertEquals(numDocs, reader.maxDoc());
+                var leafReader = reader.leaves().get(0).reader();
+
+                Set<Integer> expectedDocIds = new HashSet<>();
+                {
+                    var refDV = getTSDBBinaryValues(leafReader, binaryField);
+                    for (int docId = 0; docId < numDocs; docId++) {
+                        assertTrue(refDV.advanceExact(docId));
+                        if (BinaryDocValuesContainsTermQuery.contains(refDV.binaryValue(), containsTermRef)) {
+                            expectedDocIds.add(docId);
+                        }
+                    }
+                }
+                assertFalse("expected some matching docs", expectedDocIds.isEmpty());
+
+                var binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                DocIdSetIterator containsIter = binaryDV.tryContainsIterator(containsTermRef);
+                assertNotNull(containsIter);
+                assertEquals(-1, containsIter.docID());
+
+                Set<Integer> actualDocIds = new HashSet<>();
+                int doc;
+                while ((doc = containsIter.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                    assertTrue("Iterator returned unexpected doc " + doc, expectedDocIds.contains(doc));
+                    actualDocIds.add(doc);
+                }
+                assertEquals("Iterator should return exactly the matching docs", expectedDocIds, actualDocIds);
+
+                binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                containsIter = binaryDV.tryContainsIterator(containsTermRef);
+                assertNotNull(containsIter);
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, containsIter.advance(numDocs));
+
+                String notFoundTerm = randomUnicodeOfCodepointLengthBetween(101, 200);
+                binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                containsIter = binaryDV.tryContainsIterator(new BytesRef(notFoundTerm));
+                assertNotNull(containsIter);
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, containsIter.nextDoc());
+
+                binaryDV = getTSDBBinaryValues(leafReader, binaryField);
+                containsIter = binaryDV.tryContainsIterator(containsTermRef);
+                for (int expected : expectedDocIds.stream().sorted().toList()) {
+                    int result = containsIter.advance(expected);
+                    assertEquals("advance(" + expected + ") should land on that doc", expected, result);
+                }
+            }
+        }
+    }
+
+    private void validateRunEnd(DocIdSetIterator iterator) throws IOException {
+        int runCount = 0;
+        while (iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            int runLength = iterator.docIDRunEnd() - iterator.docID() - 1;
+            if (runLength > 1) {
+                runCount++;
+                for (int i = 0; i < runLength; i++) {
+                    int expected = iterator.docID() + 1;
+                    assertEquals(expected, iterator.advance(expected));
+                }
+            }
+        }
+        assertTrue("Expected docid runs of greater than 1", runCount > 0);
+    }
+
+    protected IndexWriterConfig getTimeSeriesIndexWriterConfig(String hostnameField, String timestampField) {
+        return getTimeSeriesIndexWriterConfig(hostnameField, false, timestampField);
+    }
+
+    protected IndexWriterConfig getTimeSeriesIndexWriterConfig(String hostnameField, boolean multiValued, String timestampField) {
+        var config = new IndexWriterConfig();
+        if (hostnameField != null) {
+            config.setIndexSort(
+                new Sort(
+                    multiValued ? new SortedSetSortField(hostnameField, false) : new SortField(hostnameField, SortField.Type.STRING, false),
+                    new SortedNumericSortField(timestampField, SortField.Type.LONG, true)
+                )
+            );
+        } else {
+            config.setIndexSort(new Sort(new SortedNumericSortField(timestampField, SortField.Type.LONG, true)));
+        }
+        config.setLeafSorter(DataStream.TIMESERIES_LEAF_READERS_SORTER);
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        config.setCodec(getCodec());
+        return config;
+    }
+
+    public static BinaryDVCompressionMode randomBinaryCompressionMode() {
+        BinaryDVCompressionMode[] modes = BinaryDVCompressionMode.values();
+        return modes[random().nextInt(modes.length)];
+    }
+
+    public static int randomNumericBlockSize() {
+        return random().nextBoolean() ? NUMERIC_LARGE_BLOCK_SHIFT : NUMERIC_BLOCK_SHIFT;
+    }
+
+    protected static TSDBBinaryDocValues getTSDBBinaryValues(LeafReader leafReader, String field) throws IOException {
+        return (TSDBBinaryDocValues) leafReader.getBinaryDocValues(field);
+    }
+
+    protected static BaseDenseNumericValues getBaseDenseNumericValues(LeafReader leafReader, String field) throws IOException {
+        return (BaseDenseNumericValues) DocValues.unwrapSingleton(leafReader.getSortedNumericDocValues(field));
+    }
+
+    protected static BaseSortedDocValues getBaseSortedDocValues(LeafReader leafReader, String field) throws IOException {
+        var sortedDocValues = leafReader.getSortedDocValues(field);
+        if (sortedDocValues == null) {
+            sortedDocValues = DocValues.unwrapSingleton(leafReader.getSortedSetDocValues(field));
+        }
+        return (BaseSortedDocValues) sortedDocValues;
+    }
+
+    abstract static class BytesRefBuilderStub implements BlockLoader.BytesRefBuilder {
+
+        @Override
+        public BlockLoader.BytesRefBuilder appendBytesRef(BytesRef value) {
+            return this;
+        }
+
+        @Override
+        public BlockLoader.Block build() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BlockLoader.Builder appendNull() {
+            return this;
+        }
+
+        @Override
+        public BlockLoader.Builder beginPositionEntry() {
+            return this;
+        }
+
+        @Override
+        public BlockLoader.Builder endPositionEntry() {
+            return this;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    protected void doTestAddIndices(List<DocValuesFormat> sourceFormats) throws IOException {
+        String timestampField = "@timestamp";
+        String hostnameField = "host.name";
+        Supplier<IndexWriterConfig> indexConfigWithRandomDVFormat = () -> {
+            IndexWriterConfig config = getTimeSeriesIndexWriterConfig(hostnameField, timestampField);
+            DocValuesFormat dvFormat = randomFrom(sourceFormats);
+            config.setCodec(new Elasticsearch900Lucene101Codec() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return dvFormat;
+                }
+            });
+            return config;
+        };
+        var allNumericFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "numeric_" + n).toList();
+        var allSortedNumericFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_numeric_" + n).toList();
+        var allSortedFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_" + n).toList();
+        var allSortedSetFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_set" + n).toList();
+        var allBinaryFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "binary_" + n).toList();
+        try (var source1 = newDirectory(); var source2 = newDirectory(); var singleDir = newDirectory(); var mergeDir = newDirectory()) {
+            try (
+                var writer1 = new IndexWriter(source1, indexConfigWithRandomDVFormat.get());
+                var writer2 = new IndexWriter(source2, indexConfigWithRandomDVFormat.get());
+                var singleWriter = new IndexWriter(singleDir, indexConfigWithRandomDVFormat.get())
+            ) {
+                int numDocs = 1 + random().nextInt(1_000);
+                long timestamp = random().nextLong(1000_000L);
+                for (int i = 0; i < numDocs; i++) {
+                    List<IndexableField> fields = new ArrayList<>();
+                    String hostName = String.format(Locale.ROOT, "host-%d", random().nextInt(5));
+                    timestamp += 1 + random().nextInt(1_000);
+                    fields.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
+                    fields.add(new SortedNumericDocValuesField(timestampField, timestamp));
+                    for (String f : ESTestCase.randomSubsetOf(allNumericFields)) {
+                        fields.add(new NumericDocValuesField(f, random().nextLong(1000L)));
+                    }
+                    for (String field : ESTestCase.randomSubsetOf(allSortedNumericFields)) {
+                        int valueCount = 1 + random().nextInt(3);
+                        for (int v = 0; v < valueCount; v++) {
+                            fields.add(new SortedNumericDocValuesField(field, random().nextLong(1000L)));
+                        }
+                    }
+                    for (String field : ESTestCase.randomSubsetOf(allSortedFields)) {
+                        fields.add(new SortedDocValuesField(field, new BytesRef("s" + random().nextInt(100))));
+                    }
+                    for (String field : ESTestCase.randomSubsetOf(allSortedSetFields)) {
+                        int valueCount = 1 + random().nextInt(3);
+                        for (int v = 0; v < valueCount; v++) {
+                            fields.add(new SortedSetDocValuesField(field, new BytesRef("ss" + random().nextInt(100))));
+                        }
+                    }
+                    for (String field : ESTestCase.randomSubsetOf(allBinaryFields)) {
+                        fields.add(new BinaryDocValuesField(field, new BytesRef("b" + random().nextInt(100))));
+                    }
+                    for (IndexWriter writer : List.of(ESTestCase.randomFrom(writer1, writer2), singleWriter)) {
+                        Randomness.shuffle(fields);
+                        writer.addDocument(fields);
+                        if (random().nextInt(100) <= 5) {
+                            writer.commit();
+                        }
+                    }
+                }
+                if (random().nextBoolean()) {
+                    writer1.forceMerge(1);
+                }
+                if (random().nextBoolean()) {
+                    writer2.forceMerge(1);
+                }
+                singleWriter.commit();
+                singleWriter.forceMerge(1);
+            }
+            try (var mergeWriter = new IndexWriter(mergeDir, getTimeSeriesIndexWriterConfig(hostnameField, timestampField))) {
+                mergeWriter.addIndexes(source1, source2);
+                mergeWriter.forceMerge(1);
+            }
+            try (var reader1 = DirectoryReader.open(singleDir); var reader2 = DirectoryReader.open(mergeDir)) {
+                assertEquals(reader1.maxDoc(), reader2.maxDoc());
+                assertEquals(1, reader1.leaves().size());
+                assertEquals(1, reader2.leaves().size());
+                for (int i = 0; i < reader1.leaves().size(); i++) {
+                    LeafReader leaf1 = reader1.leaves().get(i).reader();
+                    LeafReader leaf2 = reader2.leaves().get(i).reader();
+                    for (String f : CollectionUtils.appendToCopy(allSortedNumericFields, timestampField)) {
+                        var dv1 = leaf1.getNumericDocValues(f);
+                        var dv2 = leaf2.getNumericDocValues(f);
+                        if (dv1 == null) {
+                            assertNull(dv2);
+                            continue;
+                        }
+                        assertNotNull(dv2);
+                        while (dv1.nextDoc() != NumericDocValues.NO_MORE_DOCS) {
+                            assertNotEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                            assertEquals(dv1.docID(), dv2.docID());
+                            assertEquals(dv1.longValue(), dv2.longValue());
+                        }
+                        assertEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                    }
+                    for (String f : CollectionUtils.appendToCopy(allSortedNumericFields, timestampField)) {
+                        var dv1 = leaf1.getSortedNumericDocValues(f);
+                        var dv2 = leaf2.getSortedNumericDocValues(f);
+                        if (dv1 == null) {
+                            assertNull(dv2);
+                            continue;
+                        }
+                        assertNotNull(dv2);
+                        while (dv1.nextDoc() != NumericDocValues.NO_MORE_DOCS) {
+                            assertNotEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                            assertEquals(dv1.docID(), dv2.docID());
+                            assertEquals(dv1.docValueCount(), dv2.docValueCount());
+                            for (int v = 0; v < dv1.docValueCount(); v++) {
+                                assertEquals(dv1.nextValue(), dv2.nextValue());
+                            }
+                        }
+                        assertEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                    }
+                    for (String f : CollectionUtils.appendToCopy(allSortedFields, hostnameField)) {
+                        var dv1 = leaf1.getSortedDocValues(f);
+                        var dv2 = leaf2.getSortedDocValues(f);
+                        if (dv1 == null) {
+                            assertNull(dv2);
+                            continue;
+                        }
+                        assertNotNull(dv2);
+                        while (dv1.nextDoc() != SortedDocValues.NO_MORE_DOCS) {
+                            assertNotEquals(SortedDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                            assertEquals(dv1.docID(), dv2.docID());
+                            assertEquals(dv1.lookupOrd(dv1.ordValue()), dv2.lookupOrd(dv2.ordValue()));
+                        }
+                        assertEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                    }
+                    for (String f : allSortedSetFields) {
+                        var dv1 = leaf1.getSortedSetDocValues(f);
+                        var dv2 = leaf2.getSortedSetDocValues(f);
+                        if (dv1 == null) {
+                            assertNull(dv2);
+                            continue;
+                        }
+                        assertNotNull(dv2);
+                        while (dv1.nextDoc() != SortedDocValues.NO_MORE_DOCS) {
+                            assertNotEquals(SortedDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                            assertEquals(dv1.docID(), dv2.docID());
+                            assertEquals(dv1.docValueCount(), dv2.docValueCount());
+                            for (int v = 0; v < dv1.docValueCount(); v++) {
+                                assertEquals(dv1.lookupOrd(dv1.nextOrd()), dv2.lookupOrd(dv2.nextOrd()));
+                            }
+                        }
+                        assertEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                    }
+                    for (String f : allBinaryFields) {
+                        var dv1 = leaf1.getBinaryDocValues(f);
+                        var dv2 = leaf2.getBinaryDocValues(f);
+                        if (dv1 == null) {
+                            assertNull(dv2);
+                            continue;
+                        }
+                        assertNotNull(dv2);
+                        while (dv1.nextDoc() != SortedDocValues.NO_MORE_DOCS) {
+                            assertNotEquals(SortedDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                            assertEquals(dv1.docID(), dv2.docID());
+                            assertEquals(dv1.binaryValue(), dv2.binaryValue());
+                        }
+                        assertEquals(NumericDocValues.NO_MORE_DOCS, dv2.nextDoc());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es94/ES94TSDBDocValuesFormatTests.java
@@ -7,38 +7,38 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.index.codec.tsdb.es819;
+package org.elasticsearch.index.codec.tsdb.es94;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
-import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.index.codec.Elasticsearch93Lucene104Codec;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesFormatTestCase;
 import org.elasticsearch.index.codec.tsdb.BinaryDVCompressionMode;
+import org.elasticsearch.index.codec.tsdb.DocOffsetsCodec;
 import org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormatTests;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
+import org.elasticsearch.index.codec.tsdb.es819.ES819Version3TSDBDocValuesFormat;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT;
-import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.NUMERIC_LARGE_BLOCK_SHIFT;
+import static org.elasticsearch.index.codec.tsdb.es94.ES94TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT;
+import static org.elasticsearch.index.codec.tsdb.es94.ES94TSDBDocValuesFormat.NUMERIC_LARGE_BLOCK_SHIFT;
 import static org.hamcrest.Matchers.equalTo;
 
-public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTestCase {
+public class ES94TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTestCase {
 
-    protected final Codec codec = new Elasticsearch93Lucene104Codec() {
+    protected final Codec es94Codec = new Elasticsearch93Lucene104Codec() {
 
-        final DocValuesFormat docValuesFormat = new ES819Version3TSDBDocValuesFormat(
+        final DocValuesFormat docValuesFormat = new ES94TSDBDocValuesFormat(
             ESTestCase.randomIntBetween(2, 4096),
             ESTestCase.randomIntBetween(1, 512),
             random().nextBoolean(),
             BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
             true,
-            random().nextBoolean() ? NUMERIC_LARGE_BLOCK_SHIFT : NUMERIC_BLOCK_SHIFT,
-            random().nextBoolean()
+            random().nextBoolean() ? NUMERIC_LARGE_BLOCK_SHIFT : NUMERIC_BLOCK_SHIFT
         );
 
         @Override
@@ -47,31 +47,9 @@ public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTe
         }
     };
 
-    public static class TestES819TSDBDocValuesFormatVersion0 extends ES819TSDBDocValuesFormat {
-
-        public TestES819TSDBDocValuesFormatVersion0() {
-            super();
-        }
-
-        @Override
-        public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
-            return new ES819TSDBDocValuesConsumerVersion0(
-                state,
-                formatConfig.skipIndexIntervalSize(),
-                formatConfig.minDocsPerOrdinalForRangeEncoding(),
-                enableOptimizedMerge,
-                DATA_CODEC,
-                DATA_EXTENSION,
-                META_CODEC,
-                META_EXTENSION,
-                NUMERIC_BLOCK_SHIFT
-            );
-        }
-    }
-
     @Override
     protected Codec getCodec() {
-        return codec;
+        return es94Codec;
     }
 
     @Override
@@ -84,19 +62,22 @@ public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTe
         int numericBlockShift,
         boolean writePrefixPartitions
     ) {
-        return new ES819Version3TSDBDocValuesFormat(
+        return new ES94TSDBDocValuesFormat(
             skipIndexIntervalSize,
             minDocsPerOrdinalForRangeEncoding,
             enableOptimizedMerge,
             binaryDVCompressionMode,
             enablePerBlockCompression,
             numericBlockShift,
+            DocOffsetsCodec.GROUPED_VINT,
+            ES94TSDBDocValuesFormat.BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT,
+            ES94TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT,
             writePrefixPartitions
         );
     }
 
     public void testBinaryCompressionEnabled() {
-        ES819TSDBDocValuesFormat docValueFormat = new ES819Version3TSDBDocValuesFormat();
+        ES94TSDBDocValuesFormat docValueFormat = new ES94TSDBDocValuesFormat();
         assertThat(docValueFormat.formatConfig.binaryCompressionMode(), equalTo(BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1));
     }
 
@@ -106,6 +87,8 @@ public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTe
                 new ES87TSDBDocValuesFormatTests.TestES87TSDBDocValuesFormat(random().nextInt(4, 16)),
                 new ES819TSDBDocValuesFormat(),
                 new ES819Version3TSDBDocValuesFormat(),
+                new ES94TSDBDocValuesFormat(NUMERIC_BLOCK_SHIFT),
+                new ES94TSDBDocValuesFormat(NUMERIC_LARGE_BLOCK_SHIFT),
                 new Lucene90DocValuesFormat()
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
@@ -17,7 +17,6 @@ import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
@@ -27,20 +26,14 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
-import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.junit.AssumptionViolatedException;
@@ -303,38 +296,6 @@ public class ES920DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
         }
     }
 
-    public void testIndexSortOnFlush() throws IOException {
-        IndexWriterConfig config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format))
-            .setIndexSort(new Sort(new SortField("sort", SortField.Type.STRING)))
-            .setMergePolicy(NoMergePolicy.INSTANCE);
-        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, config)) {
-            float[] vectorA = new float[] { 0f, 3f };
-            float[] vectorB = new float[] { 0f, 2f };
-            float[] vectorC = new float[] { 0f, 1f };
-            addSortedVectorDoc(w, "c", vectorC);
-            addSortedVectorDoc(w, "a", vectorA);
-            addSortedVectorDoc(w, "b", vectorB);
-            w.commit();
-            try (IndexReader reader = DirectoryReader.open(dir)) {
-                LeafReader leafReader = getOnlyLeafReader(reader);
-
-                // we might collect the same document twice because of soar assignments
-                KnnCollector collector = new TopKnnCollector(3, Integer.MAX_VALUE);
-                leafReader.searchNearestVectors(
-                    "f",
-                    vectorA,
-                    collector,
-                    AcceptDocs.fromLiveDocs(leafReader.getLiveDocs(), leafReader.maxDoc())
-                );
-                TopDocs topDocs = collector.topDocs();
-                assertEquals(3, topDocs.scoreDocs.length);
-                assertEquals(0, topDocs.scoreDocs[0].doc);
-                assertEquals(1, topDocs.scoreDocs[1].doc);
-                assertEquals(2, topDocs.scoreDocs[2].doc);
-            }
-        }
-    }
-
     // this is a modified version of lucene's TestSearchWithThreads test case
     public void testWithThreads() throws Exception {
         final int numThreads = random().nextInt(2, 5);
@@ -384,12 +345,5 @@ public class ES920DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
                 }
             }
         }
-    }
-
-    private static void addSortedVectorDoc(IndexWriter writer, String id, float[] vector) throws IOException {
-        Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
-        doc.add(new SortedDocValuesField("sort", new BytesRef(id)));
-        writer.addDocument(doc);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormatTests.java
@@ -17,28 +17,21 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
@@ -363,74 +356,30 @@ public class ES940DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
         doRestrictiveFilter(false);
     }
 
-    public void testIndexSortOnFlush() throws IOException {
-        IndexWriterConfig config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format))
-            .setIndexSort(new Sort(new SortField("sort", SortField.Type.STRING)))
-            .setMergePolicy(NoMergePolicy.INSTANCE);
-        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, config)) {
-            float[] vectorA = new float[] { 0f, 3f };
-            float[] vectorB = new float[] { 0f, 2f };
-            float[] vectorC = new float[] { 0f, 1f };
-            addSortedVectorDoc(w, "c", vectorC);
-            addSortedVectorDoc(w, "a", vectorA);
-            addSortedVectorDoc(w, "b", vectorB);
-            w.commit();
-            try (IndexReader reader = DirectoryReader.open(dir)) {
-                LeafReader leafReader = getOnlyLeafReader(reader);
-
-                // we might collect the same document twice because of soar assignments
-                KnnCollector collector = new TopKnnCollector(3, Integer.MAX_VALUE);
-                leafReader.searchNearestVectors(
-                    "f",
-                    vectorA,
-                    collector,
-                    AcceptDocs.fromLiveDocs(leafReader.getLiveDocs(), leafReader.maxDoc())
-                );
-                TopDocs topDocs = collector.topDocs();
-                assertEquals(3, topDocs.scoreDocs.length);
-                assertEquals(0, topDocs.scoreDocs[0].doc);
-                assertEquals(1, topDocs.scoreDocs[1].doc);
-                assertEquals(2, topDocs.scoreDocs[2].doc);
-            }
-        }
-    }
-
     private void doRestrictiveFilter(boolean dense) throws IOException {
         int dimensions = random().nextInt(12, 500);
         int maxMatchingDocs = random().nextInt(1, 10);
         int matchingDocs = 0;
         int numDocs = random().nextInt(100, 3_000);
-        IndexWriterConfig iwc = newIndexWriterConfig();
-        if (random().nextBoolean()) {
-            iwc.setIndexSort(new Sort(new SortField("k", SortField.Type.STRING)));
-        }
-        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, iwc)) {
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             for (int i = 0; i < numDocs; i++) {
                 Document doc = new Document();
                 if (dense || rarely() == false) {
                     float[] vector = randomVector(dimensions);
                     doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
                 }
-                if (random().nextBoolean()) {
-                    doc.add(new StringField("k", new BytesRef("A"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("A")));
-                } else {
-                    doc.add(new StringField("k", new BytesRef("C"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("C")));
-                }
+                doc.add(new KeywordField("k", new BytesRef("B"), Field.Store.NO));
                 w.addDocument(doc);
                 if (matchingDocs < maxMatchingDocs && rarely()) {
                     matchingDocs++;
                     doc = new Document();
                     doc.add(new KnnFloatVectorField("f", randomVector(dimensions), VectorSimilarityFunction.EUCLIDEAN));
-                    doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                    doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                     w.addDocument(doc);
                 }
                 if (dense == false && rarely()) {
                     doc = new Document();
-                    doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                    doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                     w.addDocument(doc);
                 }
             }
@@ -440,77 +389,50 @@ public class ES940DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
                 float[] vector = randomVector(dimensions);
                 Document doc = new Document();
                 doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
-                doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                 w.addDocument(doc);
             }
             w.commit();
-            if (random().nextBoolean()) {
-                // force one leave
-                w.forceMerge(1);
-            }
+            // force one leave
+            w.forceMerge(1);
             try (IndexReader reader = DirectoryReader.open(w)) {
-                TopDocs[] topDocsArray = new TopDocs[reader.leaves().size()];
-                for (int i = 0; i < reader.leaves().size(); i++) {
-                    LeafReaderContext context = reader.leaves().get(i);
-                    LeafReader leafReader = context.reader();
-                    float[] vector = randomVector(dimensions);
-                    // we might collect the same document twice because of soar assignments
-                    KnnCollector collector;
-                    if (random().nextBoolean()) {
-                        collector = new TopKnnCollector(random().nextInt(2 * matchingDocs, 3 * matchingDocs), Integer.MAX_VALUE);
-                    } else {
-                        collector = new TopKnnCollector(
-                            random().nextInt(2 * matchingDocs, 3 * matchingDocs),
-                            Integer.MAX_VALUE,
-                            new IVFKnnSearchStrategy(0.25f, null)
-                        );
-                    }
-                    if (leafReader.postings(new Term("k", new BytesRef("B"))) == null) {
-                        topDocsArray[i] = TopDocsCollector.EMPTY_TOPDOCS;
-                        continue;
-                    }
-                    leafReader.searchNearestVectors(
-                        "f",
-                        vector,
-                        collector,
-                        AcceptDocs.fromIteratorSupplier(
-                            () -> leafReader.postings(new Term("k", new BytesRef("B"))),
-                            leafReader.getLiveDocs(),
-                            leafReader.maxDoc()
-                        )
-                    );
-                    TopDocs leafTopDocs = collector.topDocs();
-                    ScoreDoc[] adjusted = new ScoreDoc[leafTopDocs.scoreDocs.length];
-                    for (int docIndex = 0; docIndex < leafTopDocs.scoreDocs.length; docIndex++) {
-                        ScoreDoc scoreDoc = leafTopDocs.scoreDocs[docIndex];
-                        adjusted[docIndex] = new ScoreDoc(scoreDoc.doc + context.docBase, scoreDoc.score);
-                    }
-                    topDocsArray[i] = new TopDocs(leafTopDocs.totalHits, adjusted);
-                    // match no docs
-                    leafReader.searchNearestVectors(
-                        "f",
-                        vector,
-                        new TopKnnCollector(2, Integer.MAX_VALUE),
-                        AcceptDocs.fromIteratorSupplier(DocIdSetIterator::empty, leafReader.getLiveDocs(), leafReader.maxDoc())
+                LeafReader leafReader = getOnlyLeafReader(reader);
+                float[] vector = randomVector(dimensions);
+                // we might collect the same document twice because of soar assignments
+                KnnCollector collector;
+                if (random().nextBoolean()) {
+                    collector = new TopKnnCollector(random().nextInt(2 * matchingDocs, 3 * matchingDocs), Integer.MAX_VALUE);
+                } else {
+                    collector = new TopKnnCollector(
+                        random().nextInt(2 * matchingDocs, 3 * matchingDocs),
+                        Integer.MAX_VALUE,
+                        new IVFKnnSearchStrategy(0.25f, null)
                     );
                 }
-                TopDocs topDocs = TopDocs.merge(2 * maxMatchingDocs, topDocsArray);
+                leafReader.searchNearestVectors(
+                    "f",
+                    vector,
+                    collector,
+                    AcceptDocs.fromIteratorSupplier(
+                        () -> leafReader.postings(new Term("k", new BytesRef("A"))),
+                        leafReader.getLiveDocs(),
+                        leafReader.maxDoc()
+                    )
+                );
+                TopDocs topDocs = collector.topDocs();
                 Set<Integer> uniqueDocIds = new HashSet<>();
                 for (int i = 0; i < topDocs.scoreDocs.length; i++) {
                     uniqueDocIds.add(topDocs.scoreDocs[i].doc);
-                    Document document = reader.storedFields().document(topDocs.scoreDocs[i].doc);
-                    assertThat(document.getField("k").binaryValue().utf8ToString(), equalTo("B"));
                 }
                 assertEquals(matchingDocs, uniqueDocIds.size());
+                // match no docs
+                leafReader.searchNearestVectors(
+                    "f",
+                    vector,
+                    new TopKnnCollector(2, Integer.MAX_VALUE),
+                    AcceptDocs.fromIteratorSupplier(DocIdSetIterator::empty, leafReader.getLiveDocs(), leafReader.maxDoc())
+                );
             }
         }
-    }
-
-    private static void addSortedVectorDoc(IndexWriter writer, String id, float[] vector) throws IOException {
-        Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
-        doc.add(new SortedDocValuesField("sort", new BytesRef(id)));
-        writer.addDocument(doc);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -17,28 +17,21 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
@@ -363,74 +356,30 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
         doRestrictiveFilter(false);
     }
 
-    public void testIndexSortOnFlush() throws IOException {
-        IndexWriterConfig config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format))
-            .setIndexSort(new Sort(new SortField("sort", SortField.Type.STRING)))
-            .setMergePolicy(NoMergePolicy.INSTANCE);
-        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, config)) {
-            float[] vectorA = new float[] { 0f, 3f };
-            float[] vectorB = new float[] { 0f, 2f };
-            float[] vectorC = new float[] { 0f, 1f };
-            addSortedVectorDoc(w, "c", vectorC);
-            addSortedVectorDoc(w, "a", vectorA);
-            addSortedVectorDoc(w, "b", vectorB);
-            w.commit();
-            try (IndexReader reader = DirectoryReader.open(dir)) {
-                LeafReader leafReader = getOnlyLeafReader(reader);
-
-                // we might collect the same document twice because of soar assignments
-                KnnCollector collector = new TopKnnCollector(3, Integer.MAX_VALUE);
-                leafReader.searchNearestVectors(
-                    "f",
-                    vectorA,
-                    collector,
-                    AcceptDocs.fromLiveDocs(leafReader.getLiveDocs(), leafReader.maxDoc())
-                );
-                TopDocs topDocs = collector.topDocs();
-                assertEquals(3, topDocs.scoreDocs.length);
-                assertEquals(0, topDocs.scoreDocs[0].doc);
-                assertEquals(1, topDocs.scoreDocs[1].doc);
-                assertEquals(2, topDocs.scoreDocs[2].doc);
-            }
-        }
-    }
-
     private void doRestrictiveFilter(boolean dense) throws IOException {
         int dimensions = random().nextInt(12, 500);
         int maxMatchingDocs = random().nextInt(1, 10);
         int matchingDocs = 0;
         int numDocs = random().nextInt(100, 3_000);
-        IndexWriterConfig iwc = newIndexWriterConfig();
-        if (random().nextBoolean()) {
-            iwc.setIndexSort(new Sort(new SortField("k", SortField.Type.STRING)));
-        }
-        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, iwc)) {
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             for (int i = 0; i < numDocs; i++) {
                 Document doc = new Document();
                 if (dense || rarely() == false) {
                     float[] vector = randomVector(dimensions);
                     doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
                 }
-                if (random().nextBoolean()) {
-                    doc.add(new StringField("k", new BytesRef("A"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("A")));
-                } else {
-                    doc.add(new StringField("k", new BytesRef("C"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("C")));
-                }
+                doc.add(new KeywordField("k", new BytesRef("B"), Field.Store.NO));
                 w.addDocument(doc);
                 if (matchingDocs < maxMatchingDocs && rarely()) {
                     matchingDocs++;
                     doc = new Document();
                     doc.add(new KnnFloatVectorField("f", randomVector(dimensions), VectorSimilarityFunction.EUCLIDEAN));
-                    doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                    doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                     w.addDocument(doc);
                 }
                 if (dense == false && rarely()) {
                     doc = new Document();
-                    doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                    doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                    doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                     w.addDocument(doc);
                 }
             }
@@ -440,77 +389,50 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
                 float[] vector = randomVector(dimensions);
                 Document doc = new Document();
                 doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
-                doc.add(new StringField("k", new BytesRef("B"), Field.Store.YES));
-                doc.add(new SortedDocValuesField("k", new BytesRef("B")));
+                doc.add(new KeywordField("k", new BytesRef("A"), Field.Store.NO));
                 w.addDocument(doc);
             }
             w.commit();
-            if (random().nextBoolean()) {
-                // force one leave
-                w.forceMerge(1);
-            }
+            // force one leave
+            w.forceMerge(1);
             try (IndexReader reader = DirectoryReader.open(w)) {
-                TopDocs[] topDocsArray = new TopDocs[reader.leaves().size()];
-                for (int i = 0; i < reader.leaves().size(); i++) {
-                    LeafReaderContext context = reader.leaves().get(i);
-                    LeafReader leafReader = context.reader();
-                    float[] vector = randomVector(dimensions);
-                    // we might collect the same document twice because of soar assignments
-                    KnnCollector collector;
-                    if (random().nextBoolean()) {
-                        collector = new TopKnnCollector(random().nextInt(2 * matchingDocs, 3 * matchingDocs), Integer.MAX_VALUE);
-                    } else {
-                        collector = new TopKnnCollector(
-                            random().nextInt(2 * matchingDocs, 3 * matchingDocs),
-                            Integer.MAX_VALUE,
-                            new IVFKnnSearchStrategy(0.25f, null)
-                        );
-                    }
-                    if (leafReader.postings(new Term("k", new BytesRef("B"))) == null) {
-                        topDocsArray[i] = TopDocsCollector.EMPTY_TOPDOCS;
-                        continue;
-                    }
-                    leafReader.searchNearestVectors(
-                        "f",
-                        vector,
-                        collector,
-                        AcceptDocs.fromIteratorSupplier(
-                            () -> leafReader.postings(new Term("k", new BytesRef("B"))),
-                            leafReader.getLiveDocs(),
-                            leafReader.maxDoc()
-                        )
-                    );
-                    TopDocs leafTopDocs = collector.topDocs();
-                    ScoreDoc[] adjusted = new ScoreDoc[leafTopDocs.scoreDocs.length];
-                    for (int docIndex = 0; docIndex < leafTopDocs.scoreDocs.length; docIndex++) {
-                        ScoreDoc scoreDoc = leafTopDocs.scoreDocs[docIndex];
-                        adjusted[docIndex] = new ScoreDoc(scoreDoc.doc + context.docBase, scoreDoc.score);
-                    }
-                    topDocsArray[i] = new TopDocs(leafTopDocs.totalHits, adjusted);
-                    // match no docs
-                    leafReader.searchNearestVectors(
-                        "f",
-                        vector,
-                        new TopKnnCollector(2, Integer.MAX_VALUE),
-                        AcceptDocs.fromIteratorSupplier(DocIdSetIterator::empty, leafReader.getLiveDocs(), leafReader.maxDoc())
+                LeafReader leafReader = getOnlyLeafReader(reader);
+                float[] vector = randomVector(dimensions);
+                // we might collect the same document twice because of soar assignments
+                KnnCollector collector;
+                if (random().nextBoolean()) {
+                    collector = new TopKnnCollector(random().nextInt(2 * matchingDocs, 3 * matchingDocs), Integer.MAX_VALUE);
+                } else {
+                    collector = new TopKnnCollector(
+                        random().nextInt(2 * matchingDocs, 3 * matchingDocs),
+                        Integer.MAX_VALUE,
+                        new IVFKnnSearchStrategy(0.25f, null)
                     );
                 }
-                TopDocs topDocs = TopDocs.merge(2 * maxMatchingDocs, topDocsArray);
+                leafReader.searchNearestVectors(
+                    "f",
+                    vector,
+                    collector,
+                    AcceptDocs.fromIteratorSupplier(
+                        () -> leafReader.postings(new Term("k", new BytesRef("A"))),
+                        leafReader.getLiveDocs(),
+                        leafReader.maxDoc()
+                    )
+                );
+                TopDocs topDocs = collector.topDocs();
                 Set<Integer> uniqueDocIds = new HashSet<>();
                 for (int i = 0; i < topDocs.scoreDocs.length; i++) {
                     uniqueDocIds.add(topDocs.scoreDocs[i].doc);
-                    Document document = reader.storedFields().document(topDocs.scoreDocs[i].doc);
-                    assertThat(document.getField("k").binaryValue().utf8ToString(), equalTo("B"));
                 }
                 assertEquals(matchingDocs, uniqueDocIds.size());
+                // match no docs
+                leafReader.searchNearestVectors(
+                    "f",
+                    vector,
+                    new TopKnnCollector(2, Integer.MAX_VALUE),
+                    AcceptDocs.fromIteratorSupplier(DocIdSetIterator::empty, leafReader.getLiveDocs(), leafReader.maxDoc())
+                );
             }
         }
-    }
-
-    private static void addSortedVectorDoc(IndexWriter writer, String id, float[] vector) throws IOException {
-        Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
-        doc.add(new SortedDocValuesField("sort", new BytesRef(id)));
-        writer.addDocument(doc);
     }
 }


### PR DESCRIPTION
## Summary

Introduces the `ES94` TSDB doc values format as a drop-in replacement for `ES819`. The only difference is that numeric encoding uses a composable pipeline of stages (`delta>offset>gcd>bitpack`) via the pipeline framework from [#143589](https://github.com/elastic/elasticsearch/pull/143589) and [#143934](https://github.com/elastic/elasticsearch/pull/143934), instead of the monolithic `TSDBDocValuesEncoder`. All non-numeric field types (binary, sorted, sorted-set) are handled identically to ES819 by the shared abstract base classes from [#144324](https://github.com/elastic/elasticsearch/pull/144324).

The ES94 codec is not wired into `PerFieldFormatSupplier` yet — no index will use it until the wiring and gating PR lands. This PR focuses on the format implementation, entry factory refactoring, and test infrastructure.

### What's included

**ES94 format**: `ES94TSDBDocValuesFormat`, `ES94TSDBDocValuesConsumer`, `ES94TSDBDocValuesProducer` with the same configuration surface as ES819 (optimized merge, binary compression, block sizes, prefix partitions). Each numeric field writes a self-describing `FieldDescriptor` so decoders reconstruct themselves from segment metadata.

**Pipeline encode/decode**: `NumericEncodePipeline`, `NumericDecodePipeline`, `NumericBlockEncoder`/`NumericBlockDecoder`, `NumericCodecFactory`, `StageFactory`, `TransformEncoder`/`TransformDecoder` — the runtime that connects the pipeline framework to the doc values consumer/producer.

**Entry factory**: `EntryFactory` interface with default methods for all entry types. Each codec provides its own factory returning codec-specific entry subclasses. `PrefixPartitionedEntry` now encapsulates its own partition reading and access, eliminating `instanceof` checks from the base class.

**Test restructuring**: Shared TSDB tests extracted into `AbstractTSDBDocValuesFormatTestCase` extending Lucene's `BaseDocValuesFormatTestCase` directly. Both `ES819TSDBDocValuesFormatTests` and `ES94TSDBDocValuesFormatTests` extend this base independently — no codec test depends on another. Adding a new codec version (e.g. ES95) requires only implementing `getCodec()` and `createDocValuesFormat()` to inherit ~158 tests covering all doc value types, merge paths, block loaders, prefix partitions, and cross-format compatibility.

### Testing

```
./gradlew :server:test --tests "*ES94TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*ES819TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*ES87TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*PrefixPartitionTests*"
```