### PR TITLE
Replaced IntegratedCount with SeparateCount for binary doc value fields

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -207,6 +207,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 // match only text fields are not stored by definition
                 TextFieldMapper.SyntheticSourceHelper.syntheticSourceDelegate(false, multiFields),
                 usesBinaryDocValuesForFallbackFields,
+                indexCreatedVersion(),
                 docValuesParameters.getValue().enabled(),
                 usesBinaryDocValues()
             );
@@ -241,6 +242,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final TextFieldType textFieldType;
         private final boolean storedFieldInBinaryFormat;
         private final boolean usesBinaryDocValuesForFallbackFields;
+        private final IndexVersion indexCreatedVersion;
         private final boolean usesBinaryDocValues;
 
         public MatchOnlyTextFieldType(
@@ -253,6 +255,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             boolean storedFieldInBinaryFormat,
             KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate,
             boolean usesBinaryDocValuesForFallbackFields,
+            IndexVersion indexCreatedVersion,
             boolean hasDocValues,
             boolean usesBinaryDocValues
         ) {
@@ -261,6 +264,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.textFieldType = new TextFieldType(name, isSyntheticSource, withinMultiField, syntheticSourceDelegate);
             this.storedFieldInBinaryFormat = storedFieldInBinaryFormat;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
+            this.indexCreatedVersion = indexCreatedVersion;
             this.usesBinaryDocValues = usesBinaryDocValues;
         }
 
@@ -275,6 +279,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 false,
                 null,
                 false,
+                IndexVersion.current(),
                 false,
                 false
             );
@@ -729,6 +734,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 // if there is no delegate, load from a fallback field we created
                 if (textFieldType.syntheticSourceDelegate().isEmpty()) {
                     if (usesBinaryDocValuesForFallbackFields) {
+                        if (indexCreatedVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
+                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(syntheticSourceFallbackFieldName());
+                        }
                         return new BytesRefsFromCustomBinaryBlockLoader(syntheticSourceFallbackFieldName());
                     } else {
                         // for bwc - load from a StoredField
@@ -907,11 +915,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         if (docValuesParameters.enabled()) {
             BytesRef binaryValue = new BytesRef(utfBytes.bytes(), utfBytes.offset(), utfBytes.length());
             if (fieldType().usesBinaryDocValues()) {
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(
-                    context.doc(),
-                    fieldType().name(),
-                    binaryValue
-                );
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(context.doc(), fieldType().name(), binaryValue);
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
                 // in such cases, store the value in binary doc values instead, which don't have these length limitations
@@ -955,13 +959,13 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     private void storeValueInFallbackField(String fallbackFieldName, BytesRef bytesRef, DocumentParserContext context) {
-        // store the value in a binary doc values field, create one if it doesn't exist
-        MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fallbackFieldName);
-        if (field == null) {
-            field = new MultiValuedBinaryDocValuesField.IntegratedCount(fallbackFieldName, true);
-            context.doc().addWithKey(fallbackFieldName, field);
-        }
-        field.add(bytesRef);
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            context.doc(),
+            fallbackFieldName,
+            bytesRef,
+            indexCreatedVersion,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+        );
     }
 
     @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
@@ -50,9 +51,11 @@ import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper.MatchOnlyTextFieldType;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.hamcrest.Matchers;
 
@@ -243,6 +246,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             false,
+            IndexVersion.current(),
             false,
             false
         );
@@ -266,6 +270,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             true,
+            IndexVersion.current(),
             false,
             false
         );
@@ -273,8 +278,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         // when
         BlockLoader blockLoader = ft.blockLoader(mockContext());
 
-        // then - should load from a fallback stored field
-        assertThat(blockLoader, Matchers.instanceOf(BytesRefsFromCustomBinaryBlockLoader.class));
+        // then - should load from binary doc values using separate count format
+        assertThat(blockLoader, Matchers.instanceOf(BytesRefsFromBinaryMultiSeparateCountBlockLoader.class));
     }
 
     public void testBlockLoaderUsesSyntheticSourceDelegateWhenIgnoreAboveIsNotSet() {
@@ -296,6 +301,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             syntheticSourceDelegate,
             true,
+            IndexVersion.current(),
             false,
             false
         );
@@ -344,6 +350,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             syntheticSourceDelegate,
             false,
+            IndexVersion.current(),
             false,
             false
         );
@@ -395,6 +402,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             syntheticSourceDelegate,
             false,
+            IndexVersion.current(),
             false,
             false
         );
@@ -431,6 +439,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             keywordFieldType,
             false,
+            IndexVersion.current(),
             false,
             false
         );
@@ -480,6 +489,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             false,
+            IndexVersion.current(),
             false,
             false
         );
@@ -504,6 +514,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             true,
+            IndexVersion.current(),
             false,
             false
         );
@@ -512,7 +523,32 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         var context = mock(MappedFieldType.BlockLoaderContext.class);
         BlockLoader blockLoader = ft.blockLoader(context);
 
-        // then - should load from a fallback binary doc values field
+        // then - should load from a fallback binary doc values field using separate count format
+        assertThat(blockLoader, Matchers.instanceOf(BytesRefsFromBinaryMultiSeparateCountBlockLoader.class));
+    }
+
+    public void testBlockLoaderLoadsFromFallbackBinaryDocValuesWhenSyntheticSourceIsEnabledWithPreviousIndexVersion() {
+        // given
+        MatchOnlyTextFieldType ft = new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
+            "field",
+            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
+            mock(NamedAnalyzer.class),
+            true,
+            Collections.emptyMap(),
+            false,
+            false,
+            null,
+            true,
+            IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES),
+            false,
+            false
+        );
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then - should load from a fallback binary doc values field using integrated count format
         assertThat(blockLoader, Matchers.instanceOf(BytesRefsFromCustomBinaryBlockLoader.class));
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -55,8 +55,8 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryM
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper.MatchOnlyTextFieldType;
 import org.elasticsearch.script.ScriptCompiler;
-import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -250,6 +250,7 @@ public class IndexVersions {
     public static final IndexVersion SEMANTIC_TEXT_DEFAULTS_TO_BFLOAT16 = def(9_088_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion STORE_IGNORED_FLATTENED_FIELDS_IN_BINARY_DOC_VALUES = def(9_089_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_BEST_COMPRESSION = def(9_090_0_00, Version.LUCENE_10_4_0);
+    public static final IndexVersion DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES = def(9_091_0_00, Version.LUCENE_10_4_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -89,12 +89,14 @@ public abstract class IgnoreMalformedStoredValues {
 
     private static void saveToBinaryDocValues(DocumentParserContext context, String fieldPath, BytesRef encoded) {
         final String fieldName = name(fieldPath);
-        MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fieldName);
-        if (field == null) {
-            field = new MultiValuedBinaryDocValuesField.IntegratedCount(fieldName, true);
-            context.doc().addWithKey(fieldName, field);
-        }
-        field.add(encoded);
+        IndexVersion indexVersion = context.indexSettings().getIndexVersionCreated();
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            context.doc(),
+            fieldName,
+            encoded,
+            indexVersion,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -217,7 +217,10 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             return;
         }
 
-        ignoredSourceFormat(context.indexSettings()).writeIgnoredFields(context.getIgnoredFieldValues());
+        ignoredSourceFormat(context.indexSettings()).writeIgnoredFields(
+            context.getIgnoredFieldValues(),
+            context.indexSettings().getIndexVersionCreated()
+        );
     }
 
     // In rare cases decoding values stored in this field can fail leading to entire source
@@ -551,13 +554,19 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
 
             @Override
             public void writeIgnoredFields(Collection<NameValue> ignoredFieldValues) {
+                writeIgnoredFields(ignoredFieldValues, IndexVersion.current());
+            }
+
+            @Override
+            public void writeIgnoredFields(Collection<NameValue> ignoredFieldValues, IndexVersion indexVersion) {
                 for (NameValue nameValue : ignoredFieldValues) {
-                    MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) nameValue.doc().getByKey(NAME);
-                    if (field == null) {
-                        field = new MultiValuedBinaryDocValuesField.IntegratedCount(NAME, true, false);
-                        nameValue.doc().addWithKey(NAME, field);
-                    }
-                    field.add(SingularIgnoredSourceEncoding.encode(nameValue));
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                        nameValue.doc(),
+                        NAME,
+                        SingularIgnoredSourceEncoding.encode(nameValue),
+                        indexVersion,
+                        MultiValuedBinaryDocValuesField.ValueOrdering.UNSORTED
+                    );
                 }
             }
 
@@ -584,6 +593,10 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         ) throws IOException;
 
         public abstract void writeIgnoredFields(Collection<NameValue> ignoredFieldValues);
+
+        public void writeIgnoredFields(Collection<NameValue> ignoredFieldValues, IndexVersion indexVersion) {
+            writeIgnoredFields(ignoredFieldValues);
+        }
 
         public abstract BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1364,13 +1364,15 @@ public final class KeywordFieldMapper extends FieldMapper {
                 final String fieldName = fieldType().syntheticSourceFallbackFieldName();
 
                 if (storeIgnoredFieldsInBinaryDocValues) {
-                    // store the value in a binary doc values field, create one if it doesn't exist
-                    MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fieldName);
-                    if (field == null) {
-                        field = new MultiValuedBinaryDocValuesField.IntegratedCount(fieldName, keepDuplicatesInBinaryDocValues());
-                        context.doc().addWithKey(fieldName, field);
-                    }
-                    field.add(bytesRef);
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                        context.doc(),
+                        fieldName,
+                        bytesRef,
+                        indexCreatedVersion,
+                        keepDuplicatesInBinaryDocValues()
+                            ? MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+                            : MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    );
                 } else {
                     // otherwise for bwc, store the value in a stored fields like we used to
                     context.doc().add(new StoredField(fieldName, bytesRef));
@@ -1413,11 +1415,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         if (fieldType().usesBinaryDocValues()) {
             assert fieldType.docValuesType() == DocValuesType.NONE;
-            MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(
-                context.doc(),
-                fieldType().name(),
-                binaryValue
-            );
+            MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(context.doc(), fieldType().name(), binaryValue);
         }
 
         // If we're using binary doc values, then the values are stored in a separate MultiValuedBinaryDocValuesField (see above)

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -11,8 +11,9 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -20,32 +21,38 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * A custom implementation of {@link org.apache.lucene.index.BinaryDocValues} that uses a {@link Set} to maintain a collection of unique
+ * A custom implementation of {@link org.apache.lucene.index.BinaryDocValues} that stores a collection of
  * binary doc values for fields with multiple values per document.
  */
-
 public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesField {
 
     // vints are unlike normal ints in that they may require 5 bytes instead of 4
     // see BytesStreamOutput.writeVInt()
     private static final int VINT_MAX_BYTES = 5;
 
-    protected final Collection<BytesRef> values;
-    protected final boolean sorted;
-    protected int docValuesByteCount = 0;
-
-    MultiValuedBinaryDocValuesField(String name, boolean keepDuplicates) {
-        this(name, keepDuplicates, true);
+    /**
+     * Controls how values are collected and ordered in a multi-valued binary doc values field.
+     */
+    public enum ValueOrdering {
+        /** Values are deduplicated and sorted (backed by a {@link TreeSet}). */
+        SORTED_UNIQUE,
+        /** Duplicates are kept, values are sorted at encode time (backed by an {@link ArrayList}). */
+        SORTED,
+        /** Duplicates are kept, no sorting (backed by an {@link ArrayList}). */
+        UNSORTED
     }
 
-    MultiValuedBinaryDocValuesField(String name, boolean keepDuplicates, boolean sorted) {
+    protected final ValueOrdering ordering;
+    protected final Collection<BytesRef> values;
+    protected int docValuesByteCount = 0;
+
+    MultiValuedBinaryDocValuesField(String name, ValueOrdering ordering) {
         super(name);
-        this.values = keepDuplicates ? new ArrayList<>() : new TreeSet<>();
-        this.sorted = sorted;
+        this.ordering = ordering;
+        this.values = ordering == ValueOrdering.SORTED_UNIQUE ? new TreeSet<>() : new ArrayList<>();
     }
 
     public void add(BytesRef value) {
@@ -60,7 +67,8 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
     }
 
     protected void writeLenAndValues(BytesStreamOutput out) throws IOException {
-        if (sorted && values instanceof ArrayList<BytesRef> list) {
+        // Only ArraysLists need sorting
+        if (ordering == ValueOrdering.SORTED && values instanceof ArrayList<BytesRef> list) {
             list.sort(Comparator.naturalOrder());
         }
 
@@ -74,18 +82,60 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
     @Override
     public abstract BytesRef binaryValue();
 
+    /**
+     * Adds a value to a multi-valued binary doc values field in the given document.
+     * <p>
+     * For indices created on or after {@link IndexVersions#DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES}, the {@link SeparateCount}
+     * format is used. For older indices, the {@link IntegratedCount} format is used.
+     */
+    public static void addToBinaryFieldInDoc(
+        LuceneDocument doc,
+        String fieldName,
+        BytesRef value,
+        IndexVersion indexVersion,
+        ValueOrdering ordering
+    ) {
+        if (indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
+            SeparateCount.addToDoc(doc, fieldName, value, ordering);
+        } else {
+            IntegratedCount.addToDoc(doc, fieldName, value, ordering);
+        }
+    }
+
+    public static void addToBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef value, IndexVersion indexVersion) {
+        addToBinaryFieldInDoc(doc, fieldName, value, indexVersion, ValueOrdering.SORTED_UNIQUE);
+    }
+
+    public static void addToBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef value, ValueOrdering ordering) {
+        addToBinaryFieldInDoc(doc, fieldName, value, IndexVersion.current(), ordering);
+    }
+
+    public static void addToBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef value) {
+        addToBinaryFieldInDoc(doc, fieldName, value, IndexVersion.current(), ValueOrdering.SORTED_UNIQUE);
+    }
+
+    /**
+     * Format that integrates the value count into the binary payload itself.
+     * <p>
+     * Encoding: {@code [count][len1][val1][len2][val2]...}
+     */
     public static class IntegratedCount extends MultiValuedBinaryDocValuesField {
-        public IntegratedCount(String name, boolean keepDuplicates) {
-            super(name, keepDuplicates);
+
+        public IntegratedCount(String name, ValueOrdering ordering) {
+            super(name, ordering);
         }
 
-        public IntegratedCount(String name, boolean keepDuplicates, boolean sorted) {
-            super(name, keepDuplicates, sorted);
+        private static void addToDoc(LuceneDocument doc, String fieldName, BytesRef value, ValueOrdering ordering) {
+            var field = (IntegratedCount) doc.getByKey(fieldName);
+            if (field == null) {
+                field = new IntegratedCount(fieldName, ordering);
+                doc.addWithKey(fieldName, field);
+            }
+            field.add(value);
         }
 
         /**
-         * Encodes the collection of binary doc values as a single contiguous binary array, wrapped in {@link BytesRef}. This array takes
-         * the form of [doc value count][length of value 1][value 1][length of value 2][value 2]...
+         * Encodes the collection of binary doc values as a single contiguous binary array, wrapped in {@link BytesRef}.
          */
         @Override
         public BytesRef binaryValue() {
@@ -122,19 +172,36 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
         }
     }
 
+    /**
+     * Format that stores the value count in a separate companion {@code .counts} numeric doc values field.
+     * <p>
+     * Encoding for multiple values: {@code [len1][val1][len2][val2]...}
+     * <br>
+     * Encoding for a single value: {@code [val1]} (no length prefix)
+     */
     public static class SeparateCount extends MultiValuedBinaryDocValuesField {
+
         public static final String COUNT_FIELD_SUFFIX = ".counts";
 
-        public SeparateCount(String name, boolean keepDuplicates) {
-            super(name, keepDuplicates);
+        public SeparateCount(String name, ValueOrdering ordering) {
+            super(name, ordering);
         }
 
-        /**
-         * Encodes the collection of BytesRef into a single BytesRef. Unlike IntegratedCount, the number of values is not stored, and
-         * if there is only a single value, the length is not stored.
-         * For multiple values, the format is: [length of value 1][value 1][length of value 2][value 2]...
-         * For a single value, the format is: [value 1]
-         */
+        private static void addToDoc(LuceneDocument doc, String fieldName, BytesRef value, ValueOrdering ordering) {
+            var field = (SeparateCount) doc.getByKey(fieldName);
+            final NumericDocValuesField countField;
+            if (field == null) {
+                field = new SeparateCount(fieldName, ordering);
+                countField = NumericDocValuesField.indexedField(field.countFieldName(), -1);
+                doc.addWithKey(field.name(), field);
+                doc.addWithKey(countField.name(), countField);
+            } else {
+                countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
+            }
+            field.add(value);
+            countField.setLongValue(field.count());
+        }
+
         @Override
         public BytesRef binaryValue() {
             int docValuesCount = values.size();
@@ -148,37 +215,12 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
                 writeLenAndValues(out);
                 return out.bytes().toBytesRef();
             } catch (IOException e) {
-                throw new ElasticsearchException("Failed to get binary value", e);
+                throw new UncheckedIOException("Failed to get binary value", e);
             }
         }
 
         public String countFieldName() {
             return name() + COUNT_FIELD_SUFFIX;
-        }
-
-        public static void addToSeparateCountMultiBinaryFieldInDoc(LuceneDocument doc, String fieldName, BytesRef binaryValue) {
-            addToSeparateCountMultiBinaryFieldInDoc(doc, fieldName, binaryValue, false);
-        }
-
-        public static void addToSeparateCountMultiBinaryFieldInDoc(
-            LuceneDocument doc,
-            String fieldName,
-            BytesRef binaryValue,
-            boolean keepDuplicates
-        ) {
-            var field = (SeparateCount) doc.getByKey(fieldName);
-            final NumericDocValuesField countField;
-            if (field == null) {
-                field = new SeparateCount(fieldName, keepDuplicates);
-                countField = NumericDocValuesField.indexedField(field.countFieldName(), -1); // dummy value
-                doc.addWithKey(field.name(), field);
-                doc.addWithKey(countField.name(), countField);
-            } else {
-                countField = (NumericDocValuesField) doc.getByKey(fieldName + COUNT_FIELD_SUFFIX);
-            }
-
-            field.add(binaryValue);
-            countField.setLongValue(field.count());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1325,6 +1325,9 @@ public final class TextFieldMapper extends FieldMapper {
             // Check if we can load from a fallback field
             if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null) {
                 if (usesBinaryDocValuesForFallbackFields) {
+                    if (indexCreatedVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
+                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(syntheticSourceFallbackFieldName());
+                    }
                     return new BytesRefsFromCustomBinaryBlockLoader(syntheticSourceFallbackFieldName());
                 }
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(syntheticSourceFallbackFieldName());
@@ -1702,11 +1705,7 @@ public final class TextFieldMapper extends FieldMapper {
         if (docValuesParameters.enabled()) {
             BytesRef binaryValue = new BytesRef(value);
             if (fieldType().usesBinaryDocValues()) {
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(
-                    context.doc(),
-                    fieldType().name(),
-                    binaryValue
-                );
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(context.doc(), fieldType().name(), binaryValue);
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
                 // in such cases, store the value in binary doc values instead, which don't have these length limitations
@@ -1750,13 +1749,13 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     private void storeValueInFallbackField(String fallbackFieldName, BytesRef bytesRef, DocumentParserContext context) {
-        // store the value in a binary doc values field, create one if it doesn't exist
-        MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fallbackFieldName);
-        if (field == null) {
-            field = new MultiValuedBinaryDocValuesField.IntegratedCount(fallbackFieldName, true);
-            context.doc().addWithKey(fallbackFieldName, field);
-        }
-        field.add(bytesRef);
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            context.doc(),
+            fallbackFieldName,
+            bytesRef,
+            indexCreatedVersion,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1405,7 +1405,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             builder.usesBinaryDocValues,
             builder.hasRootDocValues(),
             mappedSubFields,
-            builder.storeIgnoredFieldsInBinaryDocValues
+            builder.storeIgnoredFieldsInBinaryDocValues,
+            builder.indexCreatedVersion
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
@@ -16,6 +16,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -46,6 +47,7 @@ class FlattenedFieldParser {
     private final boolean usesBinaryDocValues;
     private final boolean hasRootDocValues;
     private final boolean storeIgnoredFieldsInBinaryDocValues;
+    private final IndexVersion indexCreatedVersion;
 
     private final Map<String, FieldMapper> mappedSubFields;
 
@@ -60,7 +62,8 @@ class FlattenedFieldParser {
         boolean usesBinaryDocValues,
         boolean hasRootDocValues,
         Map<String, FieldMapper> mappedSubFields,
-        boolean storeIgnoredFieldsInBinaryDocValues
+        boolean storeIgnoredFieldsInBinaryDocValues,
+        IndexVersion indexCreatedVersion
     ) {
         this.rootFieldFullPath = rootFieldFullPath;
         this.keyedFieldFullPath = keyedFieldFullPath;
@@ -73,6 +76,7 @@ class FlattenedFieldParser {
         this.hasRootDocValues = hasRootDocValues;
         this.mappedSubFields = mappedSubFields;
         this.storeIgnoredFieldsInBinaryDocValues = storeIgnoredFieldsInBinaryDocValues;
+        this.indexCreatedVersion = indexCreatedVersion;
     }
 
     public void parse(final DocumentParserContext documentParserContext) throws IOException {
@@ -163,14 +167,12 @@ class FlattenedFieldParser {
         if (value.length() > ignoreAbove) {
             if (context.documentParserContext().mappingLookup().isSourceSynthetic()) {
                 if (storeIgnoredFieldsInBinaryDocValues) {
-                    MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.documentParserContext.doc()
-                        .getByKey(keyedIgnoredValuesFieldFullPath);
-                    if (field == null) {
-                        // deduplicate and sort to match the behavior of other fields that use binary doc values for ignored fields
-                        field = new MultiValuedBinaryDocValuesField.IntegratedCount(keyedIgnoredValuesFieldFullPath, false);
-                        context.documentParserContext.doc().addWithKey(keyedIgnoredValuesFieldFullPath, field);
-                    }
-                    field.add(BytesRef.deepCopyOf(bytesKeyedValue));
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                        context.documentParserContext.doc(),
+                        keyedIgnoredValuesFieldFullPath,
+                        BytesRef.deepCopyOf(bytesKeyedValue),
+                        indexCreatedVersion
+                    );
                 } else {
                     context.documentParserContext.doc().add(new StoredField(keyedIgnoredValuesFieldFullPath, bytesKeyedValue));
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
@@ -204,13 +204,13 @@ class FlattenedFieldParser {
         if (fieldType.hasDocValues()) {
             if (usesBinaryDocValues) {
                 if (hasRootDocValues) {
-                    MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
                         context.documentParserContext.doc(),
                         rootFieldFullPath,
                         bytesValue
                     );
                 }
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
                     context.documentParserContext.doc(),
                     keyedFieldFullPath,
                     bytesKeyedValue

--- a/server/src/test/java/org/elasticsearch/index/fielddata/HighCardinalityKeywordFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/HighCardinalityKeywordFieldDataTests.java
@@ -56,7 +56,7 @@ public class HighCardinalityKeywordFieldDataTests extends AbstractStringFieldDat
             fields.get(name).add(new BytesRef(value));
             countsField.setLongValue(field.count());
         } else {
-            field = new MultiValuedBinaryDocValuesField.SeparateCount(name, false);
+            field = new MultiValuedBinaryDocValuesField.SeparateCount(name, MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE);
             field.add(new BytesRef(value));
             countsField = NumericDocValuesField.indexedField(name + COUNT_FIELD_SUFFIX, 1);
             fields.put(name, field);

--- a/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.mapper.LuceneDocument;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
+
+    /**
+     * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads multi-valued binary doc values written by
+     * {@link MultiValuedBinaryDocValuesField.SeparateCount}.
+     */
+    public void testReadValuesFromSeparateCount() throws IOException {
+        // given
+        List<BytesRef> expected = List.of(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"));
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                for (BytesRef value : expected) {
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", value);
+                }
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(expected.size(), values.docValueCount());
+                List<BytesRef> actual = new ArrayList<>();
+                for (int i = 0; i < values.docValueCount(); i++) {
+                    actual.add(BytesRef.deepCopyOf(values.nextValue()));
+                }
+                assertEquals(expected, actual);
+            }
+        }
+    }
+
+    /**
+     * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads multi-valued binary doc values written by
+     * {@link MultiValuedBinaryDocValuesField.IntegratedCount}.
+     */
+    public void testReadValuesFromSeparateCountWithPreviousIndexVersion() throws IOException {
+        // given
+        List<BytesRef> expected = List.of(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"));
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion(
+                    IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES
+                );
+                for (BytesRef value : expected) {
+                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", value, previousVersion);
+                }
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(expected.size(), values.docValueCount());
+                List<BytesRef> actual = new ArrayList<>();
+                for (int i = 0; i < values.docValueCount(); i++) {
+                    actual.add(BytesRef.deepCopyOf(values.nextValue()));
+                }
+                assertEquals(expected, actual);
+            }
+        }
+    }
+
+    /**
+     * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads a single value written by
+     * {@link MultiValuedBinaryDocValuesField.SeparateCount}.
+     */
+    public void testReadSingleValueFromSeparateCount() throws IOException {
+        // given
+        BytesRef expected = new BytesRef("single");
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", expected);
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+            }
+        }
+    }
+
+    /**
+     * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads a single value written by
+     * {@link MultiValuedBinaryDocValuesField.IntegratedCount}.
+     */
+    public void testReadSingleValueFromSeparateCountWothPreviousIndexVersion() throws IOException {
+        // given
+        BytesRef expected = new BytesRef("single");
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion(
+                    IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES
+                );
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", expected, previousVersion);
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
@@ -266,8 +266,18 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
                 LuceneDocument doc = new LuceneDocument();
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded1, true);
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded2, true);
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    doc,
+                    dvFieldName,
+                    encoded1,
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+                );
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    doc,
+                    dvFieldName,
+                    encoded2,
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+                );
                 iw.addDocument(doc);
             }
 
@@ -353,7 +363,12 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
                 LuceneDocument doc = new LuceneDocument();
-                MultiValuedBinaryDocValuesField.SeparateCount.addToSeparateCountMultiBinaryFieldInDoc(doc, dvFieldName, encoded, true);
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    doc,
+                    dvFieldName,
+                    encoded,
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
+                );
                 iw.addDocument(doc);
             }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.IntegratedCount;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.SeparateCount;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ValueOrdering;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
+
+    // =====================================================================================================================================
+    // IntegratedCount tests
+    // =====================================================================================================================================
+
+    public void testIntegratedCountSingleValue() throws IOException {
+        // given
+        var field = new IntegratedCount("field", ValueOrdering.SORTED_UNIQUE);
+        field.add(new BytesRef("potato"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then
+        try (var in = new BytesStreamOutput()) {
+            in.writeVInt(1);  // value count
+            in.writeVInt(6);  // length of "potato"
+            in.writeBytes(new byte[] { 'p', 'o', 't', 'a', 't', 'o' }, 0, 6);
+            assertEquals(in.bytes().toBytesRef(), binary);
+        }
+    }
+
+    public void testIntegratedCountMultipleValues() throws IOException {
+        // given
+        var field = new IntegratedCount("field", ValueOrdering.SORTED_UNIQUE);
+        field.add(new BytesRef("bbb"));
+        field.add(new BytesRef("aaa"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — TreeSet sorts, so aaa comes first
+        try (var in = new BytesStreamOutput()) {
+            in.writeVInt(2);  // value count
+            in.writeVInt(3);
+            in.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            in.writeVInt(3);
+            in.writeBytes(new byte[] { 'b', 'b', 'b' }, 0, 3);
+            assertEquals(in.bytes().toBytesRef(), binary);
+        }
+    }
+
+    public void testIntegratedCountDeduplicates() {
+        // given
+        var field = new IntegratedCount("field", ValueOrdering.SORTED_UNIQUE);
+
+        // when
+        field.add(new BytesRef("aaa"));
+        field.add(new BytesRef("aaa"));
+
+        // then
+        assertEquals(1, field.count());
+    }
+
+    public void testIntegratedCountEncode() throws IOException {
+        // given
+        List<BytesRef> values = List.of(new BytesRef("aaa"), new BytesRef("bbb"));
+
+        // when
+        BytesRef encoded = IntegratedCount.encode(values);
+
+        // then
+        try (var expected = new BytesStreamOutput()) {
+            expected.writeVInt(2);  // value count
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'b', 'b', 'b' }, 0, 3);
+            assertEquals(expected.bytes().toBytesRef(), encoded);
+        }
+    }
+
+    // =====================================================================================================================================
+    // SeparateCount tests
+    // =====================================================================================================================================
+
+    public void testSeparateCountSingleValue() {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.SORTED_UNIQUE);
+        field.add(new BytesRef("hello"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — single value is stored raw, no length prefix
+        assertEquals(new BytesRef("hello"), binary);
+    }
+
+    public void testSeparateCountMultipleValues() throws IOException {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.SORTED_UNIQUE);
+        field.add(new BytesRef("bbb"));
+        field.add(new BytesRef("aaa"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — TreeSet sorts, so aaa comes first; no count prefix
+        try (var expected = new BytesStreamOutput()) {
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'b', 'b', 'b' }, 0, 3);
+            assertEquals(expected.bytes().toBytesRef(), binary);
+        }
+    }
+
+    public void testSeparateCountDeduplicates() {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.SORTED_UNIQUE);
+
+        // when
+        field.add(new BytesRef("aaa"));
+        field.add(new BytesRef("aaa"));
+
+        // then
+        assertEquals(1, field.count());
+    }
+
+    public void testSeparateCountFieldName() {
+        // given
+        var field = new SeparateCount("my_field", ValueOrdering.SORTED_UNIQUE);
+
+        // then
+        assertEquals("my_field.counts", field.countFieldName());
+    }
+
+    // =====================================================================================================================================
+    // ValueOrdering tests
+    // =====================================================================================================================================
+
+    public void testSortedUniqueOrderingDeduplicatesAndSorts() throws IOException {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.SORTED_UNIQUE);
+        field.add(new BytesRef("ccc"));
+        field.add(new BytesRef("aaa"));
+        field.add(new BytesRef("aaa"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — duplicates removed, sorted
+        assertEquals(2, field.count());
+        try (var expected = new BytesStreamOutput()) {
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'c', 'c', 'c' }, 0, 3);
+            assertEquals(expected.bytes().toBytesRef(), binary);
+        }
+    }
+
+    public void testSortedOrderingKeepsDuplicatesAndSorts() throws IOException {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.SORTED);
+        field.add(new BytesRef("ccc"));
+        field.add(new BytesRef("aaa"));
+        field.add(new BytesRef("aaa"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — duplicates kept, sorted at encode time
+        assertEquals(3, field.count());
+        try (var expected = new BytesStreamOutput()) {
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'c', 'c', 'c' }, 0, 3);
+            assertEquals(expected.bytes().toBytesRef(), binary);
+        }
+    }
+
+    public void testUnsortedOrderingKeepsDuplicatesAndInsertionOrder() throws IOException {
+        // given
+        var field = new SeparateCount("field", ValueOrdering.UNSORTED);
+        field.add(new BytesRef("ccc"));
+        field.add(new BytesRef("aaa"));
+        field.add(new BytesRef("aaa"));
+
+        // when
+        BytesRef binary = field.binaryValue();
+
+        // then — duplicates kept, insertion order preserved
+        assertEquals(3, field.count());
+        try (var expected = new BytesStreamOutput()) {
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'c', 'c', 'c' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            expected.writeVInt(3);
+            expected.writeBytes(new byte[] { 'a', 'a', 'a' }, 0, 3);
+            assertEquals(expected.bytes().toBytesRef(), binary);
+        }
+    }
+
+    // =====================================================================================================================================
+    // addToBinaryFieldInDoc version dispatch tests
+    // =====================================================================================================================================
+
+    public void testAddToBinaryFieldInDocUsesSeparateCountForCurrentVersion() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+
+        // when
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", new BytesRef("val"));
+
+        // then
+        assertNotNull(doc.getByKey("field"));
+        assertTrue(doc.getByKey("field") instanceof SeparateCount);
+        assertNotNull(doc.getByKey("field.counts"));
+    }
+
+    public void testAddToBinaryFieldInDocUsesIntegratedCountForPreviousVersion() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+        IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES);
+
+        // when
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", new BytesRef("val"), previousVersion);
+
+        // then
+        assertNotNull(doc.getByKey("field"));
+        assertTrue(doc.getByKey("field") instanceof IntegratedCount);
+        assertNull(doc.getByKey("field.counts"));
+    }
+
+    public void testAddToBinaryFieldInDocAccumulatesValues() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+
+        // when
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", new BytesRef("aaa"));
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, "field", new BytesRef("bbb"));
+
+        // then
+        var field = (SeparateCount) doc.getByKey("field");
+        assertEquals(2, field.count());
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryByteLengthBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryByteLengthBlockLoaderTests.java
@@ -44,7 +44,10 @@ public class BinaryByteLengthBlockLoaderTests extends AbstractBlockLoaderTestCas
             int docCount = 10_000;
             int cardinality = between(16, 2048);
             for (int i = 0; i < docCount; i++) {
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".repeat(i % cardinality)));
                 NumericDocValuesField countField;
                 if (multiValues && i % cardinality == 0) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMaxBytesRefsBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMaxBytesRefsBlockLoaderTests.java
@@ -44,7 +44,10 @@ public class BinaryMvMaxBytesRefsBlockLoaderTests extends AbstractBlockLoaderTes
             int docCount = 10_000;
             int cardinality = between(16, 2048);
             for (int i = 0; i < docCount; i++) {
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 int baseLength = (i % cardinality) + 1;
                 char c = 'z';
                 field.add(new BytesRef(("" + c).repeat(baseLength)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMinBytesRefsBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMinBytesRefsBlockLoaderTests.java
@@ -43,7 +43,10 @@ public class BinaryMvMinBytesRefsBlockLoaderTests extends AbstractBlockLoaderTes
             int docCount = 10_000;
             int cardinality = between(16, 2048);
             for (int i = 0; i < docCount; i++) {
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 int baseLength = (i % cardinality) + 1;
                 char c = 'z';
                 field.add(new BytesRef(("" + c).repeat(baseLength)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryUtf8CodePointLengthBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryUtf8CodePointLengthBlockLoaderTests.java
@@ -45,7 +45,10 @@ public class BinaryUtf8CodePointLengthBlockLoaderTests extends AbstractBlockLoad
             int docCount = 10_000;
             int cardinality = between(16, 2048);
             for (int i = 0; i < docCount; i++) {
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".repeat(i % cardinality)));
                 NumericDocValuesField countField;
                 if (multiValues && i % cardinality == 0) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper.flattened;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MockFieldMapper.FakeFieldType;
 import org.elasticsearch.index.mapper.TestDocumentParserContext;
@@ -45,7 +46,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             true,
             true,
             Map.of(),
-            true
+            true,
+            IndexVersion.current()
         );
     }
 
@@ -312,7 +314,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             false,
             true,
             Map.of(),
-            true
+            true,
+            IndexVersion.current()
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -340,7 +343,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             false,
             true,
             Map.of(),
-            true
+            true,
+            IndexVersion.current()
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -363,7 +367,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             true,
             true,
             Map.of(),
-            true
+            true,
+            IndexVersion.current()
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -386,7 +391,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             false,
             true,
             Map.of(),
-            false
+            false,
+            IndexVersion.current()
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -415,7 +421,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             true,
             true,
             Map.of(),
-            true
+            true,
+            IndexVersion.current()
         );
 
         TestDocumentParserContext configuredContext = new TestDocumentParserContext(createXContentParser(input));

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
@@ -219,7 +219,10 @@ public class RootFlattenedFromKeyedFieldDataTests extends ESTestCase {
     private static void addDoc(RandomIndexWriter writer, boolean binary, String... keyedValues) throws IOException {
         Document doc = new Document();
         if (binary) {
-            var field = new MultiValuedBinaryDocValuesField.SeparateCount(KEYED_FIELD, false);
+            var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                KEYED_FIELD,
+                MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+            );
             for (String kv : keyedValues) {
                 field.add(new BytesRef(kv));
             }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
@@ -229,7 +229,10 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
 
     private static void addSingleValueDoc(RandomIndexWriter writer, String fieldName, String value) throws IOException {
         Document document = new Document();
-        var field = new MultiValuedBinaryDocValuesField.SeparateCount(fieldName, false);
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+            fieldName,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+        );
         field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
         var countField = NumericDocValuesField.indexedField(fieldName + ".counts", 1);
         document.add(field);
@@ -239,7 +242,10 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
 
     private static void addMultiValueDoc(RandomIndexWriter writer, String fieldName, String... values) throws IOException {
         Document document = new Document();
-        var field = new MultiValuedBinaryDocValuesField.SeparateCount(fieldName, false);
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+            fieldName,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+        );
         for (String value : values) {
             field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
         }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
@@ -43,7 +43,10 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 for (var val : values) {
                     Document document = new Document();
-                    var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                    var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                        "field",
+                        MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    );
                     field.add(val);
                     var countField = NumericDocValuesField.indexedField("field.counts", 1);
                     document.add(field);
@@ -89,7 +92,10 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 for (var valuesForDoc : values) {
                     Document document = new Document();
-                    var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                    var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                        "field",
+                        MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    );
                     for (var val : valuesForDoc) {
                         field.add(val);
                     }
@@ -131,7 +137,10 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 Document document = new Document();
 
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".getBytes(StandardCharsets.UTF_8)));
                 var countField = NumericDocValuesField.indexedField("field.counts", 1);
                 document.add(field);

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermInSetQueryTests.java
@@ -42,7 +42,10 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                     for (int i = 0; i < entry.getValue(); i++) {
                         Document document = new Document();
 
-                        var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                            "field",
+                            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                        );
                         field.add(new BytesRef(entry.getKey().getBytes(StandardCharsets.UTF_8)));
                         var countField = new NumericDocValuesField("field.counts", 1);
 
@@ -120,7 +123,10 @@ public class SlowCustomBinaryDocValuesTermInSetQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 Document document = new Document();
 
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".getBytes(StandardCharsets.UTF_8)));
                 var countField = new NumericDocValuesField("field.counts", 1);
                 document.add(field);

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
@@ -40,7 +40,10 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
                     for (int i = 0; i < entry.getValue(); i++) {
                         Document document = new Document();
 
-                        var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                            "field",
+                            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                        );
                         field.add(new BytesRef(entry.getKey().getBytes(StandardCharsets.UTF_8)));
                         var countField = new NumericDocValuesField("field.counts", 1);
 
@@ -86,7 +89,10 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 Document document = new Document();
 
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".getBytes(StandardCharsets.UTF_8)));
                 var countField = new NumericDocValuesField("field.counts", 1);
                 document.add(field);

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
@@ -56,7 +56,10 @@ public class SlowCustomBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     for (int i = 0; i < entry.getValue(); i++) {
                         Document document = new Document();
 
-                        var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                            "field",
+                            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                        );
                         field.add(new BytesRef(entry.getKey().getBytes(StandardCharsets.UTF_8)));
                         var countField = NumericDocValuesField.indexedField("field.counts", 1);
 
@@ -102,7 +105,10 @@ public class SlowCustomBinaryDocValuesWildcardQueryTests extends ESTestCase {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
                 Document document = new Document();
 
-                var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", false);
+                var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+                    "field",
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                );
                 field.add(new BytesRef("a".getBytes(StandardCharsets.UTF_8)));
                 var countField = NumericDocValuesField.indexedField("field.counts", 1);
                 document.add(field);
@@ -128,7 +134,10 @@ public class SlowCustomBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     Document document = new Document();
                     document.add(new SortedSetDocValuesField("baseline_field", new BytesRef(randomValue)));
 
-                    var binaryDVField = new MultiValuedBinaryDocValuesField.SeparateCount("contender_field", false);
+                    var binaryDVField = new MultiValuedBinaryDocValuesField.SeparateCount(
+                        "contender_field",
+                        MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    );
                     binaryDVField.add(new BytesRef(randomValue.getBytes(StandardCharsets.UTF_8)));
                     var countField = NumericDocValuesField.indexedField("contender_field.counts", 1);
                     document.add(binaryDVField);
@@ -267,7 +276,10 @@ public class SlowCustomBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
     private static void addDoc(RandomIndexWriter writer, String fieldName, String... values) throws IOException {
         Document document = new Document();
-        var field = new MultiValuedBinaryDocValuesField.SeparateCount(fieldName, false);
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+            fieldName,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+        );
         for (String value : values) {
             field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
         }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -1396,7 +1396,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
                     : matchesList().item("column_at_a_time:constant_nulls");
             case TDIGEST -> matchesList().item("column_at_a_time:BlockDocValuesReader.TDigest");
             case TEXT -> syntheticSourceByDefault()
-                ? matchesList().item("column_at_a_time:BlockDocValuesReader.BytesCustom")
+                ? matchesList().item("column_at_a_time:BlockDocValuesReader.Bytes")
                 : matchesList().item("column_at_a_time:null").item("row_stride:BlockSourceReader.Bytes");
             case VERSION -> matchesList().item("column_at_a_time:BytesRefsFromOrds.Singleton");
             default -> matchesList();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQueryTests.java
@@ -254,7 +254,7 @@ public class SingleValueMatchQueryTests extends MapperServiceTestCase {
 
     private static List<IndexableField> docFor(Iterable<Object> values, DocValuesMode docValuesMode) {
         long count = 0;
-        var mvField = new MultiValuedBinaryDocValuesField.SeparateCount("foo", false);
+        var mvField = new MultiValuedBinaryDocValuesField.SeparateCount("foo", MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE);
         List<IndexableField> fields = new ArrayList<>();
 
         for (Object v : values) {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -1079,13 +1079,12 @@ public class WildcardFieldMapper extends FieldMapper {
                 context.addIgnoredField(fullPath());
                 if (storeIgnored) {
                     if (storeIgnoredFieldsInBinaryDocValues) {
-                        MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) parseDoc.getByKey(originalName());
-                        if (field == null) {
-                            // sort to match the behavior of other field mappers
-                            field = new MultiValuedBinaryDocValuesField.IntegratedCount(originalName(), false);
-                            parseDoc.addWithKey(originalName(), field);
-                        }
-                        field.add(new BytesRef(value));
+                        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                            parseDoc,
+                            originalName(),
+                            new BytesRef(value),
+                            indexVersionCreated
+                        );
                     } else {
                         parseDoc.add(new StoredField(originalName(), new BytesRef(value)));
                     }


### PR DESCRIPTION
With `multi_value = no`, it would be nice to automatically figure out whether we used a `MultiValuedBinaryDocValuesField` or a `BinaryDocValuesField`. Doing so eliminates the need to pass `multiValue` all over the place and perform if-checks. The best place to do that would be [here](https://github.com/elastic/elasticsearch/blob/5c1c9209b2910b2e0206ba0d732ee1917af4d513/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java#L45); ie. if there is no `.count` field, we assume that only a single-value was written. Unfortunately, this check is already taken by the `IntegratedCount` format.

That being said, `IntegratedCount` and `SeparateCount` should, in theory, be interchangeable. They're both used for the same thing and the storage footprint of both is equal, with some exceptions where `SeparateCount` is actually more efficient. As a result, we can remove `IntegratedCount` entirely. 

Note, for BWC purposes, `IntegratedCount` remains, gated behind an index version check.

Most of the code changes are attributed to two new tests that I've added: `MultiValuedSortedBinaryDocValuesTests` and `MultiValuedBinaryDocValuesFieldTests`.

This addresses https://github.com/elastic/logs-program/issues/55.