### PR TITLE
Fix RecursiveChunkingSettings.validate() logic bug and add test coverage

### DIFF
--- a/docs/changelog/145314.yaml
+++ b/docs/changelog/145314.yaml
@@ -1,0 +1,6 @@
+pr: 145314
+summary: Fix RecursiveChunkingSettings.validate() logic bug where separator validation was skipped
+area: Inference
+type: bug
+issues:
+ - 144815

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
@@ -60,13 +60,13 @@ public class RecursiveChunkingSettings implements ChunkingSettings {
             validationException.addValidationError(
                 ChunkingSettingsOptions.MAX_CHUNK_SIZE + "[" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
             );
-
-            if (separators != null && separators.isEmpty()) {
-                validationException.addValidationError("Recursive chunking settings can not have an empty list of separators");
-            }
-
-            validationException.throwIfValidationErrorsExist();
         }
+
+        if (separators != null && separators.isEmpty()) {
+            validationException.addValidationError("Recursive chunking settings can not have an empty list of separators");
+        }
+
+        validationException.throwIfValidationErrorsExist();
     }
 
     public static RecursiveChunkingSettings fromMap(Map<String, Object> map) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class RecursiveChunkingSettings implements ChunkingSettings {
     public static final String NAME = "RecursiveChunkingSettings";
     private static final ChunkingStrategy STRATEGY = ChunkingStrategy.RECURSIVE;
-    private static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 10;
+    static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 10;
 
     private static final Set<String> VALID_KEYS = Set.of(
         ChunkingSettingsOptions.STRATEGY.toString(),
@@ -58,7 +58,7 @@ public class RecursiveChunkingSettings implements ChunkingSettings {
 
         if (maxChunkSize < MAX_CHUNK_SIZE_LOWER_LIMIT) {
             validationException.addValidationError(
-                ChunkingSettingsOptions.MAX_CHUNK_SIZE + "[" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
+                ChunkingSettingsOptions.MAX_CHUNK_SIZE + " [" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
             );
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettings.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class SentenceBoundaryChunkingSettings implements ChunkingSettings {
     public static final String NAME = "SentenceBoundaryChunkingSettings";
     private static final ChunkingStrategy STRATEGY = ChunkingStrategy.SENTENCE;
-    private static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 20;
+    static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 20;
     private static final Set<String> VALID_KEYS = Set.of(
         ChunkingSettingsOptions.STRATEGY.toString(),
         ChunkingSettingsOptions.MAX_CHUNK_SIZE.toString(),
@@ -66,7 +66,7 @@ public class SentenceBoundaryChunkingSettings implements ChunkingSettings {
 
         if (maxChunkSize < MAX_CHUNK_SIZE_LOWER_LIMIT) {
             validationException.addValidationError(
-                ChunkingSettingsOptions.MAX_CHUNK_SIZE + "[" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
+                ChunkingSettingsOptions.MAX_CHUNK_SIZE + " [" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
             );
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettings.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class WordBoundaryChunkingSettings implements ChunkingSettings {
     public static final String NAME = "WordBoundaryChunkingSettings";
     private static final ChunkingStrategy STRATEGY = ChunkingStrategy.WORD;
-    private static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 10;
+    static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 10;
     private static final Set<String> VALID_KEYS = Set.of(
         ChunkingSettingsOptions.STRATEGY.toString(),
         ChunkingSettingsOptions.MAX_CHUNK_SIZE.toString(),
@@ -53,7 +53,7 @@ public class WordBoundaryChunkingSettings implements ChunkingSettings {
 
         if (maxChunkSize < MAX_CHUNK_SIZE_LOWER_LIMIT) {
             validationException.addValidationError(
-                ChunkingSettingsOptions.MAX_CHUNK_SIZE + "[" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
+                ChunkingSettingsOptions.MAX_CHUNK_SIZE + " [" + maxChunkSize + "] must be above " + MAX_CHUNK_SIZE_LOWER_LIMIT
             );
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.inference.chunking;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ChunkingStrategy;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.elasticsearch.xpack.core.inference.chunking.RecursiveChunkingSettings.MAX_CHUNK_SIZE_LOWER_LIMIT;
 import static org.hamcrest.Matchers.containsString;
 
 public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestCase<RecursiveChunkingSettings> {
@@ -75,26 +77,39 @@ public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestC
     }
 
     public void testValidateWithValidSettings() {
-        var settings = new RecursiveChunkingSettings(randomIntBetween(10, 300), List.of("\n\n", "\n"));
+        var settings = new RecursiveChunkingSettings(randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300), List.of("\n\n", "\n"));
+        settings.validate(); // should not throw
+    }
+
+    public void testValidateWithBoundaryMaxChunkSize() {
+        var settings = new RecursiveChunkingSettings(MAX_CHUNK_SIZE_LOWER_LIMIT, List.of("\n\n", "\n"));
         settings.validate(); // should not throw
     }
 
     public void testValidateWithInvalidMaxChunkSize() {
-        var settings = new RecursiveChunkingSettings(randomIntBetween(0, 9), List.of("\n\n", "\n"));
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new RecursiveChunkingSettings(invalidMaxChunkSize, List.of("\n\n", "\n"));
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
     }
 
     public void testValidateWithEmptySeparators() {
-        var settings = new RecursiveChunkingSettings(randomIntBetween(10, 300), List.of());
+        var settings = new RecursiveChunkingSettings(randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300), List.of());
         var e = assertThrows(ValidationException.class, settings::validate);
         assertThat(e.getMessage(), containsString("can not have an empty list of separators"));
     }
 
     public void testValidateWithInvalidMaxChunkSizeAndEmptySeparators() {
-        var settings = new RecursiveChunkingSettings(randomIntBetween(0, 9), List.of());
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new RecursiveChunkingSettings(invalidMaxChunkSize, List.of());
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
         assertThat(e.getMessage(), containsString("can not have an empty list of separators"));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestCase<RecursiveChunkingSettings> {
 
     public void testFromMapValidSettingsWithSeparators() {
@@ -70,6 +72,30 @@ public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestC
         );
 
         assertThrows(ValidationException.class, () -> RecursiveChunkingSettings.fromMap(invalidSettings));
+    }
+
+    public void testValidateWithValidSettings() {
+        var settings = new RecursiveChunkingSettings(randomIntBetween(10, 300), List.of("\n\n", "\n"));
+        settings.validate(); // should not throw
+    }
+
+    public void testValidateWithInvalidMaxChunkSize() {
+        var settings = new RecursiveChunkingSettings(randomIntBetween(0, 9), List.of("\n\n", "\n"));
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+    }
+
+    public void testValidateWithEmptySeparators() {
+        var settings = new RecursiveChunkingSettings(randomIntBetween(10, 300), List.of());
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("can not have an empty list of separators"));
+    }
+
+    public void testValidateWithInvalidMaxChunkSizeAndEmptySeparators() {
+        var settings = new RecursiveChunkingSettings(randomIntBetween(0, 9), List.of());
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(e.getMessage(), containsString("can not have an empty list of separators"));
     }
 
     public void testFromMapEmptySeparators() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettingsTests.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class SentenceBoundaryChunkingSettingsTests extends AbstractWireSerializingTestCase<SentenceBoundaryChunkingSettings> {
 
     public void testMaxChunkSizeNotProvided() {
@@ -31,6 +33,30 @@ public class SentenceBoundaryChunkingSettingsTests extends AbstractWireSerializi
         chunkingSettingsMap.put(randomAlphaOfLength(10), randomNonNegativeInt());
 
         assertThrows(ValidationException.class, () -> { SentenceBoundaryChunkingSettings.fromMap(chunkingSettingsMap); });
+    }
+
+    public void testValidateWithValidSettings() {
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(20, 300), randomFrom(0, 1));
+        settings.validate(); // should not throw
+    }
+
+    public void testValidateWithInvalidMaxChunkSize() {
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(0, 19), randomFrom(0, 1));
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+    }
+
+    public void testValidateWithInvalidSentenceOverlap() {
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(20, 300), randomFrom(-1, 2));
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be either 0 or 1"));
+    }
+
+    public void testValidateWithBothInvalid() {
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(0, 19), randomFrom(-1, 2));
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(e.getMessage(), containsString("must be either 0 or 1"));
     }
 
     public void testValidInputsProvided() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/SentenceBoundaryChunkingSettingsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.inference.chunking;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ChunkingStrategy;
@@ -17,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.elasticsearch.xpack.core.inference.chunking.SentenceBoundaryChunkingSettings.MAX_CHUNK_SIZE_LOWER_LIMIT;
 import static org.hamcrest.Matchers.containsString;
 
 public class SentenceBoundaryChunkingSettingsTests extends AbstractWireSerializingTestCase<SentenceBoundaryChunkingSettings> {
@@ -36,26 +38,39 @@ public class SentenceBoundaryChunkingSettingsTests extends AbstractWireSerializi
     }
 
     public void testValidateWithValidSettings() {
-        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(20, 300), randomFrom(0, 1));
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300), randomFrom(0, 1));
+        settings.validate(); // should not throw
+    }
+
+    public void testValidateWithBoundaryMaxChunkSize() {
+        var settings = new SentenceBoundaryChunkingSettings(MAX_CHUNK_SIZE_LOWER_LIMIT, randomFrom(0, 1));
         settings.validate(); // should not throw
     }
 
     public void testValidateWithInvalidMaxChunkSize() {
-        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(0, 19), randomFrom(0, 1));
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new SentenceBoundaryChunkingSettings(invalidMaxChunkSize, randomFrom(0, 1));
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
     }
 
     public void testValidateWithInvalidSentenceOverlap() {
-        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(20, 300), randomFrom(-1, 2));
+        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300), randomFrom(-1, 2));
         var e = assertThrows(ValidationException.class, settings::validate);
         assertThat(e.getMessage(), containsString("must be either 0 or 1"));
     }
 
     public void testValidateWithBothInvalid() {
-        var settings = new SentenceBoundaryChunkingSettings(randomIntBetween(0, 19), randomFrom(-1, 2));
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new SentenceBoundaryChunkingSettings(invalidMaxChunkSize, randomFrom(-1, 2));
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
         assertThat(e.getMessage(), containsString("must be either 0 or 1"));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettingsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.inference.chunking;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ChunkingStrategy;
@@ -17,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings.MAX_CHUNK_SIZE_LOWER_LIMIT;
 import static org.hamcrest.Matchers.containsString;
 
 public class WordBoundaryChunkingSettingsTests extends AbstractWireSerializingTestCase<WordBoundaryChunkingSettings> {
@@ -50,28 +52,41 @@ public class WordBoundaryChunkingSettingsTests extends AbstractWireSerializingTe
     }
 
     public void testValidateWithValidSettings() {
-        var maxChunkSize = randomIntBetween(10, 300);
+        var maxChunkSize = randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300);
         var settings = new WordBoundaryChunkingSettings(maxChunkSize, randomIntBetween(1, maxChunkSize / 2));
         settings.validate(); // should not throw
     }
 
+    public void testValidateWithBoundaryMaxChunkSize() {
+        var settings = new WordBoundaryChunkingSettings(MAX_CHUNK_SIZE_LOWER_LIMIT, 1);
+        settings.validate(); // should not throw
+    }
+
     public void testValidateWithInvalidMaxChunkSize() {
-        var settings = new WordBoundaryChunkingSettings(randomIntBetween(0, 9), 1);
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new WordBoundaryChunkingSettings(invalidMaxChunkSize, 1);
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
     }
 
     public void testValidateWithOverlapTooLarge() {
-        var maxChunkSize = randomIntBetween(10, 300);
+        var maxChunkSize = randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300);
         var settings = new WordBoundaryChunkingSettings(maxChunkSize, (maxChunkSize / 2) + 1);
         var e = assertThrows(ValidationException.class, settings::validate);
         assertThat(e.getMessage(), containsString("must be less than or equal to half of max chunk size"));
     }
 
     public void testValidateWithBothInvalid() {
-        var settings = new WordBoundaryChunkingSettings(randomIntBetween(0, 9), 100);
+        var invalidMaxChunkSize = randomIntBetween(0, MAX_CHUNK_SIZE_LOWER_LIMIT - 1);
+        var settings = new WordBoundaryChunkingSettings(invalidMaxChunkSize, 100);
         var e = assertThrows(ValidationException.class, settings::validate);
-        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("max_chunk_size [%s] must be above %s", invalidMaxChunkSize, MAX_CHUNK_SIZE_LOWER_LIMIT))
+        );
         assertThat(e.getMessage(), containsString("must be less than or equal to half of max chunk size"));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/WordBoundaryChunkingSettingsTests.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class WordBoundaryChunkingSettingsTests extends AbstractWireSerializingTestCase<WordBoundaryChunkingSettings> {
 
     public void testMaxChunkSizeNotProvided() {
@@ -45,6 +47,32 @@ public class WordBoundaryChunkingSettingsTests extends AbstractWireSerializingTe
         assertThrows(ValidationException.class, () -> {
             WordBoundaryChunkingSettings.fromMap(buildChunkingSettingsMap(Optional.of(maxChunkSize), Optional.of(overlap)));
         });
+    }
+
+    public void testValidateWithValidSettings() {
+        var maxChunkSize = randomIntBetween(10, 300);
+        var settings = new WordBoundaryChunkingSettings(maxChunkSize, randomIntBetween(1, maxChunkSize / 2));
+        settings.validate(); // should not throw
+    }
+
+    public void testValidateWithInvalidMaxChunkSize() {
+        var settings = new WordBoundaryChunkingSettings(randomIntBetween(0, 9), 1);
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+    }
+
+    public void testValidateWithOverlapTooLarge() {
+        var maxChunkSize = randomIntBetween(10, 300);
+        var settings = new WordBoundaryChunkingSettings(maxChunkSize, (maxChunkSize / 2) + 1);
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be less than or equal to half of max chunk size"));
+    }
+
+    public void testValidateWithBothInvalid() {
+        var settings = new WordBoundaryChunkingSettings(randomIntBetween(0, 9), 100);
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(e.getMessage(), containsString("must be above"));
+        assertThat(e.getMessage(), containsString("must be less than or equal to half of max chunk size"));
     }
 
     public void testValidInputsProvided() {


### PR DESCRIPTION
## Summary
- Fix logic bug in `RecursiveChunkingSettings.validate()` where separator validation and `throwIfValidationErrorsExist()` were nested inside the `maxChunkSize < MAX_CHUNK_SIZE_LOWER_LIMIT` if-block, so they never ran when maxChunkSize was valid
- Move both out of the if-block to match the correct pattern used by `SentenceBoundaryChunkingSettings` and `WordBoundaryChunkingSettings`
- Add direct `validate()` test coverage for all three chunking settings implementations (as noted missing in the issue)

Closes #144815

## Test plan
- [x] `RecursiveChunkingSettingsTests` — 4 new validate() tests (valid settings, invalid maxChunkSize, empty separators, both invalid)
- [x] `SentenceBoundaryChunkingSettingsTests` — 4 new validate() tests (valid settings, invalid maxChunkSize, invalid sentenceOverlap, both invalid)
- [x] `WordBoundaryChunkingSettingsTests` — 4 new validate() tests (valid settings, invalid maxChunkSize, overlap too large, both invalid)
- [x] All existing tests continue to pass

