### PR TITLE
Use repeatedParamAsList() to support multiple match[] selectors for label values API

### DIFF
--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusLabelValuesRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusLabelValuesRestIT.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -133,6 +134,17 @@ public class PrometheusLabelValuesRestIT extends ESRestTestCase {
 
         assertThat(values, hasItem("filtered_job"));
         assertThat(values, not(hasItem("other_job")));
+    }
+
+    public void testMultipleMatchSelectorsReturnUnionOfValues() throws Exception {
+        writeMetric("multi_match_alpha", Map.of("job", "alpha"));
+        writeMetric("multi_match_beta", Map.of("job", "beta"));
+        writeMetric("multi_match_gamma", Map.of("job", "gamma"));
+
+        List<String> values = labelValuesData(client().performRequest(labelValuesRequest("job", "multi_match_alpha", "multi_match_beta")));
+
+        assertThat(values, containsInAnyOrder("alpha", "beta"));
+        assertThat(values, not(hasItem("gamma")));
     }
 
     public void testGetValuesAreSorted() throws Exception {

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
@@ -73,9 +73,7 @@ public class PrometheusLabelValuesRestAction extends BaseRestHandler {
         String labelName = PrometheusLabelNameUtils.decodeLabelName(rawName);
         String index = request.param(INDEX_PARAM, "*");
 
-        // TODO: support multiple match[] selectors once multi-value param support is added
-        String matchSelector = request.param(MATCH_PARAM);
-        List<String> matchSelectors = matchSelector != null ? List.of(matchSelector) : List.of();
+        List<String> matchSelectors = request.repeatedParamAsList(MATCH_PARAM);
 
         // Time range
         String endParam = request.param(END_PARAM);


### PR DESCRIPTION
Mirrors the approach from fc92df4 for the label values endpoint.

- Replaces the single `request.param(MATCH_PARAM)` call with `request.repeatedParamAsList(MATCH_PARAM)`, removing the TODO comment.
- Adds an integration test asserting that multiple `match[]` parameters return the union of label values.

Depends on https://github.com/elastic/elasticsearch/pull/145223