### PR TITLE
Handle legacy 'type' property in plugin descriptors from 7.x

### DIFF
--- a/docs/changelog/145147.yaml
+++ b/docs/changelog/145147.yaml
@@ -1,0 +1,6 @@
+pr: 145147
+summary: Handle legacy 'type' property in plugin descriptors from 7.x
+area: Infra/Plugins
+type: bug
+issues:
+ - 144317

--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -273,6 +273,10 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         boolean modular = module != null;
         DeploymentTarget deploymentTarget = readDeploymentTarget(propsMap, name);
 
+        // Consume legacy properties from older Elasticsearch versions to allow reading
+        // plugin descriptors written by those versions (e.g. during a rolling upgrade from 7.x).
+        propsMap.remove("type");
+
         return new PluginDescriptor(
             name,
             desc,

--- a/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
@@ -329,6 +329,11 @@ public class PluginDescriptorTests extends ESTestCase {
         assertThat(names, contains("a", "b", "c", "d", "e"));
     }
 
+    public void testLegacyTypePropertyIsIgnored() throws Exception {
+        PluginDescriptor info = mockInternalDescriptor("type", "isolated");
+        assertEquals("my_plugin", info.getName());
+    }
+
     public void testUnknownProperties() throws Exception {
         assertBothDescriptors(writer -> {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> writer.write("extra", "property"));


### PR DESCRIPTION
## Summary

When upgrading from Elasticsearch 7.x to 8.x+, running `elasticsearch-plugin list` throws:

```
java.lang.IllegalArgumentException: Unknown properties for plugin [repository-gcs] in plugin descriptor: [type]
```

The 7.x plugin descriptor format included a `type` property (with value `isolated`) that the current parser does not recognize. The parser consumes known properties via `Map.remove()` and then throws if any remain — so the leftover `type` entry triggers the error.

**Fix:** Consume the legacy `type` property in `readerInternalDescriptor()`, consistent with how other optional properties (`extended.plugins`, `modulename`, `deployment.target`) are handled. This covers both filesystem reads (`readFromProperties`) and stream reads (`readInternalDescriptorFromStream`).

## Test plan

- Added `testLegacyTypePropertyIsIgnored` — verifies a descriptor containing `type=isolated` parses successfully
- Existing `testUnknownProperties` still passes — truly unknown properties (e.g. `extra`) still throw `IllegalArgumentException`
- `./gradlew :server:test --tests "org.elasticsearch.plugins.PluginDescriptorTests"` passes

Closes #144317