### PR TITLE
[DiskBBQ] Fix bug in NeighborQueue#popRawAndAddRaw

### DIFF
--- a/docs/changelog/145324.yaml
+++ b/docs/changelog/145324.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 145324
+summary: "[DiskBBQ] Fix bug in `NeighborQueue#popRawAndAddRaw`"
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
@@ -143,7 +143,7 @@ public class NeighborQueue {
     }
 
     /**
-     * if the new element is the new top then return its node id. Otherwise,
+     * if the new element is the new top then return its raw value. Otherwise,
      * removes the current top element, returns its node id and adds the new element
      * to the queue.
      * */

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
@@ -150,7 +150,7 @@ public class NeighborQueue {
     public long popRawAndAddRaw(long raw) {
         long top = heap.top();
         if (raw < top) {
-            return decodeNodeId(raw);
+            return raw;
         }
         heap.updateTop(raw);
         return top;

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueueTests.java
@@ -116,4 +116,20 @@ public class NeighborQueueTests extends ESTestCase {
         assertEquals("Neighbors[0]", new NeighborQueue(2, false).toString());
     }
 
+    public void testPopRawAndAddRawReturnsRawWhenNewTop() {
+        NeighborQueue nn = new NeighborQueue(2, false);
+        long first = nn.encode(1, 1.0f);
+        long second = nn.encode(2, 2.0f);
+        nn.insertWithOverflow(first);
+        nn.insertWithOverflow(second);
+
+        long newTop = nn.encode(3, 0.5f);
+        assertTrue(newTop < nn.peek());
+
+        long result = nn.popRawAndAddRaw(newTop);
+        assertEquals(newTop, result);
+        assertEquals(2, nn.size());
+        assertEquals(first, nn.peek());
+    }
+
 }


### PR DESCRIPTION
Introduced in https://github.com/elastic/elasticsearch/pull/141058, we are returning the decodeId instead of the raw value when the add raw value is the top value.