### PR TITLE
PromQL: fix UnresolvedException when grouping by an absent label

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1391,10 +1391,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 var source = promql.source();
                 var localRelation = new LocalRelation(
                     source,
-                    List.of(
-                        new ReferenceAttribute(source, null, promql.valueColumnName(), DOUBLE, Nullability.FALSE, promql.valueId(), false),
-                        new ReferenceAttribute(source, null, promql.stepColumnName(), DATETIME, Nullability.FALSE, promql.stepId(), false)
-                    ),
+                    List.of(promql.valueAttribute(), promql.stepAttribute()),
                     EmptyLocalSupplier.EMPTY
                 );
                 // Wrap in an explicit LIMIT 0 so that AddImplicitLimit skips the "No limit defined" warning,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -274,6 +274,14 @@ public class PromqlCommand extends UnaryPlan
         return stepId;
     }
 
+    public ReferenceAttribute valueAttribute() {
+        return new ReferenceAttribute(source(), null, valueColumnName, DataType.DOUBLE, Nullability.FALSE, valueId, false);
+    }
+
+    public ReferenceAttribute stepAttribute() {
+        return new ReferenceAttribute(source(), null, stepColumnName(), DataType.DATETIME, Nullability.FALSE, stepId, false);
+    }
+
     @Override
     public Expression timestamp() {
         return timestamp;
@@ -284,8 +292,8 @@ public class PromqlCommand extends UnaryPlan
         if (output == null) {
             List<Attribute> additionalOutput = promqlPlan.output();
             output = new ArrayList<>(additionalOutput.size() + 2);
-            output.add(new ReferenceAttribute(source(), null, valueColumnName, DataType.DOUBLE, Nullability.FALSE, valueId, false));
-            output.add(new ReferenceAttribute(source(), null, stepColumnName(), DataType.DATETIME, Nullability.FALSE, stepId, false));
+            output.add(valueAttribute());
+            output.add(stepAttribute());
             output.addAll(additionalOutput);
         }
         return output;

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
@@ -77,21 +77,14 @@ class PromqlQueryPlanBuilder {
         );
 
         // TO_LONG converts the step datetime to epoch millis, avoiding the need to parse a date string in the response listener.
-        Alias stepAlias = new Alias(
-            Source.EMPTY,
-            PromqlCommand.STEP_COLUMN_NAME,
-            new ToLong(
-                Source.EMPTY,
-                promqlCommand.output().stream().filter(a -> a.name().equals(PromqlCommand.STEP_COLUMN_NAME)).findFirst().get()
-            )
-        );
+        Alias stepAlias = new Alias(Source.EMPTY, PromqlCommand.STEP_COLUMN_NAME, new ToLong(Source.EMPTY, promqlCommand.stepAttribute()));
         // Eval's mergeOutputAttributes drops step(datetime) and appends step_alias(long) at the end,
         // producing [value, ...dimensions, step(long)] — the order the response listener expects.
         Eval eval = new Eval(Source.EMPTY, promqlCommand, List.of(stepAlias));
 
         // Sort by step (timestamp) ascending so Prometheus clients receive values in chronological order.
-        Attribute stepAttr = stepAlias.toAttribute();
-        Order stepOrder = new Order(Source.EMPTY, stepAttr, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
+        Attribute stepOutput = stepAlias.toAttribute();
+        Order stepOrder = new Order(Source.EMPTY, stepOutput, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         OrderBy orderBy = new OrderBy(Source.EMPTY, eval, List.of(stepOrder));
 
         return new EsqlStatement(orderBy, List.of());

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilderTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilderTests.java
@@ -59,6 +59,21 @@ public class PromqlQueryPlanBuilderTests extends ESTestCase {
         assertThat(((NamedExpression) ((InstantSelector) promqlCommand.promqlPlan()).series()).name(), equalTo("up"));
     }
 
+    public void testBuildStatementWithGroupByAbsentLabel() {
+        EsqlStatement statement = PromqlQueryPlanBuilder.buildStatement(
+            "sum(rate(http_request_duration_microseconds_count[1m])) by (handler)",
+            "*",
+            "2025-01-01T00:00:00Z",
+            "2025-01-01T01:00:00Z",
+            "15s"
+        );
+        assertThat(statement.plan(), instanceOf(OrderBy.class));
+        Eval eval = (Eval) ((OrderBy) statement.plan()).child();
+        assertThat(eval.fields().size(), equalTo(1));
+        assertThat(eval.fields().get(0).name(), equalTo("step"));
+        assertThat(eval.child(), instanceOf(PromqlCommand.class));
+    }
+
     public void testBuildStatementWithNumericStep() {
         EsqlStatement statement = PromqlQueryPlanBuilder.buildStatement("up", "*", "1735689600", "1735693200", "60");
         assertThat(statement.plan(), instanceOf(OrderBy.class));


### PR DESCRIPTION
## Summary

- Calling `output()` on an unanalyzed `PromqlCommand` whose PromQL plan contains an `AcrossSeriesAggregate` with unresolved grouping labels caused an `UnresolvedException` (`Invalid call to dataType on an unresolved object`).
- The root cause was in `PromqlQueryPlanBuilder.buildStatement`, which called `promqlCommand.output()` pre-analysis solely to locate the step attribute.
- Fix by adding `valueAttribute()` and `stepAttribute()` factory methods to `PromqlCommand` and using them directly, eliminating the need to call `output()` before analysis.