### PR TITLE
ESQL: Fix ROUND_TO tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -369,6 +369,30 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidShortWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145241
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:approximation.Approximated column and null}
+  issue: https://github.com/elastic/elasticsearch/issues/145248
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:approximation.Warn on no stats}
+  issue: https://github.com/elastic/elasticsearch/issues/145249
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:approximation.Exact stats by on small multi-valued data}
+  issue: https://github.com/elastic/elasticsearch/issues/145250
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:approximation.Exact stats on small multi-valued data}
+  issue: https://github.com/elastic/elasticsearch/issues/145251
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.math.RoundToTests
+  method: testFold {TestCase=<int, 15 fixed-interval ints>}
+  issue: https://github.com/elastic/elasticsearch/issues/145254
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.math.RoundToTests
+  method: testFold {TestCase=<long, 15 fixed-interval longs>}
+  issue: https://github.com/elastic/elasticsearch/issues/145255
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.math.RoundToTests
+  method: testEvaluateInManyThreads {TestCase=<long, 11 fixed-interval longs>}
+  issue: https://github.com/elastic/elasticsearch/issues/145256
+- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+  method: testWatcherWithApiKey {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/131964
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -369,9 +369,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidShortWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145241
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.math.RoundToTests
-  method: testCrankyEvaluateBlockWithoutNulls {TestCase=<int, 20 fixed-interval ints>}
-  issue: https://github.com/elastic/elasticsearch/issues/145245
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
@@ -210,7 +210,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
             long max = p.stream().mapToLong(l -> l).min().getAsLong();
             for (long l : p) {
-                if (l > max && f.doubleValue() > l) {
+                if (l > max && f.doubleValue() >= l) {
                     max = l;
                 }
             }
@@ -228,7 +228,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
             int max = p.stream().mapToInt(i -> i).min().getAsInt();
             for (int l : p) {
-                if (l > max && f.doubleValue() > l) {
+                if (l > max && f.doubleValue() >= l) {
                     max = l;
                 }
             }
@@ -263,7 +263,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
             double max = p.stream().mapToDouble(d -> d).min().getAsDouble();
             for (double d : p) {
-                if (d > max && f.doubleValue() > d) {
+                if (d > max && f.doubleValue() >= d) {
                     max = d;
                 }
             }
@@ -281,7 +281,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
             long max = p.stream().mapToLong(l -> l).min().getAsLong();
             for (long l : p) {
-                if (l > max && f.doubleValue() > l) {
+                if (l > max && f.doubleValue() >= l) {
                     max = l;
                 }
             }
@@ -299,7 +299,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
         return supplier(name, fieldType, fieldSupplier, pointsTypes, pointsSupplier, (f, p) -> {
             int max = p.stream().mapToInt(i -> i).min().getAsInt();
             for (int l : p) {
-                if (l > max && f.doubleValue() > l) {
+                if (l > max && f.doubleValue() >= l) {
                     max = l;
                 }
             }


### PR DESCRIPTION
It's a boundary condition thing - `>` vs `>=`.

Closes #145245
