### PR TITLE
Update allow_no_indices to accurately describe its two-part role

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -116,7 +116,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -124,7 +124,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. Only allowed when providing an index expression."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -107,7 +107,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -56,7 +56,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -66,7 +66,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "conflicts": {
         "type": "enum",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -69,7 +69,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -51,7 +51,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
@@ -56,7 +56,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -54,7 +54,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -46,7 +46,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -46,7 +46,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
@@ -46,7 +46,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -41,7 +41,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -52,7 +52,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
@@ -39,7 +39,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -54,7 +54,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -45,7 +45,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -41,7 +41,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -70,7 +70,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -57,7 +57,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -42,7 +42,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -75,7 +75,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -46,7 +46,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -50,7 +50,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -65,7 +65,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": false,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -51,7 +51,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty.",
         "default": true
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -44,7 +44,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -35,7 +35,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
@@ -56,7 +56,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -51,7 +51,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. Only allowed when providing an index expression."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -47,7 +47,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty.",
         "default": true
       },
       "mode": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -42,7 +42,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -51,7 +51,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -52,7 +52,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -43,7 +43,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "ignore_throttled": {
         "deprecated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -39,7 +39,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. Only set if datafeed_config is provided."
       },
       "ignore_throttled": {
         "deprecated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -43,7 +43,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "ignore_throttled": {
         "deprecated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -94,7 +94,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -47,7 +47,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -107,7 +107,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -57,7 +57,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": false,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -56,7 +56,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -40,7 +40,7 @@
       },
       "allow_no_indices": {
         "type": "boolean",
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "expand_wildcards": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -66,7 +66,7 @@
       "allow_no_indices": {
         "type": "boolean",
         "default": true,
-        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        "description": "Whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty."
       },
       "conflicts": {
         "type": "enum",


### PR DESCRIPTION
This matches a similar change to the elasticsearch-specification repo: https://github.com/elastic/elasticsearch-specification/pull/6153