### PR TITLE
Fix UnresolvedException on PromQL by(step) grouping

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
@@ -20,8 +20,6 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import java.util.List;
 import java.util.Objects;
 
-import static java.util.function.Predicate.not;
-
 /**
  * Represents a PromQL aggregate function call that operates across multiple time series.
  * <p>
@@ -115,7 +113,7 @@ public final class AcrossSeriesAggregate extends PromqlFunctionCall {
         if (grouping == Grouping.WITHOUT) {
             return List.of(timeseriesAttribute);
         }
-        return groupings.stream().filter(not(a -> a.dataType() == DataType.NULL)).toList();
+        return groupings.stream().filter(a -> a.resolved() == false || a.dataType() != DataType.NULL).toList();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -55,7 +55,7 @@ public class PromqlCommand extends UnaryPlan
     /**
      * The name of the column containing the step value (aka time bucket) in range queries.
      */
-    public static final String STEP_COLUMN_NAME = "step";
+    private static final String STEP_COLUMN_NAME = "step";
 
     private final LogicalPlan promqlPlan;
     private final Literal start;
@@ -406,6 +406,21 @@ public class PromqlCommand extends UnaryPlan
                 case AcrossSeriesAggregate agg -> {
                     if (agg.grouping() == AcrossSeriesAggregate.Grouping.WITHOUT && usesWithoutGrouping(agg.child())) {
                         failures.add(fail(agg, "nested WITHOUT over WITHOUT is not supported at this time [{}]", agg.sourceText()));
+                    }
+                    // Reject labels whose name collides with the built-in step column.
+                    // If this proves too restrictive, we could add an option to rename the built-in step column.
+                    for (Attribute grouping : agg.groupings()) {
+                        if (stepColumnName().equals(grouping.name())) {
+                            failures.add(
+                                fail(
+                                    agg,
+                                    "label [{}] collides with the built-in [{}] output column [{}]",
+                                    stepColumnName(),
+                                    stepColumnName(),
+                                    agg.sourceText()
+                                )
+                            );
+                        }
                     }
                 }
                 case PromqlFunctionCall functionCall -> {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer.promql;
 
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -81,6 +82,18 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
             var plan = planPromql("PROMQL index=k8s step=1m " + query);
             assertThat(as(plan, LocalRelation.class).supplier(), equalTo(EmptyLocalSupplier.EMPTY));
         });
+    }
+
+    public void testGroupByStepCollision() {
+        // "step" as a BY label collides with the built-in step output column.
+        // If this proves too restrictive, we could add an option to rename the built-in step column.
+        for (String query : List.of(
+            "PROMQL index=k8s step=1m result=(sum by (step) (network.eth0.rx))",
+            "PROMQL index=k8s step=1m result=(sum by (step, pod) (network.eth0.rx))"
+        )) {
+            var e = expectThrows(VerificationException.class, () -> planPromql(query));
+            assertThat(e.getMessage(), containsString("label [step] collides with the built-in [step] output column"));
+        }
     }
 
     public void testGroupByNonExistentLabel() {

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
@@ -77,7 +77,7 @@ class PromqlQueryPlanBuilder {
         );
 
         // TO_LONG converts the step datetime to epoch millis, avoiding the need to parse a date string in the response listener.
-        Alias stepAlias = new Alias(Source.EMPTY, PromqlCommand.STEP_COLUMN_NAME, new ToLong(Source.EMPTY, promqlCommand.stepAttribute()));
+        Alias stepAlias = new Alias(Source.EMPTY, promqlCommand.stepColumnName(), new ToLong(Source.EMPTY, promqlCommand.stepAttribute()));
         // Eval's mergeOutputAttributes drops step(datetime) and appends step_alias(long) at the end,
         // producing [value, ...dimensions, step(long)] — the order the response listener expects.
         Eval eval = new Eval(Source.EMPTY, promqlCommand, List.of(stepAlias));


### PR DESCRIPTION
Fixes an `UnresolvedException: Invalid call to dataType on an unresolved object ?step` seen on serverless when a PromQL query groups by a label named `step`, which collides with the built-in `step` time bucket output column.

- Guard `AcrossSeriesAggregate.output()` against calling `dataType()` on unresolved attributes
- Reject `by(step)` groupings in `postAnalysisVerification` with a clear error message, since the label name collides with the built-in step column
- Make `STEP_COLUMN_NAME` private and use `stepColumnName()` accessor throughout