### PR TITLE
[9.2] Add in-response-to field to saml successful response (#137599)

### DIFF
--- a/docs/changelog/137599.yaml
+++ b/docs/changelog/137599.yaml
@@ -1,0 +1,6 @@
+pr: 137599
+summary: In-response-to in saml successful response
+area: Authentication
+type: enhancement
+issues:
+ - 128179

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.action.saml;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 
@@ -26,14 +27,27 @@ public final class SamlAuthenticateResponse extends ActionResponse {
     private final String realm;
     private final TimeValue expiresIn;
     private final Authentication authentication;
+    private final String inResponseTo;
 
+    // Constructor used in Serverless
     public SamlAuthenticateResponse(Authentication authentication, String tokenString, String refreshToken, TimeValue expiresIn) {
+        this(authentication, tokenString, refreshToken, expiresIn, null);
+    }
+
+    public SamlAuthenticateResponse(
+        Authentication authentication,
+        String tokenString,
+        String refreshToken,
+        TimeValue expiresIn,
+        @Nullable String inResponseTo
+    ) {
         this.principal = authentication.getEffectiveSubject().getUser().principal();
         this.realm = authentication.getEffectiveSubject().getRealm().getName();
         this.tokenString = tokenString;
         this.refreshToken = refreshToken;
         this.expiresIn = expiresIn;
         this.authentication = authentication;
+        this.inResponseTo = inResponseTo;
     }
 
     public String getPrincipal() {
@@ -60,6 +74,13 @@ public final class SamlAuthenticateResponse extends ActionResponse {
         return authentication;
     }
 
+    public String getInResponseTo() {
+        return inResponseTo;
+    }
+
+    // note that this method is not used in any current code path,
+    // but is left here for compatibility with old versions, and as such
+    // is not up to date, i.e. it does not write 'inResponseTo'
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(principal);
@@ -70,5 +91,6 @@ public final class SamlAuthenticateResponse extends ActionResponse {
         out.writeString(refreshToken);
         out.writeTimeValue(expiresIn);
         authentication.writeTo(out);
+        // intentionally missing inResponseTo
     }
 }

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -35,6 +35,8 @@ public class SamlInResponseToIT extends SamlRestTestCase {
         String requestId = generateRandomRequestId();
         var response = authUser(username, requestId, requestId);
         assertThat(response, hasKey("access_token"));
+        assertThat(response, hasKey("in_response_to"));
+        assertThat(response.get("in_response_to"), equalTo(requestId));
     }
 
     public void testInResponseTo_requestAndTokenHaveDifferentValues() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -120,7 +120,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
     }
 
     private void findAndInvalidateTokens(SamlRealm realm, SamlLogoutRequestHandler.Result result, ActionListener<Integer> listener) {
-        final Map<String, Object> tokenMetadata = realm.createTokenMetadata(result.getNameId(), result.getSession());
+        final Map<String, Object> tokenMetadata = realm.createTokenMetadata(result.getNameId(), result.getSession(), null);
         if (Strings.isNullOrEmpty((String) tokenMetadata.get(SamlRealm.TOKEN_METADATA_NAMEID_VALUE))) {
             // If we don't have a valid name-id to match against, don't do anything
             LOGGER.debug("Logout request [{}] has no NameID value, so cannot invalidate any sessions", result);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/DefaultSamlAuthenticateResponseHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/DefaultSamlAuthenticateResponseHandler.java
@@ -36,10 +36,17 @@ public final class DefaultSamlAuthenticateResponseHandler implements SamlAuthent
     ) {
         @SuppressWarnings("unchecked")
         final Map<String, Object> tokenMeta = (Map<String, Object>) authenticationResult.getMetadata().get(SamlRealm.CONTEXT_TOKEN_DATA);
+        final String inResponseTo = (String) tokenMeta.get(SamlRealm.TOKEN_METADATA_IN_RESPONSE_TO);
         tokenService.createOAuth2Tokens(authentication, originatingAuthentication, tokenMeta, true, ActionListener.wrap(tokenResult -> {
             final TimeValue expiresIn = tokenService.getExpirationDelay();
             listener.onResponse(
-                new SamlAuthenticateResponse(authentication, tokenResult.getAccessToken(), tokenResult.getRefreshToken(), expiresIn)
+                new SamlAuthenticateResponse(
+                    authentication,
+                    tokenResult.getAccessToken(),
+                    tokenResult.getRefreshToken(),
+                    expiresIn,
+                    inResponseTo
+                )
             );
         }, listener::onFailure));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributes.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributes.java
@@ -27,12 +27,20 @@ public class SamlAttributes implements Releasable {
 
     private final SamlNameId name;
     private final String session;
+    private final String inResponseTo;
     private final List<SamlAttribute> attributes;
     private final List<SamlPrivateAttribute> privateAttributes;
 
-    SamlAttributes(SamlNameId name, String session, List<SamlAttribute> attributes, List<SamlPrivateAttribute> privateAttributes) {
+    SamlAttributes(
+        SamlNameId name,
+        String session,
+        String inResponseTo,
+        List<SamlAttribute> attributes,
+        List<SamlPrivateAttribute> privateAttributes
+    ) {
         this.name = name;
         this.session = session;
+        this.inResponseTo = inResponseTo;
         this.attributes = attributes;
         this.privateAttributes = privateAttributes;
     }
@@ -89,9 +97,24 @@ public class SamlAttributes implements Releasable {
         return session;
     }
 
+    String inResponseTo() {
+        return inResponseTo;
+    }
+
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + name + ")[" + session + "]{" + attributes + "}{" + privateAttributes + "}";
+        return getClass().getSimpleName()
+            + "("
+            + name
+            + ")["
+            + session
+            + "]["
+            + inResponseTo
+            + "]{"
+            + attributes
+            + "}{"
+            + privateAttributes
+            + "}";
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticator.java
@@ -117,7 +117,7 @@ class SamlAuthenticator extends SamlResponseHandler {
         final Assertion assertion = details.v1();
         final SamlNameId nameId = SamlNameId.forSubject(assertion.getSubject());
         final String session = getSessionIndex(assertion);
-        final SamlAttributes samlAttributes = buildSamlAttributes(nameId, session, details.v2());
+        final SamlAttributes samlAttributes = buildSamlAttributes(nameId, session, response.getInResponseTo(), details.v2());
         if (logger.isTraceEnabled()) {
             StringBuilder sb = new StringBuilder();
             sb.append("The SAML Assertion contained the following attributes: \n");
@@ -141,7 +141,7 @@ class SamlAuthenticator extends SamlResponseHandler {
         return samlAttributes;
     }
 
-    private SamlAttributes buildSamlAttributes(SamlNameId nameId, String session, List<Attribute> attributes) {
+    private SamlAttributes buildSamlAttributes(SamlNameId nameId, String session, String inResponseTo, List<Attribute> attributes) {
         List<SamlAttributes.SamlAttribute> samlAttributes = new ArrayList<>();
         List<SamlAttributes.SamlPrivateAttribute> samlPrivateAttributes = new ArrayList<>();
         for (Attribute attribute : attributes) {
@@ -151,7 +151,7 @@ class SamlAuthenticator extends SamlResponseHandler {
                 samlAttributes.add(new SamlAttributes.SamlAttribute(attribute));
             }
         }
-        return new SamlAttributes(nameId, session, samlAttributes, samlPrivateAttributes);
+        return new SamlAttributes(nameId, session, inResponseTo, samlAttributes, samlPrivateAttributes);
     }
 
     private static String getSessionIndex(Assertion assertion) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.SuppressForbidden;
@@ -159,6 +160,7 @@ public final class SamlRealm extends Realm implements Releasable {
     public static final String TOKEN_METADATA_NAMEID_SP_QUALIFIER = "saml_nameid_sp_qual";
     public static final String TOKEN_METADATA_NAMEID_SP_PROVIDED_ID = "saml_nameid_sp_id";
     public static final String TOKEN_METADATA_SESSION = "saml_session";
+    public static final String TOKEN_METADATA_IN_RESPONSE_TO = "saml_in_response_to";
     public static final String TOKEN_METADATA_REALM = "saml_realm";
 
     public static final String PRIVATE_ATTRIBUTES_METADATA = "saml_private_attributes";
@@ -588,7 +590,7 @@ public final class SamlRealm extends Realm implements Releasable {
             return;
         }
 
-        final Map<String, Object> tokenMetadata = createTokenMetadata(attributes.name(), attributes.session());
+        final Map<String, Object> tokenMetadata = createTokenMetadata(attributes.name(), attributes.session(), attributes.inResponseTo());
         final Map<String, List<SecureString>> privateAttributesMetadata = attributes.privateAttributes()
             .stream()
             .collect(Collectors.toMap(SamlPrivateAttribute::name, SamlPrivateAttribute::values));
@@ -639,7 +641,7 @@ public final class SamlRealm extends Realm implements Releasable {
         }));
     }
 
-    public Map<String, Object> createTokenMetadata(SamlNameId nameId, String session) {
+    public Map<String, Object> createTokenMetadata(@Nullable SamlNameId nameId, String session, @Nullable String inResponseTo) {
         final Map<String, Object> tokenMeta = new HashMap<>();
         if (nameId != null) {
             tokenMeta.put(TOKEN_METADATA_NAMEID_VALUE, nameId.value);
@@ -655,6 +657,9 @@ public final class SamlRealm extends Realm implements Releasable {
             tokenMeta.put(TOKEN_METADATA_NAMEID_SP_PROVIDED_ID, null);
         }
         tokenMeta.put(TOKEN_METADATA_SESSION, session);
+        if (inResponseTo != null) {
+            tokenMeta.put(TOKEN_METADATA_IN_RESPONSE_TO, inResponseTo);
+        }
         tokenMeta.put(TOKEN_METADATA_REALM, name());
         return tokenMeta;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
@@ -102,6 +102,9 @@ public class RestSamlAuthenticateAction extends SamlBaseRestHandler implements R
                         if (response.getAuthentication() != null) {
                             builder.field("authentication", response.getAuthentication());
                         }
+                        if (response.getInResponseTo() != null) {
+                            builder.field("in_response_to", response.getInResponseTo());
+                        }
                         builder.endObject();
                         return new RestResponse(RestStatus.OK, builder);
                     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -463,7 +463,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
             .user(new User("bob"))
             .realmRef(new RealmRef("native", NativeRealmSettings.TYPE, "node01"))
             .build(false);
-        final Map<String, Object> metadata = samlRealm.createTokenMetadata(nameId, session);
+        final Map<String, Object> metadata = samlRealm.createTokenMetadata(nameId, session, null);
         final PlainActionFuture<TokenService.CreateTokenResult> future = new PlainActionFuture<>();
         tokenService.createOAuth2Tokens(userTokenBytes, refreshTokenBytes, authentication, authentication, metadata, future);
         return future.actionGet();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -278,7 +278,8 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
         final Authentication.RealmRef realmRef = new Authentication.RealmRef(samlRealm.name(), SingleSpSamlRealmSettings.TYPE, "node01");
         final Map<String, Object> tokenMetadata = samlRealm.createTokenMetadata(
             new SamlNameId(NameID.TRANSIENT, nameId, null, null, null),
-            session
+            session,
+            null
         );
         final Authentication authentication = Authentication.newRealmAuthentication(user, realmRef);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributesTests.java
@@ -19,9 +19,11 @@ public class SamlAttributesTests extends SamlTestCase {
         final String nameFormat = randomFrom(NameID.TRANSIENT, NameID.PERSISTENT, NameID.EMAIL);
         final String nameId = randomIdentifier();
         final String session = randomAlphaOfLength(16);
+        final String inResponseTo = randomAlphanumericOfLength(16);
         final SamlAttributes attributes = new SamlAttributes(
             new SamlNameId(nameFormat, nameId, null, null, null),
             session,
+            inResponseTo,
             List.of(
                 new SamlAttributes.SamlAttribute("urn:oid:0.9.2342.19200300.100.1.1", null, List.of("peter.ng")),
                 new SamlAttributes.SamlAttribute("urn:oid:2.5.4.3", "name", List.of("Peter Ng")),
@@ -46,6 +48,8 @@ public class SamlAttributesTests extends SamlTestCase {
                     + ("NameId(" + nameFormat + ")=" + nameId)
                     + ")["
                     + session
+                    + "]["
+                    + inResponseTo
                     + "]{["
                     + "urn:oid:0.9.2342.19200300.100.1.1=[peter.ng](len=1)"
                     + ", "


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Add in-response-to field to saml successful response (#137599)](https://github.com/elastic/elasticsearch/pull/137599)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)