### PR TITLE
Avoid tracking timestamp in TimeSeriesBlockHash

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
@@ -44,14 +44,22 @@ public final class TimeSeriesBlockHash extends BlockHash {
     private final BytesRefHashTable tsidHash;
     private final LongLongHashTable finalHash;
     private final BytesRef scratch = new BytesRef();
+    private final boolean trackTimestamp;
     private long minTimestamp = Long.MAX_VALUE;
     private long maxTimestamp = Long.MIN_VALUE;
 
-    public TimeSeriesBlockHash(int tsidChannel, int timestampChannel, boolean reverseOutput, BlockFactory blockFactory) {
+    public TimeSeriesBlockHash(
+        int tsidChannel,
+        int timestampChannel,
+        boolean reverseOutput,
+        boolean trackTimestamp,
+        BlockFactory blockFactory
+    ) {
         super(blockFactory);
         this.tsidChannel = tsidChannel;
         this.timestampChannel = timestampChannel;
         this.reverseOutput = reverseOutput;
+        this.trackTimestamp = trackTimestamp;
         boolean success = false;
         try {
             this.tsidHash = HashImplFactory.newBytesRefHash(blockFactory);
@@ -81,6 +89,9 @@ public final class TimeSeriesBlockHash extends BlockHash {
         if (timestampVector == null) {
             throw new IllegalStateException("Expected a vector for timestamp");
         }
+        if (trackTimestamp) {
+            trackTimestampFromVector(timestampVector);
+        }
         if (tsidVector.isConstant()) {
             addConstant(tsidVector, timestampVector, addInput);
             return;
@@ -97,7 +108,6 @@ public final class TimeSeriesBlockHash extends BlockHash {
         final int tsid = Math.toIntExact(hashOrdToGroup(tsidHash.add(tsidVector.getBytesRef(0, scratch))));
         final int positionCount = timestamps.getPositionCount();
         long prevTimestamp = timestamps.getLong(0);
-        trackTimestamp(prevTimestamp);
         int prevGroupId = (int) hashOrdToGroup(finalHash.add(tsid, prevTimestamp));
         if (timestamps.isConstant() || constantTimestamp(timestamps, prevTimestamp, positionCount)) {
             try (var groups = blockFactory.newConstantIntVector(prevGroupId, positionCount)) {
@@ -111,7 +121,6 @@ public final class TimeSeriesBlockHash extends BlockHash {
             for (int p = 1; p < positionCount; p++) {
                 long timestamp = timestamps.getLong(p);
                 if (prevTimestamp != timestamp) {
-                    trackTimestamp(timestamp);
                     prevGroupId = (int) hashOrdToGroup(finalHash.add(tsid, timestamp));
                     prevTimestamp = timestamp;
                 }
@@ -138,59 +147,39 @@ public final class TimeSeriesBlockHash extends BlockHash {
     }
 
     private void addOrdinals(OrdinalBytesRefVector tsidVector, LongVector timestamps, GroupingAggregatorFunction.AddInput addInput) {
-        final int positionCount = tsidVector.getPositionCount();
-        final IntVector groupIds;
-        try (var tsidOrds = ordsForTsidDict(tsidVector)) {
-            final long firstTimestamp = timestamps.getLong(0);
-            if (timestamps.isConstant() || constantTimestamp(timestamps, firstTimestamp, positionCount)) {
-                groupIds = groupIdsForOrdinalsWithConstantTimestamp(positionCount, tsidOrds, firstTimestamp);
-            } else {
-                groupIds = groupIdsForOrdinals(positionCount, tsidOrds, timestamps);
+        final IntVector ordinalsVector = tsidVector.getOrdinalsVector();
+        final int ordinalsLength = ordinalsVector.getPositionCount();
+        final BytesRefVector dictVector = tsidVector.getDictionaryVector();
+        final int dictLength = dictVector.getPositionCount();
+        long acquiredBytes = (long) Integer.BYTES * (ordinalsLength + dictLength);
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "TimeSeriesBlockHash");
+        try {
+            final int[] dictOrds = new int[dictLength];
+            for (int p = 0; p < dictLength; p++) {
+                BytesRef v = dictVector.getBytesRef(p, scratch);
+                dictOrds[p] = Math.toIntExact(hashOrdToGroup(tsidHash.add(v)));
             }
-        }
-        try (groupIds) {
-            addInput.add(0, groupIds);
-        }
-    }
-
-    private IntVector groupIdsForOrdinals(int positionCount, IntVector tsidOrds, LongVector timestamps) {
-        try (var groupIds = blockFactory.newIntVectorFixedBuilder(positionCount)) {
-            int prevTsid = tsidOrds.getInt(0);
+            final int[] groupIds = new int[ordinalsLength];
+            int prevTsid = dictOrds[ordinalsVector.getInt(0)];
             long prevTimestamp = timestamps.getLong(0);
-            trackTimestamp(prevTimestamp);
             int prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(prevTsid, prevTimestamp)));
-            groupIds.appendInt(0, prevGroupId);
-            for (int p = 1; p < positionCount; p++) {
+            groupIds[0] = prevGroupId;
+            for (int p = 1; p < ordinalsLength; p++) {
                 final long timestamp = timestamps.getLong(p);
-                trackTimestamp(timestamp);
-                int tsid = tsidOrds.getInt(p);
+                int tsid = dictOrds[ordinalsVector.getInt(p)];
                 if (tsid != prevTsid || timestamp != prevTimestamp) {
-                    prevTimestamp = timestamps.getLong(p);
+                    prevTimestamp = timestamp;
                     prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(tsid, prevTimestamp)));
                     prevTsid = tsid;
                 }
-                groupIds.appendInt(p, prevGroupId);
+                groupIds[p] = prevGroupId;
             }
-            return groupIds.build();
-        }
-    }
-
-    private IntVector groupIdsForOrdinalsWithConstantTimestamp(int positionCount, IntVector tsidOrds, long timestamp) {
-        trackTimestamp(timestamp);
-        try (var groupIds = blockFactory.newIntVectorFixedBuilder(positionCount)) {
-            int prevTsid = tsidOrds.getInt(0);
-            int prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(prevTsid, timestamp)));
-            groupIds.appendInt(0, prevGroupId);
-
-            for (int p = 1; p < positionCount; p++) {
-                int tsid = tsidOrds.getInt(p);
-                if (tsid != prevTsid) {
-                    prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(tsid, timestamp)));
-                    prevTsid = tsid;
-                }
-                groupIds.appendInt(p, prevGroupId);
+            try (var groupsVector = blockFactory.newIntArrayVector(groupIds, ordinalsLength, acquiredBytes)) {
+                acquiredBytes = 0;
+                addInput.add(0, groupsVector);
             }
-            return groupIds.build();
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 
@@ -206,37 +195,12 @@ public final class TimeSeriesBlockHash extends BlockHash {
             }
             for (int p = 0; p < positionCount; p++) {
                 long timestamp = timestamps.getLong(p);
-                trackTimestamp(timestamp);
                 ords[p] = Math.toIntExact(hashOrdToGroup(finalHash.add(ords[p], timestamp)));
             }
             try (var groupIds = blockFactory.newIntArrayVector(ords, positionCount, acquiredBytes)) {
                 acquiredBytes = 0;
                 addInput.add(0, groupIds);
             }
-        } finally {
-            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
-        }
-    }
-
-    private IntVector ordsForTsidDict(OrdinalBytesRefVector tsidVector) {
-        final BytesRefVector dict = tsidVector.getDictionaryVector();
-        final IntVector positions = tsidVector.getOrdinalsVector();
-        long acquiredBytes = (long) Integer.BYTES * (positions.getPositionCount() + dict.getPositionCount());
-        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "TimeSeriesBlockHash");
-        try {
-            final int[] dictOrds = new int[dict.getPositionCount()];
-            for (int p = 0; p < dict.getPositionCount(); p++) {
-                BytesRef v = dict.getBytesRef(p, scratch);
-                dictOrds[p] = Math.toIntExact(hashOrdToGroup(tsidHash.add(v)));
-            }
-            final int[] tsidOrds = new int[positions.getPositionCount()];
-            for (int p = 0; p < positions.getPositionCount(); p++) {
-                tsidOrds[p] = dictOrds[positions.getInt(p)];
-            }
-            final long positionBytes = (long) Integer.BYTES * positions.getPositionCount();
-            final var result = blockFactory.newIntArrayVector(tsidOrds, positions.getPositionCount(), positionBytes);
-            acquiredBytes -= positionBytes;
-            return result;
         } finally {
             blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
@@ -344,25 +308,39 @@ public final class TimeSeriesBlockHash extends BlockHash {
         return finalHash.find(tsid, timestamp);
     }
 
-    public long addGroup(int tsid, long timestamp) {
-        trackTimestamp(timestamp);
+    public long addExtraGroup(int tsid, long timestamp) {
         return finalHash.add(tsid, timestamp);
-    }
-
-    private void trackTimestamp(long timestamp) {
-        minTimestamp = Math.min(minTimestamp, timestamp);
-        maxTimestamp = Math.max(maxTimestamp, timestamp);
     }
 
     public long numGroups() {
         return finalHash.size();
     }
 
+    private void maybeScanTimestampsFromFinalHash() {
+        if (minTimestamp > maxTimestamp) {
+            for (long i = 0; i < finalHash.size(); i++) {
+                long t = finalHash.getKey2(i);
+                minTimestamp = Math.min(t, minTimestamp);
+                maxTimestamp = Math.max(t, maxTimestamp);
+            }
+        }
+    }
+
+    private void trackTimestampFromVector(LongVector timestampVector) {
+        for (int p = 0; p < timestampVector.getPositionCount(); p++) {
+            long t = timestampVector.getLong(p);
+            minTimestamp = Math.min(t, minTimestamp);
+            maxTimestamp = Math.max(t, maxTimestamp);
+        }
+    }
+
     public long minTimestamp() {
+        maybeScanTimestampsFromFinalHash();
         return minTimestamp;
     }
 
     public long maxTimestamp() {
+        maybeScanTimestampsFromFinalHash();
         return maxTimestamp;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -55,6 +55,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
     ) implements OperatorFactory {
         @Override
         public Operator get(DriverContext driverContext) {
+            final boolean outputFinal = aggregatorMode.isOutputPartial() == false;
             return new TimeSeriesAggregationOperator(
                 timeBucket,
                 dateNanos ? DateFieldMapper.Resolution.NANOSECONDS : DateFieldMapper.Resolution.MILLISECONDS,
@@ -66,9 +67,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                         var g1 = groups.get(0);
                         var g2 = groups.get(1);
                         if (g1.elementType() == ElementType.BYTES_REF && g2.elementType() == ElementType.LONG) {
-                            return new TimeSeriesBlockHash(g1.channel(), g2.channel(), false, driverContext.blockFactory());
+                            return new TimeSeriesBlockHash(g1.channel(), g2.channel(), false, outputFinal, driverContext.blockFactory());
                         } else if (g1.elementType() == ElementType.LONG && g2.elementType() == ElementType.BYTES_REF) {
-                            return new TimeSeriesBlockHash(g2.channel(), g1.channel(), true, driverContext.blockFactory());
+                            return new TimeSeriesBlockHash(g2.channel(), g1.channel(), true, outputFinal, driverContext.blockFactory());
                         }
                     }
                     // Broken optimizations are allowed as the inputs are vectors.
@@ -210,7 +211,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             bucket = Math.max(bucket, tsBlockHash.minTimestamp());
             // Fill the missing buckets between (timestamp-window, timestamp)
             while (bucket < endTimestamp) {
-                if (tsBlockHash.addGroup(tsid, bucket) >= 0) {
+                if (tsBlockHash.addExtraGroup(tsid, bucket) >= 0) {
                     expandingGroups.addGroup(Math.toIntExact(groupId));
                 }
                 bucket = optimizedTimeBucket.nextRoundingValue(bucket);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -1602,7 +1602,7 @@ public class BlockHashTests extends BlockHashTestCase {
 
     public void testTimeSeriesBlockHash() throws Exception {
         long endTime = randomLongBetween(10_000_000, 20_000_000);
-        var hash1 = new TimeSeriesBlockHash(0, 1, false, blockFactory);
+        var hash1 = new TimeSeriesBlockHash(0, 1, false, randomBoolean(), blockFactory);
         var hash2 = BlockHash.build(
             List.of(new BlockHash.GroupSpec(0, ElementType.BYTES_REF), new BlockHash.GroupSpec(1, ElementType.LONG)),
             blockFactory,
@@ -1725,8 +1725,8 @@ public class BlockHashTests extends BlockHashTestCase {
 
     public void testTimeSeriesBlockHashReverseOutput() throws Exception {
         long endTime = randomLongBetween(10_000_000, 20_000_000);
-        var hash1 = new TimeSeriesBlockHash(0, 1, false, blockFactory);
-        var hash2 = new TimeSeriesBlockHash(0, 1, true, blockFactory);
+        var hash1 = new TimeSeriesBlockHash(0, 1, false, randomBoolean(), blockFactory);
+        var hash2 = new TimeSeriesBlockHash(0, 1, true, randomBoolean(), blockFactory);
         int numPages = between(1, 100);
         int globalTsid = -1;
         long timestamp = endTime;


### PR DESCRIPTION
`trackTimestamp` shows up in async-profiler where it shouldn't. Only the final time-series aggregation needs min/max timestamps; partial aggregations don't. This change avoids tracking timestamps in partial aggregations.