### PR TITLE
[9.3] Entitlements: remove AccessControlException from NotEntitledException (#144519)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/NotEntitledException.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/NotEntitledException.java
@@ -9,9 +9,7 @@
 
 package org.elasticsearch.entitlement.bridge;
 
-import java.security.AccessControlException;
-
-public class NotEntitledException extends AccessControlException {
+public class NotEntitledException extends RuntimeException {
     public NotEntitledException(String message) {
         super(message);
     }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Entitlements: remove AccessControlException from NotEntitledException (#144519)