### PR TITLE
ESQL: DS: datasource file plugins should not return TEXT types

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -500,6 +500,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     /**
      * Parse CSV type names to ESQL DataType. Small numeric types (SHORT, BYTE, FLOAT, etc.)
      * are widened to INTEGER/DOUBLE since the planner expects widened types.
+     * Typed-schema aliases TEXT and TXT map to KEYWORD (same string family as KEYWORD/STRING).
      */
     private DataType parseDataType(String typeName) {
         String upper = typeName.toUpperCase(Locale.ROOT);
@@ -511,8 +512,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             case "LONG", "L" -> DataType.LONG;
             case "FLOAT", "F", "HALF_FLOAT", "SCALED_FLOAT" -> DataType.DOUBLE;
             case "DOUBLE", "D" -> DataType.DOUBLE;
-            case "KEYWORD", "K", "STRING", "S" -> DataType.KEYWORD;
-            case "TEXT", "TXT" -> DataType.TEXT;
+            case "KEYWORD", "K", "STRING", "S", "TEXT", "TXT" -> DataType.KEYWORD;
             case "BOOLEAN", "BOOL" -> DataType.BOOLEAN;
             case "DATETIME", "DATE", "DT" -> DataType.DATETIME;
             case "IP" -> DataType.IP;

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -75,6 +75,24 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertEquals(DataType.BOOLEAN, schema.get(3).dataType());
     }
 
+    public void testTypedSchemaTextAndTxtAliasesMapToKeyword() throws IOException {
+        String csv = """
+            a:text,b:txt
+            hello,world
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        List<Attribute> schema = reader.schema(object);
+
+        assertEquals(2, schema.size());
+        assertEquals("a", schema.get(0).name());
+        assertEquals(DataType.KEYWORD, schema.get(0).dataType());
+        assertEquals("b", schema.get(1).name());
+        assertEquals(DataType.KEYWORD, schema.get(1).dataType());
+    }
+
     public void testSchemaWithComments() throws IOException {
         String csv = """
             // This is a comment

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -331,8 +331,7 @@ public class OrcFormatReader implements FormatReader {
             case BYTE, SHORT, INT -> DataType.INTEGER;
             case LONG -> DataType.LONG;
             case FLOAT, DOUBLE -> DataType.DOUBLE;
-            case STRING -> DataType.TEXT;
-            case VARCHAR, CHAR -> DataType.KEYWORD;
+            case STRING, VARCHAR, CHAR -> DataType.KEYWORD;
             case TIMESTAMP, TIMESTAMP_INSTANT -> DataType.DATETIME;
             case DATE -> DataType.DATETIME;
             case DECIMAL -> DataType.DOUBLE;

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -111,7 +111,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         assertEquals(DataType.LONG, attributes.get(0).dataType());
 
         assertEquals("name", attributes.get(1).name());
-        assertEquals(DataType.TEXT, attributes.get(1).dataType());
+        assertEquals(DataType.KEYWORD, attributes.get(1).dataType());
 
         assertEquals("age", attributes.get(2).name());
         assertEquals(DataType.INTEGER, attributes.get(2).dataType());
@@ -614,7 +614,7 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         SourceMetadata metadata = reader.metadata(storageObject);
         List<Attribute> attributes = metadata.schema();
-        assertEquals(DataType.TEXT, attributes.get(1).dataType());
+        assertEquals(DataType.KEYWORD, attributes.get(1).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
             assertTrue(iterator.hasNext());

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -515,9 +515,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
                     yield DataType.DOUBLE;
                 }
-                if (logical instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
-                    yield DataType.TEXT;
-                }
                 yield DataType.KEYWORD;
             }
             default -> DataType.UNSUPPORTED;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -121,7 +121,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals(DataType.LONG, attributes.get(0).dataType());
 
         assertEquals("name", attributes.get(1).name());
-        assertEquals(DataType.TEXT, attributes.get(1).dataType());
+        assertEquals(DataType.KEYWORD, attributes.get(1).dataType());
 
         assertEquals("age", attributes.get(2).name());
         assertEquals(DataType.INTEGER, attributes.get(2).dataType());
@@ -1127,7 +1127,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
         SourceMetadata metadata = reader.metadata(storageObject);
-        assertEquals(DataType.TEXT, metadata.schema().get(0).dataType());
+        assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
             assertTrue(iterator.hasNext());
@@ -1335,7 +1335,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Parquet string-annotated BINARY maps to TEXT; planner KEYWORD is still readable (both ESQL strings).
+     * Parquet string-annotated BINARY maps to KEYWORD; planner KEYWORD is still readable (both ESQL strings).
      */
     public void testPlannerKeywordCompatibleWithTextParquetColumnReadRange() throws Exception {
         MessageType schema = Types.buildMessage()

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
@@ -100,18 +100,16 @@ public class ExternalDistributedSpecIT extends AbstractExternalSourceSpecTestCas
         assumeTrue("External source connectors not available", hasExternalSourceConnectors());
     }
 
+    // TODO: replace it with a better system
     private boolean hasExternalSourceConnectors() {
         try {
             Request request = new Request("POST", "/_query");
-            request.setJsonEntity("{\"query\": \"EXTERNAL \\\"s3://probe/test.parquet\\\"\"}");
+            request.setJsonEntity("{\"query\": \"EXTERNAL \\\"s3://THIS_IS_JUST_A_PROBING_QUERY/IT_SHOULD_FAIL.csv\\\"\"}");
             client().performRequest(request);
             return true;
         } catch (Exception e) {
             String msg = e.getMessage();
-            if (msg != null && msg.contains("Unsupported storage scheme")) {
-                return false;
-            }
-            return true;
+            return msg == null || msg.contains("Unsupported storage scheme") == false;
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/FixtureUtils.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/FixtureUtils.java
@@ -11,6 +11,7 @@ import com.github.luben.zstd.ZstdOutputStream;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
 import java.io.ByteArrayOutputStream;
@@ -31,6 +32,8 @@ import java.util.jar.JarFile;
 import java.util.zip.GZIPOutputStream;
 
 public class FixtureUtils {
+    private static final Logger logger = LogManager.getLogger(FixtureUtils.class);
+
     /** Resource path for test fixtures */
     public static final String FIXTURES_RESOURCE_PATH = "/iceberg-fixtures";
 
@@ -52,49 +55,71 @@ public class FixtureUtils {
             if (Files.exists(fixturesPath) == false) {
                 throw new IllegalStateException("Fixtures path does not exist: " + fixturesPath);
             }
-            Files.walkFileTree(fixturesPath, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    String name = file.getFileName().toString();
-                    if (COMPRESSED_EXTENSIONS.stream().anyMatch(name::endsWith)) {
-                        return FileVisitResult.CONTINUE;
-                    }
-                    String relativePath = fixturesPath.relativize(file).toString();
-                    byte[] content = Files.readAllBytes(file);
-                    consumer.accept(relativePath, content);
+            logger.info("Iterating {} from filesystem [{}] (anchor [{}])", FIXTURES_RESOURCE_PATH, fixturesPath, anchor.getName());
+            forEachFixtureEntryFromFilesystem(fixturesPath, consumer);
+        } else if (resourceUrl.getProtocol().equals("jar")) {
+            logger.info("Iterating {} from JAR [{}] (anchor [{}])", FIXTURES_RESOURCE_PATH, resourceUrl, anchor.getName());
+            forEachFixtureEntryFromJar(resourceUrl, consumer);
+        } else {
+            logger.warn("Unsupported fixtures resource protocol [{}] for [{}]", resourceUrl.getProtocol(), resourceUrl);
+            throw new IllegalStateException("Unsupported resource protocol: " + resourceUrl);
+        }
+    }
+
+    /**
+     * Iterate fixture files under a resolved {@code iceberg-fixtures} directory on the filesystem.
+     */
+    static void forEachFixtureEntryFromFilesystem(Path fixturesPath, CheckedBiConsumer<String, byte[], IOException> consumer)
+        throws IOException {
+        Files.walkFileTree(fixturesPath, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                String name = file.getFileName().toString();
+                if (COMPRESSED_EXTENSIONS.stream().anyMatch(name::endsWith)) {
                     return FileVisitResult.CONTINUE;
                 }
-            });
-        } else if (resourceUrl.getProtocol().equals("jar")) {
-            JarURLConnection jarConnection = (JarURLConnection) resourceUrl.openConnection();
-            String entryPrefix = jarConnection.getEntryName();
-            if (entryPrefix.endsWith("/") == false) {
-                entryPrefix = entryPrefix + "/";
+                String relativePath = fixturesPath.relativize(file).toString();
+                logger.debug("Fixture [{}] from filesystem path [{}]", relativePath, file.toAbsolutePath());
+                byte[] content = Files.readAllBytes(file);
+                consumer.accept(relativePath, content);
+                return FileVisitResult.CONTINUE;
             }
-            try (JarFile jarFile = jarConnection.getJarFile()) {
-                Enumeration<JarEntry> entries = jarFile.entries();
-                while (entries.hasMoreElements()) {
-                    JarEntry entry = entries.nextElement();
-                    String entryName = entry.getName();
-                    if (entry.isDirectory() || entryName.startsWith(entryPrefix) == false) {
-                        continue;
-                    }
-                    String relativePath = entryName.substring(entryPrefix.length());
-                    if (relativePath.isEmpty()) {
-                        continue;
-                    }
-                    String fileName = relativePath.contains("/") ? relativePath.substring(relativePath.lastIndexOf('/') + 1) : relativePath;
-                    if (COMPRESSED_EXTENSIONS.stream().anyMatch(fileName::endsWith)) {
-                        continue;
-                    }
-                    try (InputStream is = jarFile.getInputStream(entry)) {
-                        byte[] content = is.readAllBytes();
-                        consumer.accept(relativePath, content);
-                    }
+        });
+    }
+
+    /**
+     * Iterate fixture entries packaged under {@code iceberg-fixtures} inside a JAR.
+     *
+     * @param jarResourceUrl {@code jar:} URL for the resource directory (from {@link Class#getResource(String)})
+     */
+    static void forEachFixtureEntryFromJar(URL jarResourceUrl, CheckedBiConsumer<String, byte[], IOException> consumer) throws IOException {
+        JarURLConnection jarConnection = (JarURLConnection) jarResourceUrl.openConnection();
+        String entryPrefix = jarConnection.getEntryName();
+        if (entryPrefix.endsWith("/") == false) {
+            entryPrefix = entryPrefix + "/";
+        }
+        try (JarFile jarFile = jarConnection.getJarFile()) {
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                String entryName = entry.getName();
+                if (entry.isDirectory() || entryName.startsWith(entryPrefix) == false) {
+                    continue;
+                }
+                String relativePath = entryName.substring(entryPrefix.length());
+                if (relativePath.isEmpty()) {
+                    continue;
+                }
+                String fileName = relativePath.contains("/") ? relativePath.substring(relativePath.lastIndexOf('/') + 1) : relativePath;
+                if (COMPRESSED_EXTENSIONS.stream().anyMatch(fileName::endsWith)) {
+                    continue;
+                }
+                logger.debug("Fixture [{}] from JAR entry [{}] in [{}]", relativePath, entryName, jarFile.getName());
+                try (InputStream is = jarFile.getInputStream(entry)) {
+                    byte[] content = is.readAllBytes();
+                    consumer.accept(relativePath, content);
                 }
             }
-        } else {
-            throw new IllegalStateException("Unsupported resource protocol: " + resourceUrl);
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
@@ -19,25 +19,16 @@ import org.elasticsearch.logging.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.JarURLConnection;
 import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiPredicate;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
@@ -346,87 +337,29 @@ public final class S3FixtureUtils {
          */
         public void loadFixturesFromResources() {
             try {
-                URL resourceUrl = getClass().getResource(FixtureUtils.FIXTURES_RESOURCE_PATH);
-                if (resourceUrl == null) {
-                    throw new IllegalStateException("Fixtures resource path not found: " + FixtureUtils.FIXTURES_RESOURCE_PATH);
-                }
-
-                if (resourceUrl.getProtocol().equals("file")) {
-                    Path fixturesPath = Paths.get(resourceUrl.toURI());
-                    loadFixturesFromPath(fixturesPath);
-                } else if (resourceUrl.getProtocol().equals("jar")) {
-                    loadFixturesFromJar(resourceUrl);
+                Set<String> loadedKeys = new HashSet<>();
+                FixtureUtils.forEachFixtureEntry(S3FixtureUtils.class, (relativePath, content) -> {
+                    String key = WAREHOUSE + "/" + relativePath;
+                    addBlobToFixture(handler, key, content);
+                    loadedKeys.add(key);
+                });
+                URL resourceUrl = S3FixtureUtils.class.getResource(FixtureUtils.FIXTURES_RESOURCE_PATH);
+                if (resourceUrl != null && "jar".equals(resourceUrl.getProtocol())) {
+                    fixtureLogger.info(
+                        "Loaded {} fixture files from JAR {}: {}",
+                        loadedKeys.size(),
+                        resourceUrl,
+                        String.join(", ", loadedKeys)
+                    );
+                } else if (resourceUrl != null && "file".equals(resourceUrl.getProtocol())) {
+                    fixtureLogger.info("Loaded {} fixture files from {}", loadedKeys.size(), Paths.get(resourceUrl.toURI()));
                 } else {
-                    throw new IllegalStateException("Unsupported resource protocol: " + resourceUrl);
+                    fixtureLogger.info("Loaded {} fixture files into S3 fixture", loadedKeys.size());
                 }
             } catch (Exception e) {
                 fixtureLogger.error("Failed to load fixtures from resources", e);
                 throw new RuntimeException(e);
             }
-        }
-
-        private void loadFixturesFromJar(URL jarUrl) throws IOException {
-            JarURLConnection jarConnection = (JarURLConnection) jarUrl.openConnection();
-            String entryPrefix = jarConnection.getEntryName();
-            if (entryPrefix.endsWith("/") == false) {
-                entryPrefix = entryPrefix + "/";
-            }
-
-            Set<String> loadedFiles = new HashSet<>();
-            try (JarFile jarFile = jarConnection.getJarFile()) {
-                Enumeration<JarEntry> entries = jarFile.entries();
-                while (entries.hasMoreElements()) {
-                    JarEntry entry = entries.nextElement();
-                    String entryName = entry.getName();
-                    if (entry.isDirectory() || entryName.startsWith(entryPrefix) == false) {
-                        continue;
-                    }
-                    String relativePath = entryName.substring(entryPrefix.length());
-                    if (relativePath.isEmpty()) {
-                        continue;
-                    }
-                    String fileName = relativePath.contains("/") ? relativePath.substring(relativePath.lastIndexOf('/') + 1) : relativePath;
-                    if (FixtureUtils.COMPRESSED_EXTENSIONS.stream().anyMatch(fileName::endsWith)) {
-                        continue;
-                    }
-                    String key = WAREHOUSE + "/" + relativePath;
-                    try (InputStream is = jarFile.getInputStream(entry)) {
-                        byte[] content = is.readAllBytes();
-                        addBlobToFixture(handler, key, content);
-                        loadedFiles.add(key);
-                    }
-                }
-            }
-            fixtureLogger.info("Loaded {} fixture files from JAR {}: {}", loadedFiles.size(), jarUrl, String.join(", ", loadedFiles));
-        }
-
-        private void loadFixturesFromPath(Path fixturesPath) throws IOException {
-            if (Files.exists(fixturesPath) == false) {
-                fixtureLogger.warn("Fixtures path does not exist: {}", fixturesPath);
-                return;
-            }
-
-            Set<String> loadedFiles = new HashSet<>();
-
-            Files.walkFileTree(fixturesPath, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    String name = file.getFileName().toString();
-                    if (FixtureUtils.COMPRESSED_EXTENSIONS.stream().anyMatch(name::endsWith)) {
-                        return FileVisitResult.CONTINUE;
-                    }
-                    String relativePath = fixturesPath.relativize(file).toString();
-                    String key = WAREHOUSE + "/" + relativePath;
-
-                    byte[] content = Files.readAllBytes(file);
-                    addBlobToFixture(handler, key, content);
-                    loadedFiles.add(key);
-
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-
-            fixtureLogger.info("Loaded {} fixture files from {}", loadedFiles.size(), fixturesPath);
         }
 
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
@@ -771,7 +771,7 @@ EXTERNAL "{{books}}"
 | KEEP title, completion
 ;
 
-title:text                         | completion:keyword
+title:keyword                      | completion:keyword
 War and Peace                      | WAR AND PEACE
 War and Peace: A Novel (6 Volumes) | WAR AND PEACE: A NOVEL (6 VOLUMES)
 ;
@@ -788,7 +788,7 @@ EXTERNAL "{{books}}"
 | KEEP book_no, title, author, _score
 ;
 
-book_no:keyword | title:text                                            | author:text                                 | _score:double
+book_no:keyword | title:keyword                                         | author:keyword                              | _score:double
 5327            | War and Peace                                         | Leo Tolstoy                                 | 0.08
 4536            | War and Peace (Signet Classics)                       | [Leo Tolstoy, Pat Conroy, John Hockenberry] | 0.03
 9032            | War and Peace: A Novel (6 Volumes)                    | Tolstoy Leo                                 | 0.03
@@ -837,7 +837,7 @@ EXTERNAL "{{books}}"
 | WHERE book_no::INTEGER == 9607
 ;
 
-book_no:keyword|title:text                           |description:text                                                                                   |snippets:keyword
+book_no:keyword|title:keyword                        |description:keyword                                                                                 |snippets:keyword
 9607           |Beowolf: The monsters and the critics|A collection of seven essays by J.R.R. Tolkien arising out of Tolkien's work in medieval literature|A collection of seven essays by J.R.R. Tolkien arising out of Tolkien's work in medieval literature
 ;
 
@@ -852,7 +852,7 @@ EXTERNAL "{{books}}"
 | WHERE book_no::INTEGER == 9607
 ;
 
-book_no:keyword|title:text                           |description:text                                                                                   |score:double
+book_no:keyword|title:keyword                        |description:keyword                                                                                 |score:double
 9607           |Beowolf: The monsters and the critics|A collection of seven essays by J.R.R. Tolkien arising out of Tolkien's work in medieval literature|0.0
 ;
 


### PR DESCRIPTION
This updates CSV, ORC and Parquet file plugins to no longer return TEXT type, but just KEYWORD.

This change also adds a small consolidation around fixtures: S3 now delegates to existing infra, already used by GCP and Azure.