### PR TITLE
Various mapping microoptimizations

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -908,13 +908,7 @@ public abstract class DocumentParserContext {
      * @param fieldName   the name of the field to be flattened
      */
     public final DocumentParserContext createFlattenContext(String fieldName) {
-        XContentParser flatteningParser = new FlatteningXContentParser(parser(), fieldName);
-        return new Wrapper(this.parent(), this) {
-            @Override
-            public XContentParser parser() {
-                return flatteningParser;
-            }
-        };
+        return switchParser(new FlatteningXContentParser(parser(), fieldName));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -49,10 +49,12 @@ public abstract class DocumentParserContext {
      */
     private static class Wrapper extends DocumentParserContext {
         private final DocumentParserContext in;
+        private final boolean isWithinCopyTo; // cached to avoid method chain overhead and dynamic dispatch
 
         private Wrapper(ObjectMapper parent, DocumentParserContext in) {
             super(parent, parent.dynamic == null ? in.dynamic : parent.dynamic, in);
             this.in = in;
+            this.isWithinCopyTo = in.isWithinCopyTo();
         }
 
         // Used to create a copy_to context.
@@ -60,6 +62,7 @@ public abstract class DocumentParserContext {
         private Wrapper(RootObjectMapper root, DocumentParserContext in) {
             super(root, ObjectMapper.Dynamic.getRootDynamic(in.mappingLookup()), in);
             this.in = in;
+            this.isWithinCopyTo = in.isWithinCopyTo();
         }
 
         @Override
@@ -69,7 +72,7 @@ public abstract class DocumentParserContext {
 
         @Override
         public boolean isWithinCopyTo() {
-            return in.isWithinCopyTo();
+            return isWithinCopyTo;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -194,6 +194,8 @@ public abstract class DocumentParserContext {
     // Indicates if the source for this context has been marked to be recorded. Applies to synthetic source only.
     private boolean recordedSource;
 
+    private final FieldNamesFieldMapper fieldNamesFieldMapper; // cached from mappingLookup
+
     private DocumentParserContext(
         MappingLookup mappingLookup,
         MappingParserContext mappingParserContext,
@@ -239,6 +241,7 @@ public abstract class DocumentParserContext {
         this.copyToFields = copyToFields;
         this.dynamicMappersSize = dynamicMapperSize;
         this.recordedSource = recordedSource;
+        this.fieldNamesFieldMapper = (FieldNamesFieldMapper) getMetadataMapper(FieldNamesFieldMapper.NAME);
     }
 
     private DocumentParserContext(ObjectMapper parent, ObjectMapper.Dynamic dynamic, DocumentParserContext in) {
@@ -430,7 +433,6 @@ public abstract class DocumentParserContext {
      * or norms.
      */
     public final void addToFieldNames(String field) {
-        FieldNamesFieldMapper fieldNamesFieldMapper = (FieldNamesFieldMapper) getMetadataMapper(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldMapper != null) {
             fieldNamesFieldMapper.addFieldNames(this, field);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -188,6 +188,7 @@ public abstract class DocumentParserContext {
      * that copy_to field in introduced using a dynamic template
      * in this document and therefore is not present in mapping yet.
      */
+    private final Set<String> mappingCopyToFields;
     private final Set<String> copyToFields;
 
     // Indicates if the source for this context has been marked to be recorded. Applies to synthetic source only.
@@ -211,6 +212,7 @@ public abstract class DocumentParserContext {
         ObjectMapper parent,
         ObjectMapper.Dynamic dynamic,
         Set<String> fieldsAppliedFromTemplates,
+        Set<String> mappingCopyToFields,
         Set<String> copyToFields,
         DynamicMapperSize dynamicMapperSize,
         boolean recordedSource
@@ -232,6 +234,8 @@ public abstract class DocumentParserContext {
         this.parent = parent;
         this.dynamic = dynamic;
         this.fieldsAppliedFromTemplates = fieldsAppliedFromTemplates;
+        this.mappingCopyToFields = mappingCopyToFields;
+        assert this.mappingCopyToFields == Set.copyOf(this.mappingCopyToFields); // ensure that we've been passed an ImmutableSet(12|N)
         this.copyToFields = copyToFields;
         this.dynamicMappersSize = dynamicMapperSize;
         this.recordedSource = recordedSource;
@@ -256,6 +260,7 @@ public abstract class DocumentParserContext {
             parent,
             dynamic,
             in.fieldsAppliedFromTemplates,
+            in.mappingCopyToFields,
             in.copyToFields,
             in.dynamicMappersSize,
             in.recordedSource
@@ -287,7 +292,8 @@ public abstract class DocumentParserContext {
             parent,
             dynamic,
             new HashSet<>(),
-            new HashSet<>(mappingLookup.fieldTypesLookup().getCopyToDestinationFields()),
+            mappingLookup.fieldTypesLookup().getCopyToDestinationFields(),
+            new HashSet<>(),
             new DynamicMapperSize(),
             false
         );
@@ -500,7 +506,7 @@ public abstract class DocumentParserContext {
     }
 
     public boolean isCopyToDestinationField(String name) {
-        return copyToFields.contains(name);
+        return mappingCopyToFields.contains(name) || copyToFields.contains(name);
     }
 
     public void processArrayOffsets(DocumentParserContext context) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -108,6 +108,8 @@ public abstract class FieldMapper extends Mapper {
     protected final MappedFieldType mappedFieldType;
     protected final BuilderParams builderParams;
 
+    private SyntheticSourceMode syntheticSourceMode;
+
     /**
      * @param simpleName        the leaf name of the mapper
      * @param params            initialization params for this field mapper
@@ -116,6 +118,7 @@ public abstract class FieldMapper extends Mapper {
         super(simpleName);
         this.mappedFieldType = mappedFieldType;
         this.builderParams = params;
+        this.syntheticSourceMode = null;
 
         // could be blank but not empty on indices created < 8.6.0
         assert mappedFieldType.name().isEmpty() == false;
@@ -454,7 +457,7 @@ public abstract class FieldMapper extends Mapper {
      * </p>
      * @return {@link SyntheticSourceMode}
      */
-    final SyntheticSourceMode syntheticSourceMode() {
+    private SyntheticSourceMode calculateSyntheticSourceMode() {
         if (hasScript()) {
             return SyntheticSourceMode.NATIVE;
         }
@@ -467,6 +470,13 @@ public abstract class FieldMapper extends Mapper {
         }
 
         return syntheticSourceSupport().mode();
+    }
+
+    final SyntheticSourceMode syntheticSourceMode() {
+        if (syntheticSourceMode == null) {
+            this.syntheticSourceMode = calculateSyntheticSourceMode();
+        }
+        return syntheticSourceMode;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
@@ -96,13 +96,15 @@ public class LuceneDocument implements Iterable<IndexableField> {
     /**
      * only add the key to the keyedFields, it don't add the field to the field list
      */
-    public void onlyAddKey(Object key, IndexableField field) {
+    public void onlyAddKey(final Object key, final IndexableField field) {
+        assert field != null : "field must not be null";
         if (keyedFields == null) {
             keyedFields = new HashMap<>();
-        } else if (keyedFields.containsKey(key)) {
+        }
+        final var existing = keyedFields.put(key, field);
+        if (existing != null) {
             throw new IllegalStateException("Only one field can be stored per key");
         }
-        keyedFields.put(key, field);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -66,6 +66,10 @@ public final class MappingLookup {
     private final int totalFieldsCount;
     private final IndexMode indexMode;
 
+    // cached booleans from the _source field mapper
+    private final boolean isSourceEnabled;
+    private final boolean isSourceSynthetic;
+
     /**
      * Creates a new {@link MappingLookup} instance by parsing the provided mapping and extracting its field definitions.
      *
@@ -231,6 +235,11 @@ public final class MappingLookup {
 
         runtimeFields.stream().flatMap(RuntimeField::asMappedFieldTypes).map(MappedFieldType::name).forEach(this::validateDoesNotShadow);
         assert assertMapperNamesInterned(this.fieldMappers, this.objectMappers);
+
+        // cache these properties of the _source field for instantaneous access
+        SourceFieldMapper sfm = mapping.getMetadataMapperByClass(SourceFieldMapper.class);
+        this.isSourceEnabled = sfm != null && sfm.enabled();
+        this.isSourceSynthetic = sfm != null && sfm.isSynthetic();
     }
 
     private static boolean assertMapperNamesInterned(Map<String, Mapper> mappers, Map<String, ObjectMapper> objectMappers) {
@@ -501,16 +510,14 @@ public final class MappingLookup {
      * Will there be {@code _source}.
      */
     public boolean isSourceEnabled() {
-        SourceFieldMapper sfm = mapping.getMetadataMapperByClass(SourceFieldMapper.class);
-        return sfm != null && sfm.enabled();
+        return isSourceEnabled;
     }
 
     /**
      * Does the source need to be rebuilt on the fly?
      */
     public boolean isSourceSynthetic() {
-        SourceFieldMapper sfm = mapping.getMetadataMapperByClass(SourceFieldMapper.class);
-        return sfm != null && sfm.isSynthetic();
+        return isSourceSynthetic;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -167,12 +167,14 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
             boolean keepDuplicates
         ) {
             var field = (SeparateCount) doc.getByKey(fieldName);
-            var countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
+            final NumericDocValuesField countField;
             if (field == null) {
                 field = new SeparateCount(fieldName, keepDuplicates);
                 countField = NumericDocValuesField.indexedField(field.countFieldName(), -1); // dummy value
                 doc.addWithKey(field.name(), field);
                 doc.addWithKey(countField.name(), countField);
+            } else {
+                countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
             }
 
             field.add(binaryValue);


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/144853

I've been crunching benchmarks and profiles for the last few weeks looking at `IndexShard.prepareIndex` and its callees, and these are all hot enough to show up in a flamegraph. None of these are earth shattering performance gains, but little bits do add up. Other higher impact (and higher lines-of-code-count) PRs to follow, this is just an omnibus PR to get a bunch of quick hits off my machine.

-----

`isWithinCopyTo` gets called frequently from `parseObjectOrField`:
<img width="1728" height="806" alt="Screenshot 2026-03-27 at 11 38 17 AM" src="https://github.com/user-attachments/assets/3b990b80-f10c-4a1e-8ee5-1468e240eaf0" />

-----

Re-hashing the `copyToFields` in the `DocumentParserContext` constructor:
<img width="1727" height="655" alt="Screenshot 2026-03-27 at 11 43 11 AM" src="https://github.com/user-attachments/assets/7b9e7543-85c1-433d-ad9e-1f91c3372b23" />

-----

Looking up the `syntheticSourceMode` dynamically is surprisingly slow due to dynamic dispatch:
<img width="1728" height="535" alt="Screenshot 2026-03-27 at 11 48 34 AM" src="https://github.com/user-attachments/assets/8fe4c357-b8a3-473d-a4ee-babcf9f0f2d8" />

-----

`isSourceSynthetic` is diffuse but adds up to real money:
<img width="1728" height="692" alt="Screenshot 2026-03-27 at 11 50 48 AM" src="https://github.com/user-attachments/assets/5bc66bbe-46e7-4466-b49d-d49025f144bd" />