### PR TITLE
ESQL: Fix Windows path handling and ExtraFS filtering in local storage tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -219,9 +219,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/suggested_type}
   issue: https://github.com/elastic/elasticsearch/issues/142525
-- class: org.elasticsearch.xpack.esql.datasources.GlobDiscoveryLocalTests
-  method: testRecursiveDoubleStarAllFiles
-  issue: https://github.com/elastic/elasticsearch/issues/142576
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/suggested_type}
   issue: https://github.com/elastic/elasticsearch/issues/142525

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
@@ -118,11 +118,7 @@ public final class LocalStorageProvider implements StorageProvider {
      */
     @SuppressForbidden(reason = "LocalStorageProvider converts user-supplied file:// URIs to Path objects")
     private Path toFilePath(StoragePath storagePath) {
-        String pathStr = storagePath.path();
-
-        // Handle file:// URLs - the path() method returns the path component after the scheme
-        // For file:///absolute/path, path() returns "/absolute/path"
-        // For file://relative/path, path() returns "relative/path"
+        String pathStr = storagePath.localPath();
 
         if (pathStr == null || pathStr.isEmpty()) {
             throw new IllegalArgumentException("Path cannot be empty for file:// scheme");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
@@ -138,6 +138,19 @@ public final class StoragePath {
         return path;
     }
 
+    /**
+     * Returns the path component adjusted for use as a local filesystem path.
+     * On Windows, file:// URIs produce paths like {@code /C:/dir/file} where the
+     * leading slash is invalid for the OS. This method strips it when a drive letter
+     * is detected so the result can be passed to {@code PathUtils.get()} safely.
+     */
+    public String localPath() {
+        if (path.length() >= 3 && path.charAt(0) == '/' && Character.isLetter(path.charAt(1)) && path.charAt(2) == ':') {
+            return path.substring(1);
+        }
+        return path;
+    }
+
     public String objectName() {
         if (path.isEmpty() || path.equals(PATH_SEPARATOR)) {
             return "";

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobDiscoveryLocalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobDiscoveryLocalTests.java
@@ -281,7 +281,7 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
 
         @Override
         public StorageIterator listObjects(StoragePath prefix, boolean recursive) throws IOException {
-            Path dirPath = PathUtils.get(prefix.path());
+            Path dirPath = PathUtils.get(prefix.localPath());
             if (Files.exists(dirPath) == false || Files.isDirectory(dirPath) == false) {
                 return emptyIterator();
             }
@@ -291,7 +291,7 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
                 Files.walkFileTree(dirPath, new SimpleFileVisitor<>() {
                     @Override
                     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                        if (attrs.isRegularFile()) {
+                        if (attrs.isRegularFile() && isExtraFSFile(file) == false) {
                             entries.add(toEntry(file, attrs));
                         }
                         return FileVisitResult.CONTINUE;
@@ -301,7 +301,7 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(dirPath)) {
                     for (Path entry : stream) {
                         BasicFileAttributes attrs = Files.readAttributes(entry, BasicFileAttributes.class);
-                        if (attrs.isRegularFile()) {
+                        if (attrs.isRegularFile() && isExtraFSFile(entry) == false) {
                             entries.add(toEntry(entry, attrs));
                         }
                     }
@@ -330,7 +330,7 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
 
         @Override
         public boolean exists(StoragePath path) {
-            return Files.exists(PathUtils.get(path.path()));
+            return Files.exists(PathUtils.get(path.localPath()));
         }
 
         @Override
@@ -344,6 +344,10 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
         private static StorageEntry toEntry(Path file, BasicFileAttributes attrs) {
             StoragePath storagePath = StoragePath.of(StoragePath.fileUri(file));
             return new StorageEntry(storagePath, attrs.size(), attrs.lastModifiedTime().toInstant());
+        }
+
+        private static boolean isExtraFSFile(Path file) {
+            return file.getFileName().toString().startsWith("extra");
         }
 
         private static StorageIterator emptyIterator() {
@@ -393,7 +397,7 @@ public class GlobDiscoveryLocalTests extends ESTestCase {
 
         @Override
         public boolean exists() {
-            return Files.exists(PathUtils.get(path.path()));
+            return Files.exists(PathUtils.get(path.localPath()));
         }
 
         @Override


### PR DESCRIPTION
## Summary

`StoragePath.path()` returns a URI path component (e.g. `/C:/path/...`) which is invalid when passed directly to `PathUtils.get()` on Windows — the leading slash before the drive letter causes `InvalidPathException`. This affected both `LocalStorageProvider` and the test-only `TestLocalStorageProvider` in `GlobDiscoveryLocalTests`.

Separately, Lucene's ExtraFS test infrastructure creates extra files in temp directories that the `TestLocalStorageProvider` did not filter out, causing `testRecursiveDoubleStarAllFiles` to find more files than expected.

- **StoragePath**: Add `localPath()` method that strips the leading `/` before Windows drive letters
- **LocalStorageProvider**: Use `localPath()` instead of `path()` when converting to filesystem paths
- **GlobDiscoveryLocalTests**: Use `localPath()` for path conversion and filter out ExtraFS files in `TestLocalStorageProvider`
- **muted-tests.yml**: Unmute `GlobDiscoveryLocalTests.testRecursiveDoubleStarAllFiles`

Closes #142574
Closes #142576
Closes #142631