### PR TITLE
Update failing ConnectorIndexServiceTests, unmute test class

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -14,8 +14,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
   issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-  issue: https://github.com/elastic/elasticsearch/issues/116087
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start already started transform}
   issue: https://github.com/elastic/elasticsearch/issues/98802

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -11,6 +11,8 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
@@ -22,6 +24,7 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.UpdateScript;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.action.ConnectorCreateActionResponse;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorApiKeyIdAction;
@@ -55,6 +58,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry.MANAGED_CONNECTOR_INDEX_PREFIX;
 import static org.elasticsearch.xpack.application.connector.ConnectorTestUtils.getRandomConnectorFeatures;
 import static org.elasticsearch.xpack.application.connector.ConnectorTestUtils.getRandomCronExpression;
@@ -231,15 +235,12 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         ConnectorCreateActionResponse resp = awaitCreateConnector(connectorId, connector);
         assertThat(resp.status(), anyOf(equalTo(RestStatus.CREATED), equalTo(RestStatus.OK)));
 
+        indexConnectorConfiguration(connectorId, connector.getConfiguration());
+
         Map<String, Object> connectorNewConfiguration = connector.getConfiguration()
             .entrySet()
             .stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> Map.of(ConnectorConfiguration.VALUE_FIELD.getPreferredName(), randomAlphaOfLengthBetween(3, 10))
-                )
-            );
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> randomAlphaOfLengthBetween(3, 10)));
 
         UpdateConnectorConfigurationAction.Request updateConfigurationRequest = new UpdateConnectorConfigurationAction.Request(
             connectorId,
@@ -265,17 +266,14 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         ConnectorCreateActionResponse resp = awaitCreateConnector(connectorId, connector);
         assertThat(resp.status(), anyOf(equalTo(RestStatus.CREATED), equalTo(RestStatus.OK)));
 
+        indexConnectorConfiguration(connectorId, connector.getConfiguration());
+
         Set<String> configKeys = connector.getConfiguration().keySet();
 
         Set<String> keysToUpdate = new HashSet<>(randomSubsetOf(configKeys));
 
         Map<String, Object> connectorNewConfigurationPartialValuesUpdate = keysToUpdate.stream()
-            .collect(
-                Collectors.toMap(
-                    key -> key,
-                    key -> Map.of(ConnectorConfiguration.VALUE_FIELD.getPreferredName(), randomAlphaOfLengthBetween(3, 10))
-                )
-            );
+            .collect(Collectors.toMap(key -> key, key -> randomAlphaOfLengthBetween(3, 10)));
 
         UpdateConnectorConfigurationAction.Request updateConfigurationRequest = new UpdateConnectorConfigurationAction.Request(
             connectorId,
@@ -1541,6 +1539,36 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         }
         assertNotNull("Received null response from update error request", resp.get());
         return resp.get();
+    }
+
+    private void indexConnectorConfiguration(String connectorId, Map<String, ConnectorConfiguration> configuration) throws Exception {
+        XContentBuilder builder = jsonBuilder();
+        builder.startObject();
+        builder.xContentValuesMap(Connector.CONFIGURATION_FIELD.getPreferredName(), configuration);
+        builder.endObject();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Exception> exc = new AtomicReference<>(null);
+        client().update(
+            new UpdateRequest(ConnectorIndexService.CONNECTOR_INDEX_NAME, connectorId).doc(builder)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+            new ActionListener<>() {
+                @Override
+                public void onResponse(UpdateResponse updateResponse) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    exc.set(e);
+                    latch.countDown();
+                }
+            }
+        );
+        assertTrue("Timeout waiting for index configuration", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        if (exc.get() != null) {
+            throw exc.get();
+        }
     }
 
     private UpdateResponse awaitUpdateConnectorApiKeyIdOrApiKeySecretId(


### PR DESCRIPTION
## Summary

Fixes [#116087](https://github.com/elastic/elasticsearch/issues/116087)

The `ConnectorIndexServiceTests` class was failing intermittently in CI (0.9% fail rate) and was muted. Two test methods were affected: `testUpdateConnectorConfiguration_PartialValuesUpdate` and `testUpdateConnectorConfiguration_PartialValuesUpdate_SelectedKeys`.

Seems like some adjacent changes have been made since this test was muted, so I needed to update some logic as well. Changes include:
- Adding an `indexConnectorConfiguration()` test helper that writes the full `ConnectorConfiguration` map to the connector document via `UpdateRequest` with immediate refresh
- Fixing the configuration update maps in both affected tests to pass raw string values instead of nested value maps
- Removing the mute entry for `ConnectorIndexServiceTests` from `muted-tests.yml`

## Testing

- Ran `./gradlew :x-pack:plugin:ent-search:test --tests org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests` locally to verify the fix
- Ran a stress-test with `-Dtests.iters=100` to test flakiness. Didn't encounter any issues, but results may vary on CI