### PR TITLE
Convert vector scorers to use IndexInputUtils and slices

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
@@ -53,7 +53,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
-            checkInvariants(values.size(), values.dimension(), input);
+            checkInvariants(values.size(), values.getVectorByteLength(), input);
             return switch (similarityType) {
                 case COSINE, DOT_PRODUCT -> Optional.of(new FloatVectorScorerSupplier.DotProductSupplier(msInput, values));
                 case EUCLIDEAN -> Optional.of(new FloatVectorScorerSupplier.EuclideanSupplier(msInput, values));
@@ -91,7 +91,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
-            checkInvariants(values.size(), values.dimension(), input);
+            checkInvariants(values.size(), values.getVectorByteLength(), input);
             return switch (similarityType) {
                 case COSINE -> Optional.of(new ByteVectorScorerSupplier.CosineSupplier(msInput, values));
                 case DOT_PRODUCT -> Optional.of(new ByteVectorScorerSupplier.DotProductSupplier(msInput, values));
@@ -131,7 +131,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
         if (input instanceof MemorySegmentAccessInput msInput) {
-            checkInvariants(values.size(), values.dimension(), input);
+            checkInvariants(values.size(), values.getVectorByteLength(), input);
             return switch (similarityType) {
                 case COSINE, DOT_PRODUCT -> Optional.of(
                     new Int7SQVectorScorerSupplier.DotProductSupplier(msInput, values, scoreCorrectionConstant)

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BulkScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BulkScorer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+import java.lang.foreign.MemorySegment;
+
+@FunctionalInterface
+interface BulkScorer {
+    void score(MemorySegment a, MemorySegment b, int length, int pitch, MemorySegment offsets, int count, MemorySegment scores);
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/ByteVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/ByteVectorScorer.java
@@ -9,16 +9,11 @@
 
 package org.elasticsearch.simdvec.internal;
 
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.elasticsearch.core.DirectAccessInput;
-import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -27,85 +22,22 @@ import java.util.Optional;
 import static org.elasticsearch.simdvec.internal.Similarities.cosineI8;
 import static org.elasticsearch.simdvec.internal.Similarities.dotProductI8;
 import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceI8;
-import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 
-public abstract sealed class ByteVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
-
-    final int dimensions;
-    final int vectorByteSize;
-    final IndexInput input;
-    final MemorySegment query;
-    byte[] scratch;
+public abstract sealed class ByteVectorScorer extends NativeVectorScorer {
 
     public static Optional<RandomVectorScorer> create(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector) {
-        if (SUPPORTS_HEAP_SEGMENTS == false) {
-            return Optional.empty();
-        }
         checkDimensions(queryVector.length, values.dimension());
-        IndexInput input = values instanceof HasIndexSlice slice ? slice.getSlice() : null;
-        if (input == null) {
-            return Optional.empty();
-        }
-        input = FilterIndexInput.unwrapOnlyTest(input);
-        input = MemorySegmentAccessInputAccess.unwrap(input);
-        if (input instanceof MemorySegmentAccessInput || input instanceof DirectAccessInput) {
-            IndexInputUtils.checkInputType(input);
-            checkInvariants(values.size(), values.getVectorByteLength(), input);
 
-            return switch (sim) {
-                case COSINE -> Optional.of(new CosineScorer(input, values, queryVector));
-                case DOT_PRODUCT -> Optional.of(new DotProductScorer(input, values, queryVector));
-                case EUCLIDEAN -> Optional.of(new EuclideanScorer(input, values, queryVector));
-                case MAXIMUM_INNER_PRODUCT -> Optional.of(new MaxInnerProductScorer(input, values, queryVector));
-            };
-        }
-        return Optional.empty();
+        return getNativeAccessibleSegment(values).map(input -> switch (sim) {
+            case COSINE -> new CosineScorer(input, values, queryVector);
+            case DOT_PRODUCT -> new DotProductScorer(input, values, queryVector);
+            case EUCLIDEAN -> new EuclideanScorer(input, values, queryVector);
+            case MAXIMUM_INNER_PRODUCT -> new MaxInnerProductScorer(input, values, queryVector);
+        });
     }
 
     ByteVectorScorer(IndexInput input, ByteVectorValues values, byte[] queryVector) {
-        super(values);
-        this.input = input;
-        assert queryVector.length == values.dimension();
-        this.dimensions = values.dimension();
-        this.vectorByteSize = values.getVectorByteLength();
-        this.query = MemorySegment.ofArray(queryVector);
-    }
-
-    byte[] getScratch(int length) {
-        if (scratch == null || scratch.length < length) {
-            scratch = new byte[length];
-        }
-        return scratch;
-    }
-
-    static void checkInvariants(int maxOrd, int vectorByteLength, IndexInput input) {
-        if (input.length() < (long) vectorByteLength * maxOrd) {
-            throw new IllegalArgumentException("input length is less than expected vector data");
-        }
-    }
-
-    final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd()) {
-            throw new IllegalArgumentException("illegal ordinal: " + ord);
-        }
-    }
-
-    /**
-     * Resolves native memory addresses for the given node ordinals and calls
-     * the sparse scoring function. Returns true if addresses were resolved
-     * (via mmap or DirectAccessInput), false if fallback scoring is needed.
-     */
-    final boolean bulkScoreWithSparse(int[] nodes, float[] scores, int numNodes, SparseScorer sparseScorer) throws IOException {
-        if (numNodes == 0) {
-            return false;
-        }
-        long[] offsets = new long[numNodes];
-        for (int i = 0; i < numNodes; i++) {
-            offsets[i] = (long) nodes[i] * vectorByteSize;
-        }
-        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, a -> {
-            sparseScorer.score(a, query, dimensions, numNodes, MemorySegment.ofArray(scores));
-        });
+        super(input, values, MemorySegment.ofArray(queryVector));
     }
 
     public static final class DotProductScorer extends ByteVectorScorer {
@@ -239,12 +171,6 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
             } else {
                 return super.bulkScore(nodes, scores, numNodes);
             }
-        }
-    }
-
-    static void checkDimensions(int queryLen, int fieldLen) {
-        if (queryLen != fieldLen) {
-            throw new IllegalArgumentException("vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
         }
     }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/FloatVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/FloatVectorScorer.java
@@ -9,102 +9,48 @@
 
 package org.elasticsearch.simdvec.internal;
 
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.util.Optional;
 
 import static org.elasticsearch.simdvec.internal.Similarities.dotProductF32;
-import static org.elasticsearch.simdvec.internal.Similarities.dotProductF32BulkWithOffsets;
 import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceF32;
-import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceF32BulkWithOffsets;
-import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 
-public abstract sealed class FloatVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
-
-    final int dimensions;
-    final int vectorByteSize;
-    final MemorySegmentAccessInput input;
-    final MemorySegment query;
-    byte[] scratch;
+public abstract sealed class FloatVectorScorer extends NativeVectorScorer {
 
     public static Optional<RandomVectorScorer> create(VectorSimilarityFunction sim, FloatVectorValues values, float[] queryVector) {
-        if (SUPPORTS_HEAP_SEGMENTS == false) {
-            return Optional.empty();
-        }
         checkDimensions(queryVector.length, values.dimension());
-        IndexInput input = values instanceof HasIndexSlice slice ? slice.getSlice() : null;
-        if (input == null) {
-            return Optional.empty();
-        }
-        input = FilterIndexInput.unwrapOnlyTest(input);
-        input = MemorySegmentAccessInputAccess.unwrap(input);
-        if (input instanceof MemorySegmentAccessInput msInput) {
-            checkInvariants(values.size(), values.dimension(), input);
-
-            return switch (sim) {
-                case COSINE, DOT_PRODUCT -> Optional.of(new DotProductScorer(msInput, values, queryVector));
-                case EUCLIDEAN -> Optional.of(new EuclideanScorer(msInput, values, queryVector));
-                case MAXIMUM_INNER_PRODUCT -> Optional.of(new MaxInnerProductScorer(msInput, values, queryVector));
-            };
-        }
-        return Optional.empty();
+        return getNativeAccessibleSegment(values).map(input -> switch (sim) {
+            case COSINE, DOT_PRODUCT -> new DotProductScorer(input, values, queryVector);
+            case EUCLIDEAN -> new EuclideanScorer(input, values, queryVector);
+            case MAXIMUM_INNER_PRODUCT -> new MaxInnerProductScorer(input, values, queryVector);
+        });
     }
 
-    FloatVectorScorer(MemorySegmentAccessInput input, FloatVectorValues values, float[] queryVector) {
-        super(values);
-        this.input = input;
-        assert queryVector.length == values.dimension();
-        this.dimensions = values.dimension();
-        this.vectorByteSize = values.getVectorByteLength();
-        this.query = MemorySegment.ofArray(queryVector);
-    }
-
-    final MemorySegment getSegment(int ord) throws IOException {
-        checkOrdinal(ord);
-        long byteOffset = (long) ord * vectorByteSize;
-        MemorySegment seg = input.segmentSliceOrNull(byteOffset, vectorByteSize);
-        if (seg == null) {
-            if (scratch == null) {
-                scratch = new byte[vectorByteSize];
-            }
-            input.readBytes(byteOffset, scratch, 0, vectorByteSize);
-            seg = MemorySegment.ofArray(scratch);
-        }
-        return seg;
-    }
-
-    static void checkInvariants(int maxOrd, int vectorByteLength, IndexInput input) {
-        if (input.length() < (long) vectorByteLength * maxOrd) {
-            throw new IllegalArgumentException("input length is less than expected vector data");
-        }
-    }
-
-    final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd()) {
-            throw new IllegalArgumentException("illegal ordinal: " + ord);
-        }
+    FloatVectorScorer(IndexInput input, FloatVectorValues values, float[] queryVector) {
+        super(input, values, MemorySegment.ofArray(queryVector));
     }
 
     public static final class DotProductScorer extends FloatVectorScorer {
-        public DotProductScorer(MemorySegmentAccessInput in, FloatVectorValues values, float[] query) {
+        public DotProductScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }
 
         @Override
         public float score(int node) throws IOException {
             checkOrdinal(node);
-            float dotProduct = dotProductF32(query, getSegment(node), dimensions);
-            return VectorUtil.normalizeToUnitInterval(dotProduct);
+            long byteOffset = (long) node * vectorByteSize;
+            input.seek(byteOffset);
+            return IndexInputUtils.withSlice(input, vectorByteSize, this::getScratch, seg -> {
+                float dp = dotProductF32(query, seg, dimensions);
+                return VectorUtil.normalizeToUnitInterval(dp);
+            });
         }
 
         @Override
@@ -112,35 +58,34 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
             if (numNodes == 0) {
                 return Float.NEGATIVE_INFINITY;
             }
-            MemorySegment vectorsSeg = input.segmentSliceOrNull(0, input.length());
-            if (vectorsSeg == null) {
-                return super.bulkScore(nodes, scores, numNodes);
-            } else {
-                var ordinalsSeg = MemorySegment.ofArray(nodes);
-                var scoresSeg = MemorySegment.ofArray(scores);
 
-                dotProductF32BulkWithOffsets(vectorsSeg, query, dimensions, vectorByteSize, ordinalsSeg, numNodes, scoresSeg);
-
+            if (bulkScore(nodes, scores, numNodes, Similarities::dotProductF32BulkWithOffsets)) {
                 float max = Float.NEGATIVE_INFINITY;
                 for (int i = 0; i < numNodes; ++i) {
                     scores[i] = VectorUtil.normalizeToUnitInterval(scores[i]);
                     max = Math.max(max, scores[i]);
                 }
                 return max;
+            } else {
+                return super.bulkScore(nodes, scores, numNodes);
             }
         }
     }
 
     public static final class EuclideanScorer extends FloatVectorScorer {
-        public EuclideanScorer(MemorySegmentAccessInput in, FloatVectorValues values, float[] query) {
+        public EuclideanScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }
 
         @Override
         public float score(int node) throws IOException {
             checkOrdinal(node);
-            float sqDist = squareDistanceF32(query, getSegment(node), dimensions);
-            return VectorUtil.normalizeDistanceToUnitInterval(sqDist);
+            long byteOffset = (long) node * vectorByteSize;
+            input.seek(byteOffset);
+            return IndexInputUtils.withSlice(input, vectorByteSize, this::getScratch, seg -> {
+                float dp = squareDistanceF32(query, seg, dimensions);
+                return VectorUtil.normalizeDistanceToUnitInterval(dp);
+            });
         }
 
         @Override
@@ -148,35 +93,34 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
             if (numNodes == 0) {
                 return Float.NEGATIVE_INFINITY;
             }
-            MemorySegment vectorsSeg = input.segmentSliceOrNull(0, input.length());
-            if (vectorsSeg == null) {
-                return super.bulkScore(nodes, scores, numNodes);
-            } else {
-                var ordinalsSeg = MemorySegment.ofArray(nodes);
-                var scoresSeg = MemorySegment.ofArray(scores);
 
-                squareDistanceF32BulkWithOffsets(vectorsSeg, query, dimensions, vectorByteSize, ordinalsSeg, numNodes, scoresSeg);
-
+            if (bulkScore(nodes, scores, numNodes, Similarities::squareDistanceF32BulkWithOffsets)) {
                 float max = Float.NEGATIVE_INFINITY;
                 for (int i = 0; i < numNodes; ++i) {
                     scores[i] = VectorUtil.normalizeDistanceToUnitInterval(scores[i]);
                     max = Math.max(max, scores[i]);
                 }
                 return max;
+            } else {
+                return super.bulkScore(nodes, scores, numNodes);
             }
         }
     }
 
     public static final class MaxInnerProductScorer extends FloatVectorScorer {
-        public MaxInnerProductScorer(MemorySegmentAccessInput in, FloatVectorValues values, float[] query) {
+        public MaxInnerProductScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }
 
         @Override
         public float score(int node) throws IOException {
             checkOrdinal(node);
-            float dotProduct = dotProductF32(query, getSegment(node), dimensions);
-            return VectorUtil.scaleMaxInnerProductScore(dotProduct);
+            long byteOffset = (long) node * vectorByteSize;
+            input.seek(byteOffset);
+            return IndexInputUtils.withSlice(input, vectorByteSize, this::getScratch, seg -> {
+                float dp = dotProductF32(query, seg, dimensions);
+                return VectorUtil.scaleMaxInnerProductScore(dp);
+            });
         }
 
         @Override
@@ -184,28 +128,17 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
             if (numNodes == 0) {
                 return Float.NEGATIVE_INFINITY;
             }
-            MemorySegment vectorsSeg = input.segmentSliceOrNull(0, input.length());
-            if (vectorsSeg == null) {
-                return super.bulkScore(nodes, scores, numNodes);
-            } else {
-                var ordinalsSeg = MemorySegment.ofArray(nodes);
-                var scoresSeg = MemorySegment.ofArray(scores);
 
-                dotProductF32BulkWithOffsets(vectorsSeg, query, dimensions, vectorByteSize, ordinalsSeg, numNodes, scoresSeg);
-
+            if (bulkScore(nodes, scores, numNodes, Similarities::dotProductF32BulkWithOffsets)) {
                 float max = Float.NEGATIVE_INFINITY;
                 for (int i = 0; i < numNodes; ++i) {
                     scores[i] = VectorUtil.scaleMaxInnerProductScore(scores[i]);
                     max = Math.max(max, scores[i]);
                 }
                 return max;
+            } else {
+                return super.bulkScore(nodes, scores, numNodes);
             }
-        }
-    }
-
-    static void checkDimensions(int queryLen, int fieldLen) {
-        if (queryLen != fieldLen) {
-            throw new IllegalArgumentException("vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
         }
     }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
@@ -92,6 +92,29 @@ public final class IndexInputUtils {
         return copyAndApply(in, Math.toIntExact(length), scratchSupplier, action);
     }
 
+    public static boolean trySingleSlice(IndexInput in, long length, CheckedConsumer<MemorySegment, IOException> action)
+        throws IOException {
+        checkInputType(in);
+        if (in instanceof MemorySegmentAccessInput msai) {
+            long offset = in.getFilePointer();
+            MemorySegment slice = msai.segmentSliceOrNull(offset, length);
+            if (slice != null) {
+                in.skipBytes(length);
+                action.accept(slice);
+                return true;
+            }
+        }
+        if (in instanceof DirectAccessInput dai) {
+            long offset = in.getFilePointer();
+            return dai.withByteBufferSlice(offset, length, bb -> {
+                assert bb.isDirect();
+                in.skipBytes(length);
+                action.accept(MemorySegment.ofBuffer(bb));
+            });
+        }
+        return false;
+    }
+
     /**
      * Bulk variant of {@link #withSlice}. Resolves {@code count} byte ranges
      * at the given file offsets to {@link MemorySegment}s and passes a

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/NativeVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/NativeVectorScorer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MemorySegmentAccessInput;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.elasticsearch.core.DirectAccessInput;
+import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.util.Optional;
+
+import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
+
+abstract class NativeVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+
+    static Optional<IndexInput> getNativeAccessibleSegment(KnnVectorValues values) {
+        if (SUPPORTS_HEAP_SEGMENTS == false) {
+            return Optional.empty();
+        }
+        IndexInput input = values instanceof HasIndexSlice slice ? slice.getSlice() : null;
+        if (input == null) {
+            return Optional.empty();
+        }
+        input = FilterIndexInput.unwrapOnlyTest(input);
+        input = MemorySegmentAccessInputAccess.unwrap(input);
+        if (input instanceof MemorySegmentAccessInput || input instanceof DirectAccessInput) {
+            IndexInputUtils.checkInputType(input);
+            checkInvariants(values.size(), values.getVectorByteLength(), input);
+            return Optional.of(input);
+        }
+        return Optional.empty();
+    }
+
+    static void checkInvariants(int maxOrd, int vectorByteLength, IndexInput input) {
+        if (input.length() < (long) vectorByteLength * maxOrd) {
+            throw new IllegalArgumentException("input length is less than expected vector data");
+        }
+    }
+
+    static void checkDimensions(int queryLen, int fieldLen) {
+        if (queryLen != fieldLen) {
+            throw new IllegalArgumentException("vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
+        }
+    }
+
+    final int dimensions;
+    final int vectorByteSize;
+    final IndexInput input;
+    final MemorySegment query;
+
+    byte[] scratch;
+
+    NativeVectorScorer(IndexInput input, KnnVectorValues values, MemorySegment query) {
+        super(values);
+        this.input = input;
+        this.dimensions = values.dimension();
+        this.vectorByteSize = values.getVectorByteLength();
+        this.query = query;
+    }
+
+    byte[] getScratch(int length) {
+        if (scratch == null || scratch.length < length) {
+            scratch = new byte[length];
+        }
+        return scratch;
+    }
+
+    final boolean bulkScore(int[] nodes, float[] scores, int numNodes, BulkScorer bulkScorer) throws IOException {
+        if (numNodes == 0) {
+            return false;
+        }
+        return IndexInputUtils.trySingleSlice(input, input.length(), a -> {
+            bulkScorer.score(a, query, dimensions, vectorByteSize, MemorySegment.ofArray(nodes), numNodes, MemorySegment.ofArray(scores));
+        });
+    }
+
+    /**
+     * Resolves native memory addresses for the given node ordinals and calls
+     * the sparse scoring function. Returns true if addresses were resolved
+     * (via mmap or DirectAccessInput), false if fallback scoring is needed.
+     */
+    final boolean bulkScoreWithSparse(int[] nodes, float[] scores, int numNodes, SparseScorer sparseScorer) throws IOException {
+        if (numNodes == 0) {
+            return false;
+        }
+        long[] offsets = new long[numNodes];
+        for (int i = 0; i < numNodes; i++) {
+            offsets[i] = (long) nodes[i] * vectorByteSize;
+        }
+        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, a -> {
+            sparseScorer.score(a, query, dimensions, numNodes, MemorySegment.ofArray(scores));
+        });
+    }
+
+    final void checkOrdinal(int ord) {
+        if (ord < 0 || ord >= maxOrd()) {
+            throw new IllegalArgumentException("illegal ordinal: " + ord);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/OffHeapBFloat16VectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/OffHeapBFloat16VectorValues.java
@@ -62,7 +62,7 @@ public abstract class OffHeapBFloat16VectorValues extends FloatVectorValues impl
         this.byteSize = byteSize;
         this.similarityFunction = similarityFunction;
         this.flatVectorsScorer = flatVectorsScorer;
-        bfloatBytes = new byte[dimension * BFloat16.BYTES];
+        bfloatBytes = new byte[byteSize];
         value = new float[dimension];
     }
 
@@ -83,7 +83,7 @@ public abstract class OffHeapBFloat16VectorValues extends FloatVectorValues impl
 
     @Override
     public int getVectorByteLength() {
-        return dimension * BFloat16.BYTES;
+        return byteSize;
     }
 
     @Override
@@ -151,11 +151,6 @@ public abstract class OffHeapBFloat16VectorValues extends FloatVectorValues impl
         @Override
         public DenseOffHeapVectorValues copy() throws IOException {
             return new DenseOffHeapVectorValues(dimension, size, slice.clone(), byteSize, flatVectorsScorer, similarityFunction);
-        }
-
-        @Override
-        public int ordToDoc(int ord) {
-            return ord;
         }
 
         @Override


### PR DESCRIPTION
Use the new functionality in `IndexInputUtils` to use native access with DirectAccessInput implementations