### PR TITLE
[9.3] [ES|QL] Fix capability on 46_downsample test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -357,9 +357,6 @@ tests:
 - class: org.elasticsearch.indices.IndicesRequestCacheIT
   method: testCanCache
   issue: https://github.com/elastic/elasticsearch/issues/144526
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/46_downsample/Stats from downsampled and non-downsampled index simultaneously with implicit casting}
-  issue: https://github.com/elastic/elasticsearch/issues/145163
 
 # Examples:
 #

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -260,7 +260,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_default_metric, dense_vector_agg_metric_double_if_version]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:


### PR DESCRIPTION
The branch has support for running stats on AMD using the default_metric so this test should be gated on this capability.

Fixes #145163
