### PR TITLE
[9.3][DiskBBQ] Fix failure in testIndexSortOnFlush

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
@@ -281,16 +281,22 @@ public class ES920DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase
     public void testIndexSortOnFlush() throws IOException {
         IndexWriterConfig config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format))
             .setIndexSort(new Sort(new SortField("sort", SortField.Type.STRING)))
-            .setMergePolicy(NoMergePolicy.INSTANCE);
+            .setMergePolicy(NoMergePolicy.INSTANCE)
+            .setMaxBufferedDocs(10)
+            .setRAMBufferSizeMB(1);
+        ;
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, config)) {
-            float[] vectorA = new float[] { 0f, 3f };
-            float[] vectorB = new float[] { 0f, 2f };
-            float[] vectorC = new float[] { 0f, 1f };
+            float[] vectorA = new float[] { 3f, 3f };
+            float[] vectorB = new float[] { 0f, 0f };
+            float[] vectorC = new float[] { -3f, -3f };
             addSortedVectorDoc(w, "c", vectorC);
             addSortedVectorDoc(w, "a", vectorA);
             addSortedVectorDoc(w, "b", vectorB);
             w.commit();
             try (IndexReader reader = DirectoryReader.open(dir)) {
+                if (reader.leaves().size() != 1) {
+                    w.forceMerge(1);
+                }
                 LeafReader leafReader = getOnlyLeafReader(reader);
 
                 // we might collect the same document twice because of soar assignments

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -322,11 +322,14 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
     public void testIndexSortOnFlush() throws IOException {
         IndexWriterConfig config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format))
             .setIndexSort(new Sort(new SortField("sort", SortField.Type.STRING)))
-            .setMergePolicy(NoMergePolicy.INSTANCE);
+            .setMergePolicy(NoMergePolicy.INSTANCE)
+            .setMaxBufferedDocs(10)
+            .setRAMBufferSizeMB(1);
+        ;
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, config)) {
-            float[] vectorA = new float[] { 0f, 3f };
-            float[] vectorB = new float[] { 0f, 2f };
-            float[] vectorC = new float[] { 0f, 1f };
+            float[] vectorA = new float[] { 3f, 3f };
+            float[] vectorB = new float[] { 0f, 0f };
+            float[] vectorC = new float[] { -3f, -3f };
             addSortedVectorDoc(w, "c", vectorC);
             addSortedVectorDoc(w, "a", vectorA);
             addSortedVectorDoc(w, "b", vectorB);


### PR DESCRIPTION
backport https://github.com/elastic/elasticsearch/pull/145082