### PR TITLE
ESQL: Limit the `toString` of plan nodes (#145140)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
@@ -142,7 +142,7 @@ public final class Alias extends NamedExpression {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return child.nodeString() + " AS " + name() + "#" + id();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
@@ -220,7 +220,7 @@ public abstract class Attribute extends NamedExpression {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
@@ -224,7 +224,12 @@ public abstract class Expression extends Node<Expression> implements Resolvable 
     }
 
     @Override
-    public String propertiesToString(boolean skipIfChild) {
-        return super.propertiesToString(false);
+    public String toString(NodeStringFormat format) {
+        return toString();
+    }
+
+    @Override
+    public String propertiesToString(boolean skipIfChild, NodeStringFormat format) {
+        return super.propertiesToString(false, format);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Literal.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Literal.java
@@ -171,7 +171,7 @@ public class Literal extends LeafExpression implements Accountable {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString() + "[" + dataType + "]";
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NamedExpression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NamedExpression.java
@@ -117,7 +117,7 @@ public abstract class NamedExpression extends Expression implements NamedWriteab
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return name();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedAttribute.java
@@ -144,7 +144,7 @@ public class UnresolvedAttribute extends Attribute implements Unresolvable {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedStar.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedStar.java
@@ -77,7 +77,7 @@ public class UnresolvedStar extends UnresolvedNamedExpression {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
@@ -59,10 +59,10 @@ public abstract class Function extends Expression {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         StringJoiner sj = new StringJoiner(",", functionName() + "(", ")");
         for (Expression ex : arguments()) {
-            sj.add(ex.nodeString());
+            sj.add(ex.nodeString(format));
         }
         return sj.toString();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
@@ -65,7 +65,7 @@ public abstract class BinaryPredicate<T, U, R, F extends PredicateBiFunction<T, 
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return left().nodeString() + " " + symbol() + " " + right().nodeString();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
@@ -11,8 +11,6 @@ import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 
 import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -37,8 +35,18 @@ import static java.util.Collections.emptyList;
  * @param <T> node type
  */
 public abstract class Node<T extends Node<T>> implements NamedWriteable {
+    /**
+     * Maximum number of properties rendered by {@link #toString}.
+     */
     private static final int TO_STRING_MAX_PROP = 10;
+    /**
+     * Maximum number of characters per line rendered by {@link #toString}.
+     */
     public static final int TO_STRING_MAX_WIDTH = 110;
+    /**
+     * Maximum number of lines rendered by {@link #toString}.
+     */
+    public static final int TO_STRING_MAX_LINES = 25;
 
     private final Source source;
     private final List<T> children;
@@ -63,7 +71,7 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         return source.text();
     }
 
-    public List<T> children() {
+    public final List<T> children() {
         return children;
     }
 
@@ -384,139 +392,47 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         return info().properties();
     }
 
-    public String nodeString() {
+    public enum NodeStringFormat {
+        /** No list truncation, no line breaks due to string width. */
+        FULL(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE),
+        /** List truncation and line breaks due to string width applied. */
+        LIMITED(TO_STRING_MAX_PROP, TO_STRING_MAX_WIDTH, TO_STRING_MAX_LINES);
+
+        final int maxProperties;
+        final int maxWidth;
+        final int maxLines;
+
+        NodeStringFormat(int maxProperties, int maxWidth, int maxLines) {
+            this.maxProperties = maxProperties;
+            this.maxWidth = maxWidth;
+            this.maxLines = maxLines;
+        }
+    }
+
+    public final String nodeString() {
+        return nodeString(NodeStringFormat.LIMITED);
+    }
+
+    public String nodeString(NodeStringFormat format) {
         StringBuilder sb = new StringBuilder();
         sb.append(nodeName());
         sb.append("[");
-        sb.append(propertiesToString(true));
+        sb.append(propertiesToString(true, format));
         sb.append("]");
         return sb.toString();
     }
 
     @Override
     public String toString() {
-        return treeString(new StringBuilder(), 0, new BitSet()).toString();
+        return toString(NodeStringFormat.LIMITED);
     }
 
-    /**
-     * Render this {@link Node} as a tree like
-     * <pre>
-     * {@code
-     * Project[[i{f}#0]]
-     * \_Filter[i{f}#1]
-     *   \_SubQueryAlias[test]
-     *     \_EsRelation[test][i{f}#2]
-     * }
-     * </pre>
-     */
-    final StringBuilder treeString(StringBuilder sb, int depth, BitSet hasParentPerDepth) {
-        if (depth > 0) {
-            // draw children
-            for (int column = 0; column < depth; column++) {
-                if (hasParentPerDepth.get(column)) {
-                    sb.append("|");
-                    // if not the last elder, adding padding (since each column has two chars ("|_" or "\_")
-                    if (column < depth - 1) {
-                        sb.append(" ");
-                    }
-                } else {
-                    // if the child has no parent (elder on the previous level), it means its the last sibling
-                    sb.append((column == depth - 1) ? "\\" : "  ");
-                }
-            }
-
-            sb.append("_");
-        }
-
-        sb.append(nodeString());
-
-        @SuppressWarnings("HiddenField")
-        List<T> children = children();
-        if (children.isEmpty() == false) {
-            sb.append("\n");
-        }
-        for (int i = 0; i < children.size(); i++) {
-            T t = children.get(i);
-            hasParentPerDepth.set(depth, i < children.size() - 1);
-            t.treeString(sb, depth + 1, hasParentPerDepth);
-            if (i < children.size() - 1) {
-                sb.append("\n");
-            }
-        }
-        return sb;
+    public String toString(NodeStringFormat format) {
+        return new NodeToString(format).treeString(this, 0).toString();
     }
 
-    /**
-     * Render the properties of this {@link Node} one by
-     * one like {@code foo bar baz}. These go inside the
-     * {@code [} and {@code ]} of the output of {@link #treeString}.
-     */
-    public String propertiesToString(boolean skipIfChild) {
-        StringBuilder sb = new StringBuilder();
-
-        @SuppressWarnings("HiddenField")
-        List<?> children = children();
-        // eliminate children (they are rendered as part of the tree)
-        int remainingProperties = TO_STRING_MAX_PROP;
-        int maxWidth = 0;
-        boolean needsComma = false;
-
-        List<Object> props = nodeProperties();
-        for (Object prop : props) {
-            // consider a property if it is not ignored AND
-            // it's not a child (optional)
-            if ((skipIfChild && (children.contains(prop) || children.equals(prop))) == false) {
-                if (remainingProperties-- < 0) {
-                    sb.append("...").append(props.size() - TO_STRING_MAX_PROP).append("fields not shown");
-                    break;
-                }
-
-                if (needsComma) {
-                    sb.append(",");
-                }
-
-                String stringValue = toString(prop);
-
-                // : Objects.toString(prop);
-                if (maxWidth + stringValue.length() > TO_STRING_MAX_WIDTH) {
-                    int cutoff = Math.max(0, TO_STRING_MAX_WIDTH - maxWidth);
-                    sb.append(stringValue.substring(0, cutoff));
-                    sb.append("\n");
-                    stringValue = stringValue.substring(cutoff);
-                    maxWidth = 0;
-                }
-                maxWidth += stringValue.length();
-                sb.append(stringValue);
-
-                needsComma = true;
-            }
-        }
-
-        return sb.toString();
-    }
-
-    private static String toString(Object obj) {
-        StringBuilder sb = new StringBuilder();
-        toString(sb, obj);
-        return sb.toString();
-    }
-
-    private static void toString(StringBuilder sb, Object obj) {
-        if (obj instanceof Iterable) {
-            sb.append("[");
-            for (Iterator<?> it = ((Iterable<?>) obj).iterator(); it.hasNext();) {
-                Object o = it.next();
-                toString(sb, o);
-                if (it.hasNext()) {
-                    sb.append(", ");
-                }
-            }
-            sb.append("]");
-        } else if (obj instanceof Node<?>) {
-            sb.append(((Node<?>) obj).nodeString());
-        } else {
-            sb.append(Objects.toString(obj));
-        }
+    protected String propertiesToString(boolean skipIfChild, NodeStringFormat format) {
+        return new NodePropertiesToString(format, this, skipIfChild).propertiesToString();
     }
 
     private <U> boolean containsNull(List<U> us) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodePropertiesToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodePropertiesToString.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.tree;
+
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+
+import java.util.List;
+
+/**
+ * Renders the properties of a {@link Node} as a string.
+ */
+class NodePropertiesToString {
+    private final Node.NodeStringFormat format;
+    private final Node<?> node;
+    private final boolean skipIfChild;
+    private final StringBuilder result = new StringBuilder();
+    private int charactersRemainingInLine;
+    private int linesUsed = 0;
+
+    NodePropertiesToString(Node.NodeStringFormat format, Node<?> node, boolean skipIfChild) {
+        this.format = format;
+        this.node = node;
+        this.skipIfChild = skipIfChild;
+        this.charactersRemainingInLine = format.maxWidth;
+    }
+
+    /**
+     * Render the properties of this {@link Node} one by
+     * one like {@code foo bar baz}. These go inside the
+     * {@code [} and {@code ]} of the output of {@link NodeToString#treeString}.
+     */
+    String propertiesToString() {
+        List<Object> props = node.nodeProperties();
+        int remainingProperties = format.maxProperties;
+        boolean firstProperty = true;
+        for (Object prop : props) {
+            // if skipping children, check skip if this is a child
+            if (skipIfChild && (node.children().contains(prop) || node.children().equals(prop))) {
+                continue;
+            }
+            if (remainingProperties-- < 0) {
+                result.append("...").append(props.size() - format.maxProperties).append("fields not shown");
+                break;
+            }
+
+            if (firstProperty) {
+                firstProperty = false;
+            } else {
+                appendString(",");
+            }
+            boolean canContinue = prop instanceof Iterable<?> iterable ? appendIterable(iterable) : appendString(propertyToString(prop));
+            if (canContinue == false) {
+                break;
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Append {@code stringValue} to {@link #result}, wrapping at line boundaries.
+     * Returns {@code true} if rendering can continue, {@code false} if the line budget is exhausted.
+     */
+    private boolean appendString(String stringValue) {
+        int start = 0;
+        while (stringValue.length() - start > charactersRemainingInLine) {
+            result.append(stringValue, start, start + charactersRemainingInLine);
+            if (linesUsed >= format.maxLines - 1) {
+                result.append("...");
+                return false;
+            }
+            result.append("\n");
+            linesUsed++;
+            start += charactersRemainingInLine;
+            charactersRemainingInLine = format.maxWidth;
+        }
+        result.append(stringValue, start, stringValue.length());
+        charactersRemainingInLine -= stringValue.length() - start;
+        return true;
+    }
+
+    private boolean appendIterable(Iterable<?> iterable) {
+        if (appendString("[") == false) {
+            return false;
+        }
+        boolean firstElement = true;
+        for (Object element : iterable) {
+            if (firstElement == false) {
+                if (appendString(", ") == false) {
+                    return false;
+                }
+            }
+            if (appendString(propertyToString(element)) == false) {
+                return false;
+            }
+            firstElement = false;
+        }
+        return appendString("]");
+    }
+
+    private String propertyToString(Object obj) {
+        return switch (obj) {
+            case null -> "null";
+            case Node<?> n -> n.nodeString(format);
+            case NameId nameId -> "#" + obj;
+            default -> String.valueOf(obj);
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeToString.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.tree;
+
+import java.util.BitSet;
+import java.util.List;
+
+/**
+ * Renders {@link Node} trees as strings.
+ */
+class NodeToString {
+    private final StringBuilder sb = new StringBuilder();
+    private final BitSet hasParentPerDepth = new BitSet();
+    private final Node.NodeStringFormat format;
+
+    NodeToString(Node.NodeStringFormat format) {
+        this.format = format;
+    }
+
+    /**
+     * Render this {@link Node} as a tree like
+     * {@snippet lang=txt :
+     * Project[[i{f}#0]]
+     * \_Filter[i{f}#1]
+     *   \_SubQueryAlias[test]
+     *     \_EsRelation[test][i{f}#2]
+     * }
+     */
+    StringBuilder treeString(Node<?> node, int depth) {
+        indent(depth);
+
+        sb.append(node.nodeString(format));
+
+        List<? extends Node<?>> children = node.children();
+        if (children.isEmpty() == false) {
+            sb.append("\n");
+        }
+        for (int i = 0; i < children.size(); i++) {
+            Node<?> t = children.get(i);
+            hasParentPerDepth.set(depth, i < children.size() - 1);
+            treeString(t, depth + 1);
+            if (i < children.size() - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb;
+    }
+
+    private void indent(int depth) {
+        if (depth == 0) {
+            return;
+        }
+        // draw children
+        for (int column = 0; column < depth; column++) {
+            if (hasParentPerDepth.get(column)) {
+                sb.append("|");
+                // if not the last elder, adding padding (since each column has two chars ("|_" or "\_")
+                if (column < depth - 1) {
+                    sb.append(" ");
+                }
+            } else {
+                // if the child has no parent (elder on the previous level), it means its the last sibling
+                sb.append((column == depth - 1) ? "\\" : "  ");
+            }
+        }
+        sb.append("_");
+    }
+
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
@@ -112,7 +112,7 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunction.java
@@ -164,7 +164,7 @@ public class UnresolvedFunction extends Function implements Unresolvable {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
@@ -164,7 +164,7 @@ public final class UnsupportedAttribute extends FieldAttribute implements Unreso
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return toString();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -71,8 +71,8 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
     }
 
     @Override
-    public String nodeString() {
-        return name() + "(" + field().nodeString() + ", \"" + pattern().pattern() + "\", " + caseInsensitive() + ")";
+    public String nodeString(NodeStringFormat format) {
+        return name() + "(" + field().nodeString(format) + ", \"" + pattern().pattern() + "\", " + caseInsensitive() + ")";
     }
 
     void serializeCaseInsensitivity(StreamOutput out) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -160,7 +160,7 @@ public class EsRelation extends LeafPlan {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return nodeName()
             + "["
             + indexPattern

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Subquery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Subquery.java
@@ -83,7 +83,7 @@ public class Subquery extends UnaryPlan implements TelemetryAware, SortAgnostic 
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return nodeName() + "[]";
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -241,7 +241,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         StringBuilder sb = new StringBuilder();
         sb.append(nodeName());
         sb.append(" start=[").append(start);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -347,7 +347,7 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return nodeName()
             + "["
             + indexPattern

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
@@ -126,7 +126,7 @@ public class EsSourceExec extends LeafExec {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return nodeName() + "[" + indexPattern + "]" + NodeUtils.limitedToString(attributes);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
@@ -164,7 +164,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return nodeName()
             + "["
             + indexPattern

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -206,7 +206,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         return Strings.format(
             "%s<%s,%s>",
             nodeName() + NodeUtils.limitedToString(attributesToExtract),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
@@ -128,7 +128,7 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString() {
+    public String nodeString(NodeStringFormat format) {
         StringBuilder sb = new StringBuilder();
         sb.append(nodeName());
         sb.append("[filter=");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/tree/NodeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/tree/NodeTests.java
@@ -9,43 +9,204 @@ package org.elasticsearch.xpack.esql.core.tree;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.hamcrest.Matcher;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.esql.core.tree.SourceTests.randomSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class NodeTests extends ESTestCase {
-    public void testToString() {
-        assertEquals("NoChildren[thing]", new NoChildren(randomSource(), "thing").toString());
-        {
-            ChildrenAreAProperty empty = new ChildrenAreAProperty(randomSource(), emptyList(), "thing");
-            assertEquals("ChildrenAreAProperty[thing]", empty.toString());
-            assertEquals(
-                "ChildrenAreAProperty[single]\n\\_ChildrenAreAProperty[thing]",
-                new ChildrenAreAProperty(randomSource(), singletonList(empty), "single").toString()
-            );
-            assertEquals(
-                """
-                    ChildrenAreAProperty[many]
-                    |_ChildrenAreAProperty[thing]
-                    \\_ChildrenAreAProperty[thing]""",
-                new ChildrenAreAProperty(randomSource(), Arrays.asList(empty, empty), "many").toString()
-            );
+    public void testToStringNoChildren() {
+        assertToString(new NoChildren(randomSource(), "thing"), equalTo("NoChildren[thing]"));
+    }
+
+    public void testToStringDepth1() {
+        assertToString(dummy(), equalTo("ChildrenAreAProperty[thing]"));
+    }
+
+    public void testToStringDepth2() {
+        assertToString(dummy(dummy()), equalTo("""
+            ChildrenAreAProperty[thing]
+            \\_ChildrenAreAProperty[thing]"""));
+
+        int length = between(2, 100);
+        StringBuilder expected = new StringBuilder("ChildrenAreAProperty[thing]");
+        expected.append("\n|_ChildrenAreAProperty[thing]".repeat(Math.max(0, length - 1)));
+        expected.append("\n\\_ChildrenAreAProperty[thing]");
+        assertToString(dummy(IntStream.range(0, length).mapToObj(i -> dummy()).toArray(Dummy[]::new)), equalTo(expected.toString()));
+    }
+
+    public void testToStringDepth3() {
+        assertToString(dummy(dummy(dummy())), equalTo("""
+            ChildrenAreAProperty[thing]
+            \\_ChildrenAreAProperty[thing]
+              \\_ChildrenAreAProperty[thing]"""));
+
+        int length = between(2, 10);
+        StringBuilder expected = new StringBuilder("ChildrenAreAProperty[thing]");
+        for (int i = 0; i < length - 1; i++) {
+            expected.append("\n|_ChildrenAreAProperty[thing]");
+            expected.append("\n| \\_ChildrenAreAProperty[thing]");
         }
-        {
-            NoChildren empty = new NoChildren(randomSource(), "thing");
-            assertEquals(
-                "AChildIsAProperty[single]\n" + "\\_NoChildren[thing]",
-                new AChildIsAProperty(randomSource(), empty, "single").toString()
-            );
+        expected.append("\n\\_ChildrenAreAProperty[thing]");
+        expected.append("\n  \\_ChildrenAreAProperty[thing]");
+        assertToString(dummy(IntStream.range(0, length).mapToObj(i -> dummy(dummy())).toArray(Dummy[]::new)), equalTo(expected.toString()));
+    }
+
+    public void testToStringDeepChain() {
+        int depth = between(3, 100);
+        Dummy node = dummy();
+        for (int i = 1; i < depth; i++) {
+            node = dummy(node);
         }
+        StringBuilder expected = new StringBuilder("ChildrenAreAProperty[thing]");
+        for (int i = 1; i < depth; i++) {
+            expected.append("\n").append("  ".repeat(i - 1)).append("\\_ChildrenAreAProperty[thing]");
+        }
+        assertToString(node, equalTo(expected.toString()));
+    }
+
+    private Dummy dummy(Dummy... children) {
+        return new ChildrenAreAProperty(randomSource(), List.of(children), "thing");
+    }
+
+    private FunctionLike fn(FunctionLike... children) {
+        return new FunctionLike(randomSource(), List.of(children));
+    }
+
+    public void testToStringAChildIsAProperty() {
+        NoChildren empty = new NoChildren(randomSource(), "thing");
+        assertToString(new AChildIsAProperty(randomSource(), empty, "single"), equalTo("""
+            AChildIsAProperty[single]
+            \\_NoChildren[thing]"""));
+    }
+
+    public void testToStringFunctionLike() {
+        assertToString(new NoChildren(randomSource(), fn()), equalTo("NoChildren[FunctionLike()]"));
+        assertToString(new NoChildren(randomSource(), fn(fn(), fn())), equalTo("NoChildren[FunctionLike(FunctionLike(),FunctionLike())]"));
+    }
+
+    public void testToStringMaxLineWidth() {
+        assertToString(new NoChildren(randomSource(), "a".repeat(110)), equalTo("NoChildren[" + "a".repeat(110) + "]"));
+    }
+
+    public void testToStringLongProperty() {
+        assertToString(
+            new NoChildren(randomSource(), "a".repeat(200)),
+            equalTo("NoChildren[" + "a".repeat(110) + "\n" + "a".repeat(90) + "]"),
+            equalTo("NoChildren[" + "a".repeat(200) + "]")
+        );
+    }
+
+    public void testToStringVeryLongProperty() {
+        assertToString(
+            new NoChildren(randomSource(), "a".repeat(1000)),
+            equalTo("NoChildren[" + ("a".repeat(110) + "\n").repeat(9) + "a".repeat(10) + "]"),
+            equalTo("NoChildren[" + "a".repeat(1000) + "]")
+        );
+    }
+
+    public void testToStringTruncatesAtMaxLines() {
+        int len = Node.TO_STRING_MAX_LINES * Node.TO_STRING_MAX_WIDTH + 1;
+        assertToString(
+            new NoChildren(randomSource(), "a".repeat(len)),
+            equalTo(
+                "NoChildren["
+                    + ("a".repeat(Node.TO_STRING_MAX_WIDTH) + "\n").repeat(Node.TO_STRING_MAX_LINES - 1)
+                    + "a".repeat(Node.TO_STRING_MAX_WIDTH)
+                    + "..."
+                    + "]"
+            ),
+            equalTo("NoChildren[" + "a".repeat(len) + "]")
+        );
+    }
+
+    public void testToStringNameId() {
+        NameId nameId = new NameId();
+        assertToString(new NoChildren(randomSource(), nameId), equalTo("NoChildren[#" + nameId + "]"));
+    }
+
+    public void testToStringList() {
+        assertToString(
+            new NoChildren(randomSource(), List.of("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj")),
+            equalTo("NoChildren[[aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj]]")
+        );
+    }
+
+    public void testToStringListWrapping() {
+        assertToString(
+            new NoChildren(
+                randomSource(),
+                List.of(
+                    "aaaaaaaaaa",
+                    "bbbbbbbbbb",
+                    "cccccccccc",
+                    "dddddddddd",
+                    "eeeeeeeeee",
+                    "ffffffffff",
+                    "gggggggggg",
+                    "hhhhhhhhhh",
+                    "iiiiiiiiii",
+                    "jjjjjjjjjj"
+                )
+            ),
+            equalTo("""
+                NoChildren[[aaaaaaaaaa, bbbbbbbbbb, cccccccccc, dddddddddd, eeeeeeeeee, ffffffffff, gggggggggg, hhhhhhhhhh, iiiiiiiiii, j
+                jjjjjjjjj]]"""),
+            equalTo(
+                "NoChildren[[aaaaaaaaaa, bbbbbbbbbb, cccccccccc, dddddddddd, "
+                    + "eeeeeeeeee, ffffffffff, gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj]]"
+            )
+        );
+    }
+
+    public void testToStringListPathologicalWrapping() {
+        List<String> strings = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            strings.add(String.valueOf((char) ('a' + (i % 26))));
+        }
+        assertToString(new NoChildren(randomSource(), strings), equalTo("""
+            NoChildren[[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, a, b, c, d, e, f, g, h, i, j, k
+            , l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u,\s
+            v, w, x, y, z, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v]]"""), equalTo("NoChildren[" + strings + "]"));
+    }
+
+    private static void assertToString(Node<?> node, Matcher<String> expected) {
+        assertToString(node, expected, expected);
+    }
+
+    private static void assertToString(Node<?> node, Matcher<String> limitedExpected, Matcher<String> fullExpected) {
+        assertThat(node.toString(), limitedExpected);
+        assertThat(node.toString(Node.NodeStringFormat.LIMITED), limitedExpected);
+        assertThat(node.toString(Node.NodeStringFormat.FULL), fullExpected);
+    }
+
+    public void testRandomToString() {
+        NoChildren node = new NoChildren(randomSource(), randomNestedList(3));
+        String[] lines = node.toString().split("\n", -1);
+        assertThat(lines.length, lessThanOrEqualTo(Node.TO_STRING_MAX_LINES));
+        if (lines.length == 1) {
+            assertThat(lines[0].length(), lessThanOrEqualTo(Node.TO_STRING_MAX_WIDTH + "NoChildren[]".length()));
+            return;
+        }
+        assertThat(lines[0].length(), lessThanOrEqualTo(Node.TO_STRING_MAX_WIDTH + "NoChildren[".length()));
+        for (int i = 1; i < lines.length - 1; i++) {
+            assertThat(lines[i].length(), lessThanOrEqualTo(Node.TO_STRING_MAX_WIDTH));
+        }
+        assertThat(lines[lines.length - 1].length(), lessThanOrEqualTo(Node.TO_STRING_MAX_WIDTH + "...]".length()));
     }
 
     public void testWithNullChild() {
@@ -64,8 +225,8 @@ public class NodeTests extends ESTestCase {
     public abstract static class Dummy extends Node<Dummy> {
         private final String thing;
 
-        public Dummy(Source source, List<Dummy> children, String thing) {
-            super(source, children);
+        public Dummy(Source source, List<? extends Dummy> children, String thing) {
+            super(source, new ArrayList<>(children));
             this.thing = thing;
         }
 
@@ -117,6 +278,31 @@ public class NodeTests extends ESTestCase {
         }
     }
 
+    public static class FunctionLike extends Dummy {
+        public FunctionLike(Source source, List<? extends Dummy> children) {
+            super(source, children, "");
+        }
+
+        @Override
+        protected NodeInfo<FunctionLike> info() {
+            return NodeInfo.create(this, FunctionLike::new, children());
+        }
+
+        @Override
+        public FunctionLike replaceChildren(List<Dummy> newChildren) {
+            return new FunctionLike(source(), newChildren);
+        }
+
+        @Override
+        public String nodeString(NodeStringFormat format) {
+            StringJoiner sj = new StringJoiner(",", nodeName() + "(", ")");
+            for (Dummy child : children()) {
+                sj.add(child.nodeString(format));
+            }
+            return sj.toString();
+        }
+    }
+
     public static class AChildIsAProperty extends Dummy {
         public AChildIsAProperty(Source source, Dummy child, String thing) {
             super(source, singletonList(child), thing);
@@ -138,19 +324,29 @@ public class NodeTests extends ESTestCase {
     }
 
     public static class NoChildren extends Dummy {
-        public NoChildren(Source source, String thing) {
-            super(source, emptyList(), thing);
+        private final Object thing;
+
+        public NoChildren(Source source, Object thing) {
+            super(source, emptyList(), thing.toString());
+            this.thing = thing;
         }
 
         @Override
         protected NodeInfo<NoChildren> info() {
-            return NodeInfo.create(this, NoChildren::new, thing());
+            return NodeInfo.create(this, NoChildren::new, thing);
         }
 
         @Override
         public Dummy replaceChildren(List<Dummy> newChildren) {
             throw new UnsupportedOperationException("no children to replace");
         }
+    }
+
+    private static List<Object> randomNestedList(int allowedDepth) {
+        Supplier<Object> element = allowedDepth > 0
+            ? () -> randomBoolean() ? randomNestedList(allowedDepth - 1) : randomAlphaOfLengthBetween(0, 10)
+            : () -> randomAlphaOfLengthBetween(0, 10);
+        return randomList(10, element);
     }
 
     // Returns an empty list. The returned list may be backed various implementations, some

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -138,7 +138,11 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     private static final Predicate<String> CLASSNAME_FILTER = className -> {
         boolean esqlCore = className.startsWith(ESQL_CORE_CLASS_PREFIX) != false;
         boolean esqlProper = className.startsWith(ESQL_CLASS_PREFIX) != false;
-        return (esqlCore || esqlProper);
+        if ((esqlCore || esqlProper) == false) {
+            return false;
+        }
+        int dollarIdx = className.indexOf('$');
+        return dollarIdx < 0 || false == className.substring(0, dollarIdx).endsWith("Tests");
     };
 
     /**


### PR DESCRIPTION
Truncates the `toString` for ESQL's plan nodes when used outside the golden tests to 10 lines of 110 characters each.

Why 110? Because that's where we truncated before I got to this code.

Why 10 lines? Because we weren't truncating at all before. Just splitting at 110 characters one time. 10 lines of body for each plan node is quite large, really. Imagine a pathologically large plan, like 1000 nodes. That means at worst it's `toString` would be a little more than a megabyte. That's terrible! But I'm still ok logging it.
