### PR TITLE
Make Settings.Builder.remove() fluent

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -63,9 +63,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
 
     @Override
     protected Settings.Builder setRandomIndexSettings(Random random, Settings.Builder builder) {
-        var b = super.setRandomIndexSettings(random, builder);
-        b.remove(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey());
-        return b;
+        return super.setRandomIndexSettings(random, builder).remove(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey());
     }
 
     private static final Set<ShardId> failOnFlushShards = ConcurrentCollections.newConcurrentSet();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -479,9 +479,10 @@ public class MetadataRolloverService {
                 && index.getIndexMode() == IndexMode.TIME_SERIES
                 && originalSettings.keySet().contains(IndexSettings.TIME_SERIES_START_TIME.getKey()) == false
                 && originalSettings.keySet().contains(IndexSettings.TIME_SERIES_END_TIME.getKey()) == false) {
-                final Settings.Builder settingsBuilder = Settings.builder().put(originalSettings);
-                settingsBuilder.remove(IndexSettings.MODE.getKey());
-                settingsBuilder.remove(IndexMetadata.INDEX_ROUTING_PATH.getKey());
+                final Settings.Builder settingsBuilder = Settings.builder()
+                    .put(originalSettings)
+                    .remove(IndexSettings.MODE.getKey())
+                    .remove(IndexMetadata.INDEX_ROUTING_PATH.getKey());
                 long newVersion = index.getSettingsVersion() + 1;
                 projectBuilder.put(IndexMetadata.builder(index).settings(settingsBuilder.build()).settingsVersion(newVersion));
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -207,11 +207,11 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
         final ResizeNumberOfShardsCalculator resizeNumberOfShardsCalculator
     ) {
         final CreateIndexRequest targetIndex = resizeRequest.getTargetIndexRequest();
-        final Settings.Builder targetIndexSettingsBuilder = Settings.builder()
+        final Settings targetIndexSettings = Settings.builder()
             .put(targetIndex.settings())
-            .normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX);
-        targetIndexSettingsBuilder.remove(IndexMetadata.SETTING_HISTORY_UUID);
-        final Settings targetIndexSettings = targetIndexSettingsBuilder.build();
+            .normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX)
+            .remove(IndexMetadata.SETTING_HISTORY_UUID)
+            .build();
         final Integer requestedNumberOfShards;
         if (IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.exists(targetIndexSettings)) {
             requestedNumberOfShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -829,9 +829,10 @@ public class MetadataCreateIndexService {
         final boolean isSystem = validateDotIndex(request.index(), isHiddenAfterTemplates);
 
         // remove the setting it's temporary and is only relevant once we create the index
-        final Settings.Builder settingsBuilder = Settings.builder().put(aggregatedIndexSettings);
-        settingsBuilder.remove(IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.getKey());
-        final Settings indexSettings = settingsBuilder.build();
+        final Settings indexSettings = Settings.builder()
+            .put(aggregatedIndexSettings)
+            .remove(IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.getKey())
+            .build();
 
         final IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(request.index());
         tmpImdBuilder.setRoutingNumShards(routingNumShards);

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -932,10 +932,19 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
         }
 
         /**
-         * Removes the provided setting from the internal map holding the current list of settings.
+         * Removes the provided setting from the internal map holding the current list of settings,
+         * and returns the setting's value.
          */
-        public String remove(String key) {
+        public String removeAndGet(String key) {
             return Settings.toString(map.remove(key));
+        }
+
+        /**
+         * Removes the provided setting from the internal map holding the current list of settings
+         */
+        public Builder remove(String key) {
+            map.remove(key);
+            return this;
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
@@ -159,7 +159,7 @@ public class InternalSettingsPreparer {
             }
         }
         for (String forcedSetting : forcedSettings) {
-            String value = output.remove(forcedSetting);
+            String value = output.removeAndGet(forcedSetting);
             output.put(forcedSetting.substring("force.".length()), value);
         }
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -203,14 +203,10 @@ public final class MetadataMigrateToDataTiersRoutingService {
         ProjectMetadata.Builder newProjectMetadataBuilder = ProjectMetadata.builder(currentProjectMetadata);
 
         // remove ENFORCE_DEFAULT_TIER_PREFERENCE from the persistent settings
-        Settings.Builder persistentSettingsBuilder = Settings.builder().put(mb.persistentSettings());
-        persistentSettingsBuilder.remove(ENFORCE_DEFAULT_TIER_PREFERENCE);
-        mb.persistentSettings(persistentSettingsBuilder.build());
+        mb.persistentSettings(Settings.builder().put(mb.persistentSettings()).remove(ENFORCE_DEFAULT_TIER_PREFERENCE).build());
 
         // and remove it from the transient settings, just in case it was there
-        Settings.Builder transientSettingsBuilder = Settings.builder().put(mb.transientSettings());
-        transientSettingsBuilder.remove(ENFORCE_DEFAULT_TIER_PREFERENCE);
-        mb.transientSettings(transientSettingsBuilder.build());
+        mb.transientSettings(Settings.builder().put(mb.transientSettings()).remove(ENFORCE_DEFAULT_TIER_PREFERENCE).build());
 
         String removedIndexTemplateName = null;
         if (Strings.hasText(indexTemplateToDelete)) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -461,10 +461,10 @@ public final class IndexLifecycleTransition {
         Settings.Builder newSettings = Settings.builder().put(idxSettings);
         boolean notChanged = true;
 
-        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
-        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.getKey()));
-        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_SKIP_SETTING.getKey()));
-        notChanged &= Strings.isNullOrEmpty(newSettings.remove(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.removeAndGet(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.removeAndGet(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.removeAndGet(LifecycleSettings.LIFECYCLE_SKIP_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.removeAndGet(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.getKey()));
         long newSettingsVersion = notChanged ? indexMetadata.getSettingsVersion() : 1 + indexMetadata.getSettingsVersion();
 
         IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/SystemIndexMigrationInfo.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/SystemIndexMigrationInfo.java
@@ -198,10 +198,10 @@ final class SystemIndexMigrationInfo extends SystemResourceMigrationInfo {
         final Settings settings;
         final String mapping;
         if (descriptor.isAutomaticallyManaged()) {
-            Settings.Builder settingsBuilder = Settings.builder();
-            settingsBuilder.put(descriptor.getSettings());
-            settingsBuilder.remove(IndexMetadata.SETTING_VERSION_CREATED); // Simplifies testing, should never impact real uses.
-            settings = settingsBuilder.build();
+            settings = Settings.builder()
+                .put(descriptor.getSettings())
+                .remove(IndexMetadata.SETTING_VERSION_CREATED) // Simplifies testing, should never impact real uses.
+                .build();
 
             mapping = descriptor.getMappings();
         } else {

--- a/x-pack/plugin/security/qa/smoke-test-all-realms/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/PkiRealmAuthIT.java
+++ b/x-pack/plugin/security/qa/smoke-test-all-realms/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/PkiRealmAuthIT.java
@@ -25,13 +25,13 @@ public class PkiRealmAuthIT extends SecurityRealmSmokeTestCase {
 
     @Override
     protected Settings restClientSettings() {
-        Settings.Builder builder = Settings.builder()
+        return Settings.builder()
             .put(super.restClientSettings())
             .put(CLIENT_CERT_PATH, getDataPath("/ssl/pki-auth.crt"))
             .put(CLIENT_KEY_PATH, getDataPath("/ssl/pki-auth.key"))
-            .put(CLIENT_KEY_PASSWORD, "http-password");
-        builder.remove(ThreadContext.PREFIX + ".Authorization");
-        return builder.build();
+            .put(CLIENT_KEY_PASSWORD, "http-password")
+            .remove(ThreadContext.PREFIX + ".Authorization")
+            .build();
     }
 
     public void testAuthenticationUsingPkiRealm() throws IOException {

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -270,12 +270,13 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
         MappingMetadata mapping = index.getMappings().get(index.getIndices()[0]);
 
         Settings settings = index.getSettings().get(index.getIndices()[0]);
-        Settings.Builder newSettings = Settings.builder().put(settings);
-        newSettings.remove("index.provided_name");
-        newSettings.remove("index.uuid");
-        newSettings.remove("index.creation_date");
-        newSettings.remove("index.version.created");
-        newSettings.remove("index.transport_version.created");
+        Settings.Builder newSettings = Settings.builder()
+            .put(settings)
+            .remove("index.provided_name")
+            .remove("index.uuid")
+            .remove("index.creation_date")
+            .remove("index.version.created")
+            .remove("index.transport_version.created");
 
         assertAcked(indicesAdmin().prepareCreate(to).setMapping(mapping.sourceAsMap()).setSettings(newSettings));
         ensureGreen(to);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/Account.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/Account.java
@@ -254,14 +254,14 @@ public class Account {
             }
 
             static void replace(Settings.Builder settings, String currentKey, String newKey) {
-                String value = settings.remove(currentKey);
+                String value = settings.removeAndGet(currentKey);
                 if (value != null) {
                     settings.put(newKey, value);
                 }
             }
 
             static void replaceTimeValue(Settings.Builder settings, String currentKey, String newKey) {
-                String value = settings.remove(currentKey);
+                String value = settings.removeAndGet(currentKey);
                 if (value != null) {
                     settings.put(newKey, TimeValue.parseTimeValue(value, currentKey).millis());
                 }

--- a/x-pack/plugin/write-load-forecaster/src/main/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecaster.java
+++ b/x-pack/plugin/write-load-forecaster/src/main/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecaster.java
@@ -120,8 +120,9 @@ class LicensedWriteLoadForecaster extends AbstractLicenseCheckingWriteLoadForeca
             final IndexMetadata.Builder previousWriteIndexMetadataBuilder = IndexMetadata.builder(previousWriteIndexMetadata)
                 .indexWriteLoadForecast(null);
             if (previousWriteIndexMetadata.getSettings().hasValue(OVERRIDE_WRITE_LOAD_FORECAST_SETTING.getKey())) {
-                Settings.Builder previousWriteIndexSettings = Settings.builder().put(previousWriteIndexMetadata.getSettings());
-                previousWriteIndexSettings.remove(OVERRIDE_WRITE_LOAD_FORECAST_SETTING.getKey());
+                Settings.Builder previousWriteIndexSettings = Settings.builder()
+                    .put(previousWriteIndexMetadata.getSettings())
+                    .remove(OVERRIDE_WRITE_LOAD_FORECAST_SETTING.getKey());
                 previousWriteIndexMetadataBuilder.settings(previousWriteIndexSettings);
                 previousWriteIndexMetadataBuilder.settingsVersion(previousWriteIndexMetadata.getSettingsVersion() + 1);
             }


### PR DESCRIPTION
Settings.Builder.remove() currently returns the previously set value of the key being removed. The vast majority of the callsites of this method ignore the return value, and would in fact benefit from it instead returning the Builder instance itself. This changes remove() to return the Builder to allow fluent chaining of calls, and adds a new removeAndGet() method for the handful of callsites that do use the returned value.