### PR TITLE
refactor(tsdb): introduce `EntryFactory` for doc values entry creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -79,6 +79,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     private static final int DEFAULT_NUMERIC_BLOCK_SHIFT = 7;
     private final TSDBDocValuesFormatConfig formatConfig;
     private final DocOffsetsCodec.Decoder docOffsetsDecoder;
+    private final EntryFactory entryFactory;
 
     @SuppressWarnings("this-escape")
     protected AbstractTSDBDocValuesProducer(
@@ -88,9 +89,11 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         final String metaCodec,
         final String metaExtension,
         final TSDBDocValuesFormatConfig formatConfig,
-        final DocOffsetsCodec.Decoder docOffsetsDecoder
+        final DocOffsetsCodec.Decoder docOffsetsDecoder,
+        final EntryFactory entryFactory
     ) throws IOException {
         this.docOffsetsDecoder = docOffsetsDecoder;
+        this.entryFactory = entryFactory;
         this.numerics = new IntObjectHashMap<>();
         this.binaries = new IntObjectHashMap<>();
         this.sorted = new IntObjectHashMap<>();
@@ -170,6 +173,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     protected AbstractTSDBDocValuesProducer(final AbstractTSDBDocValuesProducer original) {
         this.docOffsetsDecoder = original.docOffsetsDecoder;
+        this.entryFactory = original.entryFactory;
         this.numerics = original.numerics;
         this.binaries = original.binaries;
         this.sorted = original.sorted;
@@ -1324,20 +1328,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
         @Override
         public int prefixPartitionBits() {
-            if (entry instanceof PrefixPartitionedEntry partition) {
-                return partition.partitionNumBits;
-            }
-            return 0;
+            return entry.prefixPartitionBits();
         }
 
         @Override
         public PrefixPartitions prefixPartitions(PrefixPartitions reused) throws IOException {
-            if (entry instanceof PrefixPartitionedEntry partitioned) {
-                var slice = data.slice("partitioning", partitioned.partitionStartPointer, partitioned.partitionDataLength);
-                return PrefixedPartitionsReader.prefixPartitions(slice, reused);
-            } else {
-                return null;
-            }
+            return entry.prefixPartitions(data, reused);
         }
     }
 
@@ -1960,7 +1956,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private NumericEntry readNumeric(IndexInput meta, int numericBlockShift) throws IOException {
-        final NumericEntry entry = new NumericEntry();
+        final NumericEntry entry = entryFactory.createNumericEntry();
         readNumeric(meta, entry, numericBlockShift);
         return entry;
     }
@@ -1982,13 +1978,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private BinaryEntry readBinary(IndexInput meta, int version) throws IOException {
-        final BinaryDVCompressionMode compression;
+        final BinaryEntry entry = entryFactory.createBinaryEntry();
         if (version >= formatConfig.versionBinaryCompression()) {
-            compression = BinaryDVCompressionMode.fromMode(meta.readByte());
+            entry.compression = BinaryDVCompressionMode.fromMode(meta.readByte());
         } else {
-            compression = BinaryDVCompressionMode.NO_COMPRESS;
+            entry.compression = BinaryDVCompressionMode.NO_COMPRESS;
         }
-        final BinaryEntry entry = new BinaryEntry(compression);
 
         entry.dataOffset = meta.readLong();
         entry.dataLength = meta.readLong();
@@ -2000,7 +1995,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         entry.minLength = meta.readInt();
         entry.maxLength = meta.readInt();
 
-        if (compression == BinaryDVCompressionMode.NO_COMPRESS) {
+        if (entry.compression == BinaryDVCompressionMode.NO_COMPRESS) {
             if (entry.minLength < entry.maxLength) {
                 entry.addressesOffset = meta.readLong();
                 long numAddresses = entry.numDocsWithField + 1L;
@@ -2030,7 +2025,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private SortedNumericEntry readSortedNumeric(IndexInput meta, int numericBlockShift) throws IOException {
-        final SortedNumericEntry entry = new SortedNumericEntry();
+        final SortedNumericEntry entry = entryFactory.createSortedNumericEntry();
         readSortedNumeric(meta, entry, numericBlockShift);
         return entry;
     }
@@ -2048,20 +2043,14 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     private SortedEntry readSorted(int version, IndexInput meta, int numericBlockShift, int termsDictBlockLz4Shift, boolean primarySorted)
         throws IOException {
-        SortedEntry entry = new SortedEntry();
-        entry.ordsEntry = new NumericEntry();
-        entry.termsDictEntry = new TermsDictEntry();
+        SortedEntry entry = entryFactory.createSortedEntry();
+        entry.ordsEntry = entryFactory.createNumericEntry();
+        entry.termsDictEntry = entryFactory.createTermsDictEntry();
         if (version >= formatConfig.versionPrefixPartitions()) {
             readTermDict(meta, entry.termsDictEntry, termsDictBlockLz4Shift);
             readNumeric(meta, entry.ordsEntry, numericBlockShift);
             if (primarySorted && meta.readByte() == 1) {
-                PrefixPartitionedEntry partitioned = new PrefixPartitionedEntry();
-                partitioned.ordsEntry = entry.ordsEntry;
-                partitioned.termsDictEntry = entry.termsDictEntry;
-                partitioned.partitionNumBits = meta.readByte();
-                partitioned.partitionStartPointer = meta.readLong();
-                partitioned.partitionDataLength = meta.readVLong();
-                return partitioned;
+                entry.readMeta(meta);
             }
         } else {
             readNumeric(meta, entry.ordsEntry, numericBlockShift);
@@ -2077,7 +2066,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         int termsDictBlockLz4Shift,
         boolean primarySorted
     ) throws IOException {
-        SortedSetEntry entry = new SortedSetEntry();
+        SortedSetEntry entry = entryFactory.createSortedSetEntry();
         byte multiValued = meta.readByte();
         switch (multiValued) {
             case 0: // singlevalued
@@ -2088,9 +2077,9 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             default:
                 throw new CorruptIndexException("Invalid multiValued flag: " + multiValued, meta);
         }
-        entry.ordsEntry = new SortedNumericEntry();
+        entry.ordsEntry = entryFactory.createSortedNumericEntry();
         readSortedNumeric(meta, entry.ordsEntry, numericBlockShift);
-        entry.termsDictEntry = new TermsDictEntry();
+        entry.termsDictEntry = entryFactory.createTermsDictEntry();
         readTermDict(meta, entry.termsDictEntry, termsDictBlockLz4Shift);
         return entry;
     }
@@ -2685,6 +2674,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     private record DocValuesSkipperEntry(long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {}
 
+    /** Numeric field entry holding block index, value offsets, and DISI metadata. */
     public static class NumericEntry {
         public long docsWithFieldOffset;
         public long docsWithFieldLength;
@@ -2701,9 +2691,9 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         public NumericFieldReader fieldReader;
     }
 
-    static class BinaryEntry {
-        final BinaryDVCompressionMode compression;
-
+    /** Binary field entry holding data offsets, compression mode, and address metadata. */
+    public static class BinaryEntry {
+        BinaryDVCompressionMode compression;
         long dataOffset;
         long dataLength;
         long docsWithFieldOffset;
@@ -2722,36 +2712,77 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         int numCompressedBlocks;
         DirectMonotonicReader.Meta addressesMeta;
         DirectMonotonicReader.Meta docOffsetMeta;
-
-        BinaryEntry(BinaryDVCompressionMode compression) {
-            this.compression = compression;
-        }
     }
 
+    /** Sorted-numeric field entry extending {@link NumericEntry} with per-document value count addresses. */
     public static class SortedNumericEntry extends NumericEntry {
         public DirectMonotonicReader.Meta addressesMeta;
         public long addressesOffset;
         public long addressesLength;
     }
 
-    static class SortedEntry {
+    /**
+     * Sorted field entry holding ordinal and terms dictionary metadata.
+     * Subclasses may override {@link #readMeta}, {@link #prefixPartitionBits},
+     * and {@link #prefixPartitions} to encapsulate codec-specific behavior.
+     */
+    public static class SortedEntry {
         NumericEntry ordsEntry;
         TermsDictEntry termsDictEntry;
+
+        /** Reads codec-specific sorted metadata from the meta stream. */
+        void readMeta(IndexInput meta) throws IOException {}
+
+        /** @return partition bit count, 0 if not partitioned */
+        int prefixPartitionBits() {
+            return 0;
+        }
+
+        /** @return prefix partitions, null if not partitioned */
+        PartitionedDocValues.PrefixPartitions prefixPartitions(IndexInput data, PartitionedDocValues.PrefixPartitions reused)
+            throws IOException {
+            return null;
+        }
     }
 
-    static class PrefixPartitionedEntry extends SortedEntry {
-        int partitionNumBits;
-        long partitionStartPointer;
-        long partitionDataLength;
+    /**
+     * ES819 sorted entry carrying prefix partition metadata. Encapsulates
+     * reading and access to partition data as an implementation detail.
+     */
+    public static class PrefixPartitionedEntry extends SortedEntry {
+        private int partitionNumBits;
+        private long partitionStartPointer;
+        private long partitionDataLength;
+
+        @Override
+        void readMeta(IndexInput meta) throws IOException {
+            partitionNumBits = meta.readByte();
+            partitionStartPointer = meta.readLong();
+            partitionDataLength = meta.readVLong();
+        }
+
+        @Override
+        int prefixPartitionBits() {
+            return partitionNumBits;
+        }
+
+        @Override
+        PartitionedDocValues.PrefixPartitions prefixPartitions(IndexInput data, PartitionedDocValues.PrefixPartitions reused)
+            throws IOException {
+            IndexInput slice = data.slice("partitioning", partitionStartPointer, partitionDataLength);
+            return PrefixedPartitionsReader.prefixPartitions(slice, reused);
+        }
     }
 
-    static class SortedSetEntry {
+    /** Sorted-set field entry holding either a single-valued {@link SortedEntry} or multi-valued ordinals. */
+    public static class SortedSetEntry {
         SortedEntry singleValueEntry;
         SortedNumericEntry ordsEntry;
         TermsDictEntry termsDictEntry;
     }
 
-    static class TermsDictEntry {
+    /** Terms dictionary entry holding term data offsets, address metadata, and reverse index pointers. */
+    public static class TermsDictEntry {
         long termsDictSize;
         DirectMonotonicReader.Meta termsAddressesMeta;
         int maxTermLength;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/EntryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/EntryFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.BinaryEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.NumericEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedNumericEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.SortedSetEntry;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.TermsDictEntry;
+
+/**
+ * Factory for creating entry instances during segment metadata reading.
+ * Each codec version provides its own factory to return codec-specific
+ * subclasses of the base entry types. All methods have default implementations
+ * returning base types; codecs override only the entries they need.
+ */
+public interface EntryFactory {
+
+    /**
+     * Creates a numeric entry.
+     *
+     * @return the numeric entry
+     */
+    default NumericEntry createNumericEntry() {
+        return new NumericEntry();
+    }
+
+    /**
+     * Creates a sorted-numeric entry.
+     *
+     * @return the sorted-numeric entry
+     */
+    default SortedNumericEntry createSortedNumericEntry() {
+        return new SortedNumericEntry();
+    }
+
+    /**
+     * Creates a sorted entry.
+     *
+     * @return the sorted entry
+     */
+    default SortedEntry createSortedEntry() {
+        return new SortedEntry();
+    }
+
+    /**
+     * Creates a sorted-set entry.
+     *
+     * @return the sorted-set entry
+     */
+    default SortedSetEntry createSortedSetEntry() {
+        return new SortedSetEntry();
+    }
+
+    /**
+     * Creates a terms dictionary entry.
+     *
+     * @return the terms dictionary entry
+     */
+    default TermsDictEntry createTermsDictEntry() {
+        return new TermsDictEntry();
+    }
+
+    /**
+     * Creates a binary entry.
+     *
+     * @return the binary entry
+     */
+    default BinaryEntry createBinaryEntry() {
+        return new BinaryEntry();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819NumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819NumericEntry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+
+/**
+ * ES819 numeric entry. Currently identical to the base type; exists so that
+ * the ES819 {@link org.elasticsearch.index.codec.tsdb.EntryFactory} returns
+ * a codec-specific type for every entry kind.
+ */
+final class ES819NumericEntry extends AbstractTSDBDocValuesProducer.NumericEntry {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819SortedNumericEntry.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819SortedNumericEntry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
+
+/**
+ * ES819 sorted-numeric entry. Currently identical to the base type; exists so
+ * that the ES819 {@link org.elasticsearch.index.codec.tsdb.EntryFactory} returns
+ * a codec-specific type for every entry kind.
+ */
+final class ES819SortedNumericEntry extends AbstractTSDBDocValuesProducer.SortedNumericEntry {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.packed.DirectMonotonicReader;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesConsumer;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer;
 import org.elasticsearch.index.codec.tsdb.DocOffsetsCodec;
+import org.elasticsearch.index.codec.tsdb.EntryFactory;
 import org.elasticsearch.index.codec.tsdb.NumericFieldReader;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
@@ -29,6 +30,23 @@ import java.io.IOException;
  */
 final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
 
+    private static final EntryFactory ENTRY_FACTORY = new EntryFactory() {
+        @Override
+        public NumericEntry createNumericEntry() {
+            return new ES819NumericEntry();
+        }
+
+        @Override
+        public SortedNumericEntry createSortedNumericEntry() {
+            return new ES819SortedNumericEntry();
+        }
+
+        @Override
+        public SortedEntry createSortedEntry() {
+            return new PrefixPartitionedEntry();
+        }
+    };
+
     ES819TSDBDocValuesProducer(
         final SegmentReadState state,
         final String dataCodec,
@@ -38,7 +56,7 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
         final TSDBDocValuesFormatConfig formatConfig,
         final DocOffsetsCodec.Decoder docOffsetsDecoder
     ) throws IOException {
-        super(state, dataCodec, dataExtension, metaCodec, metaExtension, formatConfig, docOffsetsDecoder);
+        super(state, dataCodec, dataExtension, metaCodec, metaExtension, formatConfig, docOffsetsDecoder, ENTRY_FACTORY);
     }
 
     private ES819TSDBDocValuesProducer(final ES819TSDBDocValuesProducer original) {


### PR DESCRIPTION
## Summary

Part 2/4 of introducing the ES94 TSDB doc values codec. This PR introduces an `EntryFactory` so that each codec owns its entry creation and the base class never needs to know about codec-specific entry types.

Currently, `AbstractTSDBDocValuesProducer` hardcodes entry creation with `new` and uses `instanceof PrefixPartitionedEntry` to access ES819-specific partition data. This coupling prevents new codecs from introducing their own entry subclasses (e.g. ES94 needs entries that carry a `PipelineDescriptor` for self-describing numeric encoding). The factory decouples entry creation from the base class: each codec provides its own factory that returns the right entry types, and the base class interacts with entries only through their declared base types.

Builds on [#144324](https://github.com/elastic/elasticsearch/pull/144324) (shared base classes).

### What's included

**Entry factory**: `EntryFactory` interface with default methods for all entry types (`NumericEntry`, `SortedNumericEntry`, `SortedEntry`, `SortedSetEntry`, `TermsDictEntry`, `BinaryEntry`). Each codec provides its own factory returning codec-specific entry subclasses. ES819 overrides `createSortedEntry()` to return `PrefixPartitionedEntry` and provides `ES819NumericEntry`/`ES819SortedNumericEntry` for consistency.

**PrefixPartitionedEntry refactoring**: `PrefixPartitionedEntry` now encapsulates its own `readMeta`, `prefixPartitionBits`, and `prefixPartitions` as overridable methods on `SortedEntry`, eliminating `instanceof` checks from the base class.

### Testing

```
./gradlew :server:test --tests "*ES819TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*PrefixPartitionTests*"
./gradlew :server:test --tests "*ES819TSDBDocValuesFormatFactoryTests*"
```