### PR TITLE
[9.2] Improve SAML error handling by adding metadata (#137598)

### DIFF
--- a/docs/changelog/137598.yaml
+++ b/docs/changelog/137598.yaml
@@ -1,0 +1,6 @@
+pr: 137598
+summary: Improve SAML error handling by adding metadata
+area: Authentication
+type: enhancement
+issues:
+ - 128179

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc.saml;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.rest.ObjectPath;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+
+public class SamlInResponseToIT extends SamlRestTestCase {
+
+    private static final int REALM_NUMBER = 1;
+
+    public void testInResponseTo_matchingValues() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        String requestId = generateRandomRequestId();
+        var response = authUser(username, requestId, requestId);
+        assertThat(response, hasKey("access_token"));
+    }
+
+    public void testInResponseTo_requestAndTokenHaveDifferentValues() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        String requestIdFromRequest = generateRandomRequestId();
+        String requestIdFromToken = generateDifferentRandomRequestId(requestIdFromRequest);
+
+        var exception = expectThrows(ResponseException.class, () -> authUser(username, requestIdFromRequest, requestIdFromToken));
+        assertThat(exception.getResponse().getStatusLine().getStatusCode(), is(401));
+        String errorEntity = EntityUtils.toString(exception.getResponse().getEntity());
+        assertThat(errorEntity, containsString("\"security.saml.unsolicited_in_response_to\":\"" + requestIdFromToken + "\""));
+    }
+
+    public void testInResponseTo_requestNullTokenNotNull() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        String requestIdFromToken = generateRandomRequestId();
+
+        var exception = expectThrows(ResponseException.class, () -> authUser(username, null, requestIdFromToken));
+        assertThat(exception.getResponse().getStatusLine().getStatusCode(), is(401));
+        String errorEntity = EntityUtils.toString(exception.getResponse().getEntity());
+        assertThat(errorEntity, containsString("\"security.saml.unsolicited_in_response_to\":\"" + requestIdFromToken + "\""));
+    }
+
+    public void testInResponseTo_requestNotNullTokenNull() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        String requestIdFromRequest = generateRandomRequestId();
+
+        var response = authUser(username, requestIdFromRequest, null);
+        assertThat(response, hasKey("access_token"));
+    }
+
+    public void testInResponseTo_requestNullTokenNull() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        var response = authUser(username, null, null);
+        assertThat(response, hasKey("access_token"));
+    }
+
+    private String generateRandomRequestId() {
+        return randomAlphaOfLength(1) + randomAlphanumericOfLength(random().nextInt(10));
+    }
+
+    private String generateDifferentRandomRequestId(String existingId) {
+        String newId;
+        do {
+            newId = generateRandomRequestId();
+        } while (newId.equals(existingId));
+        return newId;
+    }
+
+    private Map<String, Object> authUser(String username, String inResponseToFromHeader, String inResponseToInSamlToken) throws Exception {
+
+        var httpsAddress = getAcsHttpsAddress();
+        var message = new SamlResponseBuilder().spEntityId("https://sp" + REALM_NUMBER + ".example.org/")
+            .idpEntityId(getIdpEntityId(REALM_NUMBER))
+            .acs(new URL("https://" + httpsAddress.getHostName() + ":" + httpsAddress.getPort() + "/acs/" + REALM_NUMBER))
+            .attribute("urn:oid:2.5.4.3", username)
+            .sign(getDataPath(SAML_SIGNING_CRT), getDataPath(SAML_SIGNING_KEY), new char[0])
+            .inResponseTo(inResponseToInSamlToken)
+            .asString();
+
+        final Map<String, Object> body = new HashMap<>();
+        body.put("content", Base64.getEncoder().encodeToString(message.getBytes(StandardCharsets.UTF_8)));
+        body.put("realm", getSamlRealmName(REALM_NUMBER));
+        if (inResponseToFromHeader != null) {
+            body.put("ids", inResponseToFromHeader);
+        }
+
+        var req = new Request("POST", "_security/saml/authenticate");
+        req.setJsonEntity(Strings.toString(JsonXContent.contentBuilder().map(body)));
+        var resp = entityAsMap(client().performRequest(req));
+        assertThat(resp, hasEntry("username", username));
+        assertThat(ObjectPath.evaluate(resp, "authentication.authentication_realm.name"), equalTo(getSamlRealmName(REALM_NUMBER)));
+        return resp;
+    }
+}

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseBuilder.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseBuilder.java
@@ -122,6 +122,11 @@ public class SamlResponseBuilder {
         return this;
     }
 
+    public SamlResponseBuilder inResponseTo(String requestId) {
+        this.inResponseTo = requestId;
+        return this;
+    }
+
     public SamlResponseBuilder sign(Path certPath, Path keyPath, char[] keyPassword) throws GeneralSecurityException, IOException {
         var privateKey = PemUtils.readPrivateKey(keyPath, () -> keyPassword);
         var certificates = PemUtils.readCertificates(List.of(certPath));

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc.saml;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpsServer;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.http.PemHttpsConfigurator;
+import org.elasticsearch.mocksocket.MockHttpServer;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.model.User;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.cert.CertificateException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SamlRestTestCase extends ESRestTestCase {
+    protected static final String SAML_SIGNING_CRT = "/saml/signing.crt";
+    protected static final String SAML_SIGNING_KEY = "/saml/signing.key";
+
+    private static HttpsServer httpsServer;
+    private static final Map<Integer, Boolean> metadataAvailable = new HashMap<>();
+    public static final ElasticsearchCluster cluster = initTestCluster();
+    private static Path caPath;
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(new RunnableTestRuleAdapter(SamlRestTestCase::initWebserver))
+        .around(cluster)
+        // during the startup, the metadata remains unavailable to prevent caching. After cluster init, make metadata available.
+        .around(new RunnableTestRuleAdapter(() -> makeMetadataAvailable(1, 2, 3)));
+
+    private static void initWebserver() {
+        try {
+            final InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress().getHostAddress(), 0);
+            final Path cert = getDataResource("/ssl/http.crt");
+            final Path key = getDataResource("/ssl/http.key");
+            httpsServer = MockHttpServer.createHttps(address, 0);
+            httpsServer.setHttpsConfigurator(new PemHttpsConfigurator(cert, key, new char[0]));
+            httpsServer.start();
+            List.of(1, 2, 3).forEach(realmNumber -> {
+                try {
+                    configureMetadataResource(realmNumber);
+                } catch (CertificateException | IOException | URISyntaxException e) {
+                    throw new RuntimeException("Cannot configure metadata for realm " + realmNumber, e);
+                }
+            });
+        } catch (URISyntaxException | IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Failed to initialise mock web server", e);
+        }
+    }
+
+    @AfterClass
+    public static void shutdownWebserver() {
+        httpsServer.stop(0);
+        httpsServer = null;
+    }
+
+    private static ElasticsearchCluster initTestCluster() {
+        return ElasticsearchCluster.local()
+            .nodes(1)
+            .module("analysis-common")
+            .setting("xpack.license.self_generated.type", "trial")
+            .setting("xpack.security.enabled", "true")
+            .setting("xpack.security.authc.token.enabled", "true")
+            .setting("xpack.security.authc.api_key.enabled", "true")
+            .setting("xpack.security.http.ssl.enabled", "true")
+            .setting("xpack.security.http.ssl.certificate", "node.crt")
+            .setting("xpack.security.http.ssl.key", "node.key")
+            .setting("xpack.security.http.ssl.certificate_authorities", "ca.crt")
+            .setting("xpack.security.transport.ssl.enabled", "true")
+            .setting("xpack.security.transport.ssl.certificate", "node.crt")
+            .setting("xpack.security.transport.ssl.key", "node.key")
+            .setting("xpack.security.transport.ssl.certificate_authorities", "ca.crt")
+            .setting("xpack.security.transport.ssl.verification_mode", "certificate")
+            .keystore("bootstrap.password", "x-pack-test-password")
+            .user("test_admin", "x-pack-test-password", User.ROOT_USER_ROLE, true)
+            .user("rest_test", "rest_password", User.ROOT_USER_ROLE, false)
+            .configFile("node.key", Resource.fromClasspath("ssl/node.key"))
+            .configFile("node.crt", Resource.fromClasspath("ssl/node.crt"))
+            .configFile("ca.crt", Resource.fromClasspath("ssl/ca.crt"))
+            .settings(node -> {
+                var acsWebServerAddress = getAcsHttpsAddress();
+                var acsHttps = "https://" + acsWebServerAddress.getHostName() + ":" + acsWebServerAddress.getPort() + "/";
+                var idpWebServerAddress = getIdpHttpsAddress();
+                var idpHttps = "https://" + idpWebServerAddress.getHostName() + ":" + idpWebServerAddress.getPort() + "/";
+                var settings = new HashMap<String, String>();
+                for (int realmNumber : List.of(1, 2, 3)) {
+                    var prefix = "xpack.security.authc.realms.saml.saml" + realmNumber;
+                    var idpEntityId = getIdpEntityId(realmNumber);
+                    settings.put(prefix + ".order", String.valueOf(realmNumber));
+                    settings.put(prefix + ".idp.entity_id", idpEntityId);
+                    settings.put(prefix + ".idp.metadata.path", idpHttps + "metadata/" + realmNumber + ".xml");
+                    settings.put(prefix + ".sp.entity_id", "https://sp" + realmNumber + ".example.org/");
+                    settings.put(prefix + ".sp.acs", acsHttps + "acs/" + realmNumber);
+                    settings.put(prefix + ".attributes.principal", "urn:oid:2.5.4.3");
+                    settings.put(prefix + ".ssl.certificate_authorities", "ca.crt");
+                }
+                return settings;
+            })
+            .build();
+    }
+
+    private static Path getDataResource(String relativePath) throws URISyntaxException {
+        return PathUtils.get(SamlRestTestCase.class.getResource(relativePath).toURI());
+    }
+
+    protected static String getIdpEntityId(int realmNumber) {
+        return "https://idp" + realmNumber + ".example.org/";
+    }
+
+    protected static String getSamlRealmName(int realmNumber) {
+        return "saml" + realmNumber;
+    }
+
+    protected static void makeMetadataAvailable(int... realms) {
+        for (int r : realms) {
+            metadataAvailable.put(Integer.valueOf(r), true);
+        }
+    }
+
+    protected static void makeAllMetadataUnavailable() {
+        metadataAvailable.keySet().forEach(k -> metadataAvailable.put(k, false));
+    }
+
+    protected static InetSocketAddress getAcsHttpsAddress() {
+        return httpsServer.getAddress();
+    }
+
+    protected static InetSocketAddress getIdpHttpsAddress() {
+        return httpsServer.getAddress();
+    }
+
+    private static void configureMetadataResource(int realmNumber) throws CertificateException, IOException, URISyntaxException {
+        metadataAvailable.putIfAbsent(realmNumber, false);
+
+        var signingCert = getDataResource(SAML_SIGNING_CRT);
+        var metadataBody = new SamlIdpMetadataBuilder().entityId(getIdpEntityId(realmNumber)).sign(signingCert).asString();
+        httpsServer.createContext("/metadata/" + realmNumber + ".xml", http -> {
+            if (metadataAvailable.get(realmNumber)) {
+                sendXmlContent(metadataBody, http);
+            } else {
+                if (randomBoolean()) {
+                    http.sendResponseHeaders(randomFrom(404, 401, 403, 500), 0);
+                    http.getResponseBody().close();
+                } else {
+                    sendXmlContent("not valid xml", http);
+                }
+            }
+        });
+    }
+
+    private static void sendXmlContent(String bodyContent, HttpExchange http) throws IOException {
+        http.getResponseHeaders().add("Content-Type", "text/xml");
+        http.sendResponseHeaders(200, bodyContent.length());
+        try (var out = http.getResponseBody()) {
+            out.write(bodyContent.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @BeforeClass
+    public static void loadCertificateAuthority() throws Exception {
+        URL resource = SamlRestTestCase.class.getResource("/ssl/ca.crt");
+        if (resource == null) {
+            throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
+        }
+        caPath = PathUtils.get(resource.toURI());
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected String getProtocol() {
+        return "https";
+    }
+
+    @Override
+    protected Settings restAdminSettings() {
+        final String token = basicAuthHeaderValue("test_admin", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        final String token = basicAuthHeaderValue("rest_test", new SecureString("rest_password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
+    }
+}

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -7,41 +7,14 @@
 
 package org.elasticsearch.xpack.security.authc.saml;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpsServer;
-
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.settings.SecureString;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.PathUtils;
-import org.elasticsearch.http.PemHttpsConfigurator;
-import org.elasticsearch.mocksocket.MockHttpServer;
-import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.model.User;
-import org.elasticsearch.test.cluster.util.resource.Resource;
-import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.security.GeneralSecurityException;
-import java.security.cert.CertificateException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -50,150 +23,11 @@ import java.util.Map;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class SamlServiceProviderMetadataIT extends ESRestTestCase {
-
-    private static HttpsServer httpsServer;
-    private static Map<Integer, Boolean> metadataAvailable = new HashMap<>();
-
-    public static ElasticsearchCluster cluster = initTestCluster();
-
-    private static Path caPath;
-
-    @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(new RunnableTestRuleAdapter(SamlServiceProviderMetadataIT::initWebserver))
-        .around(cluster);
-
-    private static void initWebserver() {
-        try {
-            final InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress().getHostAddress(), 0);
-            final Path cert = getDataResource("/ssl/http.crt");
-            final Path key = getDataResource("/ssl/http.key");
-            httpsServer = MockHttpServer.createHttps(address, 0);
-            httpsServer.setHttpsConfigurator(new PemHttpsConfigurator(cert, key, new char[0]));
-            httpsServer.start();
-            List.of(1, 2, 3).forEach(realmNumber -> {
-                try {
-                    configureMetadataResource(realmNumber);
-                } catch (CertificateException | IOException | URISyntaxException e) {
-                    throw new RuntimeException("Cannot configure metadata for realm " + realmNumber, e);
-                }
-            });
-        } catch (URISyntaxException | IOException | GeneralSecurityException e) {
-            throw new RuntimeException("Failed to initialise mock web server", e);
-        }
-    }
-
-    @AfterClass
-    public static void shutdownWebserver() {
-        httpsServer.stop(0);
-        httpsServer = null;
-    }
-
-    private static ElasticsearchCluster initTestCluster() {
-        return ElasticsearchCluster.local()
-            .nodes(1)
-            .module("analysis-common")
-            .setting("xpack.license.self_generated.type", "trial")
-            .setting("xpack.security.enabled", "true")
-            .setting("xpack.security.authc.token.enabled", "true")
-            .setting("xpack.security.authc.api_key.enabled", "true")
-            .setting("xpack.security.http.ssl.enabled", "true")
-            .setting("xpack.security.http.ssl.certificate", "node.crt")
-            .setting("xpack.security.http.ssl.key", "node.key")
-            .setting("xpack.security.http.ssl.certificate_authorities", "ca.crt")
-            .setting("xpack.security.transport.ssl.enabled", "true")
-            .setting("xpack.security.transport.ssl.certificate", "node.crt")
-            .setting("xpack.security.transport.ssl.key", "node.key")
-            .setting("xpack.security.transport.ssl.certificate_authorities", "ca.crt")
-            .setting("xpack.security.transport.ssl.verification_mode", "certificate")
-            .keystore("bootstrap.password", "x-pack-test-password")
-            .user("test_admin", "x-pack-test-password", User.ROOT_USER_ROLE, true)
-            .user("rest_test", "rest_password", User.ROOT_USER_ROLE, false)
-            .configFile("node.key", Resource.fromClasspath("ssl/node.key"))
-            .configFile("node.crt", Resource.fromClasspath("ssl/node.crt"))
-            .configFile("ca.crt", Resource.fromClasspath("ssl/ca.crt"))
-            .settings(node -> {
-                var samlWebServerAddress = httpsServer.getAddress();
-                var https = "https://" + samlWebServerAddress.getHostName() + ":" + samlWebServerAddress.getPort() + "/";
-                var settings = new HashMap<String, String>();
-                for (int realmNumber : List.of(1, 2, 3)) {
-                    var prefix = "xpack.security.authc.realms.saml.saml" + realmNumber;
-                    var idpEntityId = getIdpEntityId(realmNumber);
-                    settings.put(prefix + ".order", String.valueOf(realmNumber));
-                    settings.put(prefix + ".idp.entity_id", idpEntityId);
-                    settings.put(prefix + ".idp.metadata.path", https + "metadata/" + realmNumber + ".xml");
-                    settings.put(prefix + ".sp.entity_id", "https://sp" + realmNumber + ".example.org/");
-                    settings.put(prefix + ".sp.acs", https + "acs/" + realmNumber);
-                    settings.put(prefix + ".attributes.principal", "urn:oid:2.5.4.3");
-                    settings.put(prefix + ".ssl.certificate_authorities", "ca.crt");
-
-                }
-                return settings;
-            })
-            .build();
-    }
-
-    private static void configureMetadataResource(int realmNumber) throws CertificateException, IOException, URISyntaxException {
-        metadataAvailable.putIfAbsent(realmNumber, false);
-
-        var signingCert = getDataResource("/saml/signing.crt");
-        var metadataBody = new SamlIdpMetadataBuilder().entityId(getIdpEntityId(realmNumber)).sign(signingCert).asString();
-        httpsServer.createContext("/metadata/" + realmNumber + ".xml", http -> {
-            if (metadataAvailable.get(realmNumber)) {
-                sendXmlContent(metadataBody, http);
-            } else {
-                if (randomBoolean()) {
-                    http.sendResponseHeaders(randomFrom(404, 401, 403, 500), 0);
-                    http.getResponseBody().close();
-                } else {
-                    sendXmlContent("not valid xml", http);
-                }
-            }
-        });
-    }
-
-    private static void sendXmlContent(String bodyContent, HttpExchange http) throws IOException {
-        http.getResponseHeaders().add("Content-Type", "text/xml");
-        http.sendResponseHeaders(200, bodyContent.length());
-        try (var out = http.getResponseBody()) {
-            out.write(bodyContent.getBytes(StandardCharsets.UTF_8));
-        }
-    }
-
-    @BeforeClass
-    public static void loadCertificateAuthority() throws Exception {
-        URL resource = SamlServiceProviderMetadataIT.class.getResource("/ssl/ca.crt");
-        if (resource == null) {
-            throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
-        }
-        caPath = PathUtils.get(resource.toURI());
-    }
-
-    @Override
-    protected String getTestRestCluster() {
-        return cluster.getHttpAddresses();
-    }
-
-    @Override
-    protected String getProtocol() {
-        return "https";
-    }
-
-    @Override
-    protected Settings restAdminSettings() {
-        final String token = basicAuthHeaderValue("test_admin", new SecureString("x-pack-test-password".toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
-    }
-
-    @Override
-    protected Settings restClientSettings() {
-        final String token = basicAuthHeaderValue("rest_test", new SecureString("rest_password".toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
-    }
+public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {
         // Start with no metadata available
-        assertAllMetadataUnavailable();
+        makeAllMetadataUnavailable();
 
         final String username = randomAlphaOfLengthBetween(4, 12);
         for (int realmNumber : shuffledList(List.of(1, 2, 3))) {
@@ -215,47 +49,24 @@ public class SamlServiceProviderMetadataIT extends ESRestTestCase {
     }
 
     private void samlAuthUser(int realmNumber, String username) throws Exception {
-        var httpsAddress = httpsServer.getAddress();
+        var httpsAddress = getAcsHttpsAddress();
         var message = new SamlResponseBuilder().spEntityId("https://sp" + realmNumber + ".example.org/")
             .idpEntityId(getIdpEntityId(realmNumber))
             .acs(new URL("https://" + httpsAddress.getHostName() + ":" + httpsAddress.getPort() + "/acs/" + realmNumber))
             .attribute("urn:oid:2.5.4.3", username)
-            .sign(getDataPath("/saml/signing.crt"), getDataPath("/saml/signing.key"), new char[0])
+            .sign(getDataPath(SAML_SIGNING_CRT), getDataPath(SAML_SIGNING_KEY), new char[0])
             .asString();
 
         final Map<String, Object> body = new HashMap<>();
         body.put("content", Base64.getEncoder().encodeToString(message.getBytes(StandardCharsets.UTF_8)));
         if (randomBoolean()) {
             // If realm is not specified the action will infer it based on the ACS in the saml auth message
-            body.put("realm", "saml" + realmNumber);
+            body.put("realm", getSamlRealmName(realmNumber));
         }
         var req = new Request("POST", "_security/saml/authenticate");
         req.setJsonEntity(Strings.toString(JsonXContent.contentBuilder().map(body)));
         var resp = entityAsMap(client().performRequest(req));
         assertThat(resp.get("username"), equalTo(username));
-        assertThat(ObjectPath.evaluate(resp, "authentication.authentication_realm.name"), equalTo("saml" + realmNumber));
+        assertThat(ObjectPath.evaluate(resp, "authentication.authentication_realm.name"), equalTo(getSamlRealmName(realmNumber)));
     }
-
-    private static Path getDataResource(String relativePath) throws URISyntaxException {
-        return PathUtils.get(SamlServiceProviderMetadataIT.class.getResource(relativePath).toURI());
-    }
-
-    private static String getIdpEntityId(int realmNumber) {
-        return "https://idp" + realmNumber + ".example.org/";
-    }
-
-    private void makeMetadataAvailable(int... realms) {
-        for (int r : realms) {
-            metadataAvailable.put(Integer.valueOf(r), true);
-        }
-    }
-
-    private void assertAllMetadataUnavailable() {
-        metadataAvailable.forEach((realm, available) -> assertThat("For realm #" + realm, available, is(false)));
-    }
-
-    private void makeAllMetadataUnavailable() {
-        metadataAvailable.keySet().forEach(k -> metadataAvailable.put(k, false));
-    }
-
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -528,11 +528,7 @@ public final class SamlRealm extends Realm implements Releasable {
     }
 
     private boolean isTokenForRealm(SamlToken samlToken) {
-        if (samlToken.getAuthenticatingRealm() == null) {
-            return true;
-        } else {
-            return samlToken.getAuthenticatingRealm().equals(this.name());
-        }
+        return samlToken.getAuthenticatingRealm() != null && samlToken.getAuthenticatingRealm().equals(this.name());
     }
 
     /**
@@ -547,7 +543,8 @@ public final class SamlRealm extends Realm implements Releasable {
 
     @Override
     public void authenticate(AuthenticationToken authenticationToken, ActionListener<AuthenticationResult<User>> listener) {
-        if (authenticationToken instanceof SamlToken && isTokenForRealm((SamlToken) authenticationToken)) {
+        if (authenticationToken instanceof SamlToken samlToken
+            && (samlToken.getAuthenticatingRealm() == null || isTokenForRealm(samlToken))) {
             if (this.idpDescriptor.get() instanceof UnresolvedEntity) {
                 // This isn't an ideal check, but we don't have a better option right now
                 listener.onResponse(
@@ -564,10 +561,13 @@ public final class SamlRealm extends Realm implements Releasable {
                 logger.debug("Parsed token [{}] to attributes [{}]", token, attributes);
                 buildUser(attributes, ActionListener.releaseAfter(listener, attributes));
             } catch (ElasticsearchSecurityException e) {
-                if (SamlUtils.isSamlException(e)) {
-                    listener.onResponse(AuthenticationResult.unsuccessful("Provided SAML response is not valid for realm " + this, e));
-                } else {
+                if (isTokenForRealm(samlToken)) {
+                    // If this token is explicitly for this realm, then there is no need to try other realms.
                     listener.onFailure(e);
+                } else {
+                    // If this token's realm in not specified (null), then continue to try other realms.
+                    // Note that we can't make any assumptions about other realms, because then can be provided from a custom plugin.
+                    listener.onResponse(AuthenticationResult.unsuccessful("Provided SAML response is not valid for realm " + this, e));
                 }
             }
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseHandler.java
@@ -19,6 +19,7 @@ import java.time.Clock;
 import java.util.Collection;
 
 import static org.elasticsearch.xpack.security.authc.saml.SamlUtils.samlException;
+import static org.elasticsearch.xpack.security.authc.saml.SamlUtils.samlUnsolicitedInResponseToException;
 
 public class SamlResponseHandler extends SamlObjectHandler {
     public SamlResponseHandler(Clock clock, IdpConfiguration idp, SpConfiguration sp, TimeValue maxSkew) {
@@ -32,11 +33,7 @@ public class SamlResponseHandler extends SamlObjectHandler {
                     + "incorrectly populates the InResponseTo attribute",
                 response.getID()
             );
-            throw samlException(
-                "SAML content is in-response-to [{}] but expected one of {} ",
-                response.getInResponseTo(),
-                allowedSamlRequestIds
-            );
+            throw samlUnsolicitedInResponseToException(response.getInResponseTo(), allowedSamlRequestIds);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlToken.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,9 +31,9 @@ public class SamlToken implements AuthenticationToken {
      * @param allowedSamlRequestIds The request Ids for the authentication requests this SAML response is allowed to be in response to.
      * @param authenticatingRealm The realm that should autenticate this SAML message.
      */
-    public SamlToken(byte[] content, List<String> allowedSamlRequestIds, @Nullable String authenticatingRealm) {
+    public SamlToken(byte[] content, @Nullable List<String> allowedSamlRequestIds, @Nullable String authenticatingRealm) {
         this.content = content;
-        this.allowedSamlRequestIds = allowedSamlRequestIds;
+        this.allowedSamlRequestIds = allowedSamlRequestIds != null ? allowedSamlRequestIds : Collections.emptyList();
         this.authenticatingRealm = authenticatingRealm;
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Improve SAML error handling by adding metadata (#137598)](https://github.com/elastic/elasticsearch/pull/137598)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)