### PR TITLE
Allow resizable heap when memory locking is disabled

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
@@ -70,10 +70,12 @@ public class MachineDependentHeap {
         List<DiscoveryNodeRole> roles = NodeRoleSettings.NODE_ROLES_SETTING.get(nodeSettings);
         long availableSystemMemory = systemMemoryInfo.availableSystemMemory();
         MachineNodeRole nodeRole = mapNodeRole(roles);
-        return options(getHeapSizeMb(nodeSettings, nodeRole, availableSystemMemory));
+        int maxHeapSizeMb = getMaxHeapSizeMb(nodeSettings, nodeRole, availableSystemMemory);
+        int initialHeapSizeMb = getInitialHeapSizeMb(maxHeapSizeMb);
+        return options(initialHeapSizeMb, maxHeapSizeMb);
     }
 
-    protected int getHeapSizeMb(Settings nodeSettings, MachineNodeRole role, long availableMemory) {
+    protected int getMaxHeapSizeMb(Settings nodeSettings, MachineNodeRole role, long availableMemory) {
         return switch (role) {
             /*
              * Master-only node.
@@ -144,6 +146,10 @@ public class MachineDependentHeap {
         };
     }
 
+    protected int getInitialHeapSizeMb(int maxHeapSizeMb) {
+        return maxHeapSizeMb;
+    }
+
     protected static int mb(long bytes) {
         return (int) (bytes / (1024 * 1024));
     }
@@ -170,8 +176,8 @@ public class MachineDependentHeap {
         return Arrays.asList(items).containsAll(collection);
     }
 
-    private static List<String> options(int heapSize) {
-        return List.of("-Xms" + heapSize + "m", "-Xmx" + heapSize + "m");
+    private static List<String> options(int initialHeapSizeMb, int maxHeapSizeMb) {
+        return List.of("-Xms" + initialHeapSizeMb + "m", "-Xmx" + maxHeapSizeMb + "m");
     }
 
     protected enum MachineNodeRole {

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -233,28 +233,18 @@ final class BootstrapChecks {
         public BootstrapCheckResult check(BootstrapContext context) {
             final long initialHeapSize = getInitialHeapSize();
             final long maxHeapSize = getMaxHeapSize();
-            if (initialHeapSize != 0 && maxHeapSize != 0 && initialHeapSize != maxHeapSize) {
-                final String message;
-                if (isMemoryLocked()) {
-                    message = String.format(
+            if (initialHeapSize != 0 && maxHeapSize != 0 && initialHeapSize != maxHeapSize && isMemoryLocked()) {
+                return BootstrapCheckResult.failure(
+                    String.format(
                         Locale.ROOT,
                         "initial heap size [%d] not equal to maximum heap size [%d]; "
                             + "this can cause resize pauses and prevents memory locking from locking the entire heap",
-                        getInitialHeapSize(),
-                        getMaxHeapSize()
-                    );
-                } else {
-                    message = String.format(
-                        Locale.ROOT,
-                        "initial heap size [%d] not equal to maximum heap size [%d]; " + "this can cause resize pauses",
-                        getInitialHeapSize(),
-                        getMaxHeapSize()
-                    );
-                }
-                return BootstrapCheckResult.failure(message);
-            } else {
-                return BootstrapCheckResult.success();
+                        initialHeapSize,
+                        maxHeapSize
+                    )
+                );
             }
+            return BootstrapCheckResult.success();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.nativeaccess.ProcessLimits;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
-import org.hamcrest.Matcher;
 
 import java.net.InetAddress;
 import java.nio.ByteOrder;
@@ -46,7 +45,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -197,15 +195,13 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         assertThat(suppressed[1], hasToString(containsString("second")));
     }
 
-    public void testHeapSizeCheck() throws NodeValidationException {
+    public void testHeapSizeCheckFailsWhenMemoryLocked() throws NodeValidationException {
         final int initial = randomIntBetween(0, Integer.MAX_VALUE - 1);
         final int max = randomIntBetween(initial + 1, Integer.MAX_VALUE);
         final AtomicLong initialHeapSize = new AtomicLong(initial);
         final AtomicLong maxHeapSize = new AtomicLong(max);
-        final boolean isMemoryLocked = randomBoolean();
 
         final BootstrapChecks.HeapSizeCheck check = new BootstrapChecks.HeapSizeCheck() {
-
             @Override
             long getInitialHeapSize() {
                 return initialHeapSize.get();
@@ -218,9 +214,8 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
             @Override
             boolean isMemoryLocked() {
-                return isMemoryLocked;
+                return true;
             }
-
         };
 
         final NodeValidationException e = expectThrows(
@@ -233,18 +228,38 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
                 "initial heap size [" + initialHeapSize.get() + "] " + "not equal to maximum heap size [" + maxHeapSize.get() + "]"
             )
         );
+        assertThat(e.getMessage(), containsString("prevents memory locking from locking the entire heap"));
         assertThat(e.getMessage(), containsString("; for more information see [https://www.elastic.co/docs/"));
-        final String memoryLockingMessage = "and prevents memory locking from locking the entire heap";
-        final Matcher<String> memoryLockingMatcher;
-        if (isMemoryLocked) {
-            memoryLockingMatcher = containsString(memoryLockingMessage);
-        } else {
-            memoryLockingMatcher = not(containsString(memoryLockingMessage));
-        }
-        assertThat(e.getMessage(), memoryLockingMatcher);
 
+        // equal heap sizes should always pass
         initialHeapSize.set(maxHeapSize.get());
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
+    }
 
+    public void testHeapSizeCheckPassesWhenMemoryNotLocked() throws NodeValidationException {
+        final int initial = randomIntBetween(0, Integer.MAX_VALUE - 1);
+        final int max = randomIntBetween(initial + 1, Integer.MAX_VALUE);
+        final AtomicLong initialHeapSize = new AtomicLong(initial);
+        final AtomicLong maxHeapSize = new AtomicLong(max);
+
+        final BootstrapChecks.HeapSizeCheck check = new BootstrapChecks.HeapSizeCheck() {
+            @Override
+            long getInitialHeapSize() {
+                return initialHeapSize.get();
+            }
+
+            @Override
+            long getMaxHeapSize() {
+                return maxHeapSize.get();
+            }
+
+            @Override
+            boolean isMemoryLocked() {
+                return false;
+            }
+        };
+
+        // different heap sizes should pass when memory is not locked
         BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if the initial heap size or the max


### PR DESCRIPTION
The heap size bootstrap check rejected any configuration where `Xms` != `Xmx`, regardless of whether memory locking was enabled. When the heap is resizable, locking memory is counterproductive because `mlockall` locks the pages backing the initial heap size, so pages allocated during later heap growth remain unlocked.

This change:
1. Restricts heap-size bootstrap enforcement to when memory locking is active, where `Xms` must equal `Xmx` for the lock to cover the whole heap.
2. Refactors `MachineDependentHeap` to model max and initial heap explicitly by introducing separate methods:
   - `getMaxHeapSizeMb(...)` for max heap sizing policy
   - `getInitialHeapSizeMb(int maxHeapSizeMb)` for initial heap policy
3. Keeps base behaviour unchanged by defaulting `getInitialHeapSizeMb(...)` to `maxHeapSizeMb` (`Xms == Xmx`), while enabling subclasses to customise initial heap independently of max heap.

We explicitly do not change default heap sizing behaviour or recommendations in this commit. By default, `Xms` remains equal to `Xmx`, this only removes bootstrap enforcement when `mlock` is not enabled and introduces the API needed for downstream overrides.

[WIP]