### PR TITLE
Clear watch schedules when starting trigger engine

### DIFF
--- a/docs/changelog/145325.yaml
+++ b/docs/changelog/145325.yaml
@@ -1,5 +1,6 @@
 area: Watcher
 issues:
+ - 137562
  - 131964
 pr: 145325
 summary: Clear watch schedules when starting trigger engine

--- a/docs/changelog/145325.yaml
+++ b/docs/changelog/145325.yaml
@@ -1,0 +1,6 @@
+area: Watcher
+issues:
+ - 131964
+pr: 145325
+summary: Clear watch schedules when starting trigger engine
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -315,9 +315,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidShortWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145241
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcherWithApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/131964
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testNoInfiniteRecursiveGetObjectCalls
   issue: https://github.com/elastic/elasticsearch/issues/145269

--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module org.elasticsearch.xcore {
     requires org.slf4j;
     requires com.ibm.icu;
     requires org.elasticsearch.exponentialhistogram;
+    requires org.elasticsearch.logging;
 
     exports org.elasticsearch.index.engine.frozen;
     exports org.elasticsearch.license;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
@@ -20,6 +22,8 @@ import static org.elasticsearch.xpack.core.watcher.actions.throttler.Throttler.T
  * the last successful execution is lower than the given period, the action will be throttled.
  */
 public class PeriodThrottler implements Throttler {
+
+    private static final Logger logger = LogManager.getLogger(PeriodThrottler.class);
 
     @Nullable
     private final TimeValue period;
@@ -53,6 +57,7 @@ public class PeriodThrottler implements Throttler {
         long executionTime = status.lastSuccessfulExecution().timestamp().toInstant().toEpochMilli();
         TimeValue timeElapsed = TimeValue.timeValueMillis(now - executionTime);
         if (timeElapsed.getMillis() <= throttlePeriod.getMillis()) {
+            logger.debug("[{}] throttling action [{}] due to time elapsed since last execution [{}]", ctx.watch().id(), actionId, timeElapsed);
             return Result.throttle(
                 PERIOD,
                 "throttling interval is set to [{}] but time elapsed since last execution is [{}]",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/PeriodThrottler.java
@@ -57,7 +57,12 @@ public class PeriodThrottler implements Throttler {
         long executionTime = status.lastSuccessfulExecution().timestamp().toInstant().toEpochMilli();
         TimeValue timeElapsed = TimeValue.timeValueMillis(now - executionTime);
         if (timeElapsed.getMillis() <= throttlePeriod.getMillis()) {
-            logger.debug("[{}] throttling action [{}] due to time elapsed since last execution [{}]", ctx.watch().id(), actionId, timeElapsed);
+            logger.debug(
+                "[{}] throttling action [{}] due to time elapsed since last execution [{}]",
+                ctx.watch().id(),
+                actionId,
+                timeElapsed
+            );
             return Result.throttle(
                 PERIOD,
                 "throttling interval is set to [{}] but time elapsed since last execution is [{}]",

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
@@ -53,6 +52,7 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
 
     private final TimeValue tickInterval;
     private final Map<String, ActiveSchedule> schedules = new ConcurrentHashMap<>();
+    private final Map<String, ActiveSchedule> recentlyAddedSchedules = new ConcurrentHashMap<>();
     private final Ticker ticker;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -65,20 +65,24 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
     @Override
     public synchronized void start(Collection<Watch> jobs) {
         long startTime = clock.millis();
-        isRunning.set(true);
         logger.info("Starting watcher engine at {}", WatcherDateTimeUtils.dateTimeFormatter.formatMillis(startTime));
-        Map<String, ActiveSchedule> startingSchedules = Maps.newMapWithExpectedSize(jobs.size());
+        schedules.clear();
         for (Watch job : jobs) {
             if (job.trigger() instanceof ScheduleTrigger trigger) {
-                if (trigger.getSchedule() instanceof IntervalSchedule) {
-                    startingSchedules.put(job.id(), new ActiveSchedule(job.id(), trigger.getSchedule(), calculateLastStartTime(job)));
-                } else {
-                    startingSchedules.put(job.id(), new ActiveSchedule(job.id(), trigger.getSchedule(), startTime));
-                }
+                schedules.put(job.id(), createSchedule(job, trigger, startTime));
             }
         }
-        this.schedules.clear();
-        this.schedules.putAll(startingSchedules);
+        schedules.putAll(recentlyAddedSchedules);
+        recentlyAddedSchedules.clear();
+        isRunning.set(true);
+    }
+
+    private ActiveSchedule createSchedule(Watch job, ScheduleTrigger trigger, long currentTimeInMillis) {
+        return new ActiveSchedule(
+            job.id(),
+            trigger.getSchedule(),
+            trigger.getSchedule() instanceof IntervalSchedule ? calculateLastStartTime(job) : currentTimeInMillis
+        );
     }
 
     @Override
@@ -107,12 +111,14 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
         // watcher indexing listener
         // this also means that updating an existing watch would not retrigger the schedule time, if it remains the same schedule
         if (currentSchedule == null || currentSchedule.schedule.equals(trigger.getSchedule()) == false) {
-            if (trigger.getSchedule() instanceof IntervalSchedule) {
-                schedules.put(watch.id(), new ActiveSchedule(watch.id(), trigger.getSchedule(), calculateLastStartTime(watch)));
-            } else {
-                schedules.put(watch.id(), new ActiveSchedule(watch.id(), trigger.getSchedule(), clock.millis()));
+            synchronized (this) {
+                ActiveSchedule schedule = createSchedule(watch, trigger, clock.millis());
+                if (isRunning.get() == false) {
+                    recentlyAddedSchedules.put(watch.id(), schedule);
+                } else {
+                    schedules.put(watch.id(), schedule);
+                }
             }
-
         }
     }
 
@@ -223,6 +229,11 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
             long prevScheduledTime = scheduledTime == 0 ? time : scheduledTime;
             scheduledTime = schedule.nextScheduledTimeAfter(startTime, time);
             return prevScheduledTime;
+        }
+
+        // visible for testing
+        Schedule getSchedule() {
+            return schedule;
         }
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
@@ -77,15 +77,7 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
                 }
             }
         }
-        // why are we calling putAll() here instead of assigning a brand
-        // new concurrent hash map you may ask yourself over here
-        // This requires some explanation how TriggerEngine.start() is
-        // invoked, when a reload due to the cluster state listener is done
-        // If the watches index does not exist, and new document is stored,
-        // then the creation of that index will trigger a reload which calls
-        // this method. The index operation however will run at the same time
-        // as the reload, so if we clean out the old data structure here,
-        // that can lead to that one watch not being triggered
+        this.schedules.clear();
         this.schedules.putAll(startingSchedules);
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +53,7 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
 
     private final TimeValue tickInterval;
     private final Map<String, ActiveSchedule> schedules = new ConcurrentHashMap<>();
-    private final Map<String, ActiveSchedule> recentlyAddedSchedules = new ConcurrentHashMap<>();
+    private final Map<String, ActiveSchedule> recentlyAddedSchedules = new HashMap<>(); // used only inside synchronized blocks
     private final Ticker ticker;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -111,8 +112,8 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
         // watcher indexing listener
         // this also means that updating an existing watch would not retrigger the schedule time, if it remains the same schedule
         if (currentSchedule == null || currentSchedule.schedule.equals(trigger.getSchedule()) == false) {
+            ActiveSchedule schedule = createSchedule(watch, trigger, clock.millis());
             synchronized (this) {
-                ActiveSchedule schedule = createSchedule(watch, trigger, clock.millis());
                 if (isRunning.get() == false) {
                     recentlyAddedSchedules.put(watch.id(), schedule);
                 } else {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.IntStream.range;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.daily;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.weekly;
@@ -103,6 +105,31 @@ public class TickerScheduleEngineTests extends ESTestCase {
             fail("waiting too long for all watches to be triggered");
         }
         assertThat(bits.cardinality(), is(count));
+    }
+
+    /**
+     * When a cluster state changes and watches are restarted, the engine should clean up any previous watches because they may change
+     * the node they are running on. When not cleaned up, they may start triggering on more nodes than they should.
+     */
+    public void testStartsShouldCleanUpPreviousWatches() {
+        final List<Watch> initialWatches = createRandomWatches(2);
+        engine.start(initialWatches);
+        assertThat("Assumed initial watches added",
+            engine.getSchedules().keySet(), is(initialWatches.stream().map(Watch::id).collect(toSet()))
+        );
+
+        final List<Watch> newWatches = createRandomWatches(3);
+
+        engine.start(newWatches);
+        assertThat("Only new watches should be visible after engine restart",
+            engine.getSchedules().keySet(), is(newWatches.stream().map(Watch::id).collect(toSet()))
+        );
+    }
+
+    private List<Watch> createRandomWatches(int watchesToCreate) {
+        return range(0, watchesToCreate)
+            .mapToObj(__ -> createWatch(randomAlphanumericOfLength(5), interval("1s")))
+            .toList();
     }
 
     public void testAddHourly() throws Exception {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
@@ -114,22 +114,24 @@ public class TickerScheduleEngineTests extends ESTestCase {
     public void testStartsShouldCleanUpPreviousWatches() {
         final List<Watch> initialWatches = createRandomWatches(2);
         engine.start(initialWatches);
-        assertThat("Assumed initial watches added",
-            engine.getSchedules().keySet(), is(initialWatches.stream().map(Watch::id).collect(toSet()))
+        assertThat(
+            "Assumed initial watches added",
+            engine.getSchedules().keySet(),
+            is(initialWatches.stream().map(Watch::id).collect(toSet()))
         );
 
         final List<Watch> newWatches = createRandomWatches(3);
 
         engine.start(newWatches);
-        assertThat("Only new watches should be visible after engine restart",
-            engine.getSchedules().keySet(), is(newWatches.stream().map(Watch::id).collect(toSet()))
+        assertThat(
+            "Only new watches should be visible after engine restart",
+            engine.getSchedules().keySet(),
+            is(newWatches.stream().map(Watch::id).collect(toSet()))
         );
     }
 
     private List<Watch> createRandomWatches(int watchesToCreate) {
-        return range(0, watchesToCreate)
-            .mapToObj(__ -> createWatch(randomAlphanumericOfLength(5), interval("1s")))
-            .toList();
+        return range(0, watchesToCreate).mapToObj(__ -> createWatch(randomAlphanumericOfLength(5), interval("1s"))).toList();
     }
 
     public void testAddHourly() throws Exception {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
@@ -38,6 +38,8 @@ import static java.util.stream.IntStream.range;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.daily;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.weekly;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
@@ -128,6 +130,45 @@ public class TickerScheduleEngineTests extends ESTestCase {
             engine.getSchedules().keySet(),
             is(newWatches.stream().map(Watch::id).collect(toSet()))
         );
+    }
+
+    /**
+     * When the .watches index is first created, the index creation triggers a reload while the document indexing runs concurrently.
+     * WatcherIndexingListener.postIndex() calls add() while the engine is paused. These watches must survive the subsequent start()
+     * call even if loadWatches() returns an empty set due to the race.
+     */
+    public void testWatchesAddedWhilePausedSurviveStart() {
+        engine.start(List.of());
+        engine.pauseExecution();
+
+        Watch watch = createWatch("concurrently_indexed", interval("1s"));
+        engine.add(watch);
+
+        // start() with empty list simulates loadWatches() finding nothing due to the race
+        engine.start(List.of());
+
+        assertThat("Watch added while paused should be present after start", engine.getSchedules(), hasKey("concurrently_indexed"));
+    }
+
+    /**
+     * Watches added while paused should not override watches loaded by start() if they share the same id.
+     * The loaded version is authoritative since it comes from the index.
+     */
+    public void testConcurrentlyAddedTakesPrecedenceOverLoadedWatch() {
+        final String watchName = "watch_name";
+        engine.start(List.of());
+        engine.pauseExecution();
+
+        Watch addedWatch = createWatch(watchName, interval("1s"));
+        engine.add(addedWatch);
+
+        Watch loadedWatch = createWatch(watchName, interval("5s"));
+        engine.start(List.of(loadedWatch));
+
+        var schedules = engine.getSchedules();
+        assertThat("Loaded watch should be present", schedules, hasKey(watchName));
+        assertThat(schedules, aMapWithSize(1));
+        assertThat(schedules.get(watchName).getSchedule(), is(interval("1s")));
     }
 
     private List<Watch> createRandomWatches(int watchesToCreate) {

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.test.StreamsUtils;
-import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -209,10 +208,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
         }
     }
 
-    @TestIssueLogging(
-        value = "org.elasticsearch.xpack.restart.FullClusterRestartIT:DEBUG",
-        issueUrl = "https://github.com/elastic/elasticsearch/issues/131964"
-    )
     @SuppressWarnings("unchecked")
     public void testWatcherWithApiKey() throws Exception {
         final Request getWatchStatusRequest = new Request("GET", "/_watcher/watch/watch_with_api_key");


### PR DESCRIPTION
When new nodes appear in the cluster the watch may change the node it is running on. 
If we don't reset the schedules for a given node, there is a chance multiple nodes will execute the watch.

This could be observed in #131964 where some watcher actions were unexpectedly throttled (it happened that the same watch was run on two nodes and one of the execution was throttled.

Solving this problem uncovers another issue, related to watchers. When a watcher service is being **reloaded** (e.g. due to watcher allocation changes), and at the same time a new watcher is added, the `WatcherIndexingListener`  is directly modifying the `TickerScheduleTriggerEngine` and the trigger engine `start` method **reverts this operation**.

To fix that, the recently added watchers will be treated separately from the rest and will be re-added during the start operation even if the fresh watcher has not yet been searchable.

Closes #131964 
Closes #137562


