### PR TITLE
Only use MemorySegment scorers when slices can be obtained from the IndexInput

### DIFF
--- a/docs/changelog/145343.yaml
+++ b/docs/changelog/145343.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 145343
+summary: Only use `MemorySegment` scorers when slices can be obtained from the `IndexInput`
+type: bug

--- a/docs/changelog/145343.yaml
+++ b/docs/changelog/145343.yaml
@@ -1,5 +1,5 @@
 area: Vector Search
 issues: []
 pr: 145343
-summary: Only use `MemorySegment` scorers when slices can be obtained from the `IndexInput`
+summary: Only use MemorySegment scorers when slices can be obtained from the IndexInput
 type: bug

--- a/docs/changelog/145343.yaml
+++ b/docs/changelog/145343.yaml
@@ -1,5 +1,5 @@
 area: Vector Search
 issues: []
 pr: 145343
-summary: Only use MemorySegment scorers when slices can be obtained from the IndexInput
+summary: Only use `MemorySegment` scorers when slices can be obtained from the `IndexInput`
 type: bug

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
@@ -40,6 +40,13 @@ public final class IndexInputUtils {
     private IndexInputUtils() {}
 
     /**
+     * Returns {@code true} if {@code MemorySegment} slices can be obtained from the specified {@link IndexInput}.
+     */
+    public static boolean canUseSegmentSlices(IndexInput input) {
+        return input instanceof MemorySegmentAccessInput || input instanceof DirectAccessInput;
+    }
+
+    /**
      * Obtains a memory segment for the next {@code length} bytes of the
      * index input, passes it to {@code action}, and returns the result.
      * The position of the index input is advanced by {@code length}.

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
@@ -17,6 +17,7 @@ import org.elasticsearch.simdvec.ES92Int7VectorsScorer;
 import org.elasticsearch.simdvec.ES93BinaryQuantizedVectorScorer;
 import org.elasticsearch.simdvec.ESNextOSQVectorsScorer;
 import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
+import org.elasticsearch.simdvec.internal.IndexInputUtils;
 import org.elasticsearch.simdvec.internal.MemorySegmentES92Int7VectorsScorer;
 
 import java.io.IOException;
@@ -50,7 +51,9 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
             && ((queryBits == 4 && (indexBits == 1 || indexBits == 2 || indexBits == 4)) || (queryBits == 7 && indexBits == 7))) {
             IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
             unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
-            return new MemorySegmentESNextOSQVectorsScorer(unwrappedInput, queryBits, indexBits, dimension, dataLength, bulkSize);
+            if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+                return new MemorySegmentESNextOSQVectorsScorer(unwrappedInput, queryBits, indexBits, dimension, dataLength, bulkSize);
+            }
         }
         return new ESNextOSQVectorsScorer(input, queryBits, indexBits, dimension, dataLength, bulkSize);
     }
@@ -60,7 +63,9 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
         if (PanamaESVectorUtilSupport.HAS_FAST_INTEGER_VECTORS) {
             IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
             unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
-            return new MemorySegmentES91OSQVectorsScorer(unwrappedInput, dimension, bulkSize);
+            if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+                return new MemorySegmentES91OSQVectorsScorer(unwrappedInput, dimension, bulkSize);
+            }
         }
         return new OnHeapES91OSQVectorsScorer(input, dimension, bulkSize);
     }
@@ -69,7 +74,11 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
     public ES92Int7VectorsScorer newES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) {
         IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
         unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
-        return new MemorySegmentES92Int7VectorsScorer(unwrappedInput, dimension, bulkSize);
+
+        if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+            return new MemorySegmentES92Int7VectorsScorer(unwrappedInput, dimension, bulkSize);
+        }
+        return new ES92Int7VectorsScorer(input, dimension, bulkSize);
     }
 
     @Override
@@ -78,7 +87,9 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
         if (NATIVE_SUPPORTED) {
             IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
             unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
-            return new NativeBinaryQuantizedVectorScorer(unwrappedInput, dimensions, vectorLengthInBytes);
+            if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+                return new NativeBinaryQuantizedVectorScorer(unwrappedInput, dimensions, vectorLengthInBytes);
+            }
         }
         return new DefaultES93BinaryQuantizedVectorScorer(input, dimensions, vectorLengthInBytes);
     }


### PR DESCRIPTION
Serverless version