### PR TITLE
WIP: prune sequence numbers on integration tests

### DIFF
--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
@@ -60,6 +60,11 @@ public class MoreExpressionIT extends ESIntegTestCase {
         return Collections.singleton(ExpressionPlugin.class);
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
     private SearchRequestBuilder buildRequest(String script, Object... params) {
         ensureGreen("test");
 

--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/StoredExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/StoredExpressionIT.java
@@ -26,6 +26,12 @@ import static org.hamcrest.Matchers.containsString;
 
 //TODO: please convert to unit tests!
 public class StoredExpressionIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryConcurrentTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryConcurrentTests.java
@@ -24,6 +24,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DeleteByQueryConcurrentTests extends ReindexTestCase {
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // delete by query requires sequence numbers
+    }
+
     public void testConcurrentDeleteByQueriesOnDifferentDocs() throws Throwable {
         final int threadCount = scaledRandomIntBetween(2, 5);
         final long docs = randomIntBetween(1, 50);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWhileModifyingTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWhileModifyingTests.java
@@ -31,6 +31,11 @@ public class UpdateByQueryWhileModifyingTests extends ReindexTestCase {
     private static final int MAX_MUTATIONS = 50;
     private static final int MAX_ATTEMPTS = 50;
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
     public void testUpdateWhileReindexing() throws Exception {
         AtomicReference<String> value = new AtomicReference<>(randomSimpleString(random()));
         indexRandom(true, prepareIndex("test").setId("test").setSource("test", value.get()));

--- a/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/BulkRestIT.java
+++ b/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/BulkRestIT.java
@@ -34,6 +34,11 @@ import static org.hamcrest.Matchers.equalTo;
 public class BulkRestIT extends HttpSmokeTestCase {
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
+    @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -124,6 +124,12 @@ public class IndicesRequestIT extends ESIntegTestCase {
     }
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        // updates require sequence numbers to be available
+        return false;
+    }
+
+    @Override
     protected Settings nodeSettings(int ordinal, Settings otherSettings) {
         // must set this independently of the plugin so it overrides MockTransportService
         return Settings.builder()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -65,6 +65,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
     protected Settings.Builder setRandomIndexSettings(Random random, Settings.Builder builder) {
         var b = super.setRandomIndexSettings(random, builder);
         b.remove(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey());
+        b.remove(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey());
         return b;
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -55,6 +55,11 @@ public class BulkIntegrationIT extends ESIntegTestCase {
         return Arrays.asList(IngestTestPlugin.class);
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;
+    }
+
     public void testBulkIndexCreatesMapping() throws Exception {
         String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/bulk-log.json");
         BulkRequestBuilder bulkBuilder = client().prepareBulk();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -56,6 +56,11 @@ import static org.hamcrest.Matchers.nullValue;
 public class BulkWithUpdatesIT extends ESIntegTestCase {
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates required sequence numbers
+    }
+
+    @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(InternalSettingsPlugin.class, CustomScriptPlugin.class);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
@@ -47,6 +47,11 @@ import static org.hamcrest.Matchers.notNullValue;
 public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false; // seq no pruning is controlled explicitly
+    }
+
+    @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return CollectionUtils.appendToCopyNoNullElements(super.nodePlugins(), DataStreamsPlugin.class);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
@@ -29,8 +29,14 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ShardInfoIT extends ESIntegTestCase {
+
     private int numCopies;
     private int numNodes;
+
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
 
     public void testIndexAndDelete() throws Exception {
         prepareIndex(1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -46,6 +46,11 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 public class WaitUntilRefreshIT extends ESIntegTestCase {
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
+    @Override
     public Settings indexSettings() {
         // Use a shorter refresh interval to speed up the tests. We'll be waiting on this interval several times.
         return Settings.builder().put(super.indexSettings()).put("index.refresh_interval", "40ms").build();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -41,6 +41,11 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
             .toList();
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;
+    }
+
     public void testGlobalCheckpointSyncWithAsyncDurability() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
         prepareCreate(

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -63,6 +63,11 @@ public class IngestClientIT extends ESIntegTestCase {
         return List.of(ExtendedIngestTestPlugin.class);
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;
+    }
+
     public void testSimulate() throws Exception {
         putJsonPipeline(
             "_id",

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
@@ -34,6 +34,11 @@ public class AliasRoutingIT extends ESIntegTestCase {
         return 2;
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false; // updates require sequence numbers
+    }
+
     public void testAliasCrudRouting() throws Exception {
         createIndex("test");
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -49,6 +49,11 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         return 2;
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false; // updates require sequence numbers
+    }
+
     public String findNonMatchingRoutingValue(String index, String id) {
         ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
         IndexMetadata metadata = state.metadata().getProject().index(index);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -314,6 +314,11 @@ public class TopHitsIT extends ESIntegTestCase {
         ensureSearchable();
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // fetch features test requires sequence numbers
+    }
+
     private String key(Terms.Bucket bucket) {
         return bucket.getKeyAsString();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
@@ -81,6 +81,11 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         }
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false; // sequence number pruning is explicitly handled
+    }
+
     public void testConsistentHitsWithSameSeed() throws Exception {
         createIndex("test");
         ensureGreen(); // make sure we are done otherwise preference could change?

--- a/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
@@ -139,6 +139,11 @@ public class UpdateIT extends ESIntegTestCase {
         return Arrays.asList(UpdateScriptsPlugin.class, InternalSettingsPlugin.class);
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // sequence numbers are required for updates
+    }
+
     private void createTestIndex() throws Exception {
         logger.info("--> creating index test");
         assertAcked(prepareCreate("test").addAlias(new Alias("alias").writeIndex(randomFrom(true, null))));

--- a/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateNoopIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateNoopIT.java
@@ -26,6 +26,12 @@ import static org.hamcrest.Matchers.notNullValue;
  * Tests for noop updates.
  */
 public class UpdateNoopIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // sequence numbers required for updates
+    }
+
     public void testSingleField() throws Exception {
         updateAndCheckSource(0, 1, fields("bar", "baz"));
         updateAndCheckSource(0, 1, fields("bar", "baz"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -115,6 +115,11 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
 
     private static final Pattern EXTRACT_VERSION = Pattern.compile("current document has seqNo \\[(\\d+)\\] and primary term \\[(\\d+)\\]");
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // sequence numbers required for these tests
+    }
+
     // Test info: disrupt network for up to 8s in a number of rounds and check that we only get true positive CAS results when running
     // multiple threads doing CAS updates.
     // Wait up to 1 minute (+10s in thread to ensure it does not time out) for threads to complete previous round before initiating next

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -40,6 +40,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class SimpleVersioningIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false; // sequence numbers required for versioning
+    }
+
     public void testExternalVersioningInitialDelete() throws Exception {
         createIndex("test");
         ensureGreen();

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1058,26 +1058,6 @@ public final class IndexSettings {
             @Override
             public void validate(Boolean enabled, Map<Setting<?>, Object> settings) {
                 if (enabled) {
-                    var indexVersion = (IndexVersion) settings.get(SETTING_INDEX_VERSION_CREATED);
-                    if (indexVersion.equals(IndexVersions.ZERO)) {
-                        // Settings are validated in different places before a real indexVersion has been assigned or is missing for other
-                        // reasons (eg. composable index templates). In those cases IndexVersion.ZERO is used as fallback value, and we
-                        // don't want to fail those validations so we return early here because the next two validation checks require
-                        // the IndexMetadata.SETTING_INDEX_VERSION_CREATED to be set. At index creation time we _will_ validate with the
-                        // creation version.
-                        return;
-                    }
-                    if (indexVersion.onOrAfter(IndexVersions.DISABLE_SEQUENCE_NUMBERS) == false) {
-                        throw new IllegalArgumentException(
-                            String.format(
-                                Locale.ROOT,
-                                "The setting [%s] is only permitted for indexVersion [%s] or later. Current indexVersion: [%s].",
-                                DISABLE_SEQUENCE_NUMBERS.getKey(),
-                                IndexVersions.DISABLE_SEQUENCE_NUMBERS,
-                                indexVersion
-                            )
-                        );
-                    }
                     // Sequence numbers cannot be trimmed for points, so we enforce doc values only usage
                     var seqNoIndexOptions = (SeqNoFieldMapper.SeqNoIndexOptions) settings.get(SEQ_NO_INDEX_OPTIONS_SETTING);
                     if (seqNoIndexOptions != SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY) {

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -1194,25 +1194,4 @@ public class IndexSettingsTests extends ESTestCase {
             )
         );
     }
-
-    public void testDisableSequenceNumbersValidationWithInvalidVersion() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-        IndexVersion badVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DISABLE_SEQUENCE_NUMBERS);
-
-        Settings settings = Settings.builder().put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true).build();
-        IndexMetadata indexMetadata = newIndexMeta("some-index", settings, badVersion);
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new IndexSettings(indexMetadata, Settings.EMPTY));
-        assertThat(
-            e.getMessage(),
-            Matchers.containsString(
-                String.format(
-                    Locale.ROOT,
-                    "The setting [%s] is only permitted for indexVersion [%s] or later. Current indexVersion: [%s].",
-                    IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(),
-                    IndexVersions.DISABLE_SEQUENCE_NUMBERS,
-                    badVersion
-                )
-            )
-        );
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -512,9 +512,14 @@ public abstract class ESIntegTestCase extends ESTestCase {
         if (randomBoolean()) {
             builder.put(IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING.getKey(), randomBoolean());
         }
+        if (allowRandomSequenceNumberPruning()) {
+            builder.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
+        }
+        /*
         if (randomBoolean()) {
             builder.put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), randomFrom(SeqNoFieldMapper.SeqNoIndexOptions.values()));
         }
+         */
         return builder;
     }
 
@@ -750,6 +755,10 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     protected int numberOfReplicas() {
         return between(minimumNumberOfReplicas(), maximumNumberOfReplicas());
+    }
+
+    protected boolean allowRandomSequenceNumberPruning() {
+        return true;
     }
 
     public void setDisruptionScheme(ServiceDisruptionScheme scheme) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AsyncEsqlQueryActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AsyncEsqlQueryActionIT.java
@@ -60,6 +60,11 @@ import static org.hamcrest.Matchers.notNullValue;
 public class AsyncEsqlQueryActionIT extends AbstractPausableIntegTestCase {
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
+    @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         ArrayList<Class<? extends Plugin>> actions = new ArrayList<>(super.nodePlugins());
         actions.add(EsqlAsyncActionIT.LocalStateEsqlAsync.class);

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -70,6 +70,11 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         this.useSyntheticSource = useSyntheticSource;
     }
 
+    @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return List.of(

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/BulkUpdateTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/BulkUpdateTests.java
@@ -33,6 +33,11 @@ public class BulkUpdateTests extends SecurityIntegTestCase {
     }
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
+    @Override
     public Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -114,6 +114,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     @Override
+    protected boolean allowRandomSequenceNumberPruning() {
+        return false;   // updates require sequence numbers
+    }
+
+    @Override
     protected String configUsers() {
         final String usersPasswHashed = new String(getFastStoredHashAlgoForTests().hash(USERS_PASSWD));
         return super.configUsers()


### PR DESCRIPTION
Enables pruning sequence numbers on all integration tests unless explicitly disallowed at suite level.  Eventually this will be randomized but at the moment it's fixed to always-on to flush out tests that need it to be disabled.