### PR TITLE
PromQL: fix Unknown column error for absent metrics

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.analysis.Analyzer.ResolveRefs.insistKeyword;
 import static org.elasticsearch.xpack.esql.core.util.CollectionUtils.combine;
@@ -237,14 +238,23 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
      * again. That's what this method does.
      */
     private static LogicalPlan refreshPlan(LogicalPlan plan, Set<UnresolvedAttribute> maybeNowResolvableAttributes) {
-        var refreshed = plan.transformExpressionsOnlyUp(UnresolvedAttribute.class, ua -> {
+        Function<UnresolvedAttribute, UnresolvedAttribute> refresh = ua -> {
             if (maybeNowResolvableAttributes.remove(ua)) {
                 // Besides clearing the message, we need to refresh the nameId to avoid equality with the previous plan.
                 // (A `new UnresolvedAttribute(ua.source(), ua.name())` would save an allocation, but is problematic with subtypes.)
                 ua = (ua.withId(new NameId())).withUnresolvedMessage(null);
             }
             return ua;
-        });
+        };
+        var refreshed = plan.transformExpressionsOnlyUp(UnresolvedAttribute.class, refresh);
+        // transformExpressionsOnlyUp does not descend into the promqlPlan (a LogicalPlan property, not an Expression).
+        // Clear custom messages there too so ResolveRefs can re-resolve them against the now-updated EsRelation.
+        if (refreshed instanceof PromqlCommand promql && maybeNowResolvableAttributes.isEmpty() == false) {
+            LogicalPlan newPromqlPlan = promql.promqlPlan().transformExpressionsDown(UnresolvedAttribute.class, refresh);
+            if (newPromqlPlan != promql.promqlPlan()) {
+                refreshed = promql.withPromqlPlan(newPromqlPlan);
+            }
+        }
         return refreshed.transformDown(Fork.class, ResolveUnmapped::patchFork);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -247,13 +247,10 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
             return ua;
         };
         var refreshed = plan.transformExpressionsOnlyUp(UnresolvedAttribute.class, refresh);
-        // transformExpressionsOnlyUp does not descend into the promqlPlan (a LogicalPlan property, not an Expression).
-        // Clear custom messages there too so ResolveRefs can re-resolve them against the now-updated EsRelation.
+        // transformExpressionsOnlyUp does not descend into the promqlPlan
+        // The promqlPlan is a separate tree and its children may contain UnresolvedAttribute expressions
         if (refreshed instanceof PromqlCommand promql && maybeNowResolvableAttributes.isEmpty() == false) {
-            LogicalPlan newPromqlPlan = promql.promqlPlan().transformExpressionsDown(UnresolvedAttribute.class, refresh);
-            if (newPromqlPlan != promql.promqlPlan()) {
-                refreshed = promql.withPromqlPlan(newPromqlPlan);
-            }
+            refreshed = promql.withPromqlPlan(promql.promqlPlan().transformExpressionsDown(UnresolvedAttribute.class, refresh));
         }
         return refreshed.transformDown(Fork.class, ResolveUnmapped::patchFork);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -152,6 +152,9 @@ public class PromqlCommand extends UnaryPlan
     }
 
     public PromqlCommand withPromqlPlan(LogicalPlan newPromqlPlan) {
+        if (newPromqlPlan == promqlPlan) {
+            return this;
+        }
         return new PromqlCommand(
             source(),
             child(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -42,7 +42,10 @@ public class PromqlVerifierTests extends ESTestCase {
     }
 
     public void testPromqlIllegalNameLabelMatcher() {
-        tsdb.error("PROMQL index=test step=5m (avg({__name__=~\"*.foo.*\"}))", containsString("Unknown column [__name__]"));
+        tsdb.error(
+            "PROMQL index=test step=5m (avg({__name__=~\"*.foo.*\"}))",
+            containsString("regex label selectors on __name__ are not supported at this time")
+        );
     }
 
     public void testPromqlSubquery() {
@@ -135,6 +138,15 @@ public class PromqlVerifierTests extends ESTestCase {
         var localRelations = plan.collect(LocalRelation.class);
         assertThat(localRelations, hasSize(1));
         assertThat(localRelations.get(0).supplier(), equalTo(EmptyLocalSupplier.EMPTY));
+    }
+
+    public void testAbsentMetricWithSimilarNameReturnsEmptyResult() {
+        // Prometheus returns empty results for non-existent metrics, not errors.
+        // The metric name must be similar enough to an existing field (Levenshtein distance >= 0.5)
+        // to trigger the "did you mean" custom message in resolveAgainstList. This is the scenario
+        // where ResolveUnmapped.refreshPlan must clear the custom message inside the promqlPlan.
+        var plan = tsdb.query("PROMQL index=test step=5m network.bites_in");
+        assertTrue("Plan should be resolved even when the metric is absent", plan.resolved());
     }
 
     public void testNoMetricNameMatcherNotSupported() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -142,11 +143,20 @@ public class PromqlVerifierTests extends ESTestCase {
 
     public void testAbsentMetricWithSimilarNameReturnsEmptyResult() {
         // Prometheus returns empty results for non-existent metrics, not errors.
-        // The metric name must be similar enough to an existing field (Levenshtein distance >= 0.5)
-        // to trigger the "did you mean" custom message in resolveAgainstList. This is the scenario
-        // where ResolveUnmapped.refreshPlan must clear the custom message inside the promqlPlan.
+        // It uses the load_unmapped="nullify" functionality to do that.
+        // There was a bug in this mechanism where it would throw an exception if the metric name was similar enough to an existing field,
+        // due to a "did you mean" message being left in the plan after resolution.
+        // This test ensures that the fix for that bug is working correctly.
         var plan = tsdb.query("PROMQL index=test step=5m network.bites_in");
         assertTrue("Plan should be resolved even when the metric is absent", plan.resolved());
+    }
+
+    public void testSimilarFieldInNonPromqlQueryFailsWithDidYouMean() {
+        // Showcases the did you mean message for non PROMQL queries.
+        tsdb.error(
+            "FROM test | WHERE network.bites_in > 0",
+            allOf(containsString("Unknown column [network.bites_in], did you mean any of ["), containsString("network.bytes_in"))
+        );
     }
 
     public void testNoMetricNameMatcherNotSupported() {


### PR DESCRIPTION
When a PromQL metric name is similar to an existing field (Levenshtein distance ≥ 0.5), `ResolveRefs` attaches a "did you mean" custom message to the `UnresolvedAttribute`. `ResolveUnmapped` clears these messages in `refreshPlan` so that `ResolveRefs` can attempt resolution again — but it was only doing so for the main plan expressions, not for the `promqlPlan` sub-plan inside a `PromqlCommand` (which is a `LogicalPlan` property, not an `Expression`, so `transformExpressionsOnlyUp` does not descend into it).

The fix extends `refreshPlan` to also clear custom messages inside `promqlPlan`, allowing absent metrics with similar-sounding names to correctly resolve to an empty result rather than throwing an `Unknown column` error.

Example stack trace:

<details>
<summary>Click to expand ...</summary>

```
PromQL query_range request failed org.elasticsearch.xpack.esql.VerificationException: Found 1 problem
line 0:14: Unknown column [prometheus_tsdb_head_series_not_found], did you mean any of [prometheus_tsdb_head_series_not_found_total, prometheus_tsdb_head_series_removed_total, prometheus_tsdb_head_series_created_total, prometheus_tsdb_head_series, metrics.prometheus_tsdb_head_series_not_found_total, prometheus_tsdb_head_samples_appended_total, prometheus_tsdb_head_min_time, prometheus_tsdb_head_stale_series, prometheus_tsdb_head_chunks_created_total, prometheus_tsdb_head_chunks_removed_total, metrics.prometheus_tsdb_head_series_removed_total, metrics.prometheus_tsdb_head_series_created_total, prometheus_tsdb_head_truncations_total, prometheus_tsdb_head_gc_duration_seconds_count, prometheus_tsdb_head_min_time_seconds, prometheus_tsdb_head_active_appenders, prometheus_tsdb_head_max_time, prometheus_tsdb_wal_segment_current, prometheus_tsdb_head_max_time_seconds, prometheus_tsdb_sample_ooo_delta_count, prometheus_tsdb_mmap_chunks_total, prometheus_tsdb_head_chunks, prometheus_tsdb_wal_writes_failed_total, prometheus_tsdb_head_truncations_failed_total, prometheus_tsdb_head_gc_duration_seconds_sum, prometheus_tsdb_reloads_total, prometheus_tsdb_wal_corruptions_total, prometheus_tsdb_size_retentions_total, prometheus_tsdb_time_retentions_total, prometheus_tsdb_wal_storage_size_bytes, prometheus_tsdb_reloads_failures_total, prometheus_tsdb_lowest_timestamp_seconds, metrics.prometheus_tsdb_head_samples_appended_total, prometheus_tsdb_wal_record_bytes_saved_total, prometheus_tsdb_head_chunks_storage_size_bytes, prometheus_tsdb_wal_fsync_duration_seconds_count, prometheus_tsdb_compactions_total, prometheus_tsdb_sample_ooo_delta_sum, prometheus_sd_updates_total, prometheus_tsdb_blocks_loaded, prometheus_tsdb_clean_start, prometheus_tsdb_wal_truncations_total, prometheus_tsdb_too_old_samples_total, prometheus_tsdb_retention_limit_seconds, metrics.prometheus_tsdb_head_gc_duration_seconds_count, prometheus_http_response_size_bytes_count, prometheus_tsdb_snapshot_replay_error_total, metrics.prometheus_tsdb_head_chunks_removed_total, metrics.prometheus_tsdb_head_chunks_created_total, prometheus_tsdb_compaction_duration_seconds_count, prometheus_tsdb_wal_page_flushes_total, prometheus_tsdb_checkpoint_deletions_total, prometheus_tsdb_vertical_compactions_total, prometheus_tsdb_wal_fsync_duration_seconds, prometheus_tsdb_checkpoint_creations_total, prometheus_tsdb_data_replay_duration_seconds, prometheus_tsdb_wal_record_part_writes_total, metrics.prometheus_tsdb_head_truncations_total, prometheus_tsdb_head_out_of_order_samples_appended_total, prometheus_sd_file_read_errors_total, prometheus_tsdb_lowest_timestamp, metrics.prometheus_tsdb_head_series, prometheus_sd_nomad_failures_total, prometheus_sd_azure_cache_hit_total, prometheus_sd_http_failures_total, prometheus_sd_discovered_targets, prometheus_tsdb_retention_limit_bytes, prometheus_sd_failed_configs, prometheus_tsdb_sample_ooo_delta_bucket, prometheus_tsdb_wal_completed_pages_total, prometheus_tsdb_compactions_triggered_total, prometheus_tsdb_exemplar_exemplars_in_storage, metrics.prometheus_tsdb_head_max_time_seconds, metrics.prometheus_tsdb_head_active_appenders, metrics.prometheus_tsdb_head_min_time_seconds, prometheus_tsdb_tombstone_cleanup_seconds_count, prometheus_tsdb_checkpoint_creations_failed_total, prometheus_tsdb_compaction_chunk_size_bytes_count, prometheus_tsdb_checkpoint_deletions_failed_total, prometheus_tsdb_exemplar_exemplars_appended_total, prometheus_tsdb_wal_truncate_duration_seconds_count, prometheus_tsdb_exemplar_series_with_exemplars_in_storage, prometheus_tsdb_isolation_high_watermark, prometheus_tsdb_compaction_chunk_range_seconds_count, prometheus_tsdb_wal_truncations_failed_total, prometheus_tsdb_wal_record_parts_bytes_written_total, prometheus_sd_file_scan_duration_seconds_count, prometheus_tsdb_mmap_chunk_corruptions_total, prometheus_tsdb_compactions_failed_total, prometheus_tsdb_out_of_order_samples_total, prometheus_tsdb_compaction_chunk_samples_count, metrics.prometheus_tsdb_sample_ooo_delta_count]?
        at org.elasticsearch.xpack.esql.analysis.Analyzer.verify(Analyzer.java:285)
        at org.elasticsearch.xpack.esql.analysis.Analyzer.analyze(Analyzer.java:279)
        at org.elasticsearch.xpack.esql.session.EsqlSession.analyzedPlan(EsqlSession.java:1456)
        at org.elasticsearch.xpack.esql.session.EsqlSession.analyzeWithRetry(EsqlSession.java:1389)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$resolveIndicesAndAnalyze$26(EsqlSession.java:947)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:111)
        at org.elasticsearch.xpack.esql.inference.InferenceResolver.resolveInferenceIds(InferenceResolver.java:109)
        at org.elasticsearch.xpack.esql.inference.InferenceResolver.resolveInferenceIds(InferenceResolver.java:103)
        at org.elasticsearch.xpack.esql.inference.InferenceResolver.resolveInferenceIds(InferenceResolver.java:66)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$resolveIndicesAndAnalyze$25(EsqlSession.java:943)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:111)
        at org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver.resolvePolicies(EnrichPolicyResolver.java:133)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$resolveIndicesAndAnalyze$24(EsqlSession.java:935)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.xpack.esql.session.EsqlSession.preAnalyzeExternalSources(EsqlSession.java:1005)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$resolveIndicesAndAnalyze$23(EsqlSession.java:932)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.xpack.esql.session.EsqlSession.forAll(EsqlSession.java:1525)
        at org.elasticsearch.xpack.esql.session.EsqlSession.preAnalyzeLookupIndices(EsqlSession.java:961)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$resolveIndicesAndAnalyze$22(EsqlSession.java:931)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:111)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener$SuccessResult.complete(SubscribableListener.java:427)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.tryComplete(SubscribableListener.java:347)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.setResult(SubscribableListener.java:376)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.SubscribableListener.onResponse(SubscribableListener.java:283)
        at org.elasticsearch.xpack.esql.session.EsqlSession.forAll(EsqlSession.java:1525)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$forAll$40(EsqlSession.java:1523)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$preAnalyzeMainIndices$36(EsqlSession.java:1310)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.xpack.esql.session.IndexResolver.lambda$doResolveIndices$4(IndexResolver.java:238)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.tasks.TaskManager$1.onResponse(TaskManager.java:223)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.tasks.TaskManager$1.onResponse(TaskManager.java:217)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$RunBeforeActionListener.onResponse(ActionListenerImplementations.java:350)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:33)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:111)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction.mergeIndexResponses(TransportFieldCapabilitiesAction.java:581)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction.lambda$doExecuteForked$6(TransportFieldCapabilitiesAction.java:374)
        at org.elasticsearch.base@9.4.0-SNAPSHOT/org.elasticsearch.core.AbstractRefCounted$1.closeInternal(AbstractRefCounted.java:125)
        at org.elasticsearch.base@9.4.0-SNAPSHOT/org.elasticsearch.core.AbstractRefCounted.decRef(AbstractRefCounted.java:77)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.support.RefCountingRunnable.close(RefCountingRunnable.java:122)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.RunOnce.run(RunOnce.java:44)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.RequestDispatcher.innerExecute(RequestDispatcher.java:177)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.RequestDispatcher$1.doRun(RequestDispatcher.java:146)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction$2.onResponse(TransportFieldCapabilitiesAction.java:518)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction$2.onResponse(TransportFieldCapabilitiesAction.java:514)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractThrottledTaskRunner$1.doRun(AbstractThrottledTaskRunner.java:140)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1114)
        at org.elasticsearch.server@9.4.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```
</details>