### PR TITLE
[9.3] Fix dense_vector default index options when using BFLOAT16 (#145202)

### DIFF
--- a/docs/changelog/145202.yaml
+++ b/docs/changelog/145202.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+  - 145204
+pr: 145202
+summary: Fix `dense_vector` default index options when using BFLOAT16
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -211,6 +211,7 @@ public class IndexVersions {
     public static final IndexVersion TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX = def(9_058_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion DEFAULT_HNSW_EARLY_TERMINATION = def(9_059_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion PATTERN_TEXT_ARGS_IN_BINARY_DOC_VALUES = def(9_060_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT = def(9_060_0_01, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -218,10 +218,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
     public static final IndexVersion DEFAULT_TO_INT8 = IndexVersions.DEFAULT_DENSE_VECTOR_TO_INT8_HNSW;
     public static final IndexVersion DEFAULT_TO_BBQ = IndexVersions.DEFAULT_DENSE_VECTOR_TO_BBQ_HNSW;
     public static final IndexVersion LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION = IndexVersions.V_8_9_0;
-    public static final IndexVersion BFLOAT16_DEFAULT_INDEX_OPTIONS = IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS;
     public static final IndexVersion BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT =
         IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT;
-    public static final IndexVersion ES_VERSION_94 = IndexVersions.KEYWORD_FIELDS_KEEP_DUPLICATES_IN_BINARY_DOC_VALUES;
 
     public static final NodeFeature RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature("mapper.dense_vector.rescore_vector");
     public static final NodeFeature RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature(
@@ -420,8 +418,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         private Set<ElementType> elementTypesWithDefaultIndexOptions() {
-            if (indexVersionCreated.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS)
-                || indexVersionCreated.between(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT, ES_VERSION_94)) {
+            if (indexVersionCreated.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT)) {
                 return Set.of(ElementType.FLOAT, ElementType.BFLOAT16);
             } else {
                 return Set.of(ElementType.FLOAT);

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -218,6 +218,10 @@ public class DenseVectorFieldMapper extends FieldMapper {
     public static final IndexVersion DEFAULT_TO_INT8 = IndexVersions.DEFAULT_DENSE_VECTOR_TO_INT8_HNSW;
     public static final IndexVersion DEFAULT_TO_BBQ = IndexVersions.DEFAULT_DENSE_VECTOR_TO_BBQ_HNSW;
     public static final IndexVersion LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION = IndexVersions.V_8_9_0;
+    public static final IndexVersion BFLOAT16_DEFAULT_INDEX_OPTIONS = IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS;
+    public static final IndexVersion BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT =
+        IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT;
+    public static final IndexVersion ES_VERSION_94 = IndexVersions.KEYWORD_FIELDS_KEEP_DUPLICATES_IN_BINARY_DOC_VALUES;
 
     public static final NodeFeature RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature("mapper.dense_vector.rescore_vector");
     public static final NodeFeature RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature(
@@ -384,7 +388,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         private DenseVectorIndexOptions defaultIndexOptions(boolean defaultInt8Hnsw, boolean defaultBBQHnsw) {
-            if (elementType.getValue() != ElementType.FLOAT || indexed.getValue() == false) {
+            if (elementTypesWithDefaultIndexOptions().contains(elementType.getValue()) == false || indexed.getValue() == false) {
                 return null;
             }
 
@@ -413,6 +417,15 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 );
             }
             return null;
+        }
+
+        private Set<ElementType> elementTypesWithDefaultIndexOptions() {
+            if (indexVersionCreated.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS)
+                || indexVersionCreated.between(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT, ES_VERSION_94)) {
+                return Set.of(ElementType.FLOAT, ElementType.BFLOAT16);
+            } else {
+                return Set.of(ElementType.FLOAT);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/inference/SimilarityMeasure.java
+++ b/server/src/main/java/org/elasticsearch/inference/SimilarityMeasure.java
@@ -9,21 +9,32 @@
 
 package org.elasticsearch.inference;
 
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.TransportVersion;
 
 import java.util.EnumSet;
 import java.util.Locale;
 
 public enum SimilarityMeasure {
-    COSINE,
-    DOT_PRODUCT,
-    L2_NORM;
+    COSINE(DenseVectorFieldMapper.VectorSimilarity.COSINE),
+    DOT_PRODUCT(DenseVectorFieldMapper.VectorSimilarity.DOT_PRODUCT),
+    L2_NORM(DenseVectorFieldMapper.VectorSimilarity.L2_NORM),;
+
+    private final DenseVectorFieldMapper.VectorSimilarity vectorSimilarity;
+
+    SimilarityMeasure(DenseVectorFieldMapper.VectorSimilarity vectorSimilarity) {
+        this.vectorSimilarity = vectorSimilarity;
+    }
 
     private static final EnumSet<SimilarityMeasure> BEFORE_L2_NORM_ENUMS = EnumSet.range(COSINE, DOT_PRODUCT);
 
     @Override
     public String toString() {
         return name().toLowerCase(Locale.ROOT);
+    }
+
+    public DenseVectorFieldMapper.VectorSimilarity vectorSimilarity() {
+        return vectorSimilarity;
     }
 
     public static SimilarityMeasure fromString(String name) {

--- a/server/src/main/java/org/elasticsearch/inference/SimilarityMeasure.java
+++ b/server/src/main/java/org/elasticsearch/inference/SimilarityMeasure.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.inference;
 
-import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 import java.util.EnumSet;
 import java.util.Locale;

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
@@ -12,10 +12,18 @@ package org.elasticsearch.index.mapper.vectors;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.inference.SimilarityMeasure;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.ES_VERSION_94;
 
 public class DenseVectorFieldMapperTestUtils {
     private DenseVectorFieldMapperTestUtils() {}
@@ -54,6 +62,17 @@ public class DenseVectorFieldMapperTestUtils {
                 yield RandomNumbers.randomIntBetween(random(), 1, maxEmbeddingLength) * 8;
             }
         };
+    }
+
+    public static Set<DenseVectorFieldMapper.ElementType> elementTypesWithDefaultIndexOptions(IndexVersion indexVersion) {
+        Set<DenseVectorFieldMapper.ElementType> elementTypes = new HashSet<>();
+        elementTypes.add(DenseVectorFieldMapper.ElementType.FLOAT);
+        if (indexVersion.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS)
+            || indexVersion.between(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT, ES_VERSION_94)) {
+            elementTypes.add(DenseVectorFieldMapper.ElementType.BFLOAT16);
+        }
+
+        return Collections.unmodifiableSet(elementTypes);
     }
 
     private static Random random() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
@@ -21,9 +21,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.ES_VERSION_94;
 
 public class DenseVectorFieldMapperTestUtils {
     private DenseVectorFieldMapperTestUtils() {}
@@ -67,8 +65,7 @@ public class DenseVectorFieldMapperTestUtils {
     public static Set<DenseVectorFieldMapper.ElementType> elementTypesWithDefaultIndexOptions(IndexVersion indexVersion) {
         Set<DenseVectorFieldMapper.ElementType> elementTypes = new HashSet<>();
         elementTypes.add(DenseVectorFieldMapper.ElementType.FLOAT);
-        if (indexVersion.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS)
-            || indexVersion.between(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT, ES_VERSION_94)) {
+        if (indexVersion.onOrAfter(BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT)) {
             elementTypes.add(DenseVectorFieldMapper.ElementType.BFLOAT16);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DenseVector
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.ElementType;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.VectorSimilarity;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.search.vectors.VectorData;
@@ -1335,6 +1336,66 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
 
         assertTrue(denseVectorFieldType.indexType().hasVectors());
         assertEquals(VectorSimilarity.COSINE, denseVectorFieldType.getSimilarity());
+    }
+
+    public void testDefaultIndexOptions() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            // Pick a random index version from one of three eras that each produce different default index options
+            int era = randomIntBetween(0, 3);
+            IndexVersion indexVersion = switch (era) {
+                case 0 -> IndexVersionUtils.randomVersionBetween(
+                    IndexVersionUtils.getLowestReadCompatibleVersion(),
+                    IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.DEFAULT_TO_INT8)
+                );
+                case 1 -> IndexVersionUtils.randomVersionBetween(
+                    DenseVectorFieldMapper.DEFAULT_TO_INT8,
+                    IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.DEFAULT_TO_BBQ)
+                );
+                case 2 -> IndexVersionUtils.randomVersionBetween(
+                    DenseVectorFieldMapper.DEFAULT_TO_BBQ,
+                    IndexVersionUtils.getPreviousVersion(IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS)
+                );
+                case 3 -> IndexVersionUtils.randomVersionBetween(
+                    IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS,
+                    IndexVersion.current()
+                );
+                default -> throw new AssertionError("Unexpected value: " + era);
+            };
+
+            boolean defaultInt8Hnsw = indexVersion.onOrAfter(DenseVectorFieldMapper.DEFAULT_TO_INT8);
+            boolean defaultBBQHnsw = indexVersion.onOrAfter(DenseVectorFieldMapper.DEFAULT_TO_BBQ);
+
+            final ElementType elementType = randomFrom(ElementType.values());
+            final int dims = DenseVectorFieldMapperTestUtils.randomCompatibleDimensions(elementType, 512);
+            final VectorSimilarity similarity = randomFrom(
+                DenseVectorFieldMapperTestUtils.getSupportedSimilarities(elementType)
+                    .stream()
+                    .map(SimilarityMeasure::vectorSimilarity)
+                    .toList()
+            );
+
+            MapperService mapperService = createMapperService(indexVersion, fieldMapping(b -> {
+                b.field("type", "dense_vector");
+                b.field("index", true);
+                b.field("element_type", elementType.toString());
+                b.field("dims", dims);
+                b.field("similarity", similarity.toString());
+            }));
+
+            DenseVectorFieldMapper mapper = (DenseVectorFieldMapper) mapperService.mappingLookup().getMapper("field");
+            DenseVectorFieldMapper.DenseVectorIndexOptions indexOptions = mapper.fieldType().getIndexOptions();
+
+            if (DenseVectorFieldMapperTestUtils.elementTypesWithDefaultIndexOptions(indexVersion).contains(elementType) == false) {
+                assertNull(indexOptions);
+            } else if (defaultBBQHnsw && dims >= DenseVectorFieldMapper.BBQ_DIMS_DEFAULT_THRESHOLD) {
+                assertThat(indexOptions, instanceOf(DenseVectorFieldMapper.BBQHnswIndexOptions.class));
+            } else if (defaultInt8Hnsw) {
+                // INT8 era, or BBQ era with dims below the BBQ threshold
+                assertThat(indexOptions, instanceOf(DenseVectorFieldMapper.Int8HnswIndexOptions.class));
+            } else {
+                assertNull(indexOptions);
+            }
+        }
     }
 
     public void testValidateOnBuild() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -1344,19 +1344,23 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
             int era = randomIntBetween(0, 3);
             IndexVersion indexVersion = switch (era) {
                 case 0 -> IndexVersionUtils.randomVersionBetween(
+                    random(),
                     IndexVersionUtils.getLowestReadCompatibleVersion(),
                     IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.DEFAULT_TO_INT8)
                 );
                 case 1 -> IndexVersionUtils.randomVersionBetween(
+                    random(),
                     DenseVectorFieldMapper.DEFAULT_TO_INT8,
                     IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.DEFAULT_TO_BBQ)
                 );
                 case 2 -> IndexVersionUtils.randomVersionBetween(
+                    random(),
                     DenseVectorFieldMapper.DEFAULT_TO_BBQ,
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS)
+                    IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT)
                 );
                 case 3 -> IndexVersionUtils.randomVersionBetween(
-                    IndexVersions.DENSE_VECTOR_BFLOAT16_DEFAULT_INDEX_OPTIONS,
+                    random(),
+                    DenseVectorFieldMapper.BFLOAT16_DEFAULT_INDEX_OPTIONS_BACKPORT,
                     IndexVersion.current()
                 );
                 default -> throw new AssertionError("Unexpected value: " + era);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -1413,14 +1413,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         if (indexVersionCreated.onOrAfter(NEW_SPARSE_VECTOR)) {
             SimilarityMeasure similarity = modelSettings.similarity();
             if (similarity != null) {
-                switch (similarity) {
-                    case COSINE -> denseVectorMapperBuilder.similarity(DenseVectorFieldMapper.VectorSimilarity.COSINE);
-                    case DOT_PRODUCT -> denseVectorMapperBuilder.similarity(DenseVectorFieldMapper.VectorSimilarity.DOT_PRODUCT);
-                    case L2_NORM -> denseVectorMapperBuilder.similarity(DenseVectorFieldMapper.VectorSimilarity.L2_NORM);
-                    default -> throw new IllegalArgumentException(
-                        "Unknown similarity measure in model_settings [" + similarity.name() + "]"
-                    );
-                }
+                denseVectorMapperBuilder.similarity(similarity.vectorSimilarity());
             }
         }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix dense_vector default index options when using BFLOAT16 (#145202)](https://github.com/elastic/elasticsearch/pull/145202)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)