### PR TITLE
[ES|QL] Add schema reconciliation for multi-file external sources

### DIFF
--- a/docs/changelog/145220.yaml
+++ b/docs/changelog/145220.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145220
+summary: Add schema reconciliation for multi-file external sources
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -14,8 +14,6 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
@@ -61,8 +59,6 @@ import java.util.concurrent.Executor;
  * @see AsyncExternalSourceOperator
  */
 public class AsyncExternalSourceOperatorFactory implements SourceOperator.SourceOperatorFactory {
-
-    private static final Logger logger = LogManager.getLogger(AsyncExternalSourceOperatorFactory.class);
 
     private final StorageProvider storageProvider;
     private final FormatReader formatReader;
@@ -402,8 +398,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return cols;
     }
 
-    private CloseableIterator<Page> adaptSchema(CloseableIterator<Page> pages, FileSplit fileSplit, DriverContext driverContext) {
-        SchemaReconciliation.ColumnMapping mapping = fileSplit.columnMapping();
+    private CloseableIterator<Page> adaptSchema(
+        CloseableIterator<Page> pages,
+        SchemaReconciliation.ColumnMapping mapping,
+        DriverContext driverContext
+    ) {
         if (mapping == null || mapping.isIdentity()) {
             return pages;
         }
@@ -471,7 +470,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                                     .build();
                                 pages = formatReader.read(obj, ctx);
                             }
-                            CloseableIterator<Page> adaptedPages = adaptSchema(pages, fileSplit, driverContext);
+                            CloseableIterator<Page> adaptedPages = adaptSchema(pages, fileSplit.columnMapping(), driverContext);
                             try (adaptedPages) {
                                 int consumed = drainPagesWithBudget(adaptedPages, buffer, injector);
                                 if (rowLimit != FormatReader.NO_LIMIT) {
@@ -498,6 +497,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector
     ) {
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileSet != null ? fileSet.fileSchemaInfo() : null;
+
         executor.execute(() -> {
             try {
                 int rowsRemaining = rowLimit;
@@ -528,8 +529,18 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                             .build();
                         pages = formatReader.read(obj, ctx);
                     }
-                    try (pages) {
-                        int consumed = drainPagesWithBudget(pages, buffer, injector);
+
+                    SchemaReconciliation.ColumnMapping mapping = null;
+                    if (schemaInfo != null) {
+                        SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(entry.path());
+                        if (info != null) {
+                            mapping = info.mapping();
+                        }
+                    }
+                    CloseableIterator<Page> adaptedPages = adaptSchema(pages, mapping, driverContext);
+
+                    try (adaptedPages) {
+                        int consumed = drainPagesWithBudget(adaptedPages, buffer, injector);
                         if (rowLimit != FormatReader.NO_LIMIT) {
                             rowsRemaining -= consumed;
                         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -402,6 +402,15 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return cols;
     }
 
+    private CloseableIterator<Page> adaptSchema(CloseableIterator<Page> pages, FileSplit fileSplit, DriverContext driverContext) {
+        SchemaReconciliation.ColumnMapping mapping = fileSplit.columnMapping();
+        if (mapping == null || mapping.isIdentity()) {
+            return pages;
+        }
+        List<Attribute> dataColumns = attributes.subList(0, mapping.columnCount());
+        return new SchemaAdaptingIterator(pages, dataColumns, mapping, driverContext.blockFactory());
+    }
+
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
         executor.execute(() -> {
             try {
@@ -462,8 +471,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                                     .build();
                                 pages = formatReader.read(obj, ctx);
                             }
-                            try (pages) {
-                                int consumed = drainPagesWithBudget(pages, buffer, injector);
+                            CloseableIterator<Page> adaptedPages = adaptSchema(pages, fileSplit, driverContext);
+                            try (adaptedPages) {
+                                int consumed = drainPagesWithBudget(adaptedPages, buffer, injector);
                                 if (rowLimit != FormatReader.NO_LIMIT) {
                                     rowsRemaining -= consumed;
                                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
@@ -22,6 +22,28 @@ import java.util.Objects;
  * micro-partitions) would otherwise each become an independent work item.
  * Operators that encounter a {@code CoalescedSplit} iterate over its children
  * and process each one individually.
+ * <p>
+ * <b>Schema mapping duplication:</b> when schema reconciliation is active, each
+ * child {@link FileSplit} carries its own {@link SchemaReconciliation.ColumnMapping}.
+ * On the coordinator all splits from the same file share a single object reference
+ * (see {@code FileSplitProvider}), but each is serialized independently on the wire.
+ * {@link SplitCoalescer} groups splits by size, not by file, so a single
+ * {@code CoalescedSplit} may contain children from multiple files with different
+ * mappings. To eliminate the duplication on the wire, one of these approaches
+ * could be used in a follow-up:
+ * <ul>
+ *   <li><b>Dedup table:</b> add a {@code List<ColumnMapping>} table here;
+ *       each child writes a 1-byte index into the table instead of the full mapping.
+ *       Cleanest wire saving but couples this generic container to schema-specific types.</li>
+ *   <li><b>Group-by-file coalescing:</b> modify {@link SplitCoalescer} to group
+ *       splits by file first, so each {@code CoalescedSplit} has a single shared
+ *       mapping. Simple but may reduce bin-packing quality.</li>
+ *   <li><b>Post-deser dedup:</b> after deserializing children, replace content-equal
+ *       mappings with a single instance. Saves heap but not wire bytes.</li>
+ * </ul>
+ * For typical schemas (&lt; 200 columns) and split counts (&lt; 50 per file), the
+ * per-split mapping overhead is well under 1 KB, making this a low-priority
+ * optimisation relative to the multi-MB data payloads.
  */
 public class CoalescedSplit implements ExternalSplit {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -104,7 +105,16 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
         }
 
         if (sliceQueue != null) {
-            return new SliceQueueSourceOperator(storageProvider, formatReader, projectedColumns, batchSize, sliceQueue);
+            return new SliceQueueSourceOperator(
+                storageProvider,
+                formatReader,
+                projectedColumns,
+                attributes,
+                batchSize,
+                rowLimit,
+                sliceQueue,
+                driverContext.blockFactory()
+            );
         }
 
         StorageObject storageObject = storageProvider.newObject(path);
@@ -205,8 +215,11 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
         private final StorageProvider storageProvider;
         private final FormatReader formatReader;
         private final List<String> projectedColumns;
+        private final List<Attribute> attributes;
         private final int batchSize;
+        private final int rowLimit;
         private final ExternalSliceQueue sliceQueue;
+        private final BlockFactory blockFactory;
         private final ArrayDeque<ExternalSplit> pendingChildren = new ArrayDeque<>();
         private CloseableIterator<Page> currentPages;
         private StoragePath currentSplitPath;
@@ -216,14 +229,20 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
             StorageProvider storageProvider,
             FormatReader formatReader,
             List<String> projectedColumns,
+            List<Attribute> attributes,
             int batchSize,
-            ExternalSliceQueue sliceQueue
+            int rowLimit,
+            ExternalSliceQueue sliceQueue,
+            BlockFactory blockFactory
         ) {
             this.storageProvider = storageProvider;
             this.formatReader = formatReader;
             this.projectedColumns = projectedColumns;
+            this.attributes = attributes;
             this.batchSize = batchSize;
+            this.rowLimit = rowLimit;
             this.sliceQueue = sliceQueue;
+            this.blockFactory = blockFactory;
         }
 
         @Override
@@ -286,7 +305,13 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
                     .firstSplit(firstSplit)
                     .lastSplit(lastSplit)
                     .build();
-                return formatReader.read(obj, ctx);
+                CloseableIterator<Page> pages = formatReader.read(obj, ctx);
+
+                SchemaReconciliation.ColumnMapping columnMapping = fileSplit.columnMapping();
+                if (columnMapping != null && columnMapping.isIdentity() == false) {
+                    pages = new SchemaAdaptingIterator(pages, attributes, columnMapping, blockFactory);
+                }
+                return pages;
             }
             throw new IllegalArgumentException("Unsupported split type: " + split.getClass().getName());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
@@ -298,8 +298,20 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
                     obj = new RangeStorageObject(obj, fileSplit.offset(), fileSplit.length());
                     firstSplit = "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
                 }
+
+                SchemaReconciliation.ColumnMapping columnMapping = fileSplit.columnMapping();
+                List<String> effectiveProjection = projectedColumns;
+                List<Attribute> dataColumns = null;
+                if (columnMapping != null && columnMapping.columnCount() < attributes.size()) {
+                    dataColumns = attributes.subList(0, columnMapping.columnCount());
+                    effectiveProjection = new ArrayList<>(dataColumns.size());
+                    for (Attribute attr : dataColumns) {
+                        effectiveProjection.add(attr.name());
+                    }
+                }
+
                 FormatReadContext ctx = FormatReadContext.builder()
-                    .projectedColumns(projectedColumns)
+                    .projectedColumns(effectiveProjection)
                     .batchSize(batchSize)
                     .rowLimit(FormatReader.NO_LIMIT)
                     .firstSplit(firstSplit)
@@ -307,9 +319,10 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
                     .build();
                 CloseableIterator<Page> pages = formatReader.read(obj, ctx);
 
-                SchemaReconciliation.ColumnMapping columnMapping = fileSplit.columnMapping();
                 if (columnMapping != null && columnMapping.isIdentity() == false) {
-                    List<Attribute> dataColumns = attributes.subList(0, columnMapping.columnCount());
+                    if (dataColumns == null) {
+                        dataColumns = attributes.subList(0, columnMapping.columnCount());
+                    }
                     pages = new SchemaAdaptingIterator(pages, dataColumns, columnMapping, blockFactory);
                 }
                 return pages;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
@@ -309,7 +309,8 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
 
                 SchemaReconciliation.ColumnMapping columnMapping = fileSplit.columnMapping();
                 if (columnMapping != null && columnMapping.isIdentity() == false) {
-                    pages = new SchemaAdaptingIterator(pages, attributes, columnMapping, blockFactory);
+                    List<Attribute> dataColumns = attributes.subList(0, columnMapping.columnCount());
+                    pages = new SchemaAdaptingIterator(pages, dataColumns, columnMapping, blockFactory);
                 }
                 return pages;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -23,18 +23,24 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Resolver for external data sources (Iceberg tables, Parquet files, etc.).
@@ -60,6 +66,10 @@ import java.util.concurrent.Executor;
 public class ExternalSourceResolver {
 
     private static final Logger LOGGER = LogManager.getLogger(ExternalSourceResolver.class);
+
+    static final String CONFIG_SCHEMA_RESOLUTION = "schema_resolution";
+
+    private static final int MAX_PARALLEL_METADATA_READS = 16;
 
     private final Executor executor;
     private final DataSourceModule dataSourceModule;
@@ -169,6 +179,16 @@ public class ExternalSourceResolver {
             throw new IllegalArgumentException("Glob pattern matched no files: " + path);
         }
 
+        FormatReader.SchemaResolution schemaResolution = parseSchemaResolution(config);
+
+        if (schemaResolution == FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+            return resolveMultiFileFirstFileWins(fileSet, config);
+        }
+        return resolveMultiFileWithReconciliation(fileSet, config, schemaResolution);
+    }
+
+    private ExternalSourceResolution.ResolvedSource resolveMultiFileFirstFileWins(FileSet fileSet, Map<String, Object> config)
+        throws Exception {
         StoragePath firstFile = fileSet.files().get(0).path();
         SourceMetadata metadata = resolveSingleSource(firstFile.toString(), config);
 
@@ -180,6 +200,170 @@ public class ExternalSourceResolver {
         }
 
         return new ExternalSourceResolution.ResolvedSource(extMetadata, fileSet);
+    }
+
+    private ExternalSourceResolution.ResolvedSource resolveMultiFileWithReconciliation(
+        FileSet fileSet,
+        Map<String, Object> config,
+        FormatReader.SchemaResolution schemaResolution
+    ) throws Exception {
+        long startNanos = System.nanoTime();
+        Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileSet, config);
+        long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
+
+        LOGGER.info("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
+
+        StoragePath firstFile = fileSet.files().get(0).path();
+        SchemaReconciliation.Result result;
+        if (schemaResolution == FormatReader.SchemaResolution.STRICT) {
+            result = SchemaReconciliation.reconcileStrict(firstFile, allMetadata);
+        } else {
+            result = SchemaReconciliation.reconcileUnionByName(allMetadata);
+        }
+
+        List<Attribute> unifiedSchema = result.unifiedSchema();
+        SourceMetadata firstMeta = allMetadata.get(firstFile);
+        ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config);
+
+        PartitionMetadata partitionMetadata = fileSet.partitionMetadata();
+        if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
+            extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
+        }
+
+        FileSet enrichedFileSet = fileSet.withSchemaInfo(result.perFileInfo());
+        return new ExternalSourceResolution.ResolvedSource(extMetadata, enrichedFileSet);
+    }
+
+    /**
+     * Reads metadata from all files in parallel with bounded concurrency.
+     * Uses a semaphore to cap the number of concurrent metadata reads.
+     */
+    private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileSet fileSet, Map<String, Object> config) throws Exception {
+        List<StorageEntry> files = fileSet.files();
+        int fileCount = files.size();
+
+        if (fileCount == 1) {
+            StoragePath filePath = files.get(0).path();
+            SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
+            return Map.of(filePath, meta);
+        }
+
+        Semaphore semaphore = new Semaphore(Math.min(fileCount, MAX_PARALLEL_METADATA_READS));
+        AtomicBoolean failed = new AtomicBoolean(false);
+
+        @SuppressWarnings("unchecked")
+        CompletableFuture<Map.Entry<StoragePath, SourceMetadata>>[] futures = new CompletableFuture[fileCount];
+
+        for (int i = 0; i < fileCount; i++) {
+            StoragePath filePath = files.get(i).path();
+            futures[i] = CompletableFuture.supplyAsync(() -> {
+                if (failed.get()) {
+                    return null;
+                }
+                try {
+                    semaphore.acquire();
+                    try {
+                        SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
+                        return Map.entry(filePath, meta);
+                    } finally {
+                        semaphore.release();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while reading metadata from [" + filePath + "]", e);
+                } catch (Exception e) {
+                    failed.set(true);
+                    throw new RuntimeException("Failed to read metadata from [" + filePath + "]: " + e.getMessage(), e);
+                }
+            }, executor);
+        }
+
+        try {
+            CompletableFuture.allOf(futures).join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException rte) {
+                throw rte;
+            }
+            throw new RuntimeException("Failed to read file metadata in parallel", cause != null ? cause : e);
+        }
+
+        Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
+        for (CompletableFuture<Map.Entry<StoragePath, SourceMetadata>> future : futures) {
+            Map.Entry<StoragePath, SourceMetadata> entry = future.get();
+            if (entry != null) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    private ExternalSourceMetadata buildUnifiedMetadata(
+        SourceMetadata referenceMeta,
+        List<Attribute> unifiedSchema,
+        Map<String, Object> queryConfig
+    ) {
+        Map<String, Object> mergedConfig = mergeConfigs(referenceMeta.config(), queryConfig);
+        List<Attribute> schema = List.copyOf(unifiedSchema);
+        return new ExternalSourceMetadata() {
+            @Override
+            public String location() {
+                return referenceMeta.location();
+            }
+
+            @Override
+            public List<Attribute> schema() {
+                return schema;
+            }
+
+            @Override
+            public String sourceType() {
+                return referenceMeta.sourceType();
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return referenceMeta.sourceMetadata();
+            }
+
+            @Override
+            public Map<String, Object> config() {
+                return mergedConfig;
+            }
+        };
+    }
+
+    static FormatReader.SchemaResolution parseSchemaResolution(@Nullable Map<String, Object> config) {
+        if (config == null) {
+            return FormatReader.SchemaResolution.FIRST_FILE_WINS;
+        }
+        Object value = config.get(CONFIG_SCHEMA_RESOLUTION);
+        if (value == null) {
+            return FormatReader.SchemaResolution.FIRST_FILE_WINS;
+        }
+        return switch (value.toString().toLowerCase(Locale.ROOT)) {
+            case "first_file_wins" -> FormatReader.SchemaResolution.FIRST_FILE_WINS;
+            case "strict" -> FormatReader.SchemaResolution.STRICT;
+            case "union_by_name" -> FormatReader.SchemaResolution.UNION_BY_NAME;
+            default -> throw new IllegalArgumentException(
+                "Unknown schema_resolution value [" + value + "]. Valid values are: first_file_wins, strict, union_by_name"
+            );
+        };
+    }
+
+    private static Map<String, Object> mergeConfigs(
+        @Nullable Map<String, Object> metadataConfig,
+        @Nullable Map<String, Object> queryConfig
+    ) {
+        if (metadataConfig == null || metadataConfig.isEmpty()) {
+            return queryConfig != null ? queryConfig : Map.of();
+        }
+        if (queryConfig == null || queryConfig.isEmpty()) {
+            return metadataConfig;
+        }
+        Map<String, Object> merged = new HashMap<>(metadataConfig);
+        merged.putAll(queryConfig);
+        return merged;
     }
 
     private static boolean isHivePartitioningEnabled(Map<String, Object> config) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -211,7 +211,7 @@ public class ExternalSourceResolver {
         Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileSet, config);
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
 
-        LOGGER.info("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
+        LOGGER.debug("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
 
         StoragePath firstFile = fileSet.files().get(0).path();
         SchemaReconciliation.Result result;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSet.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSet.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -28,18 +30,29 @@ public final class FileSet {
     private final List<StorageEntry> files;
     private final String originalPattern;
     private final PartitionMetadata partitionMetadata;
+    private final Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo;
 
     public FileSet(List<StorageEntry> files, String originalPattern) {
-        this(files, originalPattern, null);
+        this(files, originalPattern, null, null);
     }
 
     public FileSet(List<StorageEntry> files, String originalPattern, @Nullable PartitionMetadata partitionMetadata) {
+        this(files, originalPattern, partitionMetadata, null);
+    }
+
+    public FileSet(
+        List<StorageEntry> files,
+        String originalPattern,
+        @Nullable PartitionMetadata partitionMetadata,
+        @Nullable Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo
+    ) {
         if (files == null) {
             throw new IllegalArgumentException("files cannot be null");
         }
         this.files = List.copyOf(files);
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
+        this.fileSchemaInfo = fileSchemaInfo;
     }
 
     public List<StorageEntry> files() {
@@ -53,6 +66,19 @@ public final class FileSet {
     @Nullable
     public PartitionMetadata partitionMetadata() {
         return partitionMetadata;
+    }
+
+    @Nullable
+    public Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo() {
+        return fileSchemaInfo;
+    }
+
+    /**
+     * Returns a new FileSet with per-file schema info attached.
+     * Used by schema reconciliation to pass column mappings from planning to split discovery.
+     */
+    public FileSet withSchemaInfo(Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo) {
+        return new FileSet(files, originalPattern, partitionMetadata, schemaInfo);
     }
 
     public int size() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -39,6 +40,8 @@ public class FileSplit implements ExternalSplit {
     private final String format;
     private final Map<String, Object> config;
     private final Map<String, Object> partitionValues;
+    @Nullable
+    private final SchemaReconciliation.ColumnMapping columnMapping;
 
     public FileSplit(
         String sourceType,
@@ -48,6 +51,19 @@ public class FileSplit implements ExternalSplit {
         String format,
         Map<String, Object> config,
         Map<String, Object> partitionValues
+    ) {
+        this(sourceType, path, offset, length, format, config, partitionValues, null);
+    }
+
+    public FileSplit(
+        String sourceType,
+        StoragePath path,
+        long offset,
+        long length,
+        String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping
     ) {
         if (sourceType == null) {
             throw new IllegalArgumentException("sourceType cannot be null");
@@ -64,6 +80,7 @@ public class FileSplit implements ExternalSplit {
         this.partitionValues = partitionValues != null && partitionValues.isEmpty() == false
             ? Collections.unmodifiableMap(new LinkedHashMap<>(partitionValues))
             : Map.of();
+        this.columnMapping = columnMapping;
     }
 
     public FileSplit(StreamInput in) throws IOException {
@@ -74,6 +91,11 @@ public class FileSplit implements ExternalSplit {
         this.format = in.readOptionalString();
         this.config = in.readGenericMap();
         this.partitionValues = in.readGenericMap();
+        if (in.readBoolean()) {
+            this.columnMapping = new SchemaReconciliation.ColumnMapping(in);
+        } else {
+            this.columnMapping = null;
+        }
     }
 
     @Override
@@ -85,6 +107,12 @@ public class FileSplit implements ExternalSplit {
         out.writeOptionalString(format);
         out.writeGenericMap(config);
         out.writeGenericMap(partitionValues);
+        if (columnMapping != null) {
+            out.writeBoolean(true);
+            columnMapping.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -121,6 +149,11 @@ public class FileSplit implements ExternalSplit {
         return partitionValues;
     }
 
+    @Nullable
+    public SchemaReconciliation.ColumnMapping columnMapping() {
+        return columnMapping;
+    }
+
     @Override
     public long estimatedSizeInBytes() {
         return length;
@@ -141,12 +174,13 @@ public class FileSplit implements ExternalSplit {
             && Objects.equals(path, that.path)
             && Objects.equals(format, that.format)
             && Objects.equals(config, that.config)
-            && Objects.equals(partitionValues, that.partitionValues);
+            && Objects.equals(partitionValues, that.partitionValues)
+            && Objects.equals(columnMapping, that.columnMapping);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceType, path, offset, length, format, config, partitionValues);
+        return Objects.hash(sourceType, path, offset, length, format, config, partitionValues, columnMapping);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -108,7 +109,11 @@ public class FileSplitProvider implements SplitProvider {
         PartitionMetadata partitionInfo = context.partitionInfo();
         Map<String, Object> config = context.config();
         List<Expression> filterHints = context.filterHints();
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileSet.fileSchemaInfo();
         List<ExternalSplit> splits = new ArrayList<>();
+        // Dedup cache: files with content-equal mappings share the same ColumnMapping
+        // instance on the coordinator, avoiding redundant allocations.
+        Map<SchemaReconciliation.ColumnMapping, SchemaReconciliation.ColumnMapping> mappingCache = new HashMap<>();
 
         for (StorageEntry entry : fileSet.files()) {
             StoragePath filePath = entry.path();
@@ -138,14 +143,22 @@ public class FileSplitProvider implements SplitProvider {
 
             long fileLength = entry.length();
 
+            SchemaReconciliation.ColumnMapping columnMapping = null;
+            if (schemaInfo != null) {
+                SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(filePath);
+                if (info != null && info.mapping() != null && info.mapping().isIdentity() == false) {
+                    columnMapping = mappingCache.computeIfAbsent(info.mapping(), k -> k);
+                }
+            }
+
             // Try block-aligned splitting for splittable compressed files (e.g. .ndjson.bz2).
             // This is independent of targetSplitSizeBytes — compressed files with splittable
             // codecs are always split at block boundaries when possible.
-            if (tryBlockAlignedSplits(filePath, fileLength, format, config, partitionValues, splits)) {
+            if (tryBlockAlignedSplits(filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
                 continue;
             }
 
-            if (tryRangeAwareSplits(filePath, fileLength, format, config, partitionValues, splits)) {
+            if (tryRangeAwareSplits(filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
                 continue;
             }
 
@@ -153,11 +166,11 @@ public class FileSplitProvider implements SplitProvider {
                 long offset = 0;
                 while (offset < fileLength) {
                     long chunkLength = Math.min(targetSplitSizeBytes, fileLength - offset);
-                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, config, partitionValues));
+                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, config, partitionValues, columnMapping));
                     offset += chunkLength;
                 }
             } else {
-                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues));
+                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
             }
         }
 
@@ -182,6 +195,7 @@ public class FileSplitProvider implements SplitProvider {
         String format,
         Map<String, Object> config,
         Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
         List<ExternalSplit> splits
     ) {
         if (codecRegistry == null || storageRegistry == null || format == null) {
@@ -193,7 +207,7 @@ public class FileSplitProvider implements SplitProvider {
         // Prefer IndexedDecompressionCodec (e.g. zstd seekable) over SplittableDecompressionCodec
         // (e.g. bzip2) when an index is available, since index-based splitting avoids scanning.
         if (codec instanceof IndexedDecompressionCodec indexedCodec) {
-            if (tryIndexedSplits(indexedCodec, filePath, fileLength, format, config, partitionValues, splits)) {
+            if (tryIndexedSplits(indexedCodec, filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
                 return true;
             }
         }
@@ -219,7 +233,7 @@ public class FileSplitProvider implements SplitProvider {
             long[] boundaries = splittableCodec.findBlockBoundaries(object, 0, fileLength);
 
             if (boundaries.length == 0) {
-                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues));
+                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
                 return true;
             }
 
@@ -251,7 +265,7 @@ public class FileSplitProvider implements SplitProvider {
                 if (isLastMacroSplit) {
                     splitConfig.put(LAST_SPLIT_KEY, "true");
                 }
-                splits.add(new FileSplit("file", filePath, start, end - start, format, splitConfig, partitionValues));
+                splits.add(new FileSplit("file", filePath, start, end - start, format, splitConfig, partitionValues, columnMapping));
             }
             return true;
         } catch (IOException e) {
@@ -271,6 +285,7 @@ public class FileSplitProvider implements SplitProvider {
         String format,
         Map<String, Object> config,
         Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
         List<ExternalSplit> splits
     ) {
         if (formatRegistry == null || storageRegistry == null || format == null) {
@@ -310,7 +325,7 @@ public class FileSplitProvider implements SplitProvider {
             for (long[] range : ranges) {
                 long offset = range[0];
                 long length = range[1];
-                splits.add(new FileSplit("file", filePath, offset, length, format, splitConfig, partitionValues));
+                splits.add(new FileSplit("file", filePath, offset, length, format, splitConfig, partitionValues, columnMapping));
             }
             return true;
         } catch (IOException e) {
@@ -326,6 +341,7 @@ public class FileSplitProvider implements SplitProvider {
         String format,
         Map<String, Object> config,
         Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
         List<ExternalSplit> splits
     ) {
         try {
@@ -344,7 +360,7 @@ public class FileSplitProvider implements SplitProvider {
             FrameIndex index = indexedCodec.readIndex(object);
             List<FrameIndex.FrameEntry> frames = index.frames();
             if (frames.isEmpty()) {
-                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues));
+                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
                 return true;
             }
 
@@ -367,7 +383,18 @@ public class FileSplitProvider implements SplitProvider {
                     if (isLast) {
                         splitConfig.put(LAST_SPLIT_KEY, "true");
                     }
-                    splits.add(new FileSplit("file", filePath, groupStart, groupEnd - groupStart, format, splitConfig, partitionValues));
+                    splits.add(
+                        new FileSplit(
+                            "file",
+                            filePath,
+                            groupStart,
+                            groupEnd - groupStart,
+                            format,
+                            splitConfig,
+                            partitionValues,
+                            columnMapping
+                        )
+                    );
                     splitCount++;
                     accumulated = 0;
                     if (isLast == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -46,6 +46,16 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page> {
         SchemaReconciliation.ColumnMapping mapping,
         BlockFactory blockFactory
     ) {
+        if (unifiedSchema.size() != mapping.columnCount()) {
+            throw new IllegalArgumentException(
+                "Schema size ["
+                    + unifiedSchema.size()
+                    + "] does not match mapping column count ["
+                    + mapping.columnCount()
+                    + "]; callers must pass only data columns"
+                    + " (use attributes.subList(0, mapping.columnCount()) to exclude partition columns)"
+            );
+        }
         this.delegate = delegate;
         this.unifiedSchema = unifiedSchema;
         this.mapping = mapping;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Wraps a format reader's page iterator to adapt file-local schema to the unified schema.
+ * <p>
+ * For each page produced by the delegate iterator, this adapter:
+ * <ul>
+ *   <li>Reorders columns to match the unified schema ordering</li>
+ *   <li>Inserts constant NULL blocks for columns missing from this file</li>
+ *   <li>Casts blocks to the unified type where safe widening was applied</li>
+ * </ul>
+ * <p>
+ * This keeps format readers simple — they read only the columns their file has —
+ * and centralizes NULL-filling and type-casting in one place.
+ */
+final class SchemaAdaptingIterator implements CloseableIterator<Page> {
+
+    private final CloseableIterator<Page> delegate;
+    private final List<Attribute> unifiedSchema;
+    private final SchemaReconciliation.ColumnMapping mapping;
+    private final BlockFactory blockFactory;
+
+    SchemaAdaptingIterator(
+        CloseableIterator<Page> delegate,
+        List<Attribute> unifiedSchema,
+        SchemaReconciliation.ColumnMapping mapping,
+        BlockFactory blockFactory
+    ) {
+        this.delegate = delegate;
+        this.unifiedSchema = unifiedSchema;
+        this.mapping = mapping;
+        this.blockFactory = blockFactory;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public Page next() {
+        if (delegate.hasNext() == false) {
+            throw new NoSuchElementException();
+        }
+        Page filePage = delegate.next();
+        try {
+            int positions = filePage.getPositionCount();
+            int unifiedSize = unifiedSchema.size();
+
+            Block[] unifiedBlocks = new Block[unifiedSize];
+            try {
+                for (int i = 0; i < unifiedSize; i++) {
+                    int localIndex = mapping.localIndex(i);
+                    if (localIndex == -1) {
+                        unifiedBlocks[i] = blockFactory.newConstantNullBlock(positions);
+                    } else {
+                        Block block = filePage.getBlock(localIndex);
+                        DataType castTo = mapping.cast(i);
+                        if (castTo != null) {
+                            unifiedBlocks[i] = castBlock(block, castTo, positions);
+                        } else {
+                            block.incRef();
+                            unifiedBlocks[i] = block;
+                        }
+                    }
+                }
+                return new Page(positions, unifiedBlocks);
+            } catch (Exception e) {
+                Releasables.closeExpectNoException(unifiedBlocks);
+                throw new RuntimeException("Failed to adapt page to unified schema", e);
+            }
+        } finally {
+            filePage.releaseBlocks();
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            delegate.close();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to close delegate iterator", e);
+        }
+    }
+
+    private Block castBlock(Block source, DataType targetType, int positions) {
+        if (source instanceof IntBlock intBlock) {
+            if (targetType == DataType.LONG) {
+                return castIntToLong(intBlock, positions);
+            } else if (targetType == DataType.DOUBLE) {
+                return castIntToDouble(intBlock, positions);
+            }
+        } else if (source instanceof LongBlock longBlock && targetType == DataType.DATE_NANOS) {
+            return castDatetimeToDateNanos(longBlock, positions);
+        }
+        throw new UnsupportedOperationException(
+            "Unsupported block cast: " + source.getClass().getSimpleName() + " → " + targetType.typeName()
+        );
+    }
+
+    private Block castIntToLong(IntBlock intBlock, int positions) {
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(positions)) {
+            for (int pos = 0; pos < positions; pos++) {
+                int count = intBlock.getValueCount(pos);
+                if (intBlock.isNull(pos) || count == 0) {
+                    builder.appendNull();
+                } else if (count == 1) {
+                    builder.appendLong(intBlock.getInt(intBlock.getFirstValueIndex(pos)));
+                } else {
+                    int firstIdx = intBlock.getFirstValueIndex(pos);
+                    builder.beginPositionEntry();
+                    for (int v = 0; v < count; v++) {
+                        builder.appendLong(intBlock.getInt(firstIdx + v));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private Block castIntToDouble(IntBlock intBlock, int positions) {
+        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(positions)) {
+            for (int pos = 0; pos < positions; pos++) {
+                int count = intBlock.getValueCount(pos);
+                if (intBlock.isNull(pos) || count == 0) {
+                    builder.appendNull();
+                } else if (count == 1) {
+                    builder.appendDouble(intBlock.getInt(intBlock.getFirstValueIndex(pos)));
+                } else {
+                    int firstIdx = intBlock.getFirstValueIndex(pos);
+                    builder.beginPositionEntry();
+                    for (int v = 0; v < count; v++) {
+                        builder.appendDouble(intBlock.getInt(firstIdx + v));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private Block castDatetimeToDateNanos(LongBlock longBlock, int positions) {
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(positions)) {
+            for (int pos = 0; pos < positions; pos++) {
+                int count = longBlock.getValueCount(pos);
+                if (longBlock.isNull(pos) || count == 0) {
+                    builder.appendNull();
+                } else if (count == 1) {
+                    builder.appendLong(longBlock.getLong(longBlock.getFirstValueIndex(pos)) * 1_000_000L);
+                } else {
+                    int firstIdx = longBlock.getFirstValueIndex(pos);
+                    builder.beginPositionEntry();
+                    for (int v = 0; v < count; v++) {
+                        builder.appendLong(longBlock.getLong(firstIdx + v) * 1_000_000L);
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.build();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -67,20 +67,20 @@ public final class SchemaReconciliation {
      * Handles both planning-time use (with {@link DataType} references) and wire
      * serialization (via {@link Writeable}), so there is no separate "wire" class.
      * <p>
-     * Cast types are encoded as single-byte {@link CastType} ordinals on the wire,
-     * not strings. No field names are transferred — only positional indices and cast
-     * ordinals.
+     * Cast types are serialized via {@link StreamOutput#writeEnum}/{@link StreamInput#readEnum}
+     * (ordinal-based). The ordinal mapping is pinned by an {@code assertEnumSerialization} test
+     * so any reordering or insertion is caught at test time.
      * <p>
      * <b>Coordinator sharing:</b> {@code FileSplitProvider} passes the same instance
      * to all splits from the same file. A dedup cache ensures files with content-equal
      * mappings share a single object. Duplication only occurs during wire serialization.
      * <p>
      * <b>Wire-size analysis:</b> for a file split into K chunks with N unified columns,
-     * the overhead is {@code K * (4*N + N)} bytes when casts are present, or
-     * {@code K * 4*N} when no casts are needed. For typical schemas (N &lt; 200) and split
-     * counts (K &lt; 50), this is well under 50 KB total — negligible next to the data
-     * payload. See {@link CoalescedSplit} for approaches to eliminate per-split duplication
-     * on the wire for very wide schemas.
+     * the overhead is {@code K * (4*N + N)} bytes when casts are present (one VInt ordinal
+     * per cast), or {@code K * 4*N} when no casts are needed. For typical schemas
+     * (N &lt; 200) and split counts (K &lt; 50), this is well under 50 KB total — negligible
+     * next to the data payload. See {@link CoalescedSplit} for approaches to eliminate
+     * per-split duplication on the wire for very wide schemas.
      * <p>
      * <b>Bitset alternative:</b> the {@code int[]} currently encodes both "missing" ({@code -1})
      * and "local index" for present columns. A bitset could represent missing-column flags
@@ -92,8 +92,9 @@ public final class SchemaReconciliation {
 
         /**
          * Supported widening cast targets.
-         * Ordinal values are used on the wire (one byte each), so new entries
-         * must be appended at the end to preserve backward compatibility.
+         * Serialized via {@link StreamOutput#writeEnum}/{@link StreamInput#readEnum} (ordinal-based).
+         * New entries must only be appended at the end; reordering or inserting breaks the wire
+         * protocol. The ordinal mapping is pinned by {@code SchemaReconciliationTests#testCastTypeEnumSerialization}.
          */
         public enum CastType {
             NONE(null),
@@ -121,13 +122,6 @@ public final class SchemaReconciliation {
                 }
                 throw new IllegalArgumentException("Unsupported cast target type: " + type.typeName());
             }
-
-            public static CastType fromOrdinal(byte ordinal) {
-                if (ordinal < 0 || ordinal >= VALUES.length) {
-                    throw new IllegalArgumentException("Unknown cast ordinal: " + ordinal);
-                }
-                return VALUES[ordinal];
-            }
         }
 
         private final int[] globalToLocalIndex;
@@ -153,11 +147,9 @@ public final class SchemaReconciliation {
                         "cast array length [" + castLen + "] must match index array length [" + globalToLocalIndex.length + "]"
                     );
                 }
-                byte[] ordinals = new byte[castLen];
-                in.readBytes(ordinals, 0, castLen);
                 this.casts = new DataType[castLen];
                 for (int i = 0; i < castLen; i++) {
-                    this.casts[i] = CastType.fromOrdinal(ordinals[i]).toDataType();
+                    this.casts[i] = in.readEnum(CastType.class).toDataType();
                 }
             } else {
                 this.casts = null;
@@ -168,12 +160,10 @@ public final class SchemaReconciliation {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeIntArray(globalToLocalIndex);
             if (casts != null) {
-                byte[] ordinals = new byte[casts.length];
-                for (int i = 0; i < casts.length; i++) {
-                    ordinals[i] = (byte) CastType.fromDataType(casts[i]).ordinal();
+                out.writeVInt(casts.length);
+                for (DataType cast : casts) {
+                    out.writeEnum(CastType.fromDataType(cast));
                 }
-                out.writeVInt(ordinals.length);
-                out.writeBytes(ordinals);
             } else {
                 out.writeVInt(0);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Schema reconciliation algorithms for multi-file external sources.
+ * <p>
+ * Supports three strategies:
+ * <ul>
+ *   <li>{@code FIRST_FILE_WINS} — use the first file's schema (existing behavior, no reconciliation)</li>
+ *   <li>{@code STRICT} — validate all files share the exact same schema</li>
+ *   <li>{@code UNION_BY_NAME} — merge schemas by column name with safe type widening</li>
+ * </ul>
+ * <p>
+ * Type widening is intentionally conservative: only lossless promotions are allowed.
+ * This is NOT {@code EsqlDataTypeConverter.commonType()}, which allows LONG→DOUBLE (lossy above 2^53).
+ */
+public final class SchemaReconciliation {
+
+    private SchemaReconciliation() {}
+
+    /**
+     * Result of schema reconciliation during planning.
+     *
+     * @param unifiedSchema the merged/validated schema used for planning
+     * @param perFileInfo per-file schema info keyed by file path
+     */
+    public record Result(List<Attribute> unifiedSchema, Map<StoragePath, FileSchemaInfo> perFileInfo) {}
+
+    /**
+     * Per-file schema information collected during reconciliation.
+     *
+     * @param fileSchema the original schema from this file
+     * @param mapping column mapping from unified schema to file schema, null for identity mapping
+     * @param statistics optional statistics from file metadata
+     */
+    public record FileSchemaInfo(List<Attribute> fileSchema, @Nullable ColumnMapping mapping, @Nullable SourceStatistics statistics) {}
+
+    /**
+     * Maps unified schema column positions to file-local column positions.
+     * Handles both planning-time use (with {@link DataType} references) and wire
+     * serialization (via {@link Writeable}), so there is no separate "wire" class.
+     * <p>
+     * Cast types are encoded as single-byte {@link CastType} ordinals on the wire,
+     * not strings. No field names are transferred — only positional indices and cast
+     * ordinals.
+     * <p>
+     * <b>Coordinator sharing:</b> {@code FileSplitProvider} passes the same instance
+     * to all splits from the same file. A dedup cache ensures files with content-equal
+     * mappings share a single object. Duplication only occurs during wire serialization.
+     * <p>
+     * <b>Wire-size analysis:</b> for a file split into K chunks with N unified columns,
+     * the overhead is {@code K * (4*N + N)} bytes when casts are present, or
+     * {@code K * 4*N} when no casts are needed. For typical schemas (N &lt; 200) and split
+     * counts (K &lt; 50), this is well under 50 KB total — negligible next to the data
+     * payload. See {@link CoalescedSplit} for approaches to eliminate per-split duplication
+     * on the wire for very wide schemas.
+     * <p>
+     * <b>Bitset alternative:</b> the {@code int[]} currently encodes both "missing" ({@code -1})
+     * and "local index" for present columns. A bitset could represent missing-column flags
+     * in {@code ceil(N/8)} bytes and store only the present-column indices, saving ~50% on
+     * the int[] for schemas where most columns are absent. This trade-off only matters for
+     * very wide schemas and is left as a future optimisation.
+     */
+    public static final class ColumnMapping implements Writeable {
+
+        /**
+         * Supported widening cast targets.
+         * Ordinal values are used on the wire (one byte each), so new entries
+         * must be appended at the end to preserve backward compatibility.
+         */
+        public enum CastType {
+            NONE(null),
+            LONG(DataType.LONG),
+            DOUBLE(DataType.DOUBLE),
+            DATE_NANOS(DataType.DATE_NANOS);
+
+            private static final CastType[] VALUES = values();
+
+            private final DataType dataType;
+
+            CastType(@Nullable DataType dataType) {
+                this.dataType = dataType;
+            }
+
+            @Nullable
+            public DataType toDataType() {
+                return dataType;
+            }
+
+            public static CastType fromDataType(@Nullable DataType type) {
+                if (type == null) return NONE;
+                for (CastType ct : VALUES) {
+                    if (ct.dataType == type) return ct;
+                }
+                throw new IllegalArgumentException("Unsupported cast target type: " + type.typeName());
+            }
+
+            public static CastType fromOrdinal(byte ordinal) {
+                if (ordinal < 0 || ordinal >= VALUES.length) {
+                    throw new IllegalArgumentException("Unknown cast ordinal: " + ordinal);
+                }
+                return VALUES[ordinal];
+            }
+        }
+
+        private final int[] globalToLocalIndex;
+        @Nullable
+        private final DataType[] casts;
+
+        public ColumnMapping(int[] globalToLocalIndex, @Nullable DataType[] casts) {
+            if (casts != null && casts.length != globalToLocalIndex.length) {
+                throw new IllegalArgumentException(
+                    "cast array length [" + casts.length + "] must match index array length [" + globalToLocalIndex.length + "]"
+                );
+            }
+            this.globalToLocalIndex = Arrays.copyOf(globalToLocalIndex, globalToLocalIndex.length);
+            this.casts = casts != null ? Arrays.copyOf(casts, casts.length) : null;
+        }
+
+        public ColumnMapping(StreamInput in) throws IOException {
+            this.globalToLocalIndex = in.readIntArray();
+            int castLen = in.readVInt();
+            if (castLen > 0) {
+                if (castLen != globalToLocalIndex.length) {
+                    throw new IllegalArgumentException(
+                        "cast array length [" + castLen + "] must match index array length [" + globalToLocalIndex.length + "]"
+                    );
+                }
+                byte[] ordinals = new byte[castLen];
+                in.readBytes(ordinals, 0, castLen);
+                this.casts = new DataType[castLen];
+                for (int i = 0; i < castLen; i++) {
+                    this.casts[i] = CastType.fromOrdinal(ordinals[i]).toDataType();
+                }
+            } else {
+                this.casts = null;
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeIntArray(globalToLocalIndex);
+            if (casts != null) {
+                byte[] ordinals = new byte[casts.length];
+                for (int i = 0; i < casts.length; i++) {
+                    ordinals[i] = (byte) CastType.fromDataType(casts[i]).ordinal();
+                }
+                out.writeVInt(ordinals.length);
+                out.writeBytes(ordinals);
+            } else {
+                out.writeVInt(0);
+            }
+        }
+
+        public int columnCount() {
+            return globalToLocalIndex.length;
+        }
+
+        public int localIndex(int globalIndex) {
+            return globalToLocalIndex[globalIndex];
+        }
+
+        @Nullable
+        public DataType cast(int globalIndex) {
+            return casts != null ? casts[globalIndex] : null;
+        }
+
+        public boolean hasMissingColumns() {
+            for (int idx : globalToLocalIndex) {
+                if (idx == -1) return true;
+            }
+            return false;
+        }
+
+        public boolean hasCasts() {
+            if (casts == null) return false;
+            for (DataType cast : casts) {
+                if (cast != null) return true;
+            }
+            return false;
+        }
+
+        public boolean isIdentity() {
+            if (hasMissingColumns() || hasCasts()) {
+                return false;
+            }
+            for (int i = 0; i < globalToLocalIndex.length; i++) {
+                if (globalToLocalIndex[i] != i) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ColumnMapping that = (ColumnMapping) o;
+            return Arrays.equals(globalToLocalIndex, that.globalToLocalIndex) && Arrays.equals(casts, that.casts);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Arrays.hashCode(globalToLocalIndex);
+            result = 31 * result + Arrays.hashCode(casts);
+            return result;
+        }
+    }
+
+    /**
+     * Safe type widening for schema reconciliation.
+     * Only lossless promotions are allowed; returns null if no safe supertype exists.
+     * <p>
+     * Widening rules:
+     * <ul>
+     *   <li>INTEGER + LONG → LONG (lossless: int32 ⊆ int64)</li>
+     *   <li>INTEGER + DOUBLE → DOUBLE (lossless: int32 ≤ 2^31 &lt; 2^53)</li>
+     *   <li>DATETIME + DATE_NANOS → DATE_NANOS (more precise type wins)</li>
+     * </ul>
+     * All other cross-type pairs return null (incompatible).
+     *
+     * @return the widened type, or null if no safe supertype exists
+     */
+    @Nullable
+    public static DataType schemaWiden(DataType a, DataType b) {
+        if (a == b) {
+            return a;
+        }
+        DataType wider = widenOrdered(a, b);
+        if (wider != null) {
+            return wider;
+        }
+        return widenOrdered(b, a);
+    }
+
+    @Nullable
+    private static DataType widenOrdered(DataType left, DataType right) {
+        if (left == DataType.INTEGER && right == DataType.LONG) {
+            return DataType.LONG;
+        }
+        if (left == DataType.INTEGER && right == DataType.DOUBLE) {
+            return DataType.DOUBLE;
+        }
+        if (left == DataType.DATETIME && right == DataType.DATE_NANOS) {
+            return DataType.DATE_NANOS;
+        }
+        return null;
+    }
+
+    /**
+     * STRICT reconciliation: validate all files share the exact same schema.
+     * Nullability differences are tolerated; all other differences produce an error.
+     *
+     * @param referenceFile path of the first (reference) file
+     * @param fileMetadata ordered map of file path → metadata (first entry is the reference)
+     * @return reconciliation result with the reference schema and per-file info
+     * @throws IllegalArgumentException if any file's schema doesn't match
+     */
+    public static Result reconcileStrict(StoragePath referenceFile, Map<StoragePath, SourceMetadata> fileMetadata) {
+        SourceMetadata refMeta = fileMetadata.get(referenceFile);
+        if (refMeta == null) {
+            throw new IllegalArgumentException("Reference file not found in metadata: " + referenceFile);
+        }
+        List<Attribute> refSchema = refMeta.schema();
+
+        Map<StoragePath, FileSchemaInfo> perFileInfo = new LinkedHashMap<>();
+
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            StoragePath filePath = entry.getKey();
+            SourceMetadata meta = entry.getValue();
+            List<Attribute> fileSchema = meta.schema();
+            SourceStatistics stats = meta.statistics().orElse(null);
+
+            validateNoDuplicateColumns(filePath, fileSchema);
+
+            if (filePath.equals(referenceFile) == false) {
+                validateStrictMatch(referenceFile, refSchema, filePath, fileSchema);
+            }
+
+            int[] identity = new int[refSchema.size()];
+            for (int i = 0; i < identity.length; i++) {
+                identity[i] = i;
+            }
+            perFileInfo.put(filePath, new FileSchemaInfo(fileSchema, new ColumnMapping(identity, null), stats));
+        }
+
+        return new Result(List.copyOf(refSchema), Map.copyOf(perFileInfo));
+    }
+
+    private static void validateStrictMatch(
+        StoragePath refPath,
+        List<Attribute> refSchema,
+        StoragePath filePath,
+        List<Attribute> fileSchema
+    ) {
+        if (refSchema.size() != fileSchema.size()) {
+            throw new IllegalArgumentException(
+                "Schema mismatch in ["
+                    + filePath
+                    + "]: expected "
+                    + refSchema.size()
+                    + " columns (from reference file ["
+                    + refPath
+                    + "]) but found "
+                    + fileSchema.size()
+                    + " columns."
+                    + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
+            );
+        }
+        for (int i = 0; i < refSchema.size(); i++) {
+            Attribute refAttr = refSchema.get(i);
+            Attribute fileAttr = fileSchema.get(i);
+            if (refAttr.name().equals(fileAttr.name()) == false) {
+                throw new IllegalArgumentException(
+                    "Schema mismatch in ["
+                        + filePath
+                        + "]: column "
+                        + i
+                        + " is ["
+                        + fileAttr.name()
+                        + "] but reference file ["
+                        + refPath
+                        + "] has ["
+                        + refAttr.name()
+                        + "]."
+                        + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
+                );
+            }
+            if (refAttr.dataType() != fileAttr.dataType()) {
+                throw new IllegalArgumentException(
+                    "Schema mismatch in ["
+                        + filePath
+                        + "]: column ["
+                        + fileAttr.name()
+                        + "] has type ["
+                        + fileAttr.dataType().typeName()
+                        + "] but reference file ["
+                        + refPath
+                        + "] has type ["
+                        + refAttr.dataType().typeName()
+                        + "]."
+                        + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
+                );
+            }
+        }
+    }
+
+    /**
+     * UNION_BY_NAME reconciliation: merge schemas from all files into a superset.
+     * Missing columns are NULL-filled; type differences are resolved by safe widening.
+     *
+     * @param fileMetadata ordered map of file path → metadata (insertion order = file sort order)
+     * @return reconciliation result with unified schema and per-file mappings
+     * @throws IllegalArgumentException if types are incompatible
+     */
+    public static Result reconcileUnionByName(Map<StoragePath, SourceMetadata> fileMetadata) {
+        LinkedHashMap<String, MergeEntry> unified = new LinkedHashMap<>();
+
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            StoragePath filePath = entry.getKey();
+            List<Attribute> fileSchema = entry.getValue().schema();
+
+            validateNoDuplicateColumns(filePath, fileSchema);
+
+            for (Attribute attr : fileSchema) {
+                String name = attr.name();
+                MergeEntry existing = unified.get(name);
+                if (existing == null) {
+                    boolean attrNullable = attr.nullable() == Nullability.TRUE || attr.nullable() == Nullability.UNKNOWN;
+                    unified.put(name, new MergeEntry(attr.dataType(), attrNullable, filePath));
+                } else {
+                    if (existing.type != attr.dataType()) {
+                        DataType widened = schemaWiden(existing.type, attr.dataType());
+                        if (widened == null) {
+                            throw new IllegalArgumentException(
+                                "Cannot merge schemas for column ["
+                                    + name
+                                    + "]: file ["
+                                    + existing.firstSeenIn
+                                    + "] has type ["
+                                    + existing.type.typeName()
+                                    + "], file ["
+                                    + filePath
+                                    + "] has type ["
+                                    + attr.dataType().typeName()
+                                    + "]. No compatible supertype exists."
+                                    + " Consider using an explicit CAST in your query."
+                            );
+                        }
+                        existing.type = widened;
+                    }
+                    boolean fileIsNullable = attr.nullable() == Nullability.TRUE || attr.nullable() == Nullability.UNKNOWN;
+                    existing.nullable = existing.nullable || fileIsNullable;
+                }
+            }
+        }
+
+        // Mark columns as nullable when missing from any file
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            Set<String> fileColumnNames = new HashSet<>();
+            for (Attribute attr : entry.getValue().schema()) {
+                fileColumnNames.add(attr.name());
+            }
+            for (Map.Entry<String, MergeEntry> ue : unified.entrySet()) {
+                if (fileColumnNames.contains(ue.getKey()) == false) {
+                    ue.getValue().nullable = true;
+                }
+            }
+        }
+
+        List<Attribute> unifiedSchema = new ArrayList<>(unified.size());
+        for (Map.Entry<String, MergeEntry> e : unified.entrySet()) {
+            String name = e.getKey();
+            MergeEntry me = e.getValue();
+            Nullability nullability = me.nullable ? Nullability.TRUE : Nullability.FALSE;
+            unifiedSchema.add(new ReferenceAttribute(Source.EMPTY, null, name, me.type, nullability, null, false));
+        }
+
+        Map<StoragePath, FileSchemaInfo> perFileInfo = new LinkedHashMap<>();
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            StoragePath filePath = entry.getKey();
+            SourceMetadata meta = entry.getValue();
+            List<Attribute> fileSchema = meta.schema();
+            SourceStatistics stats = meta.statistics().orElse(null);
+
+            ColumnMapping mapping = computeMapping(unifiedSchema, fileSchema);
+            perFileInfo.put(filePath, new FileSchemaInfo(fileSchema, mapping, stats));
+        }
+
+        return new Result(List.copyOf(unifiedSchema), Map.copyOf(perFileInfo));
+    }
+
+    static ColumnMapping computeMapping(List<Attribute> unifiedSchema, List<Attribute> fileSchema) {
+        Map<String, Integer> fileColumnIndex = new LinkedHashMap<>();
+        Map<String, DataType> fileColumnType = new LinkedHashMap<>();
+        for (int i = 0; i < fileSchema.size(); i++) {
+            fileColumnIndex.put(fileSchema.get(i).name(), i);
+            fileColumnType.put(fileSchema.get(i).name(), fileSchema.get(i).dataType());
+        }
+
+        int[] globalToLocal = new int[unifiedSchema.size()];
+        DataType[] casts = new DataType[unifiedSchema.size()];
+        boolean anyCasts = false;
+
+        for (int i = 0; i < unifiedSchema.size(); i++) {
+            Attribute unifiedAttr = unifiedSchema.get(i);
+            Integer localIdx = fileColumnIndex.get(unifiedAttr.name());
+            if (localIdx == null) {
+                globalToLocal[i] = -1;
+                casts[i] = null;
+            } else {
+                globalToLocal[i] = localIdx;
+                DataType fileType = fileColumnType.get(unifiedAttr.name());
+                if (fileType != unifiedAttr.dataType()) {
+                    casts[i] = unifiedAttr.dataType();
+                    anyCasts = true;
+                } else {
+                    casts[i] = null;
+                }
+            }
+        }
+
+        return new ColumnMapping(globalToLocal, anyCasts ? casts : null);
+    }
+
+    private static void validateNoDuplicateColumns(StoragePath filePath, List<Attribute> schema) {
+        Set<String> seen = new HashSet<>();
+        for (Attribute attr : schema) {
+            if (seen.add(attr.name()) == false) {
+                throw new IllegalArgumentException("File [" + filePath + "] contains duplicate column name [" + attr.name() + "].");
+            }
+        }
+    }
+
+    private static class MergeEntry {
+        DataType type;
+        boolean nullable;
+        final StoragePath firstSeenIn;
+
+        MergeEntry(DataType type, boolean nullable, StoragePath firstSeenIn) {
+            this.type = type;
+            this.nullable = nullable;
+            this.firstSeenIn = firstSeenIn;
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SchemaAdaptingIteratorTests extends ESTestCase {
+
+    private final BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("test"))
+        .build();
+
+    public void testIdentityPassThrough() {
+        List<Attribute> schema = List.of(attr("a", DataType.INTEGER), attr("b", DataType.KEYWORD));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, 1 }, null);
+
+        IntBlock aBlock = blockFactory.newConstantIntBlockWith(42, 3);
+        Block bBlock = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef("hello"), 3);
+        Page inputPage = new Page(3, new Block[] { aBlock, bBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), schema, mapping, blockFactory)) {
+            assertTrue(iter.hasNext());
+            Page result = iter.next();
+            assertThat(result.getPositionCount(), equalTo(3));
+            assertThat(result.getBlockCount(), equalTo(2));
+
+            IntBlock resultA = result.getBlock(0);
+            assertThat(resultA.getInt(0), equalTo(42));
+
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    public void testColumnReorder() {
+        List<Attribute> unified = List.of(attr("b", DataType.KEYWORD), attr("a", DataType.INTEGER));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 1, 0 }, null);
+
+        IntBlock aBlock = blockFactory.newConstantIntBlockWith(10, 2);
+        Block bBlock = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef("x"), 2);
+        Page inputPage = new Page(2, new Block[] { aBlock, bBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            assertThat(result.getBlockCount(), equalTo(2));
+
+            IntBlock resultA = result.getBlock(1);
+            assertThat(resultA.getInt(0), equalTo(10));
+        }
+    }
+
+    public void testMissingColumnNullFill() {
+        List<Attribute> unified = List.of(attr("a", DataType.INTEGER), attr("missing", DataType.LONG), attr("b", DataType.KEYWORD));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, -1, 1 }, null);
+
+        IntBlock aBlock = blockFactory.newConstantIntBlockWith(1, 4);
+        Block bBlock = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef("v"), 4);
+        Page inputPage = new Page(4, new Block[] { aBlock, bBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            assertThat(result.getBlockCount(), equalTo(3));
+            assertThat(result.getPositionCount(), equalTo(4));
+
+            Block nullBlock = result.getBlock(1);
+            assertTrue(nullBlock.isNull(0));
+            assertTrue(nullBlock.isNull(3));
+        }
+    }
+
+    public void testCastIntToLong() {
+        List<Attribute> unified = List.of(attr("val", DataType.LONG));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0 },
+            new DataType[] { DataType.LONG }
+        );
+
+        IntBlock intBlock = blockFactory.newConstantIntBlockWith(123, 2);
+        Page inputPage = new Page(2, new Block[] { intBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            LongBlock longBlock = result.getBlock(0);
+            assertThat(longBlock.getLong(0), equalTo(123L));
+            assertThat(longBlock.getLong(1), equalTo(123L));
+        }
+    }
+
+    public void testCastIntToDouble() {
+        List<Attribute> unified = List.of(attr("val", DataType.DOUBLE));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0 },
+            new DataType[] { DataType.DOUBLE }
+        );
+
+        IntBlock intBlock = blockFactory.newConstantIntBlockWith(42, 3);
+        Page inputPage = new Page(3, new Block[] { intBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            DoubleBlock doubleBlock = result.getBlock(0);
+            assertThat(doubleBlock.getDouble(0), equalTo(42.0));
+            assertThat(doubleBlock.getDouble(2), equalTo(42.0));
+        }
+    }
+
+    public void testCastDatetimeToDateNanos() {
+        List<Attribute> unified = List.of(attr("ts", DataType.DATE_NANOS));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0 },
+            new DataType[] { DataType.DATE_NANOS }
+        );
+
+        long millisValue = 1711800000000L;
+        LongBlock datetimeBlock = blockFactory.newConstantLongBlockWith(millisValue, 2);
+        Page inputPage = new Page(2, new Block[] { datetimeBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            LongBlock nanosBlock = result.getBlock(0);
+            assertThat(nanosBlock.getLong(0), equalTo(millisValue * 1_000_000L));
+            assertThat(nanosBlock.getLong(1), equalTo(millisValue * 1_000_000L));
+        }
+    }
+
+    public void testEmptyPage() {
+        List<Attribute> unified = List.of(attr("a", DataType.INTEGER), attr("b", DataType.LONG));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, -1 }, null);
+
+        IntBlock emptyBlock = blockFactory.newConstantIntBlockWith(0, 0);
+        Page inputPage = new Page(0, new Block[] { emptyBlock });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            Page result = iter.next();
+            assertThat(result.getPositionCount(), equalTo(0));
+            assertThat(result.getBlockCount(), equalTo(2));
+        }
+    }
+
+    public void testMemoryCleanupOnFailure() {
+        List<Attribute> unified = List.of(attr("a", DataType.INTEGER), attr("b", DataType.LONG));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0, 1 },
+            new DataType[] { null, DataType.DATE_NANOS }
+        );
+
+        IntBlock intBlock1 = blockFactory.newConstantIntBlockWith(1, 2);
+        IntBlock intBlock2 = blockFactory.newConstantIntBlockWith(2, 2);
+        Page inputPage = new Page(2, new Block[] { intBlock1, intBlock2 });
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), unified, mapping, blockFactory)) {
+            RuntimeException e = expectThrows(RuntimeException.class, iter::next);
+            assertThat(e.getMessage(), containsString("Failed to adapt page"));
+        }
+    }
+
+    public void testCloseDelegation() {
+        List<Attribute> unified = List.of(attr("a", DataType.INTEGER));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0 }, null);
+
+        AtomicBoolean closed = new AtomicBoolean(false);
+        CloseableIterator<Page> delegate = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+
+        SchemaAdaptingIterator iter = new SchemaAdaptingIterator(delegate, unified, mapping, blockFactory);
+        assertFalse(closed.get());
+        iter.close();
+        assertTrue(closed.get());
+    }
+
+    /**
+     * Mirrors production usage: full attributes include partition columns appended after
+     * data columns, but only the data prefix is passed to SchemaAdaptingIterator via
+     * {@code attributes.subList(0, mapping.columnCount())}.
+     */
+    public void testDataColumnSubListWithPartitionSuffix() {
+        List<Attribute> dataColumns = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 1, 0 }, null);
+
+        IntBlock idBlock = blockFactory.newConstantIntBlockWith(7, 2);
+        Block nameBlock = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef("Alice"), 2);
+        Page inputPage = new Page(2, new Block[] { idBlock, nameBlock });
+
+        List<Attribute> fullAttributes = List.of(
+            attr("id", DataType.INTEGER),
+            attr("name", DataType.KEYWORD),
+            attr("year", DataType.INTEGER)
+        );
+        List<Attribute> subList = fullAttributes.subList(0, mapping.columnCount());
+        assertThat(subList.size(), equalTo(2));
+
+        try (SchemaAdaptingIterator iter = new SchemaAdaptingIterator(singlePageIterator(inputPage), subList, mapping, blockFactory)) {
+            Page result = iter.next();
+            assertThat(result.getBlockCount(), equalTo(2));
+            assertThat(result.getPositionCount(), equalTo(2));
+
+            IntBlock resultId = result.getBlock(1);
+            assertThat(resultId.getInt(0), equalTo(7));
+        }
+    }
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, null, name, type);
+    }
+
+    private static CloseableIterator<Page> singlePageIterator(Page page) {
+        return new CloseableIterator<>() {
+            private boolean consumed = false;
+
+            @Override
+            public boolean hasNext() {
+                return consumed == false;
+            }
+
+            @Override
+            public Page next() {
+                if (consumed) {
+                    throw new NoSuchElementException();
+                }
+                consumed = true;
+                return page;
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
@@ -236,6 +236,38 @@ public class SchemaAdaptingIteratorTests extends ESTestCase {
         }
     }
 
+    /**
+     * Verifies the constructor rejects a schema whose size doesn't match the mapping's
+     * column count. This guards against accidentally passing the full attributes list
+     * (including partition columns) instead of just the data column prefix.
+     */
+    public void testConstructorRejectsMismatchedSchemaSize() {
+        List<Attribute> threeColumnSchema = List.of(attr("a", DataType.INTEGER), attr("b", DataType.KEYWORD), attr("c", DataType.LONG));
+        SchemaReconciliation.ColumnMapping twoColumnMapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, 1 }, null);
+
+        CloseableIterator<Page> emptyIter = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SchemaAdaptingIterator(emptyIter, threeColumnSchema, twoColumnMapping, blockFactory)
+        );
+        assertThat(ex.getMessage(), containsString("Schema size [3] does not match mapping column count [2]"));
+        assertThat(ex.getMessage(), containsString("partition columns"));
+    }
+
     private static Attribute attr(String name, DataType type) {
         return new ReferenceAttribute(Source.EMPTY, null, name, type);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SchemaReconciliationTests extends ESTestCase {
+
+    // === schemaWiden() tests ===
+
+    public void testSchemaWidenSameType() {
+        for (DataType type : List.of(
+            DataType.INTEGER,
+            DataType.LONG,
+            DataType.DOUBLE,
+            DataType.BOOLEAN,
+            DataType.KEYWORD,
+            DataType.DATETIME,
+            DataType.DATE_NANOS
+        )) {
+            assertThat(SchemaReconciliation.schemaWiden(type, type), equalTo(type));
+        }
+    }
+
+    public void testSchemaWidenIntegerToLong() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.INTEGER, DataType.LONG), equalTo(DataType.LONG));
+    }
+
+    public void testSchemaWidenIntegerToDouble() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.INTEGER, DataType.DOUBLE), equalTo(DataType.DOUBLE));
+    }
+
+    public void testSchemaWidenDatetimeToDateNanos() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.DATETIME, DataType.DATE_NANOS), equalTo(DataType.DATE_NANOS));
+    }
+
+    public void testSchemaWidenIsCommutative() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.LONG, DataType.INTEGER), equalTo(DataType.LONG));
+        assertThat(SchemaReconciliation.schemaWiden(DataType.DOUBLE, DataType.INTEGER), equalTo(DataType.DOUBLE));
+        assertThat(SchemaReconciliation.schemaWiden(DataType.DATE_NANOS, DataType.DATETIME), equalTo(DataType.DATE_NANOS));
+    }
+
+    public void testSchemaWidenLongToDoubleRejected() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.LONG, DataType.DOUBLE), nullValue());
+    }
+
+    public void testSchemaWidenUnsignedLongRejected() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.UNSIGNED_LONG, DataType.INTEGER), nullValue());
+        assertThat(SchemaReconciliation.schemaWiden(DataType.UNSIGNED_LONG, DataType.LONG), nullValue());
+        assertThat(SchemaReconciliation.schemaWiden(DataType.UNSIGNED_LONG, DataType.DOUBLE), nullValue());
+    }
+
+    public void testSchemaWidenIncompatibleTypes() {
+        assertThat(SchemaReconciliation.schemaWiden(DataType.INTEGER, DataType.KEYWORD), nullValue());
+        assertThat(SchemaReconciliation.schemaWiden(DataType.KEYWORD, DataType.BOOLEAN), nullValue());
+        assertThat(SchemaReconciliation.schemaWiden(DataType.LONG, DataType.KEYWORD), nullValue());
+        assertThat(SchemaReconciliation.schemaWiden(DataType.DOUBLE, DataType.KEYWORD), nullValue());
+    }
+
+    // === STRICT reconciliation tests ===
+
+    public void testStrictMatchingSchemas() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema), f2, meta(schema));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileStrict(f1, metadata);
+
+        assertThat(result.unifiedSchema().size(), equalTo(2));
+        assertThat(result.unifiedSchema().get(0).name(), equalTo("id"));
+        assertThat(result.unifiedSchema().get(1).name(), equalTo("name"));
+        assertThat(result.perFileInfo().size(), equalTo(2));
+
+        SchemaReconciliation.ColumnMapping mapping = result.perFileInfo().get(f1).mapping();
+        assertThat(mapping, notNullValue());
+        assertTrue(mapping.isIdentity());
+    }
+
+    public void testStrictColumnCountMismatch() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.INTEGER));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+        assertThat(e.getMessage(), containsString("expected 2 columns"));
+        assertThat(e.getMessage(), containsString("found 1 columns"));
+        assertThat(e.getMessage(), containsString("f2.parquet"));
+        assertThat(e.getMessage(), containsString("union_by_name"));
+    }
+
+    public void testStrictTypeMismatch() {
+        List<Attribute> schema1 = List.of(attr("salary", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("salary", DataType.LONG));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+        assertThat(e.getMessage(), containsString("salary"));
+        assertThat(e.getMessage(), containsString("long"));
+        assertThat(e.getMessage(), containsString("integer"));
+    }
+
+    public void testStrictNameMismatch() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("key", DataType.INTEGER));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+        assertThat(e.getMessage(), containsString("[key]"));
+        assertThat(e.getMessage(), containsString("[id]"));
+    }
+
+    public void testStrictNullabilityTolerated() {
+        List<Attribute> schema1 = List.of(attrNullable("id", DataType.INTEGER, Nullability.TRUE));
+        List<Attribute> schema2 = List.of(attrNullable("id", DataType.INTEGER, Nullability.FALSE));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileStrict(f1, metadata);
+        assertThat(result.unifiedSchema().size(), equalTo(1));
+    }
+
+    // === UNION_BY_NAME reconciliation tests ===
+
+    public void testUnionByNameIdenticalSchemas() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema), f2, meta(schema));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().size(), equalTo(2));
+        assertThat(result.unifiedSchema().get(0).name(), equalTo("id"));
+        assertThat(result.unifiedSchema().get(1).name(), equalTo("name"));
+    }
+
+    public void testUnionByNameAddedColumn() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD), attr("bonus", DataType.DOUBLE));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().size(), equalTo(3));
+        assertThat(result.unifiedSchema().get(2).name(), equalTo("bonus"));
+        assertThat(result.unifiedSchema().get(2).nullable(), equalTo(Nullability.TRUE));
+
+        SchemaReconciliation.ColumnMapping mapping1 = result.perFileInfo().get(f1).mapping();
+        assertThat(mapping1, notNullValue());
+        assertThat(mapping1.localIndex(2), equalTo(-1));
+
+        SchemaReconciliation.ColumnMapping mapping2 = result.perFileInfo().get(f2).mapping();
+        assertThat(mapping2, notNullValue());
+        assertThat(mapping2.localIndex(2), equalTo(2));
+    }
+
+    public void testUnionByNameRemovedColumn() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD), attr("dept", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().size(), equalTo(3));
+
+        SchemaReconciliation.ColumnMapping mapping1 = result.perFileInfo().get(f1).mapping();
+        assertTrue(mapping1.isIdentity());
+
+        SchemaReconciliation.ColumnMapping mapping2 = result.perFileInfo().get(f2).mapping();
+        assertThat(mapping2.localIndex(2), equalTo(-1));
+    }
+
+    public void testUnionByNameTypeWideningIntToLong() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("id", DataType.LONG));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.LONG));
+
+        SchemaReconciliation.ColumnMapping mapping1 = result.perFileInfo().get(f1).mapping();
+        assertThat(mapping1.hasCasts(), equalTo(true));
+        assertThat(mapping1.cast(0), equalTo(DataType.LONG));
+    }
+
+    public void testUnionByNameTypeWideningIntToDouble() {
+        List<Attribute> schema1 = List.of(attr("val", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("val", DataType.DOUBLE));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.DOUBLE));
+
+        SchemaReconciliation.ColumnMapping mapping1 = result.perFileInfo().get(f1).mapping();
+        assertThat(mapping1.hasCasts(), equalTo(true));
+        assertThat(mapping1.cast(0), equalTo(DataType.DOUBLE));
+
+        SchemaReconciliation.ColumnMapping mapping2 = result.perFileInfo().get(f2).mapping();
+        assertThat(mapping2.hasCasts(), equalTo(false));
+    }
+
+    public void testUnionByNameTypeWideningDatetimeToDateNanos() {
+        List<Attribute> schema1 = List.of(attr("ts", DataType.DATETIME));
+        List<Attribute> schema2 = List.of(attr("ts", DataType.DATE_NANOS));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.DATE_NANOS));
+
+        SchemaReconciliation.ColumnMapping mapping1 = result.perFileInfo().get(f1).mapping();
+        assertThat(mapping1.hasCasts(), equalTo(true));
+        assertThat(mapping1.cast(0), equalTo(DataType.DATE_NANOS));
+
+        SchemaReconciliation.ColumnMapping mapping2 = result.perFileInfo().get(f2).mapping();
+        assertThat(mapping2.hasCasts(), equalTo(false));
+    }
+
+    public void testUnionByNameLongToDoubleRejected() {
+        List<Attribute> schema1 = List.of(attr("val", DataType.LONG));
+        List<Attribute> schema2 = List.of(attr("val", DataType.DOUBLE));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> SchemaReconciliation.reconcileUnionByName(metadata)
+        );
+        assertThat(e.getMessage(), containsString("val"));
+        assertThat(e.getMessage(), containsString("No compatible supertype"));
+    }
+
+    public void testUnionByNameColumnOrdering() {
+        List<Attribute> schema1 = List.of(attr("b", DataType.INTEGER), attr("a", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("c", DataType.DOUBLE), attr("b", DataType.INTEGER));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).name(), equalTo("b"));
+        assertThat(result.unifiedSchema().get(1).name(), equalTo("a"));
+        assertThat(result.unifiedSchema().get(2).name(), equalTo("c"));
+    }
+
+    public void testUnionByNameThreeFilesTransitiveWidening() {
+        List<Attribute> schema1 = List.of(attr("val", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("val", DataType.INTEGER));
+        List<Attribute> schema3 = List.of(attr("val", DataType.LONG));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+        StoragePath f3 = path("s3://b/f3.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(f1, meta(schema1));
+        metadata.put(f2, meta(schema2));
+        metadata.put(f3, meta(schema3));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.LONG));
+    }
+
+    // === Config parsing tests ===
+
+    public void testParseSchemaResolutionNull() {
+        assertThat(ExternalSourceResolver.parseSchemaResolution(null), equalTo(FormatReader.SchemaResolution.FIRST_FILE_WINS));
+    }
+
+    public void testParseSchemaResolutionEmpty() {
+        assertThat(ExternalSourceResolver.parseSchemaResolution(Map.of()), equalTo(FormatReader.SchemaResolution.FIRST_FILE_WINS));
+    }
+
+    public void testParseSchemaResolutionFirstFileWins() {
+        assertThat(
+            ExternalSourceResolver.parseSchemaResolution(Map.of("schema_resolution", "first_file_wins")),
+            equalTo(FormatReader.SchemaResolution.FIRST_FILE_WINS)
+        );
+    }
+
+    public void testParseSchemaResolutionStrict() {
+        assertThat(
+            ExternalSourceResolver.parseSchemaResolution(Map.of("schema_resolution", "strict")),
+            equalTo(FormatReader.SchemaResolution.STRICT)
+        );
+    }
+
+    public void testParseSchemaResolutionUnionByName() {
+        assertThat(
+            ExternalSourceResolver.parseSchemaResolution(Map.of("schema_resolution", "union_by_name")),
+            equalTo(FormatReader.SchemaResolution.UNION_BY_NAME)
+        );
+    }
+
+    public void testParseSchemaResolutionCaseInsensitive() {
+        assertThat(
+            ExternalSourceResolver.parseSchemaResolution(Map.of("schema_resolution", "UNION_BY_NAME")),
+            equalTo(FormatReader.SchemaResolution.UNION_BY_NAME)
+        );
+    }
+
+    public void testParseSchemaResolutionInvalid() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ExternalSourceResolver.parseSchemaResolution(Map.of("schema_resolution", "invalid"))
+        );
+        assertThat(e.getMessage(), containsString("Unknown schema_resolution value"));
+    }
+
+    // === Duplicate column detection tests ===
+
+    public void testStrictDuplicateColumnRejected() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("id", DataType.KEYWORD));
+        StoragePath f1 = path("s3://b/f1.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema), f1, meta(schema));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+        assertThat(e.getMessage(), containsString("duplicate column name [id]"));
+    }
+
+    public void testUnionByNameDuplicateColumnRejected() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("id", DataType.KEYWORD));
+        StoragePath f1 = path("s3://b/f1.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(f1, meta(schema));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> SchemaReconciliation.reconcileUnionByName(metadata)
+        );
+        assertThat(e.getMessage(), containsString("duplicate column name [id]"));
+    }
+
+    // === Single-file reconciliation tests ===
+
+    public void testStrictSingleFile() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER));
+        StoragePath f1 = path("s3://b/f1.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(f1, meta(schema));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileStrict(f1, metadata);
+        assertThat(result.unifiedSchema().size(), equalTo(1));
+        assertThat(result.perFileInfo().size(), equalTo(1));
+    }
+
+    public void testUnionByNameSingleFile() {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        StoragePath f1 = path("s3://b/f1.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(f1, meta(schema));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+        assertThat(result.unifiedSchema().size(), equalTo(2));
+        assertThat(result.perFileInfo().get(f1).mapping().isIdentity(), equalTo(true));
+    }
+
+    // === Incompatible union types test ===
+
+    public void testUnionByNameIntegerVsKeywordRejected() {
+        List<Attribute> schema1 = List.of(attr("val", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("val", DataType.KEYWORD));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> SchemaReconciliation.reconcileUnionByName(metadata)
+        );
+        assertThat(e.getMessage(), containsString("val"));
+        assertThat(e.getMessage(), containsString("No compatible supertype"));
+    }
+
+    // === ColumnMapping tests ===
+
+    public void testColumnMappingIdentity() {
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, 1, 2 }, null);
+        assertTrue(mapping.isIdentity());
+        assertFalse(mapping.hasMissingColumns());
+        assertFalse(mapping.hasCasts());
+    }
+
+    public void testColumnMappingWithMissing() {
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 0, -1, 1 }, null);
+        assertFalse(mapping.isIdentity());
+        assertTrue(mapping.hasMissingColumns());
+    }
+
+    public void testColumnMappingPermutationNotIdentity() {
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(new int[] { 1, 0, 2 }, null);
+        assertFalse(mapping.isIdentity());
+        assertFalse(mapping.hasMissingColumns());
+        assertFalse(mapping.hasCasts());
+    }
+
+    public void testColumnMappingWithCasts() {
+        SchemaReconciliation.ColumnMapping mapping = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0, 1 },
+            new DataType[] { DataType.LONG, null }
+        );
+        assertFalse(mapping.isIdentity());
+        assertTrue(mapping.hasCasts());
+    }
+
+    // === Helpers ===
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, null, name, type);
+    }
+
+    private static Attribute attrNullable(String name, DataType type, Nullability nullability) {
+        return new ReferenceAttribute(Source.EMPTY, null, name, type, nullability, null, false);
+    }
+
+    private static StoragePath path(String s) {
+        return StoragePath.of(s);
+    }
+
+    private static SourceMetadata meta(List<Attribute> schema) {
+        return new SimpleMetadata(schema);
+    }
+
+    private static Map<StoragePath, SourceMetadata> orderedMap(StoragePath k1, SourceMetadata v1, StoragePath k2, SourceMetadata v2) {
+        Map<StoragePath, SourceMetadata> map = new LinkedHashMap<>();
+        map.put(k1, v1);
+        map.put(k2, v2);
+        return map;
+    }
+
+    private static class SimpleMetadata implements SourceMetadata {
+        private final List<Attribute> schema;
+
+        SimpleMetadata(List<Attribute> schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public List<Attribute> schema() {
+            return schema;
+        }
+
+        @Override
+        public String sourceType() {
+            return "parquet";
+        }
+
+        @Override
+        public String location() {
+            return "test";
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -16,6 +18,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -465,6 +468,99 @@ public class SchemaReconciliationTests extends ESTestCase {
         );
         assertFalse(mapping.isIdentity());
         assertTrue(mapping.hasCasts());
+    }
+
+    // === ColumnMapping serialization round-trip tests ===
+
+    public void testColumnMappingRoundTripNoCasts() throws IOException {
+        SchemaReconciliation.ColumnMapping original = new SchemaReconciliation.ColumnMapping(new int[] { 0, 1, 2 }, null);
+
+        SchemaReconciliation.ColumnMapping deserialized = roundTrip(original);
+
+        assertThat(deserialized.columnCount(), equalTo(3));
+        assertThat(deserialized.localIndex(0), equalTo(0));
+        assertThat(deserialized.localIndex(1), equalTo(1));
+        assertThat(deserialized.localIndex(2), equalTo(2));
+        assertFalse(deserialized.hasCasts());
+        assertTrue(deserialized.isIdentity());
+        assertThat(deserialized, equalTo(original));
+    }
+
+    public void testColumnMappingRoundTripWithCasts() throws IOException {
+        SchemaReconciliation.ColumnMapping original = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0, 1, -1 },
+            new DataType[] { DataType.LONG, null, null }
+        );
+
+        SchemaReconciliation.ColumnMapping deserialized = roundTrip(original);
+
+        assertThat(deserialized.columnCount(), equalTo(3));
+        assertThat(deserialized.localIndex(0), equalTo(0));
+        assertThat(deserialized.localIndex(1), equalTo(1));
+        assertThat(deserialized.localIndex(2), equalTo(-1));
+        assertTrue(deserialized.hasCasts());
+        assertThat(deserialized.cast(0), equalTo(DataType.LONG));
+        assertThat(deserialized.cast(1), nullValue());
+        assertThat(deserialized.cast(2), nullValue());
+        assertThat(deserialized, equalTo(original));
+    }
+
+    public void testColumnMappingRoundTripAllCastTypes() throws IOException {
+        SchemaReconciliation.ColumnMapping original = new SchemaReconciliation.ColumnMapping(
+            new int[] { 0, 1, 2 },
+            new DataType[] { DataType.LONG, DataType.DOUBLE, DataType.DATE_NANOS }
+        );
+
+        SchemaReconciliation.ColumnMapping deserialized = roundTrip(original);
+
+        assertThat(deserialized.cast(0), equalTo(DataType.LONG));
+        assertThat(deserialized.cast(1), equalTo(DataType.DOUBLE));
+        assertThat(deserialized.cast(2), equalTo(DataType.DATE_NANOS));
+        assertThat(deserialized, equalTo(original));
+    }
+
+    public void testColumnMappingRoundTripEmpty() throws IOException {
+        SchemaReconciliation.ColumnMapping original = new SchemaReconciliation.ColumnMapping(new int[] {}, null);
+
+        SchemaReconciliation.ColumnMapping deserialized = roundTrip(original);
+
+        assertThat(deserialized.columnCount(), equalTo(0));
+        assertTrue(deserialized.isIdentity());
+        assertThat(deserialized, equalTo(original));
+    }
+
+    public void testColumnMappingLengthMismatchRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SchemaReconciliation.ColumnMapping(new int[] { 0, 1 }, new DataType[] { DataType.LONG })
+        );
+        assertThat(e.getMessage(), containsString("cast array length [1] must match index array length [2]"));
+    }
+
+    public void testColumnMappingRoundTripWithMissingColumnsAndCasts() throws IOException {
+        SchemaReconciliation.ColumnMapping original = new SchemaReconciliation.ColumnMapping(
+            new int[] { 1, -1, 0, -1 },
+            new DataType[] { null, null, DataType.DOUBLE, null }
+        );
+
+        SchemaReconciliation.ColumnMapping deserialized = roundTrip(original);
+
+        assertThat(deserialized.columnCount(), equalTo(4));
+        assertThat(deserialized.localIndex(0), equalTo(1));
+        assertThat(deserialized.localIndex(1), equalTo(-1));
+        assertThat(deserialized.localIndex(2), equalTo(0));
+        assertThat(deserialized.localIndex(3), equalTo(-1));
+        assertTrue(deserialized.hasMissingColumns());
+        assertTrue(deserialized.hasCasts());
+        assertThat(deserialized.cast(2), equalTo(DataType.DOUBLE));
+        assertThat(deserialized, equalTo(original));
+    }
+
+    private static SchemaReconciliation.ColumnMapping roundTrip(SchemaReconciliation.ColumnMapping mapping) throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        mapping.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        return new SchemaReconciliation.ColumnMapping(in);
     }
 
     // === Helpers ===

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EnumSerializationTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
@@ -561,6 +562,16 @@ public class SchemaReconciliationTests extends ESTestCase {
         mapping.writeTo(out);
         StreamInput in = out.bytes().streamInput();
         return new SchemaReconciliation.ColumnMapping(in);
+    }
+
+    public void testCastTypeEnumSerialization() {
+        EnumSerializationTestUtils.assertEnumSerialization(
+            SchemaReconciliation.ColumnMapping.CastType.class,
+            SchemaReconciliation.ColumnMapping.CastType.NONE,
+            SchemaReconciliation.ColumnMapping.CastType.LONG,
+            SchemaReconciliation.ColumnMapping.CastType.DOUBLE,
+            SchemaReconciliation.ColumnMapping.CastType.DATE_NANOS
+        );
     }
 
     // === Helpers ===


### PR DESCRIPTION
Adds schema reconciliation for external file sources that span multiple files
with potentially different schemas. Users select a strategy via the WITH clause:

```sql
FROM "s3://bucket/data/*.parquet" WITH {"schema_resolution": "strict"}
FROM "s3://bucket/data/*.parquet" WITH {"schema_resolution": "union_by_name"}
```

### Problem

`FIRST_FILE_WINS` (the current default) silently ignores schema differences
across files. This causes wrong column values when files have different column
ordering, or runtime errors when types don't match — with no clear message
pointing to the root cause.

### Strategies

- **STRICT** — all files must share the exact same schema. Fails at planning
  time with a descriptive error naming the offending file and column, and a
  hint to use `union_by_name`.
- **UNION_BY_NAME** — merges schemas into a superset by column name. Missing
  columns are NULL-filled. Only lossless type widening is allowed (INTEGER→LONG,
  INTEGER→DOUBLE, DATETIME→DATE_NANOS). LONG→DOUBLE is rejected (lossy above
  2^53), matching DuckDB and Spark consensus.

The default remains `first_file_wins` for backward compatibility.

### Design rationale

Informed by a survey of DuckDB, Spark, ClickHouse, and Cribl — see
`SCHEMA_RECONCILIATION_DESIGN.md`. Both strategies scan all file metadata
eagerly at planning time (footer reads only, parallelized with bounded
concurrency). This also collects per-file statistics for aggregate pushdown
Phase 2 at zero extra cost.

Type widening uses a custom `schemaWiden()` — not `EsqlDataTypeConverter.commonType()`
which allows lossy LONG→DOUBLE. Column matching is case-sensitive, consistent
with ESQL's field resolution semantics.

Developed with AI-assisted tooling