### PR TITLE
Rework raw buffer for rate aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -7,16 +7,11 @@
 package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
+
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -26,12 +21,10 @@ import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 import java.util.List;
@@ -85,7 +78,6 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     private final DoubleRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
-    private final LocalCircuitBreaker.SingletonService localCircuitBreakerService;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
     private final boolean isRateOverTime;
@@ -103,23 +95,16 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         this.channels = channels;
         this.driverContext = driverContext;
         this.isRateOverTime = isRateOverTime;
-        LocalCircuitBreaker.SingletonService localCircuitBreakerService = new LocalCircuitBreaker.SingletonService(
-            driverContext.bigArrays().breakerService(),
-            driverContext.localBreakerSettings()
-        );
-        this.bigArrays = driverContext.bigArrays().withBreakerService(localCircuitBreakerService);
+        this.bigArrays = driverContext.bigArrays();
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
         DoubleRawBuffer buffer = null;
         try {
-            buffer = new DoubleRawBuffer(bigArrays);
+            buffer = new DoubleRawBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
-
             this.rawBuffer = buffer;
-            this.localCircuitBreakerService = localCircuitBreakerService;
             buffer = null;
-            localCircuitBreakerService = null;
         } finally {
-            Releasables.close(buffer, localCircuitBreakerService);
+            Releasables.close(buffer);
         }
     }
 
@@ -369,8 +354,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
+        var flushQueues = rawBuffer.prepareForFlush();
         try (
-            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newDoubleBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -409,7 +394,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, localCircuitBreakerService);
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
@@ -417,31 +402,28 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             return;
         }
         reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
-        try (var flushQueues = rawBuffer.prepareForFlush()) {
-            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
-                var flushQueue = flushQueues.getFlushQueue(groupId);
-                if (flushQueue != null) {
-                    ReducedState state = reducedStates.get(groupId);
-                    if (state == null) {
-                        state = new ReducedState();
-                        reducedStates.set(groupId, state);
-                    }
-                    flushGroup(state, rawBuffer, flushQueue);
+        var flushQueues = rawBuffer.prepareForFlush();
+        for (int groupId = flushQueues.minGroupId(); groupId <= flushQueues.maxGroupId(); groupId++) {
+            var flushQueue = flushQueues.getFlushQueue(groupId);
+            if (flushQueue != null) {
+                ReducedState state = reducedStates.get(groupId);
+                if (state == null) {
+                    state = new ReducedState();
+                    reducedStates.set(groupId, state);
                 }
+                flushGroup(state, rawBuffer, flushQueue);
             }
         }
-        rawBuffer.minGroupId = Integer.MAX_VALUE;
-        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
     static final class DoubleRawBuffer extends RawBuffer {
-        private DoubleArray values;
+        private final DoubleBuffer values;
 
-        DoubleRawBuffer(BigArrays bigArrays) {
-            super(bigArrays);
+        DoubleRawBuffer(CircuitBreaker breaker) {
+            super(breaker);
             boolean success = false;
             try {
-                this.values = bigArrays.newDoubleArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                this.values = new DoubleBuffer(breaker, PAGE_SIZE);
                 success = true;
             } finally {
                 if (success == false) {
@@ -453,8 +435,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         void prepareForAppend(int groupId, int count, long firstTimestamp) {
             prepareSlicesOnly(groupId, firstTimestamp);
             int newSize = valueCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
+            timestamps.ensureCapacity(newSize);
+            values.ensureCapacity(newSize);
         }
 
         void appendWithoutResize(long timestamp, double value) {
@@ -464,17 +446,16 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
 
         void maybeResizeAndAppend(long timestamp, double value) {
-            timestamps = bigArrays.grow(timestamps, valueCount + 1);
-            values = bigArrays.grow(values, valueCount + 1);
+            timestamps.ensureCapacity(valueCount + 1);
+            values.ensureCapacity(valueCount + 1);
             appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, DoubleVector valueVector, LongVector timestampVector) {
-            for (int p = fromPosition; p < toPosition; p++) {
-                values.set(valueCount, valueVector.getDouble(p));
-                timestamps.set(valueCount, timestampVector.getLong(p));
-                valueCount++;
-            }
+            int count = toPosition - fromPosition;
+            timestamps.appendRange(valueCount, timestampVector, fromPosition, count);
+            values.appendRange(valueCount, valueVector, fromPosition, count);
+            valueCount += count;
         }
 
         void appendRange(int fromPosition, int toPosition, DoubleBlock valueBlock, LongVector timestampVector) {
@@ -522,19 +503,14 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             }
         }
         var prevValue = lastValue;
+        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
-                    if (val > prevValue) {
-                        state.resets += val;
-                    }
-                    prevValue = val;
-                }
+                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -542,7 +518,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                state.resets += val;
+                resets[0] += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -556,13 +532,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
         // last slice
         top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
-            if (val > prevValue) {
-                state.resets += val;
-            }
-            prevValue = val;
-        }
+        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+        state.resets = resets[0];
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
@@ -578,7 +549,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage, GroupingAggregatorEvaluationContext ctx) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
-        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
+        var flushQueues = rawBuffer.prepareForFlush();
+        try (var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selectedInPage.getInt(p);
                 var state = group < reducedStates.size() ? reducedStates.get(group) : null;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -503,14 +503,19 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             }
         }
         var prevValue = lastValue;
-        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -518,7 +523,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                resets[0] += val;
+                state.resets += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -532,8 +537,13 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
         // last slice
         top = flushQueue.top();
-        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
-        state.resets = resets[0];
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -503,14 +503,19 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             }
         }
         var prevValue = lastValue;
-        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -518,7 +523,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                resets[0] += val;
+                state.resets += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -532,8 +537,13 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
         // last slice
         top = flushQueue.top();
-        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
-        state.resets = resets[0];
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -7,16 +7,11 @@
 package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
+
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -26,12 +21,10 @@ import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 import java.util.List;
@@ -85,7 +78,6 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     private final IntRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
-    private final LocalCircuitBreaker.SingletonService localCircuitBreakerService;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
     private final boolean isRateOverTime;
@@ -103,23 +95,16 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         this.channels = channels;
         this.driverContext = driverContext;
         this.isRateOverTime = isRateOverTime;
-        LocalCircuitBreaker.SingletonService localCircuitBreakerService = new LocalCircuitBreaker.SingletonService(
-            driverContext.bigArrays().breakerService(),
-            driverContext.localBreakerSettings()
-        );
-        this.bigArrays = driverContext.bigArrays().withBreakerService(localCircuitBreakerService);
+        this.bigArrays = driverContext.bigArrays();
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
         IntRawBuffer buffer = null;
         try {
-            buffer = new IntRawBuffer(bigArrays);
+            buffer = new IntRawBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
-
             this.rawBuffer = buffer;
-            this.localCircuitBreakerService = localCircuitBreakerService;
             buffer = null;
-            localCircuitBreakerService = null;
         } finally {
-            Releasables.close(buffer, localCircuitBreakerService);
+            Releasables.close(buffer);
         }
     }
 
@@ -369,8 +354,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
+        var flushQueues = rawBuffer.prepareForFlush();
         try (
-            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newIntBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -409,7 +394,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, localCircuitBreakerService);
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
@@ -417,31 +402,28 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             return;
         }
         reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
-        try (var flushQueues = rawBuffer.prepareForFlush()) {
-            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
-                var flushQueue = flushQueues.getFlushQueue(groupId);
-                if (flushQueue != null) {
-                    ReducedState state = reducedStates.get(groupId);
-                    if (state == null) {
-                        state = new ReducedState();
-                        reducedStates.set(groupId, state);
-                    }
-                    flushGroup(state, rawBuffer, flushQueue);
+        var flushQueues = rawBuffer.prepareForFlush();
+        for (int groupId = flushQueues.minGroupId(); groupId <= flushQueues.maxGroupId(); groupId++) {
+            var flushQueue = flushQueues.getFlushQueue(groupId);
+            if (flushQueue != null) {
+                ReducedState state = reducedStates.get(groupId);
+                if (state == null) {
+                    state = new ReducedState();
+                    reducedStates.set(groupId, state);
                 }
+                flushGroup(state, rawBuffer, flushQueue);
             }
         }
-        rawBuffer.minGroupId = Integer.MAX_VALUE;
-        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
     static final class IntRawBuffer extends RawBuffer {
-        private IntArray values;
+        private final IntBuffer values;
 
-        IntRawBuffer(BigArrays bigArrays) {
-            super(bigArrays);
+        IntRawBuffer(CircuitBreaker breaker) {
+            super(breaker);
             boolean success = false;
             try {
-                this.values = bigArrays.newIntArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                this.values = new IntBuffer(breaker, PAGE_SIZE);
                 success = true;
             } finally {
                 if (success == false) {
@@ -453,8 +435,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         void prepareForAppend(int groupId, int count, long firstTimestamp) {
             prepareSlicesOnly(groupId, firstTimestamp);
             int newSize = valueCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
+            timestamps.ensureCapacity(newSize);
+            values.ensureCapacity(newSize);
         }
 
         void appendWithoutResize(long timestamp, int value) {
@@ -464,17 +446,16 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
 
         void maybeResizeAndAppend(long timestamp, int value) {
-            timestamps = bigArrays.grow(timestamps, valueCount + 1);
-            values = bigArrays.grow(values, valueCount + 1);
+            timestamps.ensureCapacity(valueCount + 1);
+            values.ensureCapacity(valueCount + 1);
             appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, IntVector valueVector, LongVector timestampVector) {
-            for (int p = fromPosition; p < toPosition; p++) {
-                values.set(valueCount, valueVector.getInt(p));
-                timestamps.set(valueCount, timestampVector.getLong(p));
-                valueCount++;
-            }
+            int count = toPosition - fromPosition;
+            timestamps.appendRange(valueCount, timestampVector, fromPosition, count);
+            values.appendRange(valueCount, valueVector, fromPosition, count);
+            valueCount += count;
         }
 
         void appendRange(int fromPosition, int toPosition, IntBlock valueBlock, LongVector timestampVector) {
@@ -522,19 +503,14 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             }
         }
         var prevValue = lastValue;
+        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
-                    if (val > prevValue) {
-                        state.resets += val;
-                    }
-                    prevValue = val;
-                }
+                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -542,7 +518,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                state.resets += val;
+                resets[0] += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -556,13 +532,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
         // last slice
         top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
-            if (val > prevValue) {
-                state.resets += val;
-            }
-            prevValue = val;
-        }
+        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+        state.resets = resets[0];
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
@@ -578,7 +549,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage, GroupingAggregatorEvaluationContext ctx) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
-        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
+        var flushQueues = rawBuffer.prepareForFlush();
+        try (var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selectedInPage.getInt(p);
                 var state = group < reducedStates.size() ? reducedStates.get(group) : null;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -7,16 +7,11 @@
 package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
+
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -26,12 +21,10 @@ import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 import java.util.List;
@@ -85,7 +78,6 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     private final LongRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
-    private final LocalCircuitBreaker.SingletonService localCircuitBreakerService;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
     private final boolean isRateOverTime;
@@ -103,23 +95,16 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         this.channels = channels;
         this.driverContext = driverContext;
         this.isRateOverTime = isRateOverTime;
-        LocalCircuitBreaker.SingletonService localCircuitBreakerService = new LocalCircuitBreaker.SingletonService(
-            driverContext.bigArrays().breakerService(),
-            driverContext.localBreakerSettings()
-        );
-        this.bigArrays = driverContext.bigArrays().withBreakerService(localCircuitBreakerService);
+        this.bigArrays = driverContext.bigArrays();
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
         LongRawBuffer buffer = null;
         try {
-            buffer = new LongRawBuffer(bigArrays);
+            buffer = new LongRawBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
-
             this.rawBuffer = buffer;
-            this.localCircuitBreakerService = localCircuitBreakerService;
             buffer = null;
-            localCircuitBreakerService = null;
         } finally {
-            Releasables.close(buffer, localCircuitBreakerService);
+            Releasables.close(buffer);
         }
     }
 
@@ -369,8 +354,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
+        var flushQueues = rawBuffer.prepareForFlush();
         try (
-            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newLongBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -409,7 +394,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, localCircuitBreakerService);
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
@@ -417,31 +402,28 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             return;
         }
         reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
-        try (var flushQueues = rawBuffer.prepareForFlush()) {
-            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
-                var flushQueue = flushQueues.getFlushQueue(groupId);
-                if (flushQueue != null) {
-                    ReducedState state = reducedStates.get(groupId);
-                    if (state == null) {
-                        state = new ReducedState();
-                        reducedStates.set(groupId, state);
-                    }
-                    flushGroup(state, rawBuffer, flushQueue);
+        var flushQueues = rawBuffer.prepareForFlush();
+        for (int groupId = flushQueues.minGroupId(); groupId <= flushQueues.maxGroupId(); groupId++) {
+            var flushQueue = flushQueues.getFlushQueue(groupId);
+            if (flushQueue != null) {
+                ReducedState state = reducedStates.get(groupId);
+                if (state == null) {
+                    state = new ReducedState();
+                    reducedStates.set(groupId, state);
                 }
+                flushGroup(state, rawBuffer, flushQueue);
             }
         }
-        rawBuffer.minGroupId = Integer.MAX_VALUE;
-        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
     static final class LongRawBuffer extends RawBuffer {
-        private LongArray values;
+        private final LongBuffer values;
 
-        LongRawBuffer(BigArrays bigArrays) {
-            super(bigArrays);
+        LongRawBuffer(CircuitBreaker breaker) {
+            super(breaker);
             boolean success = false;
             try {
-                this.values = bigArrays.newLongArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                this.values = new LongBuffer(breaker, PAGE_SIZE);
                 success = true;
             } finally {
                 if (success == false) {
@@ -453,8 +435,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         void prepareForAppend(int groupId, int count, long firstTimestamp) {
             prepareSlicesOnly(groupId, firstTimestamp);
             int newSize = valueCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
+            timestamps.ensureCapacity(newSize);
+            values.ensureCapacity(newSize);
         }
 
         void appendWithoutResize(long timestamp, long value) {
@@ -464,17 +446,16 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
 
         void maybeResizeAndAppend(long timestamp, long value) {
-            timestamps = bigArrays.grow(timestamps, valueCount + 1);
-            values = bigArrays.grow(values, valueCount + 1);
+            timestamps.ensureCapacity(valueCount + 1);
+            values.ensureCapacity(valueCount + 1);
             appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, LongVector valueVector, LongVector timestampVector) {
-            for (int p = fromPosition; p < toPosition; p++) {
-                values.set(valueCount, valueVector.getLong(p));
-                timestamps.set(valueCount, timestampVector.getLong(p));
-                valueCount++;
-            }
+            int count = toPosition - fromPosition;
+            timestamps.appendRange(valueCount, timestampVector, fromPosition, count);
+            values.appendRange(valueCount, valueVector, fromPosition, count);
+            valueCount += count;
         }
 
         void appendRange(int fromPosition, int toPosition, LongBlock valueBlock, LongVector timestampVector) {
@@ -522,19 +503,14 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             }
         }
         var prevValue = lastValue;
+        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
-                    if (val > prevValue) {
-                        state.resets += val;
-                    }
-                    prevValue = val;
-                }
+                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -542,7 +518,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                state.resets += val;
+                resets[0] += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -556,13 +532,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
         // last slice
         top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
-            if (val > prevValue) {
-                state.resets += val;
-            }
-            prevValue = val;
-        }
+        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+        state.resets = resets[0];
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
@@ -578,7 +549,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage, GroupingAggregatorEvaluationContext ctx) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
-        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
+        var flushQueues = rawBuffer.prepareForFlush();
+        try (var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selectedInPage.getInt(p);
                 var state = group < reducedStates.size() ? reducedStates.get(group) : null;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -503,14 +503,19 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             }
         }
         var prevValue = lastValue;
-        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -518,7 +523,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                resets[0] += val;
+                state.resets += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -532,8 +537,13 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
         // last slice
         top = flushQueue.top();
-        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
-        state.resets = resets[0];
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -8,12 +8,16 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+
+import java.util.Arrays;
 
 class AbstractRateGroupingFunction {
     /**
@@ -25,31 +29,28 @@ class AbstractRateGroupingFunction {
      * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
      * the slice with the greatest timestamp.
      */
+    static final int INITIAL_SLICE_CAPACITY = 512;
+
     abstract static class RawBuffer implements Releasable {
-        final BigArrays bigArrays;
-        LongArray timestamps;
+        private final CircuitBreaker breaker;
+        private long acquiredBytes;
+        LongBuffer timestamps;
         int valueCount;
 
-        IntArray sliceStarts;
-        IntArray sliceGroupIds;
+        int[] sliceStarts;
+        int[] sliceGroupIds;
         int sliceCount;
         int lastGroupId = -1;
         int minGroupId = Integer.MAX_VALUE;
         int maxGroupId = Integer.MIN_VALUE;
 
-        RawBuffer(BigArrays bigArrays) {
-            this.bigArrays = bigArrays;
-            boolean success = false;
-            try {
-                this.timestamps = bigArrays.newLongArray(PageCacheRecycler.LONG_PAGE_SIZE, false);
-                this.sliceStarts = bigArrays.newIntArray(512, false);
-                this.sliceGroupIds = bigArrays.newIntArray(512, false);
-                success = true;
-            } finally {
-                if (success == false) {
-                    close();
-                }
-            }
+        RawBuffer(CircuitBreaker breaker) {
+            this.breaker = breaker;
+            this.acquiredBytes = (long) INITIAL_SLICE_CAPACITY * Integer.BYTES * 2;
+            breaker.addEstimateBytesAndMaybeBreak(acquiredBytes, "rate-slices");
+            this.sliceStarts = new int[INITIAL_SLICE_CAPACITY];
+            this.sliceGroupIds = new int[INITIAL_SLICE_CAPACITY];
+            this.timestamps = new LongBuffer(breaker, PAGE_SIZE);
         }
 
         final void prepareSlicesOnly(int groupId, long firstTimestamp) {
@@ -58,17 +59,22 @@ class AbstractRateGroupingFunction {
                     return; // continue with the current slice
                 }
             }
-            // start a new slice
-            sliceStarts = bigArrays.grow(sliceStarts, sliceCount + 1L);
-            sliceGroupIds = bigArrays.grow(sliceGroupIds, sliceCount + 1L);
+            if (sliceCount >= sliceStarts.length) {
+                int newLen = sliceStarts.length * 2;
+                long delta = (long) (newLen - sliceStarts.length) * Integer.BYTES * 2;
+                breaker.addEstimateBytesAndMaybeBreak(delta, "rate-slices");
+                acquiredBytes += delta;
+                sliceStarts = Arrays.copyOf(sliceStarts, newLen);
+                sliceGroupIds = Arrays.copyOf(sliceGroupIds, newLen);
+            }
             if (groupId < minGroupId) {
                 minGroupId = groupId;
             }
             if (groupId > maxGroupId) {
                 maxGroupId = groupId;
             }
-            sliceStarts.set(sliceCount, valueCount);
-            sliceGroupIds.set(sliceCount, groupId);
+            sliceStarts[sliceCount] = valueCount;
+            sliceGroupIds[sliceCount] = groupId;
             lastGroupId = groupId;
             sliceCount++;
         }
@@ -78,11 +84,9 @@ class AbstractRateGroupingFunction {
                 return new FlushQueues(this, minGroupId, maxGroupId, null, null);
             }
             final int numGroups = maxGroupId - minGroupId + 1;
-            // count the number of slices in each group
             int[] runningOffsets = new int[numGroups];
             for (int i = 0; i < sliceCount; i++) {
-                int groupIndex = sliceGroupIds.get(i) - minGroupId;
-                runningOffsets[groupIndex]++;
+                runningOffsets[sliceGroupIds[i] - minGroupId]++;
             }
             int runningOffset = 0;
             for (int i = 0; i < numGroups; i++) {
@@ -90,35 +94,33 @@ class AbstractRateGroupingFunction {
                 runningOffsets[i] = runningOffset;
                 runningOffset += count;
             }
-            IntArray sliceOffsets = bigArrays.newIntArray(sliceCount * 2L, false);
+            int[] sliceOffsets = new int[sliceCount * 2];
             for (int i = 0; i < sliceCount; i++) {
-                int groupIndex = sliceGroupIds.get(i) - minGroupId;
-                int startOffset = sliceStarts.get(i);
-                final int endOffset;
-                if ((i + 1) < sliceCount) {
-                    endOffset = sliceStarts.get(i + 1);
-                } else {
-                    endOffset = valueCount;
-                }
+                int groupIndex = sliceGroupIds[i] - minGroupId;
+                int startOffset = sliceStarts[i];
+                int endOffset = (i + 1) < sliceCount ? sliceStarts[i + 1] : valueCount;
                 int dstIndex = runningOffsets[groupIndex]++;
-                sliceOffsets.set(dstIndex * 2L, startOffset);
-                sliceOffsets.set(dstIndex * 2L + 1, endOffset);
+                sliceOffsets[dstIndex * 2] = startOffset;
+                sliceOffsets[dstIndex * 2 + 1] = endOffset;
             }
             valueCount = 0;
             sliceCount = 0;
             lastGroupId = -1;
-            return new FlushQueues(this, minGroupId, maxGroupId, runningOffsets, sliceOffsets);
+            var queues = new FlushQueues(this, minGroupId, maxGroupId, runningOffsets, sliceOffsets);
+            minGroupId = Integer.MAX_VALUE;
+            maxGroupId = Integer.MIN_VALUE;
+            return queues;
         }
 
         @Override
         public void close() {
-            Releasables.close(timestamps, sliceStarts, sliceGroupIds);
+            Releasables.close(timestamps);
+            breaker.addWithoutBreaking(-acquiredBytes);
+            acquiredBytes = 0;
         }
     }
 
-    record FlushQueues(RawBuffer buffer, int minGroupId, int maxGroupId, int[] runningOffsets, IntArray sliceOffsets)
-        implements
-            Releasable {
+    record FlushQueues(RawBuffer buffer, int minGroupId, int maxGroupId, int[] runningOffsets, int[] sliceOffsets) {
         FlushQueue getFlushQueue(int groupId) {
             if (groupId < minGroupId || groupId > maxGroupId) {
                 return null;
@@ -132,8 +134,8 @@ class AbstractRateGroupingFunction {
             }
             FlushQueue queue = new FlushQueue(numSlices);
             for (int i = startIndex; i < endIndex; i++) {
-                int start = sliceOffsets.get(i * 2L);
-                int end = sliceOffsets.get(i * 2L + 1);
+                int start = sliceOffsets[i * 2];
+                int end = sliceOffsets[i * 2 + 1];
                 if (start < end) {
                     queue.valueCount += (end - start);
                     queue.add(new Slice(buffer.timestamps, start, end));
@@ -144,11 +146,6 @@ class AbstractRateGroupingFunction {
             }
             return queue;
         }
-
-        @Override
-        public void close() {
-            Releasables.close(sliceOffsets);
-        }
     }
 
     static final class Slice {
@@ -156,9 +153,9 @@ class AbstractRateGroupingFunction {
         int end;
         long nextTimestamp;
         private long lastTimestamp = Long.MAX_VALUE;
-        final LongArray timestamps;
+        final LongBuffer timestamps;
 
-        Slice(LongArray timestamps, int start, int end) {
+        Slice(LongBuffer timestamps, int start, int end) {
             this.timestamps = timestamps;
             this.start = start;
             this.end = end;
@@ -211,6 +208,268 @@ class AbstractRateGroupingFunction {
         @Override
         protected boolean lessThan(Slice a, Slice b) {
             return a.nextTimestamp > b.nextTimestamp; // want the latest timestamp first
+        }
+    }
+
+    static final int PAGE_SHIFT = 12;
+    static final int PAGE_SIZE = 1 << PAGE_SHIFT;
+    static final int PAGE_MASK = PAGE_SIZE - 1;
+
+    abstract static class BufferedArray implements Releasable {
+        protected final CircuitBreaker breaker;
+        private long acquiredBytes;
+        protected long capacity;
+        protected int numPages;
+
+        BufferedArray(CircuitBreaker breaker, long initialCapacity, int bytesPerElement) {
+            this.breaker = breaker;
+            this.numPages = Math.max(1, Math.toIntExact((initialCapacity + PAGE_SIZE - 1) >>> PAGE_SHIFT));
+            long bytes = (long) numPages * PAGE_SIZE * bytesPerElement;
+            breaker.addEstimateBytesAndMaybeBreak(bytes, "buffered-array");
+            acquiredBytes = bytes;
+            capacity = (long) numPages << PAGE_SHIFT;
+        }
+
+        final void grow(long minCapacity, int bytesPerElement) {
+            if (minCapacity <= capacity) {
+                return;
+            }
+            long newSize = BigArrays.overSize(minCapacity, PageCacheRecycler.BYTE_PAGE_SIZE, bytesPerElement);
+            int newNumPages = Math.toIntExact((newSize + PAGE_SIZE - 1) >>> PAGE_SHIFT);
+            long bytes = (long) (newNumPages - numPages) * PAGE_SIZE * bytesPerElement;
+            breaker.addEstimateBytesAndMaybeBreak(bytes, "buffered-array");
+            acquiredBytes += bytes;
+            numPages = newNumPages;
+            capacity = (long) newNumPages << PAGE_SHIFT;
+        }
+
+        @Override
+        public void close() {
+            if (acquiredBytes > 0) {
+                breaker.addWithoutBreaking(-acquiredBytes);
+                acquiredBytes = 0;
+            }
+        }
+
+        static int pageIndex(long index) {
+            return (int) (index >>> PAGE_SHIFT);
+        }
+
+        static int indexInPage(long index) {
+            return (int) (index & PAGE_MASK);
+        }
+    }
+
+    /**
+     * Paged long array backed by {@code long[][]}
+     * Avoids the VarHandle byte[]-backed LongArray and leverage {@link System#arraycopy} when possible
+     */
+    static final class LongBuffer extends BufferedArray {
+        long[][] pages;
+
+        LongBuffer(CircuitBreaker breaker, long initialCapacity) {
+            super(breaker, initialCapacity, Long.BYTES);
+            pages = new long[numPages][];
+            for (int i = 0; i < numPages; i++) {
+                pages[i] = new long[PAGE_SIZE];
+            }
+        }
+
+        long get(long index) {
+            return pages[pageIndex(index)][indexInPage(index)];
+        }
+
+        void set(long index, long value) {
+            pages[pageIndex(index)][indexInPage(index)] = value;
+        }
+
+        long scanResets(int from, int to, long prevValue, double[] resets) {
+            int indexInPageStart = indexInPage(from);
+            int indexInPageEnd = indexInPageStart + (to - from);
+            if (indexInPageEnd <= PAGE_SIZE) {
+                long[] page = pages[pageIndex(from)];
+                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
+                    long val = page[i];
+                    if (val > prevValue) {
+                        resets[0] += val;
+                    }
+                    prevValue = val;
+                }
+                return prevValue;
+            }
+            for (int pos = from; pos < to; pos++) {
+                long val = pages[pageIndex(pos)][indexInPage(pos)];
+                if (val > prevValue) {
+                    resets[0] += val;
+                }
+                prevValue = val;
+            }
+            return prevValue;
+        }
+
+        void appendRange(long dst, LongVector src, int from, int count) {
+            int indexInPageStart = indexInPage(dst);
+            if (indexInPageStart + count <= PAGE_SIZE) {
+                src.copyTo(from, pages[pageIndex(dst)], indexInPageStart, count);
+                return;
+            }
+            for (int i = 0; i < count; i++) {
+                long d = dst + i;
+                pages[pageIndex(d)][indexInPage(d)] = src.getLong(from + i);
+            }
+        }
+
+        void ensureCapacity(long minCapacity) {
+            int oldNumPages = numPages;
+            grow(minCapacity, Long.BYTES);
+            if (numPages > oldNumPages) {
+                pages = Arrays.copyOf(pages, numPages);
+                for (int i = oldNumPages; i < numPages; i++) {
+                    pages[i] = new long[PAGE_SIZE];
+                }
+            }
+        }
+    }
+
+    /**
+     * Paged double array backed by {@code double[][]}
+     * Avoids the VarHandle byte[]-backed DoubleArray and leverage {@link System#arraycopy} when possible
+     */
+    static final class DoubleBuffer extends BufferedArray {
+        double[][] pages;
+
+        DoubleBuffer(CircuitBreaker breaker, long initialCapacity) {
+            super(breaker, initialCapacity, Double.BYTES);
+            pages = new double[numPages][];
+            for (int i = 0; i < numPages; i++) {
+                pages[i] = new double[PAGE_SIZE];
+            }
+        }
+
+        double get(long index) {
+            return pages[pageIndex(index)][indexInPage(index)];
+        }
+
+        void set(long index, double value) {
+            pages[pageIndex(index)][indexInPage(index)] = value;
+        }
+
+        void appendRange(long dst, DoubleVector src, int from, int count) {
+            int indexInPageStart = indexInPage(dst);
+            if (indexInPageStart + count <= PAGE_SIZE) {
+                src.copyTo(from, pages[pageIndex(dst)], indexInPageStart, count);
+                return;
+            }
+            for (int i = 0; i < count; i++) {
+                long d = dst + i;
+                pages[pageIndex(d)][indexInPage(d)] = src.getDouble(from + i);
+            }
+        }
+
+        double scanResets(int from, int to, double prevValue, double[] resets) {
+            int indexInPageStart = indexInPage(from);
+            int indexInPageEnd = indexInPageStart + (to - from);
+            if (indexInPageEnd <= PAGE_SIZE) {
+                double[] page = pages[pageIndex(from)];
+                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
+                    double val = page[i];
+                    if (val > prevValue) {
+                        resets[0] += val;
+                    }
+                    prevValue = val;
+                }
+                return prevValue;
+            }
+            for (int pos = from; pos < to; pos++) {
+                double val = pages[pageIndex(pos)][indexInPage(pos)];
+                if (val > prevValue) {
+                    resets[0] += val;
+                }
+                prevValue = val;
+            }
+            return prevValue;
+        }
+
+        void ensureCapacity(long minCapacity) {
+            int oldNumPages = numPages;
+            grow(minCapacity, Double.BYTES);
+            if (numPages > oldNumPages) {
+                pages = Arrays.copyOf(pages, numPages);
+                for (int i = oldNumPages; i < numPages; i++) {
+                    pages[i] = new double[PAGE_SIZE];
+                }
+            }
+        }
+    }
+
+    /**
+     * Paged int array backed by {@code int[][]}
+     * Avoids the VarHandle byte[]-backed IntArray and leverage {@link System#arraycopy} when possible
+     */
+    static final class IntBuffer extends BufferedArray {
+        int[][] pages;
+
+        IntBuffer(CircuitBreaker breaker, long initialCapacity) {
+            super(breaker, initialCapacity, Integer.BYTES);
+            pages = new int[numPages][];
+            for (int i = 0; i < numPages; i++) {
+                pages[i] = new int[PAGE_SIZE];
+            }
+        }
+
+        int get(long index) {
+            return pages[pageIndex(index)][indexInPage(index)];
+        }
+
+        void set(long index, int value) {
+            pages[pageIndex(index)][indexInPage(index)] = value;
+        }
+
+        void appendRange(long dst, IntVector src, int from, int count) {
+            int indexInPageStart = indexInPage(dst);
+            if (indexInPageStart + count <= PAGE_SIZE) {
+                src.copyTo(from, pages[pageIndex(dst)], indexInPageStart, count);
+                return;
+            }
+            for (int i = 0; i < count; i++) {
+                long d = dst + i;
+                pages[pageIndex(d)][indexInPage(d)] = src.getInt(from + i);
+            }
+        }
+
+        int scanResets(int from, int to, int prevValue, double[] resets) {
+            int indexInPageStart = indexInPage(from);
+            int indexInPageEnd = indexInPageStart + (to - from);
+            if (indexInPageEnd <= PAGE_SIZE) {
+                int[] page = pages[pageIndex(from)];
+                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
+                    int val = page[i];
+                    if (val > prevValue) {
+                        resets[0] += val;
+                    }
+                    prevValue = val;
+                }
+                return prevValue;
+            }
+            for (int pos = from; pos < to; pos++) {
+                int val = pages[pageIndex(pos)][indexInPage(pos)];
+                if (val > prevValue) {
+                    resets[0] += val;
+                }
+                prevValue = val;
+            }
+            return prevValue;
+        }
+
+        void ensureCapacity(long minCapacity) {
+            int oldNumPages = numPages;
+            grow(minCapacity, Integer.BYTES);
+            if (numPages > oldNumPages) {
+                pages = Arrays.copyOf(pages, numPages);
+                for (int i = oldNumPages; i < numPages; i++) {
+                    pages[i] = new int[PAGE_SIZE];
+                }
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -283,30 +283,6 @@ class AbstractRateGroupingFunction {
             pages[pageIndex(index)][indexInPage(index)] = value;
         }
 
-        long scanResets(int from, int to, long prevValue, double[] resets) {
-            int indexInPageStart = indexInPage(from);
-            int indexInPageEnd = indexInPageStart + (to - from);
-            if (indexInPageEnd <= PAGE_SIZE) {
-                long[] page = pages[pageIndex(from)];
-                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
-                    long val = page[i];
-                    if (val > prevValue) {
-                        resets[0] += val;
-                    }
-                    prevValue = val;
-                }
-                return prevValue;
-            }
-            for (int pos = from; pos < to; pos++) {
-                long val = pages[pageIndex(pos)][indexInPage(pos)];
-                if (val > prevValue) {
-                    resets[0] += val;
-                }
-                prevValue = val;
-            }
-            return prevValue;
-        }
-
         void appendRange(long dst, LongVector src, int from, int count) {
             int indexInPageStart = indexInPage(dst);
             if (indexInPageStart + count <= PAGE_SIZE) {
@@ -366,30 +342,6 @@ class AbstractRateGroupingFunction {
             }
         }
 
-        double scanResets(int from, int to, double prevValue, double[] resets) {
-            int indexInPageStart = indexInPage(from);
-            int indexInPageEnd = indexInPageStart + (to - from);
-            if (indexInPageEnd <= PAGE_SIZE) {
-                double[] page = pages[pageIndex(from)];
-                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
-                    double val = page[i];
-                    if (val > prevValue) {
-                        resets[0] += val;
-                    }
-                    prevValue = val;
-                }
-                return prevValue;
-            }
-            for (int pos = from; pos < to; pos++) {
-                double val = pages[pageIndex(pos)][indexInPage(pos)];
-                if (val > prevValue) {
-                    resets[0] += val;
-                }
-                prevValue = val;
-            }
-            return prevValue;
-        }
-
         void ensureCapacity(long minCapacity) {
             int oldNumPages = numPages;
             grow(minCapacity, Double.BYTES);
@@ -435,30 +387,6 @@ class AbstractRateGroupingFunction {
                 long d = dst + i;
                 pages[pageIndex(d)][indexInPage(d)] = src.getInt(from + i);
             }
-        }
-
-        int scanResets(int from, int to, int prevValue, double[] resets) {
-            int indexInPageStart = indexInPage(from);
-            int indexInPageEnd = indexInPageStart + (to - from);
-            if (indexInPageEnd <= PAGE_SIZE) {
-                int[] page = pages[pageIndex(from)];
-                for (int i = indexInPageStart; i < indexInPageEnd; i++) {
-                    int val = page[i];
-                    if (val > prevValue) {
-                        resets[0] += val;
-                    }
-                    prevValue = val;
-                }
-                return prevValue;
-            }
-            for (int pos = from; pos < to; pos++) {
-                int val = pages[pageIndex(pos)][indexInPage(pos)];
-                if (val > prevValue) {
-                    resets[0] += val;
-                }
-                prevValue = val;
-            }
-            return prevValue;
         }
 
         void ensureCapacity(long minCapacity) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -7,16 +7,11 @@
 package org.elasticsearch.compute.aggregation;
 
 // begin generated imports
+
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -26,12 +21,10 @@ import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 import java.util.List;
@@ -85,7 +78,6 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
     private final $Type$RawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
-    private final LocalCircuitBreaker.SingletonService localCircuitBreakerService;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
     private final boolean isRateOverTime;
@@ -103,23 +95,16 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         this.channels = channels;
         this.driverContext = driverContext;
         this.isRateOverTime = isRateOverTime;
-        LocalCircuitBreaker.SingletonService localCircuitBreakerService = new LocalCircuitBreaker.SingletonService(
-            driverContext.bigArrays().breakerService(),
-            driverContext.localBreakerSettings()
-        );
-        this.bigArrays = driverContext.bigArrays().withBreakerService(localCircuitBreakerService);
+        this.bigArrays = driverContext.bigArrays();
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
         $Type$RawBuffer buffer = null;
         try {
-            buffer = new $Type$RawBuffer(bigArrays);
+            buffer = new $Type$RawBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
-
             this.rawBuffer = buffer;
-            this.localCircuitBreakerService = localCircuitBreakerService;
             buffer = null;
-            localCircuitBreakerService = null;
         } finally {
-            Releasables.close(buffer, localCircuitBreakerService);
+            Releasables.close(buffer);
         }
     }
 
@@ -369,8 +354,8 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
     private void evaluateIntermediate(Block[] blocks, int offset, IntVector selectedInPage) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
+        var flushQueues = rawBuffer.prepareForFlush();
         try (
-            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.new$Type$BlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -409,7 +394,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, localCircuitBreakerService);
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
@@ -417,31 +402,28 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             return;
         }
         reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
-        try (var flushQueues = rawBuffer.prepareForFlush()) {
-            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
-                var flushQueue = flushQueues.getFlushQueue(groupId);
-                if (flushQueue != null) {
-                    ReducedState state = reducedStates.get(groupId);
-                    if (state == null) {
-                        state = new ReducedState();
-                        reducedStates.set(groupId, state);
-                    }
-                    flushGroup(state, rawBuffer, flushQueue);
+        var flushQueues = rawBuffer.prepareForFlush();
+        for (int groupId = flushQueues.minGroupId(); groupId <= flushQueues.maxGroupId(); groupId++) {
+            var flushQueue = flushQueues.getFlushQueue(groupId);
+            if (flushQueue != null) {
+                ReducedState state = reducedStates.get(groupId);
+                if (state == null) {
+                    state = new ReducedState();
+                    reducedStates.set(groupId, state);
                 }
+                flushGroup(state, rawBuffer, flushQueue);
             }
         }
-        rawBuffer.minGroupId = Integer.MAX_VALUE;
-        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
     static final class $Type$RawBuffer extends RawBuffer {
-        private $Type$Array values;
+        private final $Type$Buffer values;
 
-        $Type$RawBuffer(BigArrays bigArrays) {
-            super(bigArrays);
+        $Type$RawBuffer(CircuitBreaker breaker) {
+            super(breaker);
             boolean success = false;
             try {
-                this.values = bigArrays.new$Type$Array(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                this.values = new $Type$Buffer(breaker, PAGE_SIZE);
                 success = true;
             } finally {
                 if (success == false) {
@@ -453,8 +435,8 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         void prepareForAppend(int groupId, int count, long firstTimestamp) {
             prepareSlicesOnly(groupId, firstTimestamp);
             int newSize = valueCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
+            timestamps.ensureCapacity(newSize);
+            values.ensureCapacity(newSize);
         }
 
         void appendWithoutResize(long timestamp, $type$ value) {
@@ -464,17 +446,16 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
 
         void maybeResizeAndAppend(long timestamp, $type$ value) {
-            timestamps = bigArrays.grow(timestamps, valueCount + 1);
-            values = bigArrays.grow(values, valueCount + 1);
+            timestamps.ensureCapacity(valueCount + 1);
+            values.ensureCapacity(valueCount + 1);
             appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, $Type$Vector valueVector, LongVector timestampVector) {
-            for (int p = fromPosition; p < toPosition; p++) {
-                values.set(valueCount, valueVector.get$Type$(p));
-                timestamps.set(valueCount, timestampVector.getLong(p));
-                valueCount++;
-            }
+            int count = toPosition - fromPosition;
+            timestamps.appendRange(valueCount, timestampVector, fromPosition, count);
+            values.appendRange(valueCount, valueVector, fromPosition, count);
+            valueCount += count;
         }
 
         void appendRange(int fromPosition, int toPosition, $Type$Block valueBlock, LongVector timestampVector) {
@@ -522,19 +503,14 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             }
         }
         var prevValue = lastValue;
+        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
-                    if (val > prevValue) {
-                        state.resets += val;
-                    }
-                    prevValue = val;
-                }
+                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -542,7 +518,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                state.resets += val;
+                resets[0] += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -556,13 +532,8 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
         // last slice
         top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
-            if (val > prevValue) {
-                state.resets += val;
-            }
-            prevValue = val;
-        }
+        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+        state.resets = resets[0];
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
@@ -578,7 +549,8 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
     private void evaluateFinal(Block[] blocks, int offset, IntVector selectedInPage, GroupingAggregatorEvaluationContext ctx) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selectedInPage.getPositionCount();
-        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
+        var flushQueues = rawBuffer.prepareForFlush();
+        try (var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selectedInPage.getInt(p);
                 var state = group < reducedStates.size() ? reducedStates.get(group) : null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -503,14 +503,19 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             }
         }
         var prevValue = lastValue;
-        double[] resets = new double[] { state.resets };
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
             if (top.lastTimestamp() > secondNextTimestamp) {
-                prevValue = values.scanResets(top.start, top.end, prevValue, resets);
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
                 flushQueue.pop();
                 top = flushQueue.top();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -518,7 +523,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             }
             var val = values.get(top.next());
             if (val > prevValue) {
-                resets[0] += val;
+                state.resets += val;
             }
             prevValue = val;
             if (top.exhausted()) {
@@ -532,8 +537,13 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
         // last slice
         top = flushQueue.top();
-        prevValue = values.scanResets(top.start, top.end, prevValue, resets);
-        state.resets = resets[0];
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
         state.samples += flushQueue.valueCount;
         state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.DoubleBuffer;
+import org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.IntBuffer;
+import org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.LongBuffer;
+import org.elasticsearch.compute.test.ComputeTestCase;
+
+import static org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.PAGE_SIZE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+public class BufferedArrayTests extends ComputeTestCase {
+
+    public void testLongBuffer() {
+        int count = randomIntBetween(1, PAGE_SIZE * 3);
+        try (LongBuffer buf = new LongBuffer(blockFactory().breaker(), between(1, 1024))) {
+            buf.ensureCapacity(count);
+            assertThat(buf.capacity, greaterThanOrEqualTo((long) count));
+            long[] expected = new long[count];
+            for (int i = 0; i < count; i++) {
+                expected[i] = randomLong();
+                buf.set(i, expected[i]);
+            }
+            for (int i = 0; i < count; i++) {
+                assertThat(buf.get(i), equalTo(expected[i]));
+            }
+        }
+    }
+
+    public void testDoubleBuffer() {
+        int count = randomIntBetween(1, PAGE_SIZE * 3);
+        try (DoubleBuffer buf = new DoubleBuffer(blockFactory().breaker(), between(1, 1024))) {
+            buf.ensureCapacity(count);
+            double[] expected = new double[count];
+            for (int i = 0; i < count; i++) {
+                expected[i] = randomDouble();
+                buf.set(i, expected[i]);
+            }
+            for (int i = 0; i < count; i++) {
+                assertThat(buf.get(i), equalTo(expected[i]));
+            }
+        }
+    }
+
+    public void testIntBuffer() {
+        int count = randomIntBetween(1, PAGE_SIZE * 3);
+        try (IntBuffer buf = new IntBuffer(blockFactory().breaker(), between(1, 1024))) {
+            buf.ensureCapacity(count);
+            int[] expected = new int[count];
+            for (int i = 0; i < count; i++) {
+                expected[i] = randomInt();
+                buf.set(i, expected[i]);
+            }
+            for (int i = 0; i < count; i++) {
+                assertThat(buf.get(i), equalTo(expected[i]));
+            }
+        }
+    }
+
+    public void testScanResets() {
+        int count = randomIntBetween(1000, 5000);
+        try (LongBuffer buf = new LongBuffer(blockFactory().breaker(), between(1, 1024))) {
+            buf.ensureCapacity(count);
+            long[] values = new long[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = randomLongBetween(0, 1000);
+                buf.set(i, values[i]);
+            }
+            int from = randomIntBetween(0, count / 2);
+            int to = randomIntBetween(from + 1, count);
+            long prevValue = randomLongBetween(0, 1000);
+
+            double expectedResets = 0;
+            long expectedPrev = prevValue;
+            for (int i = from; i < to; i++) {
+                if (values[i] > expectedPrev) {
+                    expectedResets += values[i];
+                }
+                expectedPrev = values[i];
+            }
+
+            double[] resets = new double[] { 0.0 };
+            long prev = buf.scanResets(from, to, prevValue, resets);
+            assertThat(prev, equalTo(expectedPrev));
+            assertThat(resets[0], equalTo(expectedResets));
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
@@ -62,4 +62,5 @@ public class BufferedArrayTests extends ComputeTestCase {
                 assertThat(buf.get(i), equalTo(expected[i]));
             }
         }
-    }}
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/BufferedArrayTests.java
@@ -62,34 +62,4 @@ public class BufferedArrayTests extends ComputeTestCase {
                 assertThat(buf.get(i), equalTo(expected[i]));
             }
         }
-    }
-
-    public void testScanResets() {
-        int count = randomIntBetween(1000, 5000);
-        try (LongBuffer buf = new LongBuffer(blockFactory().breaker(), between(1, 1024))) {
-            buf.ensureCapacity(count);
-            long[] values = new long[count];
-            for (int i = 0; i < count; i++) {
-                values[i] = randomLongBetween(0, 1000);
-                buf.set(i, values[i]);
-            }
-            int from = randomIntBetween(0, count / 2);
-            int to = randomIntBetween(from + 1, count);
-            long prevValue = randomLongBetween(0, 1000);
-
-            double expectedResets = 0;
-            long expectedPrev = prevValue;
-            for (int i = from; i < to; i++) {
-                if (values[i] > expectedPrev) {
-                    expectedResets += values[i];
-                }
-                expectedPrev = values[i];
-            }
-
-            double[] resets = new double[] { 0.0 };
-            long prev = buf.scanResets(from, to, prevValue, resets);
-            assertThat(prev, equalTo(expectedPrev));
-            assertThat(resets[0], equalTo(expectedResets));
-        }
-    }
-}
+    }}


### PR DESCRIPTION
With prefix partitions, the rate buffer is much smaller than before because we can periodically reduce the buffer to intervals. This allows switching from BigArrays to primitive array pages to speed up the rate aggregation.

1. Avoid VarHandle indirection - BigArrays converts doubles to bytes when appending and bytes back to doubles when scanning. The per-row overhead is small, but significant over millions of rows.
2. Enable `System.arraycopy` when appending ranges via `Vector.copyTo`
3. Switch to primitive arrays for slice metadata, as the number of slices is small now.