### PR TITLE
ESQL: Log the query on error for easier diagnosis

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -185,9 +185,9 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
     /**
      * Log internal server errors all the time and log queries if debug is enabled.
      */
-    public ActionListener<EsqlQueryResponse> wrapWithLogging() {
+    public ActionListener<EsqlQueryResponse> wrapWithLogging(EsqlQueryRequest esqlRequest) {
         ActionListener<EsqlQueryResponse> listener = ActionListener.wrap(this::onResponse, ex -> {
-            logOnFailure(ex);
+            logOnFailure(ex, esqlRequest);
             onFailure(ex);
         });
         if (LOGGER.isDebugEnabled() == false) {
@@ -209,10 +209,14 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
         });
     }
 
-    public static void logOnFailure(Throwable throwable) {
+    public static void logOnFailure(Throwable throwable, EsqlQueryRequest esqlRequest) {
         RestStatus status = ExceptionsHelper.status(throwable);
         var level = status.getStatus() >= 500 ? Level.WARN : Level.DEBUG;
-        LOGGER.log(level, () -> "ESQL request failed with status [" + status + "]: ", throwable);
+        LOGGER.log(
+            level,
+            () -> String.format(Locale.ROOT, "ESQL request failed with status [%s] query [%s]: ", status, esqlRequest.queryDescription()),
+            throwable
+        );
     }
 
     /*

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -68,7 +68,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
             cancellableClient.execute(
                 EsqlQueryAction.INSTANCE,
                 esqlRequest,
-                new EsqlResponseListener(channel, request, esqlRequest).wrapWithLogging()
+                new EsqlResponseListener(channel, request, esqlRequest).wrapWithLogging(esqlRequest)
             );
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementService.java
@@ -85,7 +85,7 @@ public class AsyncTaskManagementService<
 
         default void onResponseAfterTimeout(Response response) {}
 
-        default void onFailureAfterTimeout(Exception exception) {}
+        default void onFailureAfterTimeout(Request request, Exception exception) {}
     }
 
     /**
@@ -194,7 +194,7 @@ public class AsyncTaskManagementService<
                 operation.execute(
                     request,
                     searchTask,
-                    wrapStoringListener(searchTask, waitForCompletionTimeout, keepOnCompletion, listener)
+                    wrapStoringListener(request, searchTask, waitForCompletionTimeout, keepOnCompletion, listener)
                 );
                 operationStarted = true;
             } finally {
@@ -207,6 +207,7 @@ public class AsyncTaskManagementService<
     }
 
     private ActionListener<Response> wrapStoringListener(
+        Request request,
         T searchTask,
         TimeValue waitForCompletionTimeout,
         boolean keepOnCompletion,
@@ -265,7 +266,7 @@ public class AsyncTaskManagementService<
                 }
             } else {
                 // We finished after timeout - saving exception
-                operation.onFailureAfterTimeout(e);
+                operation.onFailureAfterTimeout(request, e);
                 storeResults(searchTask, new StoredAsyncResponse<>(e, searchTask.getExpirationTimeMillis()));
             }
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -300,8 +300,8 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     }
 
     @Override
-    public void onFailureAfterTimeout(Exception exception) {
-        EsqlResponseListener.logOnFailure(exception);
+    public void onFailureAfterTimeout(EsqlQueryRequest request, Exception exception) {
+        EsqlResponseListener.logOnFailure(exception, request);
     }
 
     private void innerExecute(Task task, EsqlQueryRequest request, ActionListener<EsqlQueryResponse> listener) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlResponseListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlResponseListenerTests.java
@@ -120,6 +120,35 @@ public class EsqlResponseListenerTests extends ESTestCase {
         assertThat(logEvent.getThrown().getCause().getMessage(), equalTo("dummy"));
     }
 
+    public void testLogOnFailureServerError() {
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM index | STATS count()");
+        EsqlResponseListener.logOnFailure(new IllegalStateException("something broke"), request);
+
+        assertThat(appender.events, hasSize(1));
+        LogEvent logEvent = appender.events.get(0);
+        assertThat(logEvent.getLevel(), equalTo(Level.WARN));
+        assertThat(
+            logEvent.getMessage().getFormattedMessage(),
+            equalTo("ESQL request failed with status [INTERNAL_SERVER_ERROR] query [FROM index | STATS count()]: ")
+        );
+        assertThat(logEvent.getThrown().getMessage(), equalTo("something broke"));
+    }
+
+    public void testLogOnFailureClientError() {
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM index");
+        EsqlResponseListener.logOnFailure(new org.elasticsearch.ResourceNotFoundException("not found"), request);
+
+        assertThat(appender.events, hasSize(1));
+        LogEvent logEvent = appender.events.get(0);
+        assertThat(logEvent.getLevel(), equalTo(Level.DEBUG));
+        assertThat(
+            logEvent.getMessage().getFormattedMessage(),
+            equalTo("ESQL request failed with status [NOT_FOUND] query [FROM index]: ")
+        );
+    }
+
     private SearchShardTarget target(String clusterAlias, int shardId) {
         return new SearchShardTarget("node", new ShardId("idx", "uuid", shardId), clusterAlias);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
@@ -407,7 +407,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
             }
 
             @Override
-            public void onFailureAfterTimeout(Exception exception) {
+            public void onFailureAfterTimeout(TestRequest request, Exception exception) {
                 callbackLatch.countDown();
             }
         });


### PR DESCRIPTION
- Include the full ES|QL query string in log messages when requests fail, making it significantly easier to diagnose errors in production. Previously, only the status code and exception were logged.
- Thread the request through `onFailureAfterTimeout` so that async queries that fail after timeout also include the query in the log message.
- While the query string can be long, we already log the full stack trace in these error paths, so the additional query text is proportionate.