### PR TITLE
Prevent reindex task quick back-to-back relocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -56,6 +56,7 @@ import static org.elasticsearch.core.TimeValue.timeValueNanos;
 public class BulkByScrollTask extends CancellableTask {
 
     private final boolean eligibleForRelocationOnShutdown;
+    private final boolean relocatedTask;
     // if task is a slice, RelocationOrigin won't be correct because it won't be the leader here, but it's overridden in the leader state
     private final ResumeInfo.RelocationOrigin relocationOrigin;
     private volatile LeaderBulkByScrollTaskState leaderState;
@@ -74,6 +75,7 @@ public class BulkByScrollTask extends CancellableTask {
     ) {
         super(taskId.getId(), type, action, description, parentTaskId, headers);
         this.eligibleForRelocationOnShutdown = eligibleForRelocationOnShutdown;
+        this.relocatedTask = relocationOrigin != null;
         this.relocationOrigin = relocationOrigin != null ? relocationOrigin : new ResumeInfo.RelocationOrigin(taskId, this.startTime);
     }
 
@@ -229,6 +231,11 @@ public class BulkByScrollTask extends CancellableTask {
     /** Returns the relocation origin if this task is a relocated continuation. */
     public ResumeInfo.RelocationOrigin relocationOrigin() {
         return relocationOrigin;
+    }
+
+    /** Returns true if this task was created via relocation from another node. */
+    public boolean isRelocatedTask() {
+        return relocatedTask;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -47,6 +47,13 @@ import java.util.stream.Collectors;
  */
 public class ShutdownPrepareService {
 
+    /**
+     * Minimum time a relocated reindex task must run before it can be relocated again.
+     * Prevents quick back-to-back relocations that could cause issues with reindex management endpoints,
+     * as of writing, mainly race condition in list where the two-listing approach could hit two relocations and have missing results.
+     */
+    private static final long MIN_REINDEX_RELOCATION_NANOS = TimeUnit.SECONDS.toNanos(5);
+
     private record ShutdownHook(String name, Runnable action) {}
 
     public static final Setting<TimeValue> MAXIMUM_SHUTDOWN_TIMEOUT_SETTING = Setting.positiveTimeSetting(
@@ -211,8 +218,20 @@ public class ShutdownPrepareService {
 
     // package-private for tests
     static void maybeRequestRelocationForBulkByScroll(Task task) {
+        maybeRequestRelocationForBulkByScroll(task, MIN_REINDEX_RELOCATION_NANOS);
+    }
+
+    // visible for tests
+    static void maybeRequestRelocationForBulkByScroll(Task task, long minReindexRelocationNanos) {
+        assert minReindexRelocationNanos >= 0 : "Minimum re-relocation nanos must be non-negative";
         if (task instanceof BulkByScrollTask bulkByScrollTask) {
             if (bulkByScrollTask.isEligibleForRelocationOnShutdown() && bulkByScrollTask.isRelocationRequested() == false) {
+                final boolean taskRecentlyRelocated = bulkByScrollTask.isRelocatedTask()
+                    && (System.nanoTime() - bulkByScrollTask.getStartTimeNanos()) < minReindexRelocationNanos;
+                if (taskRecentlyRelocated) {
+                    logger.debug("skipping re-relocation for recently-relocated task [{}]", bulkByScrollTask.getId());
+                    return;
+                }
                 if (bulkByScrollTask.isLeader()) {
                     logger.info("Requesting relocation task for leader bulk-by-scroll task {} and its workers", bulkByScrollTask.getId());
                 } else {

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
@@ -28,6 +28,7 @@ import static java.lang.Math.min;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueNanos;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class BulkByScrollTaskTests extends ESTestCase {
 
@@ -37,15 +38,19 @@ public class BulkByScrollTaskTests extends ESTestCase {
      * {@link BulkByScrollTask#setWorker(float, Integer)} is called.
      */
     private static BulkByScrollTask createTask(boolean eligibleForRelocationOnShutdown) {
+        return createTask(eligibleForRelocationOnShutdown, randomBoolean());
+    }
+
+    private static BulkByScrollTask createTask(boolean eligibleForRelocationOnShutdown, boolean isRelocated) {
         TaskId taskId = randomTaskId();
         String type = randomAlphaOfLengthBetween(1, 10);
         String action = randomAlphaOfLengthBetween(1, 10);
         String description = randomAlphaOfLengthBetween(0, 20);
         TaskId parentTaskId = randomTaskId();
         Map<String, String> headers = randomBoolean() ? Collections.emptyMap() : Map.of("header", randomAlphaOfLength(5));
-        ResumeInfo.RelocationOrigin origin = randomBoolean()
-            ? null
-            : new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong());
+        ResumeInfo.RelocationOrigin origin = isRelocated
+            ? new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong())
+            : null;
         return new BulkByScrollTask(taskId, type, action, description, parentTaskId, headers, eligibleForRelocationOnShutdown, origin);
     }
 
@@ -474,6 +479,12 @@ public class BulkByScrollTaskTests extends ESTestCase {
             () -> task.taskInfoGivenSubtaskInfo(localNodeId, sliceInfoList)
         );
         assertThat(exception.getMessage(), containsString("not set to be a leader"));
+    }
+
+    public void testTaskIsRelocatedIfRelocationOriginIsSet() {
+        final boolean isRelocated = randomBoolean();
+        final BulkByScrollTask task = createTask(randomBoolean(), isRelocated);
+        assertThat(task.isRelocatedTask(), equalTo(isRelocated));
     }
 
     private static float randomFloatBetween(float min, float max) {

--- a/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
@@ -46,7 +47,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             TaskId.EMPTY_TASK_ID,
             Map.of(),
             true,
-            randomOrigin()
+            null
         );
         task.setWorkerCount(randomIntBetween(1, 20));
         ShutdownPrepareService.maybeRequestRelocationForBulkByScroll(task);
@@ -78,10 +79,82 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             new TaskId("localNode", randomLong()),
             Map.of(),
             true,
-            randomOrigin()
+            null
         );
         task.setWorker(randomFloat(), randomInt());
         ShutdownPrepareService.maybeRequestRelocationForBulkByScroll(task);
+        assertThat(task.isRelocationRequested(), is(true));
+    }
+
+    public void testMaybeRequestRelocationForBulkByScroll_skipsRecentlyRelocatedTask() {
+        final BulkByScrollTask task = new BulkByScrollTask(
+            randomTaskId(),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomBoolean() ? TaskId.EMPTY_TASK_ID : new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
+            Map.of(),
+            true,
+            new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()), randomNonNegativeLong())
+        );
+        final boolean isLeader = randomBoolean();
+        if (isLeader) {
+            task.setWorkerCount(between(2, 20));
+        } else {
+            task.setWorker(randomFloat(), randomInt());
+        }
+        assertThat(task.isRelocatedTask(), is(true));
+        assertThat(task.isRelocationRequested(), is(false));
+        // task exists for less than required time, skip relocation
+        ShutdownPrepareService.maybeRequestRelocationForBulkByScroll(task, TimeUnit.SECONDS.toNanos(between(30, 120)));
+        assertThat(task.isRelocationRequested(), is(false));
+    }
+
+    public void testMaybeRequestRelocationForBulkByScroll_allowsOldRelocatedTask() {
+        final BulkByScrollTask task = new BulkByScrollTask(
+            randomTaskId(),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomBoolean() ? TaskId.EMPTY_TASK_ID : new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
+            Map.of(),
+            true,
+            new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()), randomNonNegativeLong())
+        );
+        final boolean isLeader = randomBoolean();
+        if (isLeader) {
+            task.setWorkerCount(between(2, 20));
+        } else {
+            task.setWorker(randomFloat(), randomInt());
+        }
+        assertThat(task.isRelocatedTask(), is(true));
+        assertThat(task.isRelocationRequested(), is(false));
+        // task always exists longer than 0 nanos, relocate
+        ShutdownPrepareService.maybeRequestRelocationForBulkByScroll(task, TimeUnit.SECONDS.toNanos(0));
+        assertThat(task.isRelocationRequested(), is(true));
+    }
+
+    public void testMaybeRequestRelocationForBulkByScroll_cooldownDoesNotApplyToNonRelocatedTask() {
+        final BulkByScrollTask task = new BulkByScrollTask(
+            randomTaskId(),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomBoolean() ? TaskId.EMPTY_TASK_ID : new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
+            Map.of(),
+            true,
+            null
+        );
+        final boolean isLeader = randomBoolean();
+        if (isLeader) {
+            task.setWorkerCount(between(2, 20));
+        } else {
+            task.setWorker(randomFloat(), randomInt());
+        }
+        assertThat(task.isRelocatedTask(), is(false));
+        assertThat(task.isRelocationRequested(), is(false));
+        // regardless of value, should relocate
+        ShutdownPrepareService.maybeRequestRelocationForBulkByScroll(task, TimeUnit.SECONDS.toNanos(between(0, 120)));
         assertThat(task.isRelocationRequested(), is(true));
     }
 


### PR DESCRIPTION
- Relocated reindex doesn't relocate again for a short time period, to reduce changes of race conditions in `GET _reindex` endpoint with new approach to handle race conditions
- Ran each added test for 10k iterations