### PR TITLE
feat(tsdb): add pipeline runtime and rename stage interfaces

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+
+import java.io.IOException;
+
+/**
+ * Per-field block decoder owning a mutable {@link DecodingContext}.
+ *
+ * <p>NOT thread-safe. Each instance owns a {@link DecodingContext} with mutable
+ * per-block state. Callers that may run concurrently must each hold their own
+ * decoder instance, obtained via {@link NumericDecoder#newBlockDecoder()}.
+ */
+public final class NumericBlockDecoder {
+
+    private final NumericDecodePipeline pipeline;
+    private final DecodingContext decodingContext;
+
+    NumericBlockDecoder(final NumericDecodePipeline pipeline) {
+        this.pipeline = pipeline;
+        this.decodingContext = new DecodingContext(pipeline.blockSize(), pipeline.size());
+    }
+
+    /**
+     * Decodes a block of values by reading the payload and reversing transforms.
+     *
+     * @param values the output array to populate
+     * @param count  the expected number of values
+     * @param in     the data input to read from
+     * @throws IOException if an I/O error occurs
+     */
+    public void decode(final long[] values, int count, final DataInput in) throws IOException {
+        decodingContext.clear();
+        pipeline.decode(values, count, in, decodingContext);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericBlockEncoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+
+import java.io.IOException;
+
+/**
+ * Per-field block encoder owning a mutable {@link EncodingContext}.
+ *
+ * <p>NOT thread-safe. Each instance owns an {@link EncodingContext} with mutable
+ * per-block state. Callers that may run concurrently must each hold their own
+ * encoder instance, obtained via {@link NumericEncoder#newBlockEncoder()}.
+ */
+public final class NumericBlockEncoder {
+
+    private final NumericEncodePipeline pipeline;
+    private final EncodingContext encodingContext;
+
+    NumericBlockEncoder(final NumericEncodePipeline pipeline) {
+        this.pipeline = pipeline;
+        this.encodingContext = new EncodingContext(pipeline.blockSize(), pipeline.size());
+    }
+
+    /**
+     * Encodes a block of values through the pipeline.
+     *
+     * @param values     the values to encode (modified in-place by transform stages)
+     * @param valueCount the number of valid values
+     * @param out        the data output to write the encoded block to
+     * @throws IOException if an I/O error occurs
+     */
+    public void encode(final long[] values, int valueCount, final DataOutput out) throws IOException {
+        encodingContext.clear();
+        pipeline.encode(values, valueCount, out, encodingContext);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+
+/**
+ * Factory for creating encoder/decoder instances from pipeline configurations.
+ * The consumer calls {@link #createEncoder} with a {@link PipelineConfig}.
+ * The producer calls {@link #createDecoder} with a {@link PipelineDescriptor}.
+ */
+public interface NumericCodecFactory {
+
+    /** Default factory that delegates to {@link NumericEncoder#fromConfig} and {@link NumericDecoder#fromDescriptor}. */
+    NumericCodecFactory DEFAULT = new NumericCodecFactory() {
+        @Override
+        public NumericEncoder createEncoder(PipelineConfig config) {
+            return NumericEncoder.fromConfig(config);
+        }
+
+        @Override
+        public NumericDecoder createDecoder(PipelineDescriptor descriptor) {
+            return NumericDecoder.fromDescriptor(descriptor);
+        }
+    };
+
+    /** Creates an encoder from the given pipeline configuration. */
+    NumericEncoder createEncoder(PipelineConfig config);
+
+    /** Creates a decoder from the given pipeline descriptor. */
+    NumericDecoder createDecoder(PipelineDescriptor descriptor);
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecStage.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericCodecStage.java
@@ -17,4 +17,4 @@ package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
  * deltas, removing offsets, or factoring out a GCD) so that the terminal payload
  * stage can pack them into fewer bits.
  */
-public interface NumericCodecStage extends NumericEncoder, NumericDecoder {}
+public interface NumericCodecStage extends TransformEncoder, TransformDecoder {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecodePipeline.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.BlockFormat;
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Immutable decoding pipeline: reads payload then reverses transform stages.
+ *
+ * <p>Reconstructed from a {@link PipelineDescriptor} read from segment metadata,
+ * making the format self-describing. The decoder does not need to know the
+ * pipeline configuration at compile time.
+ *
+ * <p>Instances are immutable and thread-safe. Mutable per-block state lives in
+ * {@link DecodingContext}, which must be provided by the caller.
+ */
+public final class NumericDecodePipeline {
+
+    private final NumericCodecStage[] transformStages;
+    private final PayloadCodecStage payloadStage;
+    private final int blockSize;
+    private final int payloadPosition;
+
+    NumericDecodePipeline(final NumericCodecStage[] transformStages, final PayloadCodecStage payloadStage, int blockSize) {
+        this.transformStages = transformStages;
+        this.payloadStage = payloadStage;
+        this.blockSize = blockSize;
+        this.payloadPosition = transformStages.length;
+    }
+
+    /**
+     * Reconstructs a decode pipeline from a persisted descriptor.
+     *
+     * @param descriptor the pipeline descriptor read from segment metadata
+     * @return the decode pipeline
+     */
+    public static NumericDecodePipeline fromDescriptor(final PipelineDescriptor descriptor) {
+        final int blockSize = descriptor.blockSize();
+        final int stageCount = descriptor.pipelineLength();
+        final List<NumericCodecStage> transforms = new ArrayList<>();
+
+        for (int i = 0; i < stageCount - 1; i++) {
+            final StageSpec spec = StageFactory.specFromStageId(StageId.fromId(descriptor.stageIdAt(i)));
+            transforms.add(StageFactory.newTransformStage(spec));
+        }
+        final StageSpec payloadSpec = StageFactory.specFromStageId(StageId.fromId(descriptor.stageIdAt(stageCount - 1)));
+        final PayloadCodecStage payloadStage = StageFactory.newPayloadStage(payloadSpec, blockSize);
+
+        return new NumericDecodePipeline(transforms.toArray(NumericCodecStage[]::new), payloadStage, blockSize);
+    }
+
+    /**
+     * Decodes a block of values by reading the payload and reversing transforms.
+     *
+     * @param values  the output array to populate
+     * @param count   the expected number of values
+     * @param in      the data input to read from
+     * @param context the mutable per-block decoding context
+     * @throws IOException if an I/O error occurs
+     */
+    public void decode(final long[] values, int count, final DataInput in, final DecodingContext context) throws IOException {
+        context.setDataInput(in);
+        BlockFormat.readBlock(in, values, payloadStage, context, payloadPosition);
+        for (int i = transformStages.length - 1; i >= 0; i--) {
+            if (context.isStageApplied(i)) {
+                transformStages[i].decode(values, count, context);
+            }
+        }
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return blockSize;
+    }
+
+    /** Returns the total number of stages (transforms + payload). */
+    public int size() {
+        return transformStages.length + 1;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericDecoder.java
@@ -9,33 +9,47 @@
 
 package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
 
-import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
-
-import java.io.IOException;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 /**
- * Reverses an in-place transformation as a non-terminal stage of the decode pipeline.
+ * Read-path coordinator: owns a {@link NumericDecodePipeline} and produces
+ * {@link NumericBlockDecoder} instances for decoding blocks of values.
  *
- * <p>Unlike {@link PayloadDecoder}, transform decoders do not read from a
- * {@link org.apache.lucene.store.DataInput} directly. They read metadata written
- * by the corresponding {@link NumericEncoder} via {@link DecodingContext#metadata()}.
+ * <p>Instances are immutable and thread-safe. Per-field mutable state lives in
+ * {@link NumericBlockDecoder}, which callers obtain via {@link #newBlockDecoder()}.
+ *
+ * <p>Created via {@link #fromDescriptor} or via {@link NumericCodecFactory#createDecoder}.
  */
-public interface NumericDecoder {
+public final class NumericDecoder {
+
+    private final NumericDecodePipeline pipeline;
+
+    NumericDecoder(final NumericDecodePipeline pipeline) {
+        this.pipeline = pipeline;
+    }
 
     /**
-     * Returns the unique stage identifier.
+     * Reconstructs a decoder from a persisted descriptor.
+     * Use {@link NumericCodecFactory#createDecoder} as the public entry point.
      *
-     * @return the stage ID byte
+     * @param descriptor the pipeline descriptor read from segment metadata
+     * @return the decoder
      */
-    byte id();
+    static NumericDecoder fromDescriptor(final PipelineDescriptor descriptor) {
+        return new NumericDecoder(NumericDecodePipeline.fromDescriptor(descriptor));
+    }
 
     /**
-     * Reverses the transformation on values in-place using metadata from the context.
+     * Creates a new block decoder with its own mutable decoding context.
      *
-     * @param values     the values to reverse-transform in-place
-     * @param valueCount the number of valid values in the array
-     * @param context    the decoding context for reading stage metadata
-     * @throws IOException if an I/O error occurs while reading metadata
+     * @return a fresh block decoder
      */
-    void decode(long[] values, int valueCount, DecodingContext context) throws IOException;
+    public NumericBlockDecoder newBlockDecoder() {
+        return new NumericBlockDecoder(pipeline);
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncodePipeline.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.DataOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.BlockFormat;
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Immutable encoding pipeline: transform stages followed by a terminal payload stage.
+ *
+ * <p>Transform stages run in forward order, modifying values in-place to reduce
+ * dynamic range. The payload stage serializes the result. Each stage decides
+ * per-block whether to apply itself, recorded in a position bitmap for decoding.
+ *
+ * <p>Instances are immutable and thread-safe. Mutable per-block state lives in
+ * {@link EncodingContext}, which must be provided by the caller.
+ */
+public final class NumericEncodePipeline {
+
+    private final NumericCodecStage[] transformStages;
+    private final PayloadCodecStage payloadStage;
+    private final PipelineDescriptor descriptor;
+    private final int blockSize;
+    private final int payloadPosition;
+
+    NumericEncodePipeline(
+        final NumericCodecStage[] transformStages,
+        final PayloadCodecStage payloadStage,
+        int blockSize,
+        final PipelineDescriptor descriptor
+    ) {
+        this.transformStages = transformStages;
+        this.payloadStage = payloadStage;
+        this.blockSize = blockSize;
+        this.payloadPosition = transformStages.length;
+        this.descriptor = descriptor;
+    }
+
+    /**
+     * Builds an encode pipeline from a pipeline configuration.
+     *
+     * @param config the pipeline configuration
+     * @return the encode pipeline
+     * @throws IllegalStateException if the pipeline has no payload stage
+     */
+    public static NumericEncodePipeline fromConfig(final PipelineConfig config) {
+        final int blockSize = config.blockSize();
+        final List<StageSpec> specs = config.specs();
+        final List<NumericCodecStage> transforms = new ArrayList<>();
+        PayloadCodecStage payload = null;
+
+        for (final StageSpec spec : specs) {
+            if (spec instanceof StageSpec.PayloadSpec) {
+                if (payload != null) {
+                    throw new IllegalStateException("Pipeline must have exactly one payload stage");
+                }
+                payload = StageFactory.newPayloadStage(spec, blockSize);
+            } else {
+                transforms.add(StageFactory.newTransformStage(spec));
+            }
+        }
+
+        if (payload == null) {
+            throw new IllegalStateException("Pipeline must end with a payload stage");
+        }
+
+        final byte[] ids = new byte[specs.size()];
+        for (int i = 0; i < specs.size(); i++) {
+            ids[i] = specs.get(i).stageId().id;
+        }
+        final PipelineDescriptor descriptor = new PipelineDescriptor(ids, blockSize, config.dataType());
+
+        return new NumericEncodePipeline(transforms.toArray(NumericCodecStage[]::new), payload, blockSize, descriptor);
+    }
+
+    /**
+     * Encodes a block of values through the pipeline.
+     *
+     * @param values     the values to encode (modified in-place by transform stages)
+     * @param valueCount the number of valid values
+     * @param out        the data output to write the encoded block to
+     * @param context    the mutable per-block encoding context
+     * @throws IOException if an I/O error occurs
+     */
+    public void encode(final long[] values, int valueCount, final DataOutput out, final EncodingContext context) throws IOException {
+        context.setValueCount(valueCount);
+
+        for (int i = 0; i < transformStages.length; i++) {
+            context.setCurrentPosition(i);
+            transformStages[i].encode(values, context.valueCount(), context);
+        }
+
+        context.setCurrentPosition(payloadPosition);
+        context.applyStage(payloadPosition);
+
+        BlockFormat.writeBlock(out, values, payloadStage, context);
+    }
+
+    /** Returns the pipeline descriptor for persistence via {@link FieldDescriptor}. */
+    public PipelineDescriptor descriptor() {
+        return descriptor;
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return blockSize;
+    }
+
+    /** Returns the total number of stages (transforms + payload). */
+    public int size() {
+        return transformStages.length + 1;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericEncoder.java
@@ -9,35 +9,54 @@
 
 package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
 
-import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 /**
- * Transforms values in-place as a non-terminal stage of the encode pipeline.
+ * Write-path coordinator: owns a {@link NumericEncodePipeline} and produces
+ * {@link NumericBlockEncoder} instances for encoding blocks of values.
  *
- * <p>Unlike {@link PayloadEncoder}, transform stages do not write to a
- * {@link org.apache.lucene.store.DataOutput}. They modify the {@code long[]}
- * array in-place and record any metadata needed for decoding via
- * {@link EncodingContext#metadata()}.
+ * <p>Instances are immutable and thread-safe. Per-field mutable state lives in
+ * {@link NumericBlockEncoder}, which callers obtain via {@link #newBlockEncoder()}.
+ *
+ * <p>Created via {@link #fromConfig} or via {@link NumericCodecFactory#createEncoder}.
  */
-public interface NumericEncoder {
+public final class NumericEncoder {
+
+    private final NumericEncodePipeline pipeline;
+
+    NumericEncoder(final NumericEncodePipeline pipeline) {
+        this.pipeline = pipeline;
+    }
 
     /**
-     * Returns the unique stage identifier.
+     * Builds an encoder from a pipeline configuration.
+     * Use {@link NumericCodecFactory#createEncoder} as the public entry point.
      *
-     * @return the stage ID byte
+     * @param config the pipeline configuration
+     * @return the encoder
      */
-    byte id();
+    static NumericEncoder fromConfig(final PipelineConfig config) {
+        return new NumericEncoder(NumericEncodePipeline.fromConfig(config));
+    }
 
     /**
-     * Transforms values in-place and writes any metadata to the context.
+     * Creates a new block encoder with its own mutable encoding context.
      *
-     * <p>If the stage determines that the transformation would not be effective,
-     * it may return without modifying the values or writing metadata. The pipeline
-     * checks {@link EncodingContext#isStageApplied(int)} to detect this.
-     *
-     * @param values     the values to transform in-place
-     * @param valueCount the number of valid values in the array
-     * @param context    the encoding context for metadata and stage tracking
+     * @return a fresh block encoder
      */
-    void encode(long[] values, int valueCount, EncodingContext context);
+    public NumericBlockEncoder newBlockEncoder() {
+        return new NumericBlockEncoder(pipeline);
+    }
+
+    /** Returns the pipeline descriptor for persistence via {@link FieldDescriptor}. */
+    public PipelineDescriptor descriptor() {
+        return pipeline.descriptor();
+    }
+
+    /** Returns the number of values per block. */
+    public int blockSize() {
+        return pipeline.blockSize();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadDecoder.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 /**
  * Deserializes bytes back to values as the terminal stage of the decode pipeline.
  *
- * <p>Unlike {@link NumericDecoder}, payload stages read directly from a
+ * <p>Unlike {@link TransformDecoder}, payload stages read directly from a
  * {@link org.apache.lucene.store.DataInput} rather than reading metadata from the context.
  */
 public interface PayloadDecoder {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/PayloadEncoder.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 /**
  * Serializes values to bytes as the terminal stage of the encode pipeline.
  *
- * <p>Unlike {@link NumericEncoder}, payload stages write directly to a
+ * <p>Unlike {@link TransformEncoder}, payload stages write directly to a
  * {@link org.apache.lucene.store.DataOutput} rather than modifying values in-place.
  */
 public interface PayloadEncoder {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.DocValuesForUtil;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.BitPackCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.DeltaCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.GcdCodecStage;
+import org.elasticsearch.index.codec.tsdb.pipeline.numeric.stages.OffsetCodecStage;
+
+/**
+ * Maps between {@link StageSpec} records and concrete stage instances, and between
+ * persisted {@link StageId} bytes and {@link StageSpec} records.
+ *
+ * <p>The encode path uses {@link #newTransformStage} and {@link #newPayloadStage} to
+ * create stages from a {@link PipelineConfig}.
+ * The decode path uses {@link #specFromStageId} to reconstruct specs from the persisted
+ * stage IDs in a {@link PipelineDescriptor}.
+ */
+public final class StageFactory {
+
+    private StageFactory() {}
+
+    /**
+     * Creates a transform stage from a specification.
+     *
+     * @param spec the stage specification
+     * @return the concrete stage instance
+     * @throws IllegalArgumentException if the spec is not a transform stage
+     */
+    static NumericCodecStage newTransformStage(final StageSpec spec) {
+        return switch (spec) {
+            case StageSpec.DeltaStage ignored -> DeltaCodecStage.INSTANCE;
+            case StageSpec.OffsetStage ignored -> OffsetCodecStage.INSTANCE;
+            case StageSpec.GcdStage ignored -> GcdCodecStage.INSTANCE;
+            default -> throw new IllegalArgumentException("Not a transform stage: " + spec);
+        };
+    }
+
+    /**
+     * Creates a payload stage from a specification.
+     *
+     * @param spec      the stage specification
+     * @param blockSize the number of values per block
+     * @return the concrete payload stage instance
+     * @throws IllegalArgumentException if the spec is not a payload stage
+     */
+    static PayloadCodecStage newPayloadStage(final StageSpec spec, int blockSize) {
+        return switch (spec) {
+            case StageSpec.BitPackPayload ignored -> new BitPackCodecStage(new DocValuesForUtil(blockSize));
+            default -> throw new IllegalArgumentException("Not a payload stage: " + spec);
+        };
+    }
+
+    /**
+     * Converts a persisted {@link StageId} back to its corresponding {@link StageSpec}.
+     *
+     * <p>Used on the decode path to reconstruct the pipeline from a
+     * {@link PipelineDescriptor}.
+     *
+     * @param stageId the persisted stage identifier
+     * @return the corresponding stage specification
+     */
+    static StageSpec specFromStageId(final StageId stageId) {
+        return switch (stageId) {
+            case DELTA_STAGE -> new StageSpec.DeltaStage();
+            case OFFSET_STAGE -> new StageSpec.OffsetStage();
+            case GCD_STAGE -> new StageSpec.GcdStage();
+            case BITPACK_PAYLOAD -> new StageSpec.BitPackPayload();
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformDecoder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.DecodingContext;
+
+import java.io.IOException;
+
+/**
+ * Reverses an in-place transformation as a non-terminal stage of the decode pipeline.
+ *
+ * <p>Unlike {@link PayloadDecoder}, transform decoders do not read from a
+ * {@link org.apache.lucene.store.DataInput} directly. They read metadata written
+ * by the corresponding {@link TransformEncoder} via {@link DecodingContext#metadata()}.
+ */
+public interface TransformDecoder {
+
+    /**
+     * Returns the unique stage identifier.
+     *
+     * @return the stage ID byte
+     */
+    byte id();
+
+    /**
+     * Reverses the transformation on values in-place using metadata from the context.
+     *
+     * @param values     the values to reverse-transform in-place
+     * @param valueCount the number of valid values in the array
+     * @param context    the decoding context for reading stage metadata
+     * @throws IOException if an I/O error occurs while reading metadata
+     */
+    void decode(long[] values, int valueCount, DecodingContext context) throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/TransformEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.EncodingContext;
+
+/**
+ * Transforms values in-place as a non-terminal stage of the encode pipeline.
+ *
+ * <p>Unlike {@link PayloadEncoder}, transform stages do not write to a
+ * {@link org.apache.lucene.store.DataOutput}. They modify the {@code long[]}
+ * array in-place and record any metadata needed for decoding via
+ * {@link EncodingContext#metadata()}.
+ */
+public interface TransformEncoder {
+
+    /**
+     * Returns the unique stage identifier.
+     *
+     * @return the stage ID byte
+     */
+    byte id();
+
+    /**
+     * Transforms values in-place and writes any metadata to the context.
+     *
+     * <p>If the stage determines that the transformation would not be effective,
+     * it may return without modifying the values or writing metadata. The pipeline
+     * checks {@link EncodingContext#isStageApplied(int)} to detect this.
+     *
+     * @param values     the values to transform in-place
+     * @param valueCount the number of valid values in the array
+     * @param context    the encoding context for metadata and stage tracking
+     */
+    void encode(long[] values, int valueCount, EncodingContext context);
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/package-info.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/package-info.java
@@ -8,13 +8,13 @@
  */
 
 /**
- * Encoder/decoder contracts for numeric pipeline stages.
+ * Encoder/decoder contracts and pipeline orchestration for numeric pipeline stages.
  *
  * <p>This package defines two families of stage contracts:
  * <ul>
  *   <li><strong>Transform stages</strong>:
- *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder} and
- *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecoder}
+ *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.TransformEncoder} and
+ *       {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.TransformDecoder}
  *       (combined as {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecStage})
  *       modify {@code long[]} values in-place and exchange metadata through the
  *       encoding/decoding context. Concrete implementations live in the
@@ -26,6 +26,14 @@
  *       serialize transformed values to bytes and read them back as the terminal
  *       pipeline step.</li>
  * </ul>
+ *
+ * <p>Pipeline orchestration is provided by {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncodePipeline}
+ * (write path) and {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecodePipeline} (read path).
+ * The high-level API is exposed via {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericEncoder}
+ * and {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericDecoder}, which produce per-field
+ * {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockEncoder} and
+ * {@link org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericBlockDecoder} instances owning
+ * mutable per-block context.
  *
  * <p>Each stage implementation corresponds to a
  * {@link org.elasticsearch.index.codec.tsdb.pipeline.StageSpec} and is identified by a

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineRoundTripTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/NumericPipelineRoundTripTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfig;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class NumericPipelineRoundTripTests extends ESTestCase {
+
+    private static final int BLOCK_SIZE = 128;
+
+    public void testConstantValues() throws IOException {
+        final long[] values = new long[BLOCK_SIZE];
+        Arrays.fill(values, randomLong());
+        assertRoundTrip(values);
+    }
+
+    public void testMonotonicValues() throws IOException {
+        final long[] values = new long[BLOCK_SIZE];
+        long base = randomLong() >>> 1;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            values[i] = base + (long) i * randomIntBetween(1, 100);
+        }
+        assertRoundTrip(values);
+    }
+
+    public void testRandomValues() throws IOException {
+        final long[] values = new long[BLOCK_SIZE];
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            values[i] = randomLong();
+        }
+        assertRoundTrip(values);
+    }
+
+    public void testZeros() throws IOException {
+        assertRoundTrip(new long[BLOCK_SIZE]);
+    }
+
+    public void testGcdValues() throws IOException {
+        long gcd = randomIntBetween(2, 1000);
+        final long[] values = new long[BLOCK_SIZE];
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            values[i] = gcd * randomIntBetween(0, 10000);
+        }
+        Arrays.sort(values);
+        assertRoundTrip(values);
+    }
+
+    public void testPartialBlock() throws IOException {
+        int count = randomIntBetween(1, BLOCK_SIZE - 1);
+        final long[] values = new long[BLOCK_SIZE];
+        for (int i = 0; i < count; i++) {
+            values[i] = randomLong();
+        }
+        assertRoundTrip(values, count);
+    }
+
+    public void testMultipleBlocks() throws IOException {
+        int numBlocks = randomIntBetween(2, 10);
+        final PipelineConfig config = PipelineConfig.forLongs(BLOCK_SIZE).delta().offset().gcd().bitPack();
+        final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
+        final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
+
+        final ByteBuffersDataOutput bufferOut = new ByteBuffersDataOutput();
+        final IndexOutput out = new ByteBuffersIndexOutput(bufferOut, "test", "test");
+
+        final long[][] allValues = new long[numBlocks][];
+        for (int b = 0; b < numBlocks; b++) {
+            allValues[b] = new long[BLOCK_SIZE];
+            for (int i = 0; i < BLOCK_SIZE; i++) {
+                allValues[b][i] = randomLong();
+            }
+            final long[] copy = Arrays.copyOf(allValues[b], BLOCK_SIZE);
+            blockEncoder.encode(copy, BLOCK_SIZE, out);
+        }
+        out.close();
+
+        final NumericDecoder decoder = NumericCodecFactory.DEFAULT.createDecoder(encoder.descriptor());
+        final NumericBlockDecoder blockDecoder = decoder.newBlockDecoder();
+        final ByteBuffersDataInput in = bufferOut.toDataInput();
+
+        for (int b = 0; b < numBlocks; b++) {
+            final long[] decoded = new long[BLOCK_SIZE];
+            blockDecoder.decode(decoded, BLOCK_SIZE, in);
+            assertArrayEquals("block " + b, allValues[b], decoded);
+        }
+    }
+
+    public void testDescriptorRoundTrip() {
+        final PipelineConfig config = PipelineConfig.forLongs(BLOCK_SIZE).delta().offset().gcd().bitPack();
+        final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
+        final PipelineDescriptor descriptor = encoder.descriptor();
+
+        final NumericDecoder decoder = NumericCodecFactory.DEFAULT.createDecoder(descriptor);
+        assertNotNull(decoder);
+        assertEquals(BLOCK_SIZE, decoder.blockSize());
+    }
+
+    private void assertRoundTrip(long[] values) throws IOException {
+        assertRoundTrip(values, values.length);
+    }
+
+    private void assertRoundTrip(long[] values, int count) throws IOException {
+        final PipelineConfig config = PipelineConfig.forLongs(BLOCK_SIZE).delta().offset().gcd().bitPack();
+        final NumericEncoder encoder = NumericCodecFactory.DEFAULT.createEncoder(config);
+        final NumericBlockEncoder blockEncoder = encoder.newBlockEncoder();
+
+        final ByteBuffersDataOutput bufferOut = new ByteBuffersDataOutput();
+        final IndexOutput out = new ByteBuffersIndexOutput(bufferOut, "test", "test");
+        final long[] original = Arrays.copyOf(values, values.length);
+        blockEncoder.encode(values, count, out);
+        out.close();
+
+        final NumericDecoder decoder = NumericCodecFactory.DEFAULT.createDecoder(encoder.descriptor());
+        final NumericBlockDecoder blockDecoder = decoder.newBlockDecoder();
+        final long[] decoded = new long[BLOCK_SIZE];
+        blockDecoder.decode(decoded, count, bufferOut.toDataInput());
+
+        for (int i = 0; i < count; i++) {
+            assertEquals("index " + i, original[i], decoded[i]);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/numeric/StageFactoryTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline.numeric;
+
+import org.elasticsearch.index.codec.tsdb.pipeline.StageId;
+import org.elasticsearch.index.codec.tsdb.pipeline.StageSpec;
+import org.elasticsearch.test.ESTestCase;
+
+public class StageFactoryTests extends ESTestCase {
+
+    public void testSpecFromStageIdPreservesIdentity() {
+        for (StageId id : StageId.values()) {
+            final StageSpec spec = StageFactory.specFromStageId(id);
+            assertEquals(id, spec.stageId());
+        }
+    }
+
+    public void testTransformStageCreationMatchesSpec() {
+        final StageSpec.TransformSpec[] specs = { new StageSpec.DeltaStage(), new StageSpec.OffsetStage(), new StageSpec.GcdStage() };
+        for (StageSpec.TransformSpec spec : specs) {
+            final NumericCodecStage stage = StageFactory.newTransformStage(spec);
+            assertEquals(spec.stageId().id, stage.id());
+        }
+    }
+
+    public void testPayloadStageCreationMatchesSpec() {
+        final PayloadCodecStage stage = StageFactory.newPayloadStage(new StageSpec.BitPackPayload(), 128);
+        assertEquals(StageId.BITPACK_PAYLOAD.id, stage.id());
+    }
+
+    public void testNewTransformStageRejectsPayloadSpec() {
+        expectThrows(IllegalArgumentException.class, () -> StageFactory.newTransformStage(new StageSpec.BitPackPayload()));
+    }
+
+    public void testNewPayloadStageRejectsTransformSpec() {
+        final StageSpec.TransformSpec[] specs = { new StageSpec.DeltaStage(), new StageSpec.OffsetStage(), new StageSpec.GcdStage() };
+        for (StageSpec.TransformSpec spec : specs) {
+            expectThrows(IllegalArgumentException.class, () -> StageFactory.newPayloadStage(spec, 128));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the pipeline runtime that connects the composable stage framework (from [#143589](https://github.com/elastic/elasticsearch/pull/143589) and [#143934](https://github.com/elastic/elasticsearch/pull/143934)) to the doc values consumer/producer. Also renames the stage-level interfaces to align with the POC architecture ([#141353](https://github.com/elastic/elasticsearch/pull/141353)).

### What's included

**New pipeline runtime classes**: `NumericEncodePipeline`, `NumericDecodePipeline`, `NumericBlockEncoder`/`NumericBlockDecoder`, `NumericCodecFactory`, `StageFactory`, `TransformEncoder`/`TransformDecoder`.

**Stage interface rename**: The stage-level `NumericEncoder`/`NumericDecoder` from [#143934](https://github.com/elastic/elasticsearch/pull/143934) are renamed to `TransformEncoder`/`TransformDecoder`, freeing those names for the pipeline coordinators (`NumericEncoder`/`NumericDecoder`) that the ES94 consumer/producer will interact with. This aligns with the POC architecture where transform stages and pipeline coordinators are separate concerns.

### Testing

```
./gradlew :server:test --tests "*pipeline.numeric.stages*"
```