### PR TITLE
[8.19] Use checked exceptions in entitlement constructor rules (#145234)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -238,7 +238,7 @@ class FileCheckActions {
         return readWriteFile().toFile().setWritable(true, false);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileInputStreamFile() throws IOException {
         new FileInputStream(readFile().toFile()).close();
     }
@@ -248,27 +248,27 @@ class FileCheckActions {
         new FileInputStream(FileDescriptor.in).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileInputStreamString() throws IOException {
         new FileInputStream(readFile().toString()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileOutputStreamString() throws IOException {
         new FileOutputStream(readWriteFile().toString()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileOutputStreamStringWithAppend() throws IOException {
         new FileOutputStream(readWriteFile().toString(), false).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileOutputStreamFile() throws IOException {
         new FileOutputStream(readWriteFile().toFile()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileOutputStreamFileWithAppend() throws IOException {
         new FileOutputStream(readWriteFile().toFile(), false).close();
     }
@@ -278,12 +278,12 @@ class FileCheckActions {
         new FileOutputStream(FileDescriptor.out).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileReaderFile() throws IOException {
         new FileReader(readFile().toFile()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileReaderFileCharset() throws IOException {
         new FileReader(readFile().toFile(), StandardCharsets.UTF_8).close();
     }
@@ -293,27 +293,27 @@ class FileCheckActions {
         new FileReader(FileDescriptor.in).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createFileReaderString() throws IOException {
         new FileReader(readFile().toString()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileReaderStringCharset() throws IOException {
         new FileReader(readFile().toString(), StandardCharsets.UTF_8).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterFile() throws IOException {
         new FileWriter(readWriteFile().toFile()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterFileWithAppend() throws IOException {
         new FileWriter(readWriteFile().toFile(), false).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterFileCharsetWithAppend() throws IOException {
         new FileWriter(readWriteFile().toFile(), StandardCharsets.UTF_8, false).close();
     }
@@ -323,42 +323,42 @@ class FileCheckActions {
         new FileWriter(FileDescriptor.out).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterString() throws IOException {
         new FileWriter(readWriteFile().toString()).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterStringWithAppend() throws IOException {
         new FileWriter(readWriteFile().toString(), false).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterStringCharset() throws IOException {
         new FileWriter(readWriteFile().toString(), StandardCharsets.UTF_8).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createFileWriterStringCharsetWithAppend() throws IOException {
         new FileWriter(readWriteFile().toString(), StandardCharsets.UTF_8, false).close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createRandomAccessFileStringRead() throws IOException {
         new RandomAccessFile(readFile().toString(), "r").close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createRandomAccessFileStringReadWrite() throws IOException {
         new RandomAccessFile(readWriteFile().toString(), "rw").close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createRandomAccessFileRead() throws IOException {
         new RandomAccessFile(readFile().toFile(), "r").close();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createRandomAccessFileReadWrite() throws IOException {
         new RandomAccessFile(readWriteFile().toFile(), "rw").close();
     }
@@ -395,82 +395,82 @@ class FileCheckActions {
         throw new AssertionError("Expected an exception");
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_String() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toString()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_StringCharset() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toString(), defaultCharset()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_File() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toFile()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_FileCharset() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toFile(), defaultCharset()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_FileReadOnly() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toFile(), OPEN_READ).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_FileReadAndDelete() throws IOException {
         expectZipException(() -> new ZipFile(createTempFileForWrite().toFile(), OPEN_READ | OPEN_DELETE).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_ReadOnlyCharset() throws IOException {
         expectZipException(() -> new ZipFile(readFile().toFile(), OPEN_READ, defaultCharset()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void zipFile_ReadAndDeleteCharset() throws IOException {
         expectZipException(() -> new ZipFile(createTempFileForWrite().toFile(), OPEN_READ | OPEN_DELETE, defaultCharset()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_String() throws IOException {
         expectZipException(() -> new JarFile(readFile().toString()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_StringBoolean() throws IOException {
         expectZipException(() -> new JarFile(readFile().toString(), false).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_FileReadOnly() throws IOException {
         expectZipException(() -> new JarFile(readFile().toFile(), false, OPEN_READ).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_FileReadAndDelete() throws IOException {
         expectZipException(() -> new JarFile(createTempFileForWrite().toFile(), false, OPEN_READ | OPEN_DELETE).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_FileBooleanReadOnlyVersion() throws IOException {
         expectZipException(() -> new JarFile(readFile().toFile(), false, OPEN_READ, Runtime.version()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_FileBooleanReadAndDeleteOnlyVersion() throws IOException {
         expectZipException(() -> new JarFile(createTempFileForWrite().toFile(), false, OPEN_READ | OPEN_DELETE, Runtime.version()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFile_File() throws IOException {
         expectZipException(() -> new JarFile(readFile().toFile()).close());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void jarFileFileBoolean() throws IOException {
         expectZipException(() -> new JarFile(readFile().toFile(), false).close());
     }
@@ -484,47 +484,47 @@ class FileCheckActions {
         throw new AssertionError("Expected an exception");
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createScannerFile() throws FileNotFoundException {
         new Scanner(readFile().toFile());
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = IOException.class)
     static void createScannerFileWithCharset() throws IOException {
         new Scanner(readFile().toFile(), StandardCharsets.UTF_8);
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = FileNotFoundException.class)
     static void createScannerFileWithCharsetName() throws FileNotFoundException {
         new Scanner(readFile().toFile(), "UTF-8");
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler() throws IOException {
         new FileHandler();
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler_String() throws IOException {
         new FileHandler(readFile().toString());
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler_StringBoolean() throws IOException {
         new FileHandler(readFile().toString(), false);
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler_StringIntInt() throws IOException {
         new FileHandler(readFile().toString(), 1, 2);
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler_StringIntIntBoolean() throws IOException {
         new FileHandler(readFile().toString(), 1, 2, false);
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = IOException.class)
     static void fileHandler_StringLongIntBoolean() throws IOException {
         new FileHandler(readFile().toString(), 1L, 2, false);
     }
@@ -640,7 +640,7 @@ class FileCheckActions {
         Files.createFile(file);
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = FileNotFoundException.class)
     static void javaDesktopFileAccess() throws Exception {
         // Test file access from a java.desktop class. We explicitly exclude that module from the "system modules", so we expect
         // any sensitive operation from java.desktop to fail.

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
@@ -313,7 +313,7 @@ class NetworkAccessCheckActions {
         };
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = MalformedURLException.class)
     static void createURLWithURLStreamHandler() throws MalformedURLException {
         var x = new URL("http", "host", 1234, "file", new URLStreamHandler() {
             @Override
@@ -323,7 +323,7 @@ class NetworkAccessCheckActions {
         });
     }
 
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED, expectedExceptionIfDenied = MalformedURLException.class)
     static void createURLWithURLStreamHandler2() throws MalformedURLException {
         var x = new URL(null, "spec", new URLStreamHandler() {
             @Override
@@ -444,7 +444,7 @@ class NetworkAccessCheckActions {
         URLConnection.setContentHandlerFactory(__ -> { throw new IllegalStateException(); });
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
+    @EntitlementTest(expectedAccess = PLUGINS, expectedExceptionIfDenied = SocketException.class)
     static void bindDatagramSocket() throws SocketException {
         try (var socket = new DatagramSocket(null)) {
             socket.bind(null);

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileFilter;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -317,116 +318,182 @@ public class FileInstrumentation implements InstrumentationConfig {
         builder.on(RandomAccessFile.class, rule -> {
             rule.callingStatic(RandomAccessFile::new, File.class, String.class)
                 .enforce((file1, mode) -> mode.equals("r") ? Policies.fileRead(file1) : Policies.fileWrite(file1))
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new FileNotFoundException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
             rule.callingStatic(RandomAccessFile::new, String.class, String.class)
                 .enforce((path, mode) -> mode.equals("r") ? Policies.fileRead(new File(path)) : Policies.fileWrite(new File(path)))
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new FileNotFoundException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
         });
 
         builder.on(FileInputStream.class, rule -> {
-            rule.callingStatic(FileInputStream::new, String.class)
-                .enforce(path -> Policies.fileRead(new File(path)))
-                .elseThrowNotEntitled();
-            rule.callingStatic(FileInputStream::new, File.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+            rule.callingStatic(FileInputStream::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(FileInputStream::new, File.class).enforce(Policies::fileRead).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
             rule.callingStatic(FileInputStream::new, FileDescriptor.class).enforce(Policies::fileDescriptorRead).elseThrowNotEntitled();
         });
 
         builder.on(FileOutputStream.class, rule -> {
-            rule.callingStatic(FileOutputStream::new, String.class)
-                .enforce(path -> Policies.fileWrite(new File(path)))
-                .elseThrowNotEntitled();
+            rule.callingStatic(FileOutputStream::new, String.class).enforce(path -> Policies.fileWrite(new File(path))).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
             rule.callingStatic(FileOutputStream::new, String.class, Boolean.class)
                 .enforce((path) -> Policies.fileWrite(new File(path)))
-                .elseThrowNotEntitled();
-            rule.callingStatic(FileOutputStream::new, File.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
-            rule.callingStatic(FileOutputStream::new, File.class, Boolean.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new FileNotFoundException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
+            rule.callingStatic(FileOutputStream::new, File.class).enforce(Policies::fileWrite).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(FileOutputStream::new, File.class, Boolean.class).enforce(Policies::fileWrite).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
             rule.callingStatic(FileOutputStream::new, FileDescriptor.class).enforce(Policies::fileDescriptorWrite).elseThrowNotEntitled();
         });
 
         builder.on(FileReader.class, rule -> {
-            rule.callingStatic(FileReader::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrowNotEntitled();
-            rule.callingStatic(FileReader::new, File.class).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.callingStatic(FileReader::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+            rule.callingStatic(FileReader::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(FileReader::new, File.class).enforce(Policies::fileRead).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(FileReader::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrow(IOException::new);
             rule.callingStatic(FileReader::new, FileDescriptor.class).enforce(Policies::fileDescriptorRead).elseThrowNotEntitled();
             rule.callingStatic(FileReader::new, String.class, Charset.class)
                 .enforce((name) -> Policies.fileRead(new File(name)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(FileWriter.class, rule -> {
-            rule.callingStatic(FileWriter::new, String.class).enforce(path -> Policies.fileWrite(new File(path))).elseThrowNotEntitled();
+            rule.callingStatic(FileWriter::new, String.class)
+                .enforce(path -> Policies.fileWrite(new File(path)))
+                .elseThrow(IOException::new);
             rule.callingStatic(FileWriter::new, String.class, Boolean.class)
                 .enforce((name) -> Policies.fileWrite(new File(name)))
-                .elseThrowNotEntitled();
-            rule.callingStatic(FileWriter::new, File.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
-            rule.callingStatic(FileWriter::new, File.class, Charset.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingStatic(FileWriter::new, File.class).enforce(Policies::fileWrite).elseThrow(IOException::new);
+            rule.callingStatic(FileWriter::new, File.class, Charset.class).enforce(Policies::fileWrite).elseThrow(IOException::new);
             rule.callingStatic(FileWriter::new, File.class, Charset.class, Boolean.class)
                 .enforce(Policies::fileWrite)
-                .elseThrowNotEntitled();
-            rule.callingStatic(FileWriter::new, File.class, Boolean.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingStatic(FileWriter::new, File.class, Boolean.class).enforce(Policies::fileWrite).elseThrow(IOException::new);
             rule.callingStatic(FileWriter::new, FileDescriptor.class).enforce(Policies::fileDescriptorWrite).elseThrowNotEntitled();
             rule.callingStatic(FileWriter::new, String.class, Charset.class)
                 .enforce((name) -> Policies.fileWrite(new File(name)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(FileWriter::new, String.class, Charset.class, Boolean.class)
                 .enforce((name) -> Policies.fileWrite(new File(name)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(JarFile.class, rule -> {
-            rule.callingStatic(JarFile::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrowNotEntitled();
-            rule.callingStatic(JarFile::new, File.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+            rule.callingStatic(JarFile::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrow(IOException::new);
+            rule.callingStatic(JarFile::new, File.class).enforce(Policies::fileRead).elseThrow(IOException::new);
             rule.callingStatic(JarFile::new, String.class, Boolean.class)
                 .enforce((path) -> Policies.fileRead(new File(path)))
-                .elseThrowNotEntitled();
-            rule.callingStatic(JarFile::new, File.class, Boolean.class).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.callingStatic(JarFile::new, File.class, Boolean.class, Integer.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingStatic(JarFile::new, File.class, Boolean.class).enforce(Policies::fileRead).elseThrow(IOException::new);
+            rule.callingStatic(JarFile::new, File.class, Boolean.class, Integer.class)
+                .enforce(Policies::fileRead)
+                .elseThrow(IOException::new);
             rule.callingStatic(JarFile::new, File.class, Boolean.class, Integer.class, Runtime.Version.class)
                 .enforce(Policies::fileRead)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(ZipFile.class, rule -> {
-            rule.callingStatic(ZipFile::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrowNotEntitled();
-            rule.callingStatic(ZipFile::new, File.class).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.callingStatic(ZipFile::new, File.class, Integer.class).enforce(Policies::fileWithZipMode).elseThrowNotEntitled();
+            rule.callingStatic(ZipFile::new, String.class).enforce(path -> Policies.fileRead(new File(path))).elseThrow(IOException::new);
+            rule.callingStatic(ZipFile::new, File.class).enforce(Policies::fileRead).elseThrow(IOException::new);
+            rule.callingStatic(ZipFile::new, File.class, Integer.class).enforce(Policies::fileWithZipMode).elseThrow(IOException::new);
             rule.callingStatic(ZipFile::new, String.class, Charset.class)
                 .enforce((path) -> Policies.fileRead(new File(path)))
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(ZipFile::new, File.class, Integer.class, Charset.class)
                 .enforce(Policies::fileWithZipMode)
-                .elseThrowNotEntitled();
-            rule.callingStatic(ZipFile::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+                .elseThrow(IOException::new);
+            rule.callingStatic(ZipFile::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrow(IOException::new);
         });
 
         builder.on(PrintWriter.class, rule -> {
-            rule.callingStatic(PrintWriter::new, File.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
-            rule.callingStatic(PrintWriter::new, File.class, String.class).enforce(Policies::fileWrite).elseThrowNotEntitled();
-            rule.callingStatic(PrintWriter::new, String.class).enforce(path -> Policies.fileWrite(new File(path))).elseThrowNotEntitled();
+            rule.callingStatic(PrintWriter::new, File.class).enforce(Policies::fileWrite).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(PrintWriter::new, File.class, String.class).enforce(Policies::fileWrite).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(PrintWriter::new, String.class).enforce(path -> Policies.fileWrite(new File(path))).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
             rule.callingStatic(PrintWriter::new, String.class, String.class)
                 .enforce((path) -> Policies.fileWrite(new File(path)))
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new FileNotFoundException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
         });
 
         builder.on(Scanner.class, rule -> {
-            rule.callingStatic(Scanner::new, File.class).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.callingStatic(Scanner::new, File.class, String.class).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.callingStatic(Scanner::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrowNotEntitled();
+            rule.callingStatic(Scanner::new, File.class).enforce(Policies::fileRead).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(Scanner::new, File.class, String.class).enforce(Policies::fileRead).elseThrow(e -> {
+                var ex = new FileNotFoundException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(Scanner::new, File.class, Charset.class).enforce(Policies::fileRead).elseThrow(IOException::new);
         });
 
         builder.on(FileHandler.class, rule -> {
-            rule.callingStatic(FileHandler::new).enforce(Policies::loggingFileHandler).elseThrowNotEntitled();
-            rule.callingStatic(FileHandler::new, String.class).enforce(Policies::loggingFileHandler).elseThrowNotEntitled();
-            rule.callingStatic(FileHandler::new, String.class, Boolean.class).enforce(Policies::loggingFileHandler).elseThrowNotEntitled();
+            rule.callingStatic(FileHandler::new).enforce(Policies::loggingFileHandler).elseThrow(IOException::new);
+            rule.callingStatic(FileHandler::new, String.class).enforce(Policies::loggingFileHandler).elseThrow(IOException::new);
+            rule.callingStatic(FileHandler::new, String.class, Boolean.class)
+                .enforce(Policies::loggingFileHandler)
+                .elseThrow(IOException::new);
             rule.callingStatic(FileHandler::new, String.class, Integer.class, Integer.class)
                 .enforce(Policies::loggingFileHandler)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(FileHandler::new, String.class, Integer.class, Integer.class, Boolean.class)
                 .enforce(Policies::loggingFileHandler)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(FileHandler::new, String.class, Long.class, Integer.class, Boolean.class)
                 .enforce(Policies::loggingFileHandler)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoid(FileHandler::close).enforce(Policies::loggingFileHandler).elseThrowNotEntitled();
         });
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
@@ -32,6 +32,7 @@ import java.net.FileNameMap;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.ProtocolFamily;
@@ -100,10 +101,18 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         builder.on(URL.class, rule -> {
             rule.callingStatic(URL::new, String.class, String.class, Integer.class, String.class, URLStreamHandler.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new MalformedURLException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
             rule.callingStatic(URL::new, URL.class, String.class, URLStreamHandler.class)
                 .enforce(Policies::changeNetworkHandling)
-                .elseThrowNotEntitled();
+                .elseThrow(e -> {
+                    var ex = new MalformedURLException(e.getMessage());
+                    ex.initCause(e);
+                    return ex;
+                });
             rule.callingVoidStatic(URL::setURLStreamHandlerFactory, URLStreamHandlerFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrowNotEntitled();
@@ -169,22 +178,24 @@ public class NetworkInstrumentation implements InstrumentationConfig {
                     return Policies.empty();
                 }
             }).elseThrowNotEntitled();
-            rule.callingStatic(Socket::new, String.class, Integer.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(Socket::new, String.class, Integer.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, String.class, Integer.class, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, String.class, Integer.class, Boolean.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class, Boolean.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoidStatic(Socket::setSocketImplFactory, SocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrow(IOException::new);
@@ -196,14 +207,14 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         });
 
         builder.on(ServerSocket.class, rule -> {
-            rule.callingStatic(ServerSocket::new).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(ServerSocket::new, Integer.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(ServerSocket::new).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
+            rule.callingStatic(ServerSocket::new, Integer.class).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
             rule.callingStatic(ServerSocket::new, Integer.class, Integer.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(ServerSocket::new, Integer.class, Integer.class, InetAddress.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingVoidStatic(ServerSocket::setSocketFactory, SocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrow(IOException::new);
@@ -232,44 +243,52 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         });
 
         builder.on(ServerSocket.class, rule -> {
-            rule.callingStatic(ServerSocket::new).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(ServerSocket::new, Integer.class).enforce(Policies::inboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(ServerSocket::new).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
+            rule.callingStatic(ServerSocket::new, Integer.class).enforce(Policies::inboundNetworkAccess).elseThrow(IOException::new);
             rule.callingStatic(ServerSocket::new, Integer.class, Integer.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(ServerSocket::new, Integer.class, Integer.class, InetAddress.class)
                 .enforce(Policies::inboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(Socket.class, rule -> {
             rule.callingStatic(Socket::new).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
             rule.callingStatic(Socket::new, Proxy.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(Socket::new, String.class, Integer.class).enforce(Policies::outboundNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(Socket::new, String.class, Integer.class)
+                .enforce(Policies::outboundNetworkAccess)
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, String.class, Integer.class, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class, InetAddress.class, Integer.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, String.class, Integer.class, Boolean.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
             rule.callingStatic(Socket::new, InetAddress.class, Integer.class, Boolean.class)
                 .enforce(Policies::outboundNetworkAccess)
-                .elseThrowNotEntitled();
+                .elseThrow(IOException::new);
         });
 
         builder.on(DatagramSocket.class, rule -> {
-            rule.callingStatic(DatagramSocket::new).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
-            rule.callingStatic(DatagramSocket::new, Integer.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
+            rule.callingStatic(DatagramSocket::new)
+                .enforce(Policies::allNetworkAccess)
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
+            rule.callingStatic(DatagramSocket::new, Integer.class)
+                .enforce(Policies::allNetworkAccess)
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
             rule.callingStatic(DatagramSocket::new, Integer.class, InetAddress.class)
                 .enforce(Policies::allNetworkAccess)
-                .elseThrowNotEntitled();
-            rule.callingStatic(DatagramSocket::new, SocketAddress.class).enforce(Policies::allNetworkAccess).elseThrowNotEntitled();
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
+            rule.callingStatic(DatagramSocket::new, SocketAddress.class)
+                .enforce(Policies::allNetworkAccess)
+                .elseThrow(e -> new SocketException(e.getMessage(), e));
             rule.callingVoidStatic(DatagramSocket::setDatagramSocketImplFactory, DatagramSocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrow(IOException::new);

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/NetworkInstrumentation.java
@@ -277,18 +277,26 @@ public class NetworkInstrumentation implements InstrumentationConfig {
         });
 
         builder.on(DatagramSocket.class, rule -> {
-            rule.callingStatic(DatagramSocket::new)
-                .enforce(Policies::allNetworkAccess)
-                .elseThrow(e -> new SocketException(e.getMessage(), e));
-            rule.callingStatic(DatagramSocket::new, Integer.class)
-                .enforce(Policies::allNetworkAccess)
-                .elseThrow(e -> new SocketException(e.getMessage(), e));
-            rule.callingStatic(DatagramSocket::new, Integer.class, InetAddress.class)
-                .enforce(Policies::allNetworkAccess)
-                .elseThrow(e -> new SocketException(e.getMessage(), e));
-            rule.callingStatic(DatagramSocket::new, SocketAddress.class)
-                .enforce(Policies::allNetworkAccess)
-                .elseThrow(e -> new SocketException(e.getMessage(), e));
+            rule.callingStatic(DatagramSocket::new).enforce(Policies::allNetworkAccess).elseThrow(e -> {
+                var ex = new SocketException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(DatagramSocket::new, Integer.class).enforce(Policies::allNetworkAccess).elseThrow(e -> {
+                var ex = new SocketException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(DatagramSocket::new, Integer.class, InetAddress.class).enforce(Policies::allNetworkAccess).elseThrow(e -> {
+                var ex = new SocketException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
+            rule.callingStatic(DatagramSocket::new, SocketAddress.class).enforce(Policies::allNetworkAccess).elseThrow(e -> {
+                var ex = new SocketException(e.getMessage());
+                ex.initCause(e);
+                return ex;
+            });
             rule.callingVoidStatic(DatagramSocket::setDatagramSocketImplFactory, DatagramSocketImplFactory.class)
                 .enforce(Policies::changeNetworkHandling)
                 .elseThrow(IOException::new);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Use checked exceptions in entitlement constructor rules (#145234)