### PR TITLE
Reduce Calls to Inference Service

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -171,9 +171,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointServiceNodeTests
   method: testGetCheckpointStats
   issue: https://github.com/elastic/elasticsearch/issues/141112
-- class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
-  method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
-  issue: https://github.com/elastic/elasticsearch/issues/141200
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:boolean.convertFromIntAndLong}
   issue: https://github.com/elastic/elasticsearch/issues/141375

--- a/x-pack/plugin/ent-search/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/40_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/40_rule_query_search.yml
@@ -691,6 +691,7 @@ teardown:
                     '_id': 'pinned_doc2'
   - do:
       search:
+        index: test-index-with-sparse-vector
         body:
           query:
             rule:
@@ -709,6 +710,7 @@ teardown:
 
   - do:
       search:
+        index: test-index-with-sparse-vector
         body:
           query:
             rule:
@@ -727,6 +729,7 @@ teardown:
 
   - do:
       search:
+        index: test-index-with-sparse-vector
         body:
           query:
             rule:

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceKnnVectorQueryBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceKnnVectorQueryBuilder.java
@@ -76,7 +76,7 @@ public class InterceptedInferenceKnnVectorQueryBuilder extends InterceptedInfere
         boolean interceptedCcsRequest
     ) {
         super(other, inferenceResultsMap, inferenceInfoFuture, interceptedCcsRequest);
-        this.queryVectorSupplier = null;
+        this.queryVectorSupplier = other instanceof InterceptedInferenceKnnVectorQueryBuilder knn ? knn.queryVectorSupplier : null;
     }
 
     private InterceptedInferenceKnnVectorQueryBuilder(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceSparseVectorQueryBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceSparseVectorQueryBuilder.java
@@ -73,7 +73,7 @@ public class InterceptedInferenceSparseVectorQueryBuilder extends InterceptedInf
         boolean interceptedCcsRequest
     ) {
         super(other, inferenceResultsMap, inferenceInfoFuture, interceptedCcsRequest);
-        this.queryVectorSupplier = null;
+        this.queryVectorSupplier = other instanceof InterceptedInferenceSparseVectorQueryBuilder sparse ? sparse.queryVectorSupplier : null;
     }
 
     private InterceptedInferenceSparseVectorQueryBuilder(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceKnnVectorQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceKnnVectorQueryBuilderTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.queries;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
@@ -48,6 +49,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class InterceptedInferenceKnnVectorQueryBuilderTests extends AbstractInterceptedInferenceQueryBuilderTestCase<
     KnnVectorQueryBuilder> {
@@ -521,5 +523,49 @@ public class InterceptedInferenceKnnVectorQueryBuilderTests extends AbstractInte
                 )
             );
         }
+    }
+
+    public void testCopyPreservesQueryVectorSupplier() throws IOException {
+        final String field = "test_field";
+        final TestIndex testIndex = new TestIndex("test-index", Map.of(field, DENSE_INFERENCE_ID), Map.of());
+        final KnnVectorQueryBuilder knnQuery = new KnnVectorQueryBuilder(
+            field,
+            new TextEmbeddingQueryVectorBuilder(DENSE_INFERENCE_ID, "test query"),
+            10,
+            100,
+            10f,
+            null
+        );
+
+        InterceptedInferenceKnnVectorQueryBuilder intercepted = new InterceptedInferenceKnnVectorQueryBuilder(knnQuery, Map.of());
+
+        // Before rewrite, queryVectorSupplier is null so getQuery() returns the model text
+        assertThat(intercepted.getQuery(), equalTo("test query"));
+
+        // Create a query rewrite context
+        final QueryRewriteContext queryRewriteContext = createQueryRewriteContext(
+            Map.of(testIndex.name(), testIndex.semanticTextFields()),
+            Map.of(),
+            TransportVersion.current(),
+            null
+        );
+
+        // customDoRewriteWaitForInferenceResults registers a query vector builder async action,
+        // returning a new instance with queryVectorSupplier set
+        InterceptedInferenceKnnVectorQueryBuilder afterCustomRewrite = (InterceptedInferenceKnnVectorQueryBuilder) intercepted
+            .customDoRewriteWaitForInferenceResults(queryRewriteContext);
+
+        // queryVectorSupplier is now set (non-null), so getQuery() should return null
+        assertThat(afterCustomRewrite.getQuery(), nullValue());
+
+        // copy() should preserve queryVectorSupplier
+        InterceptedInferenceKnnVectorQueryBuilder copied = afterCustomRewrite.copy(
+            afterCustomRewrite.inferenceResultsMap,
+            new PlainActionFuture<>(),
+            false
+        );
+
+        // Verify queryVectorSupplier was preserved: getQuery() should still return null
+        assertThat(copied.getQuery(), nullValue());
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceSparseVectorQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/InterceptedInferenceSparseVectorQueryBuilderTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.queries;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -33,6 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class InterceptedInferenceSparseVectorQueryBuilderTests extends AbstractInterceptedInferenceQueryBuilderTestCase<
     SparseVectorQueryBuilder> {
@@ -209,5 +211,53 @@ public class InterceptedInferenceSparseVectorQueryBuilderTests extends AbstractI
             sparseVectorQuery.shouldPruneTokens(),
             sparseVectorQuery.getTokenPruningConfig()
         ).boost(sparseVectorQuery.boost()).queryName(sparseVectorQuery.queryName());
+    }
+
+    public void testCopyPreservesQueryVectorSupplier() {
+        final String field = "test_field";
+        final TestIndex testIndex = new TestIndex("test-index", Map.of(field, SPARSE_INFERENCE_ID), Map.of());
+        final SparseVectorQueryBuilder sparseVectorQuery = new SparseVectorQueryBuilder(
+            field,
+            null,
+            SPARSE_INFERENCE_ID,
+            "test query",
+            false,
+            null
+        );
+
+        InterceptedInferenceSparseVectorQueryBuilder intercepted = new InterceptedInferenceSparseVectorQueryBuilder(
+            sparseVectorQuery,
+            Map.of()
+        );
+
+        // Before rewrite, queryVectorSupplier is null so getQuery() returns the query text
+        assertThat(intercepted.getQuery(), equalTo("test query"));
+
+        // Create a query rewrite context
+        final QueryRewriteContext queryRewriteContext = createQueryRewriteContext(
+            Map.of(testIndex.name(), testIndex.semanticTextFields()),
+            Map.of(),
+            TransportVersion.current(),
+            null
+        );
+
+        // customDoRewriteWaitForInferenceResults registers a sparse inference async action,
+        // returning a new instance with queryVectorSupplier set
+        InterceptedInferenceSparseVectorQueryBuilder afterCustomRewrite = intercepted.customDoRewriteWaitForInferenceResults(
+            queryRewriteContext
+        );
+
+        // queryVectorSupplier is now set (non-null), so getQuery() should return null
+        assertThat(afterCustomRewrite.getQuery(), nullValue());
+
+        // copy() should preserve queryVectorSupplier
+        InterceptedInferenceSparseVectorQueryBuilder copied = afterCustomRewrite.copy(
+            afterCustomRewrite.inferenceResultsMap,
+            new PlainActionFuture<>(),
+            false
+        );
+
+        // Verify queryVectorSupplier was preserved: getQuery() should still return null
+        assertThat(copied.getQuery(), nullValue());
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/141200

After reviewing the test failures in the above issue.  There's not a consistent failure but instead what seems like a timing issue probably because of other unrelated CI issues at that time.  

I iterated with Opus a bit on this and came up two potential areas where we could improve performance.  

The first only impacts the test itself and that's querying multiple indices when we only really intended, I believe, to query one `test-index-with-sparse-vector`. 

The second impacts any usage of the client that call the inference service.  I think we were unnecessarily making multiple calls to the inference service when we had already resolved the vector needed in subsequent processing.  I tried to review this both with Opus and on my own but honestly the code is complex.  I think this has no downsides and is net positive though.  Opus believes it's a reduction of 2x to 3x inference calls.  I'm not entirely convinced of this.  The hope here is that this improves runtime somewhat particularly in the scope of this test and maybe reduces test flakiness in the future.   
