### PR TITLE
Fix Group-By-All when index pattern matches multiple DS

### DIFF
--- a/docs/changelog/145348.yaml
+++ b/docs/changelog/145348.yaml
@@ -1,0 +1,6 @@
+area: "TSDB, ES|QL"
+issues:
+ - 142485
+pr: 145348
+summary: Fix Group-By-All when index pattern matches multiple DS
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -299,8 +299,9 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
                 throw new EsqlIllegalArgumentException("expected named expression for grouping; got " + group);
             }
         }
+        boolean hasDimensionValues = firstPassAggs.stream().anyMatch(a -> Alias.unwrap(a) instanceof DimensionValues);
         LogicalPlan newChild = aggregate.child().transformUp(EsRelation.class, r -> {
-            IndexMode indexMode = requiredTimeSeriesSource.get() ? r.indexMode() : IndexMode.STANDARD;
+            IndexMode indexMode = (requiredTimeSeriesSource.get() || hasDimensionValues) ? r.indexMode() : IndexMode.STANDARD;
             if (r.output().contains(tsid.get()) == false) {
                 return r.withIndexMode(indexMode).withAttributes(CollectionUtils.combine(r.output(), tsid.get()));
             } else {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -9326,6 +9326,20 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(timeSeriesAttrs.get(0).withoutFields(), equalTo(Set.of()));
     }
 
+    public void testTimeSeriesGroupByAllKeepsTimeSeriesIndexMode() {
+        assumeTrue("requires metrics group by all", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL.isEnabled());
+        var query = "TS k8s | STATS max_over_time(network.bytes_in)";
+        var plan = planMetrics(query);
+        Holder<EsRelation> relationHolder = new Holder<>();
+        plan.forEachDown(node -> {
+            if (node instanceof EsRelation rel) {
+                relationHolder.set(rel);
+            }
+        });
+        assertNotNull("expected an EsRelation in the plan", relationHolder.get());
+        assertThat(relationHolder.get().indexMode(), equalTo(IndexMode.TIME_SERIES));
+    }
+
     public void testTimeSeriesBareFieldWithBucketAndLimitZeroDoesNotFailVerifier() {
         var query = "TS k8s | STATS network.cost BY bucket(@timestamp, 1h) | LIMIT 0";
         var plan = planMetrics(query);


### PR DESCRIPTION
Group-by-all TS queries (e.g., `TS metrics-* | WHERE TRANGE(1h) | STATS system.cpu.time`) return `_timeseries` as null when the index pattern matches multiple data streams. Single data stream queries work correctly.

**Root cause**: TranslateTimeSeriesAggregate switches the EsRelation to IndexMode.STANDARD whenever no aggregate function requires a time-series source (requiredTimeSeriesSource is false). Functions like last_over_time, max_over_time, and bare metric fields (implicitly wrapped in LastOverTime) all return false for requiredTimeSeriesSource(). In STANDARD mode, LuceneSourceOperator is used instead of TimeSeriesSourceOperator, which does not guarantee data is sorted by _tsid.

However, the group-by-all path introduces DimensionValues(_timeseries) groupings (via TimeSeriesGroupByAll → TranslateTimeSeriesWithout), which are later lowered to DimensionValuesByteRefGroupingAggregatorFunction and FirstDocIdGroupingAggregatorFunction. Both aggregators assume monotonically increasing group IDs — they only store a value when groupId > maxGroupId, permanently filling skipped slots with nulls. With unsorted input from LuceneSourceOperator, groups arrive out of order across segments, causing valid dimension values to be silently dropped and replaced with nulls.

**Fix:** Keep IndexMode.TIME_SERIES when the first-pass aggregations contain DimensionValues, ensuring TimeSeriesSourceOperator provides the sorted input these aggregators require.

Closes #142485