### PR TITLE
Change querylog rollover format

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -167,7 +167,7 @@ appender.querylog.layout.type=ECSJsonLayout
 appender.querylog.layout.dataset=elasticsearch.querylog
 # Rolling policies
 appender.querylog.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs\
-  .cluster_name}_querylog-%i.json.gz
+  .cluster_name}_querylog-%d{yyyy-MM-dd}-%i.json.gz
 appender.querylog.policies.type=Policies
 appender.querylog.policies.size.type=SizeBasedTriggeringPolicy
 appender.querylog.policies.size.size=1GB


### PR DESCRIPTION
From `querying_querylog-1.json.gz` to `querying_querylog-2026-01-26-1.json.gz` - it's more convenient when they have dates. 