### PR TITLE
Unmute MMR logical plan test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -225,9 +225,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/141234
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.logical.MMR}
-  issue: https://github.com/elastic/elasticsearch/issues/142674
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819


### PR DESCRIPTION
this was fixed with https://github.com/elastic/elasticsearch/pull/144225 so we can unmute the test