### PR TITLE
[9.2] Skip automaton for literal app privs (#144685)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionGrantsBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionGrantsBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.xpack.core.security.authz.permission;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks {@link ApplicationPermission#grants} for literal resource strings.
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class ApplicationPermissionGrantsBenchmark {
+
+    @Param({ "10", "100", "1000" })
+    int resourceCount;
+
+    private ApplicationPermission permission;
+    private ApplicationPrivilege checkPrivilege;
+    private String[] resources;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        List<ApplicationPrivilegeDescriptor> stored = List.of(
+            new ApplicationPrivilegeDescriptor("myapp", "admin", Set.of("action:admin/*"), Map.of())
+        );
+
+        ApplicationPrivilege grantedPrivilege = ApplicationPrivilege.get("myapp", Set.of("admin"), stored).iterator().next();
+        permission = new ApplicationPermission(List.of(new Tuple<>(grantedPrivilege, Set.of("resource:/org:12345/*"))));
+
+        checkPrivilege = ApplicationPrivilege.get("myapp", Set.of("admin"), stored).iterator().next();
+
+        resources = new String[resourceCount];
+        for (int i = 0; i < resourceCount; i++) {
+            resources[i] = "resource:/org:12345/" + i;
+        }
+    }
+
+    @Benchmark
+    public void grantsLiteralResources(Blackhole bh) {
+        for (String resource : resources) {
+            bh.consume(permission.grants(checkPrivilege, resource));
+        }
+    }
+}

--- a/docs/changelog/144685.yaml
+++ b/docs/changelog/144685.yaml
@@ -1,0 +1,6 @@
+area: Security
+issues: []
+pr: 144685
+summary: Skip automaton construction for literal resource strings in application privilege
+  checks
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
@@ -82,8 +82,13 @@ public final class ApplicationPermission {
      * </ul>
      */
     public boolean grants(ApplicationPrivilege other, String resource) {
-        Automaton resourceAutomaton = Automatons.patterns(resource);
-        final boolean matched = permissions.stream().anyMatch(e -> e.grants(other, resourceAutomaton));
+        final boolean matched;
+        if (Automatons.isLiteralPattern(resource)) {
+            matched = permissions.stream().anyMatch(e -> e.grantsResourceLiteral(other, resource));
+        } else {
+            Automaton resourceAutomaton = Automatons.patterns(resource);
+            matched = permissions.stream().anyMatch(e -> e.grants(other, resourceAutomaton));
+        }
         logger.trace("Permission [{}] {} grant [{} , {}]", this, matched ? "does" : "does not", other, resource);
         return matched;
     }
@@ -178,16 +183,22 @@ public final class ApplicationPermission {
         private final Predicate<String> application;
         private final Set<String> resourceNames;
         private final Automaton resourceAutomaton;
+        private final Predicate<String> resourcePredicate;
 
         private PermissionEntry(ApplicationPrivilege privilege, Set<String> resourceNames, Automaton resourceAutomaton) {
             this.privilege = privilege;
             this.application = Automatons.predicate(privilege.getApplication());
             this.resourceNames = resourceNames;
             this.resourceAutomaton = resourceAutomaton;
+            this.resourcePredicate = Automatons.predicate(resourceAutomaton);
         }
 
         private boolean grants(ApplicationPrivilege other, Automaton resource) {
             return matchesPrivilege(other) && Automatons.subsetOf(resource, this.resourceAutomaton);
+        }
+
+        private boolean grantsResourceLiteral(ApplicationPrivilege other, String resource) {
+            return matchesPrivilege(other) && resourcePredicate.test(resource);
         }
 
         private boolean matchesPrivilege(ApplicationPrivilege other) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.support;
 
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
@@ -71,10 +72,6 @@ public final class Automatons {
     // these values are not final since we allow them to be set at runtime
     private static int maxDeterminizedStates = 100000;
     private static Cache<Object, Automaton> cache = buildCache(Settings.EMPTY);
-
-    static final char WILDCARD_STRING = '*';     // String equality with support for wildcards
-    static final char WILDCARD_CHAR = '?';       // Char equality with support for wildcards
-    static final char WILDCARD_ESCAPE = '\\';    // Escape character
 
     // for testing only -Dtests.jvm.argline="-Dtests.automaton.record.patterns=true"
     public static final boolean recordPatterns = System.getProperty("tests.automaton.record.patterns", "false").equals("true");
@@ -214,6 +211,24 @@ public final class Automatons {
         return str.length() > 1 && str.charAt(0) == '/' && str.charAt(str.length() - 1) == '/';
     }
 
+    /**
+     * Returns {@code true} if the string is a literal with no pattern syntax — no wildcards ({@code *}, {@code ?}),
+     * no escape sequences ({@code \}), and no leading {@code /} (which denotes a Lucene regex).
+     * The automaton built from such a string accepts exactly the string itself.
+     */
+    public static boolean isLiteralPattern(String pattern) {
+        if (!pattern.isEmpty() && pattern.charAt(0) == '/') {
+            return false;
+        }
+        for (int i = pattern.length() - 1; i >= 0; i--) {
+            char c = pattern.charAt(i);
+            if (c == WildcardQuery.WILDCARD_STRING || c == WildcardQuery.WILDCARD_CHAR || c == WildcardQuery.WILDCARD_ESCAPE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static Automaton buildAutomaton(String pattern) {
         if (pattern.startsWith("/")) { // it's a lucene regexp
             if (pattern.length() == 1 || pattern.endsWith("/") == false) {
@@ -256,13 +271,13 @@ public final class Automatons {
             final char c = text.charAt(i);
             int length = 1;
             switch (c) {
-                case WILDCARD_STRING:
+                case WildcardQuery.WILDCARD_STRING:
                     automata.add(Automata.makeAnyString());
                     break;
-                case WILDCARD_CHAR:
+                case WildcardQuery.WILDCARD_CHAR:
                     automata.add(Automata.makeAnyChar());
                     break;
-                case WILDCARD_ESCAPE:
+                case WildcardQuery.WILDCARD_ESCAPE:
                     // add the next codepoint instead, if it exists
                     if (i + length < text.length()) {
                         final char nextChar = text.charAt(i + length);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionTests.java
@@ -166,6 +166,33 @@ public class ApplicationPermissionTests extends ESTestCase {
         return privileges.iterator().next();
     }
 
+    public void testGrantsLiteralAndPatternResources() {
+        final ApplicationPermission perm = buildPermission(app1All, "dashboard/*", "user/12345");
+
+        // Literal resources (fast path via isLiteralPattern → grantsResource predicate)
+        assertThat("literal match under wildcard grant", perm.grants(app1All, "dashboard/1"), equalTo(true));
+        assertThat("literal match on exact grant", perm.grants(app1All, "user/12345"), equalTo(true));
+        assertThat("literal non-match", perm.grants(app1All, "report/1"), equalTo(false));
+        assertThat("literal non-match on partial", perm.grants(app1All, "dashboard"), equalTo(false));
+        assertThat("literal with / in non-leading position", perm.grants(app1All, "dash/board/nested"), equalTo(false));
+
+        // Wildcard * resources (old path via Automatons.patterns → subsetOf)
+        assertThat("wildcard subset of grant", perm.grants(app1All, "dashboard/*"), equalTo(true));
+        assertThat("wildcard broader than grant", perm.grants(app1All, "*"), equalTo(false));
+        assertThat("wildcard non-match", perm.grants(app1All, "report/*"), equalTo(false));
+
+        // Single-char wildcard ? resources (old path)
+        assertThat("? matching single char", perm.grants(app1All, "dashboard/?"), equalTo(true));
+        assertThat("? non-match on multi-char", perm.grants(app1All, "user/1234?"), equalTo(false));
+
+        // Escape \\ resources (old path)
+        assertThat("escaped star is literal", perm.grants(app1All, "dashboard/\\*"), equalTo(true));
+
+        // Lucene regex /.../ resources (old path)
+        assertThat("regex match", perm.grants(app1All, "/dashboard\\/.*/"), equalTo(true));
+        assertThat("regex non-match", perm.grants(app1All, "/report\\/.*/"), equalTo(false));
+    }
+
     private ApplicationPermission buildPermission(ApplicationPrivilege privilege, String... resources) {
         return buildPermission(Collections.singleton(privilege), resources);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/AutomatonsTests.java
@@ -218,6 +218,32 @@ public class AutomatonsTests extends ESTestCase {
         assertThat(Automatons.pattern(pattern), not(sameInstance(automaton)));
     }
 
+    public void testIsLiteralPattern() {
+        // Plain strings are literal
+        assertTrue(Automatons.isLiteralPattern("foo"));
+        assertTrue(Automatons.isLiteralPattern("ec:/organizations:123/deployment:abc"));
+        assertTrue(Automatons.isLiteralPattern("space:space42"));
+        assertTrue(Automatons.isLiteralPattern("a/b/c"));
+        assertTrue(Automatons.isLiteralPattern(""));
+
+        // Wildcards are not literal
+        assertFalse(Automatons.isLiteralPattern("*"));
+        assertFalse(Automatons.isLiteralPattern("foo*"));
+        assertFalse(Automatons.isLiteralPattern("*foo"));
+        assertFalse(Automatons.isLiteralPattern("fo*o"));
+        assertFalse(Automatons.isLiteralPattern("foo?"));
+        assertFalse(Automatons.isLiteralPattern("f?o"));
+
+        // Escape sequences are not literal
+        assertFalse(Automatons.isLiteralPattern("foo\\*"));
+        assertFalse(Automatons.isLiteralPattern("\\foo"));
+
+        // Leading slash (Lucene regex) is not literal
+        assertFalse(Automatons.isLiteralPattern("/foo/"));
+        assertFalse(Automatons.isLiteralPattern("/foo.*/"));
+        assertFalse(Automatons.isLiteralPattern("/"));
+    }
+
     // This isn't use directly in the code, but it's sometimes needed when debugging failing tests
     // (and it is annoying to have to rewrite it each time it's needed)
     public static <A extends Appendable> A debug(Automaton a, A out) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Skip automaton for literal app privs (#144685)