### PR TITLE
Fix "[approximation] is only available in snapshot" for test-release builds

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeApproximationIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeApproximationIT.java
@@ -13,7 +13,9 @@ import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.qa.rest.generative.GenerativeApproximationRestTest;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.nio.file.Path;
@@ -22,6 +24,11 @@ import java.nio.file.Path;
 public class GenerativeApproximationIT extends GenerativeApproximationRestTest {
 
     private static final Path CSV_DATA_PATH = CsvTestUtils.createCsvDataDirectory();
+
+    @Before
+    public void checkCapability() {
+        assumeTrue("approximation available in snapshot", EsqlCapabilities.Cap.APPROXIMATION_V6.isEnabled());
+    }
 
     @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(CSV_DATA_PATH, spec -> {


### PR DESCRIPTION
I'm seeing failures of the form `Setting [approximation] is only available in snapshot builds` 
in my https://github.com/elastic/elasticsearch/pull/144704 which needs the `test-release` label.
For example:

- https://buildkite.com/elastic/elasticsearch-pull-request/builds/133616/steps/canvas?jid=019d4566-93d9-45ca-8b30-26cb6abbdb57&tab=output

Here is the first of many such errors:

```
REPRODUCE WITH: ./gradlew ":x-pack:plugin:esql:qa:server:single-node:javaRestTest" --tests "org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT" -Dtests.method="test {csv-spec:row.min}" -Dtests.seed=58AB9E52130B6B2D -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dlicense.key=x-pack/license-tools/src/test/resources/public.key -Dtests.locale=he-IL -Dtests.timezone=CET -Druntime.java=25

GenerativeApproximationIT > test > test {csv-spec:row.min} FAILED
   org.elasticsearch.client.ResponseException: method [POST], host [http://[::1]:43187], URI [/_query?pretty=true&error_trace=true], status line [HTTP/1.1 400 Bad Request]
   ---
   error:
     root_cause:
     - type: "parsing_exception"
       reason: "line 1:1: Setting [approximation] is only available in snapshot builds"
       stack_trace: "org.elasticsearch.xpack.esql.parser.ParsingException: line 1:1:\
         \ Setting [approximation] is only available in snapshot builds\n\tat org.elasticsearch.xpack.esql.plan.QuerySettings.validate(QuerySettings.java:165)\n\
         \tat org.elasticsearch.xpack.esql.action.EsqlQueryRequest.parse(EsqlQueryRequest.java:178)\n\
```

The REPRODUCTION line reproduced the failure for me locally in the main branch.

We saw similar problems last month e.g. https://github.com/elastic/elasticsearch/issues/144086 for `test-release` builds.
This adds a check to prevent this test from running in that case.
It is inspired by the fix to a similar problem https://github.com/elastic/elasticsearch/pull/144088/changes 

Please feel free to close this if there is a better solution.
