### PR TITLE
[8.19] [Build] Tweak BWC tasks caching (#117423)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PomValidationTask.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PomValidationTask.java
@@ -16,6 +16,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.FileReader;
@@ -37,6 +39,7 @@ public class PomValidationTask extends PrecommitTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public RegularFileProperty getPomFile() {
         return pomFile;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -115,9 +115,9 @@ public class BwcSetupExtension {
 
             if (OS.current() == OS.WINDOWS) {
                 loggedExec.getExecutable().set("cmd");
-                loggedExec.args("/C", "call", new File(checkoutDir.get(), "gradlew").toString());
+                loggedExec.args("/C", "call", "gradlew");
             } else {
-                loggedExec.getExecutable().set(new File(checkoutDir.get(), "gradlew").toString());
+                loggedExec.getExecutable().set("./gradlew");
             }
 
             if (useUniqueUserHome) {
@@ -184,7 +184,7 @@ public class BwcSetupExtension {
         }
     }
 
-    public static abstract class JavaHomeValueSource implements ValueSource<String, JavaHomeValueSource.Params> {
+    public abstract static class JavaHomeValueSource implements ValueSource<String, JavaHomeValueSource.Params> {
 
         private String minimumCompilerVersionPath(Version bwcVersion) {
             return (bwcVersion.onOrAfter(BUILD_TOOL_MINIMUM_VERSION))

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JvmToolchainsPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -375,7 +376,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             File expectedOutputFile = useNativeExpanded
                 ? new File(projectArtifact.expandedDistDir, "elasticsearch-" + bwcVersion.get() + (isReleaseBuild ? "" : "-SNAPSHOT"))
                 : projectArtifact.distFile;
-            c.getInputs().file(new File(project.getBuildDir(), "refspec"));
+            c.getInputs().file(new File(project.getBuildDir(), "refspec")).withPathSensitivity(PathSensitivity.RELATIVE);
             if (useNativeExpanded) {
                 c.getOutputs().dir(expectedOutputFile);
             } else {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -48,12 +49,18 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin {
         if ("jar".equals(checkstyleConfUrl.getProtocol())) {
             try {
                 JarURLConnection jarURLConnection = (JarURLConnection) checkstyleConfUrl.openConnection();
-                copyCheckstyleConf.configure(t -> t.getInputs().file(jarURLConnection.getJarFileURL()));
+                copyCheckstyleConf.configure(
+                    t -> t.getInputs().file(jarURLConnection.getJarFileURL()).withPathSensitivity(PathSensitivity.RELATIVE)
+                );
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         } else if ("file".equals(checkstyleConfUrl.getProtocol())) {
-            copyCheckstyleConf.configure(t -> t.getInputs().files(checkstyleConfUrl.getFile(), checkstyleSuppressionsUrl.getFile()));
+            copyCheckstyleConf.configure(
+                t -> t.getInputs()
+                    .files(checkstyleConfUrl.getFile(), checkstyleSuppressionsUrl.getFile())
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+            );
         }
 
         // Explicitly using an Action interface as java lambdas

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsTask.java
@@ -19,6 +19,8 @@ import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskAction;
@@ -79,6 +81,7 @@ public abstract class FilePermissionsTask extends DefaultTask {
     @InputFiles
     @IgnoreEmptyDirectories
     @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileCollection getFiles() {
         return getSources().get()
             .stream()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -24,6 +24,8 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -105,6 +107,7 @@ public abstract class CopyRestTestsTask extends DefaultTask {
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getInputDir() {
         FileTree coreFileTree = null;
         FileTree xpackFileTree = null;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -20,6 +20,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -51,6 +52,7 @@ import javax.inject.Inject;
  * Exec task implementation.
  */
 @SuppressWarnings("unchecked")
+@CacheableTask
 public abstract class LoggedExec extends DefaultTask implements FileSystemOperationsAware {
 
     private static final Logger LOGGER = Logging.getLogger(LoggedExec.class);
@@ -85,6 +87,14 @@ public abstract class LoggedExec extends DefaultTask implements FileSystemOperat
     abstract public Property<Boolean> getCaptureOutput();
 
     @Input
+    public Provider<String> getWorkingDirPath() {
+        return getWorkingDir().map(file -> {
+            String relativeWorkingDir = projectLayout.getProjectDirectory().getAsFile().toPath().relativize(file.toPath()).toString();
+            return relativeWorkingDir;
+        });
+    }
+
+    @Internal
     abstract public Property<File> getWorkingDir();
 
     private String output;
@@ -111,9 +121,10 @@ public abstract class LoggedExec extends DefaultTask implements FileSystemOperat
      * can be reused across different build invocations.
      * */
     private void setupDefaultEnvironment(ProviderFactory providerFactory) {
-        getEnvironment().putAll(providerFactory.environmentVariablesPrefixedBy("BUILDKITE"));
         getEnvironment().putAll(providerFactory.environmentVariablesPrefixedBy("GRADLE_BUILD_CACHE"));
-        getEnvironment().putAll(providerFactory.environmentVariablesPrefixedBy("VAULT"));
+
+        getNonTrackedEnvironment().putAll(providerFactory.environmentVariablesPrefixedBy("BUILDKITE"));
+        getNonTrackedEnvironment().putAll(providerFactory.environmentVariablesPrefixedBy("VAULT"));
         Provider<String> javaToolchainHome = providerFactory.environmentVariable("JAVA_TOOLCHAIN_HOME");
         if (javaToolchainHome.isPresent()) {
             getEnvironment().put("JAVA_TOOLCHAIN_HOME", javaToolchainHome);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GeneratePluginPropertiesTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GeneratePluginPropertiesTask.java
@@ -19,10 +19,13 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;
@@ -39,6 +42,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+@CacheableTask
 public abstract class GeneratePluginPropertiesTask extends DefaultTask {
 
     public static final String PROPERTIES_FILENAME = "plugin-descriptor.properties";
@@ -82,6 +86,7 @@ public abstract class GeneratePluginPropertiesTask extends DefaultTask {
     public abstract Property<Boolean> getIsLicensed();
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getModuleInfoFile();
 
     @OutputFile


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Build] Tweak BWC tasks caching (#117423)](https://github.com/elastic/elasticsearch/pull/117423)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)