### PR TITLE
Guard unresolved canonicalization in aggregate rewrite

### DIFF
--- a/docs/changelog/145332.yaml
+++ b/docs/changelog/145332.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145332
+summary: Guard unresolved canonicalization in aggregate rewrite
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEval.java
@@ -78,7 +78,7 @@ public final class ReplaceAggregateNestedExpressionWithEval extends OptimizerRul
         // map to track common expressions
         Map<Expression, Attribute> expToAttribute = new HashMap<>();
         for (Alias a : evals) {
-            expToAttribute.put(a.child().canonical(), a.toAttribute());
+            expToAttribute.put(canonicalIfResolved(a.child()), a.toAttribute());
         }
 
         int[] counter = new int[] { 0 };
@@ -176,7 +176,7 @@ public final class ReplaceAggregateNestedExpressionWithEval extends OptimizerRul
         // if the field is a nested expression (not attribute or literal), replace it
         if (field instanceof Attribute == false && field.foldable() == false) {
             // create a new alias if one doesn't exist yet
-            Attribute attr = expToAttribute.computeIfAbsent(field.canonical(), k -> {
+            Attribute attr = expToAttribute.computeIfAbsent(canonicalIfResolved(field), k -> {
                 Alias newAlias = new Alias(k.source(), syntheticName(k, af, counter[0]++), k, null, true);
                 evals.add(newAlias);
                 return newAlias.toAttribute();
@@ -192,5 +192,9 @@ public final class ReplaceAggregateNestedExpressionWithEval extends OptimizerRul
 
     private static String syntheticName(Expression expression, Expression func, int counter) {
         return TemporaryNameGenerator.temporaryName(expression, func, counter);
+    }
+
+    private static Expression canonicalIfResolved(Expression expression) {
+        return expression.resolved() ? expression.canonical() : expression;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
@@ -237,5 +238,27 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
             """);
         TimeSeriesAggregate tsAggregate = plan.collect(TimeSeriesAggregate.class).getFirst();
         assertThat(tsAggregate.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(10)));
+    }
+
+    public void testPromqlTimeFunctionMissingTimestampDoesNotCrashWithUnresolvedStep() {
+        Exception e = assertThrows(Exception.class, () -> planPromqlWithoutTimestamp("""
+            PROMQL index=no_ts step=1m result=(time() - avg(network.bytes_in))
+            """));
+
+        assertThat(e.getMessage(), not(containsString("Invalid call to dataType on an unresolved object ?step")));
+        assertThat(
+            e.getMessage(),
+            org.hamcrest.Matchers.anyOf(
+                containsString("requires an @timestamp"),
+                containsString("Unknown column [@timestamp]"),
+                containsString("unresolved")
+            )
+        );
+    }
+
+    private LogicalPlan planPromqlWithoutTimestamp(String query) {
+        var noTimestampAnalyzer = org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer().addIndex("no_ts", "mapping-basic.json");
+        var analyzed = noTimestampAnalyzer.query(query);
+        return logicalOptimizer.optimize(analyzed);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEvalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEvalTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
+
+import java.util.List;
+
+public class ReplaceAggregateNestedExpressionWithEvalTests extends ESTestCase {
+
+    // Regression for unresolved `step` reaching this rule: canonicalization must not
+    // call dataType() on unresolved attributes.
+    public void testUnresolvedGroupingAliasDoesNotThrowDuringCanonicalization() {
+        Source source = Source.EMPTY;
+        Alias stepAlias = new Alias(source, "step", new UnresolvedAttribute(source, "step"));
+        Aggregate aggregate = new Aggregate(
+            source,
+            new StubRelation(source, List.of()),
+            List.of(stepAlias),
+            List.of(stepAlias.toAttribute())
+        );
+
+        Aggregate rewritten = (Aggregate) new ReplaceAggregateNestedExpressionWithEval().apply(aggregate);
+        assertTrue(rewritten.child() instanceof Eval);
+    }
+}


### PR DESCRIPTION
This bug was caused by `ReplaceAggregateNestedExpressionWithEval` calling `canonical()` on unresolved expressions (for example unresolved synthetic PromQL `step`), which ends up calling `dataType()` and throwing `UnresolvedException`. The fix is to canonicalize only resolved expressions and use unresolved expressions as-is for dedup keys, so we avoid internal optimizer crashes and continue to return normal user-facing errors. Added tests cover both the rule-level unresolved `step` case and a PromQL query path that previously hit this failure.

This is separate from https://github.com/elastic/elasticsearch/pull/145307, I think we want to have a bit of hardening in the optimizer separate from the PromQL-to-ESQL validation steps.