### PR TITLE
fix: pin 3 unpinned action(s)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+    uses: elastic/docs-builder/.github/workflows/preview-build.yml@42b43e9b1093f392298afa717c8bf9c67e47e4c7 # main
     with:
       enable-vale-linting: true
       include-paths: |

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
+    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@42b43e9b1093f392298afa717c8bf9c67e47e4c7 # main
     permissions:
       contents: none
       id-token: write

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -49,7 +49,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: elastic/oblt-actions/updatecli/run@v1
+      - uses: elastic/oblt-actions/updatecli/run@31fd8582a94d1829536be22c624697f851fdf60e # v1
         with:
           # Runs in "--debug" mode to provide logs if the PR creation fails
           command: --experimental compose apply --debug


### PR DESCRIPTION
Re-submission of #145027. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins GitHub Actions to immutable commit SHAs instead of mutable version tags.

- Pin 3 unpinned actions to full 40-character SHAs
- Add version comments for readability

> **Note:** All pinned actions are Elastic org actions (`elastic/docs-builder`, `elastic/oblt-actions`). Pinning is still recommended as defense-in-depth, but the supply chain risk is lower since you control the repositories.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@main` becomes `action@abc123 # main`, original ref preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)