### PR TITLE
Reproduce transient 404 for alias APIs due to race condition 

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -281,6 +281,17 @@ setup:
   - match: { test_index.aliases.test_alias: { } }
 
 ---
+"Non-existent alias with ignore_unavailable still returns 404":
+  - do:
+      catch: missing
+      indices.get_alias:
+        name: non-existent
+        ignore_unavailable: true
+
+  - match: { 'status': 404 }
+  - match: { 'error': 'alias [non-existent] missing' }
+
+---
 "Getting alias on an non-existent index should return 404":
 
   - do:

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/GetAliasesRaceIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/GetAliasesRaceIntegTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authz;
+
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+
+public class GetAliasesRaceIntegTests extends SecurityIntegTestCase {
+
+    @Override
+    protected String configUsers() {
+        final String hash = new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
+        return super.configUsers() + "race_user:" + hash + "\n";
+    }
+
+    @Override
+    protected String configUsersRoles() {
+        return super.configUsersRoles() + "race_role:race_user\n";
+    }
+
+    @Override
+    protected String configRoles() {
+        return super.configRoles() + """
+
+            race_role:
+              indices:
+                - names: '*'
+                  privileges: [ all ]
+            """;
+    }
+
+    public void testGetAliasesFailsWhenConcurrentAliasRemoval() throws Exception {
+        Map<String, String> authHeaders = Collections.singletonMap(
+            BASIC_AUTH_HEADER,
+            basicAuthHeaderValue("race_user", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)
+        );
+        Client authedClient = client(internalCluster().getMasterName()).filterWithHeader(authHeaders);
+
+        assertAcked(indicesAdmin().prepareCreate("target_index").addAlias(new Alias("target_alias")));
+        for (int i = 0; i < 5; i++) {
+            assertAcked(indicesAdmin().prepareCreate("churn_index_" + i).addAlias(new Alias("churn_alias_" + i)));
+        }
+
+        AtomicBoolean stop = new AtomicBoolean(false);
+        CopyOnWriteArrayList<Exception> failures = new CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(2);
+
+        Thread reader = new Thread(() -> {
+            try {
+                while (stop.get() == false) {
+                    try {
+                        authedClient.execute(GetAliasesAction.INSTANCE, new GetAliasesRequest(TEST_REQUEST_TIMEOUT, "target_alias"))
+                            .actionGet();
+                    } catch (IndexNotFoundException e) {
+                        failures.add(e);
+                    }
+                }
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        Thread writer = new Thread(() -> {
+            try {
+                int iter = 0;
+                while (stop.get() == false) {
+                    int idx = iter % 5;
+                    try {
+                        authedClient.admin()
+                            .indices()
+                            .aliases(
+                                new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).addAliasAction(
+                                    IndicesAliasesRequest.AliasActions.remove().index("churn_index_" + idx).alias("churn_alias_" + idx)
+                                )
+                            )
+                            .actionGet();
+                        authedClient.admin()
+                            .indices()
+                            .aliases(
+                                new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).addAliasAction(
+                                    IndicesAliasesRequest.AliasActions.add().index("churn_index_" + idx).alias("churn_alias_" + idx)
+                                )
+                            )
+                            .actionGet();
+                    } catch (Exception e) {
+                        // alias may already be removed/added; ignore
+                    }
+                    iter++;
+                }
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        reader.start();
+        writer.start();
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        stop.set(true);
+        latch.await(10, TimeUnit.SECONDS);
+
+        assertFalse(
+            "Expected at least one IndexNotFoundException from the GetAliases reader thread, "
+                + "triggered by security's index expansion racing with alias removal",
+            failures.isEmpty()
+        );
+        for (Exception e : failures) {
+            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("churn_alias_"));
+        }
+    }
+}

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/GetAliasesRaceIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/GetAliasesRaceIntegTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.SecurityIntegTestCase;
@@ -51,6 +52,25 @@ public class GetAliasesRaceIntegTests extends SecurityIntegTestCase {
     }
 
     public void testGetAliasesFailsWhenConcurrentAliasRemoval() throws Exception {
+        CopyOnWriteArrayList<Exception> failures = runAliasRace(null);
+
+        assertFalse("Expected at least one IndexNotFoundException from the reader thread", failures.isEmpty());
+        for (Exception e : failures) {
+            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("churn_alias_"));
+        }
+    }
+
+    public void testGetAliasesWithIgnoreUnavailableSurvivesConcurrentAliasRemoval() throws Exception {
+        IndicesOptions withIgnoreUnavailable = IndicesOptions.builder(GetAliasesRequest.DEFAULT_INDICES_OPTIONS)
+            .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
+            .build();
+
+        CopyOnWriteArrayList<Exception> failures = runAliasRace(withIgnoreUnavailable);
+
+        assertTrue("ignore_unavailable=true should prevent IndexNotFoundException, but got: " + failures, failures.isEmpty());
+    }
+
+    private CopyOnWriteArrayList<Exception> runAliasRace(IndicesOptions readerOptions) throws Exception {
         Map<String, String> authHeaders = Collections.singletonMap(
             BASIC_AUTH_HEADER,
             basicAuthHeaderValue("race_user", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)
@@ -70,8 +90,11 @@ public class GetAliasesRaceIntegTests extends SecurityIntegTestCase {
             try {
                 while (stop.get() == false) {
                     try {
-                        authedClient.execute(GetAliasesAction.INSTANCE, new GetAliasesRequest(TEST_REQUEST_TIMEOUT, "target_alias"))
-                            .actionGet();
+                        GetAliasesRequest req = new GetAliasesRequest(TEST_REQUEST_TIMEOUT, "target_alias");
+                        if (readerOptions != null) {
+                            req.indicesOptions(readerOptions);
+                        }
+                        authedClient.execute(GetAliasesAction.INSTANCE, req).actionGet();
                     } catch (IndexNotFoundException e) {
                         failures.add(e);
                     }
@@ -119,13 +142,6 @@ public class GetAliasesRaceIntegTests extends SecurityIntegTestCase {
         stop.set(true);
         latch.await(10, TimeUnit.SECONDS);
 
-        assertFalse(
-            "Expected at least one IndexNotFoundException from the GetAliases reader thread, "
-                + "triggered by security's index expansion racing with alias removal",
-            failures.isEmpty()
-        );
-        for (Exception e : failures) {
-            assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("churn_alias_"));
-        }
+        return failures;
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -1851,6 +1851,45 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         assertThat(e.getIndex().getName(), equalTo("foobarfoo"));
     }
 
+    public void testGetAliasesWithIgnoreUnavailableSurvivesAliasRemoval() {
+        GetAliasesRequest request = new GetAliasesRequest(TEST_REQUEST_TIMEOUT);
+        request.aliases("foofoobar");
+        request.indicesOptions(
+            IndicesOptions.builder(GetAliasesRequest.DEFAULT_INDICES_OPTIONS)
+                .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
+                .build()
+        );
+        final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
+        resolveIndices(request, authorizedIndices);
+
+        assertThat(Arrays.asList(request.indices()), hasItem("foobarfoo"));
+
+        ProjectMetadata modifiedMetadata = ProjectMetadata.builder(projectMetadata)
+            .put(IndexMetadata.builder(projectMetadata.index("foobar")).removeAlias("foobarfoo"))
+            .build();
+
+        IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
+        String[] resolved = resolver.concreteIndexNamesWithSystemIndexAccess(modifiedMetadata, request);
+        assertThat(resolved.length, Matchers.greaterThan(0));
+    }
+
+    public void testGetAliasesWithIgnoreUnavailableStill404sForNonExistentAlias() {
+        GetAliasesRequest request = new GetAliasesRequest(TEST_REQUEST_TIMEOUT);
+        request.aliases("no_such_alias");
+        request.indicesOptions(
+            IndicesOptions.builder(GetAliasesRequest.DEFAULT_INDICES_OPTIONS)
+                .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
+                .build()
+        );
+        final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
+        resolveIndices(request, authorizedIndices);
+
+        IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
+        String[] resolved = resolver.concreteIndexNamesWithSystemIndexAccess(projectMetadata, request);
+        Map<String, List<AliasMetadata>> aliases = projectMetadata.findAliases(new String[] { "no_such_alias" }, resolved);
+        assertTrue("findAliases should return empty for a non-existent alias", aliases.isEmpty());
+    }
+
     public void testResolveAllGetAliasesRequestExpandWildcardsOpenOnly() {
         GetAliasesRequest request = new GetAliasesRequest(TEST_REQUEST_TIMEOUT);
         // set indices options to have wildcards resolved to open indices only (default is open and closed)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -1829,6 +1829,28 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         assertThat(request.aliases(), arrayContainingInAnyOrder("alias1"));
     }
 
+    public void testGetAliasesFailsWhenSecurityExpandedAliasRemovedFromClusterState() {
+        GetAliasesRequest request = new GetAliasesRequest(TEST_REQUEST_TIMEOUT);
+        request.aliases("foofoobar");
+        final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
+        resolveIndices(request, authorizedIndices);
+
+        assertThat(Arrays.asList(request.indices()), hasItem("foobarfoo"));
+        assertThat(Arrays.asList(request.indices()), hasItem("foofoobar"));
+
+        ProjectMetadata modifiedMetadata = ProjectMetadata.builder(projectMetadata)
+            .put(IndexMetadata.builder(projectMetadata.index("foobar")).removeAlias("foobarfoo"))
+            .build();
+        assertNull(modifiedMetadata.getIndicesLookup().get("foobarfoo"));
+
+        IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
+        IndexNotFoundException e = expectThrows(
+            IndexNotFoundException.class,
+            () -> resolver.concreteIndexNamesWithSystemIndexAccess(modifiedMetadata, request)
+        );
+        assertThat(e.getIndex().getName(), equalTo("foobarfoo"));
+    }
+
     public void testResolveAllGetAliasesRequestExpandWildcardsOpenOnly() {
         GetAliasesRequest request = new GetAliasesRequest(TEST_REQUEST_TIMEOUT);
         // set indices options to have wildcards resolved to open indices only (default is open and closed)


### PR DESCRIPTION
A unit test and an integration test that reproduce a race condition for the `GET/HEAD _alias/{name}` API. 

Additionally tests that confirm a workaround (using `ignore_unavailable=true`).