### PR TITLE
[ES|QL] Fix capability on 46_downsample test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -266,8 +266,8 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_default_metric, dense_vector_agg_metric_double_if_version]
-      reason: "Requires default metric to run TS ... | STATS max(agg_metric)"
+          capabilities: [aggregate_metric_double_avg_as_default_metric, dense_vector_agg_metric_double_if_version]
+      reason: "Requires default metric (using avg) to run TS ... | STATS max(agg_metric)"
 
   - do:
       allowed_warnings:


### PR DESCRIPTION
The end result of this test is unchanged between the old version of default_metric (which used max) and the current version (which uses avg) but because the implementation changed I think to be safe the capability of this test should be updated so that it is not run against older versions (like 9.3).

Relates #145163
Should be merged in before #145293
