### PR TITLE
[9.1] [Inference API] Support chunking settings for sparse embeddings in custom service (#138776)

### DIFF
--- a/docs/changelog/138776.yaml
+++ b/docs/changelog/138776.yaml
@@ -1,0 +1,6 @@
+pr: 138776
+summary: "[Inference API] Support chunking settings for sparse embeddings in custom\
+  \ service"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomService.java
@@ -97,7 +97,7 @@ public class CustomService extends SenderService {
             Map<String, Object> taskSettingsMap = removeFromMapOrDefaultEmpty(config, ModelConfigurations.TASK_SETTINGS);
 
             ChunkingSettings chunkingSettings = null;
-            if (TaskType.TEXT_EMBEDDING.equals(taskType)) {
+            if (TaskType.SPARSE_EMBEDDING.equals(taskType) || TaskType.TEXT_EMBEDDING.equals(taskType)) {
                 chunkingSettings = ChunkingSettingsBuilder.fromMap(
                     removeFromMapOrDefaultEmpty(config, ModelConfigurations.CHUNKING_SETTINGS)
                 );
@@ -160,7 +160,7 @@ public class CustomService extends SenderService {
          * For request context, removeFromMapOrDefaultEmpty returns an empty map which results in the newer sentence boundary chunking
          * settings being used as the default.
          */
-        if (TaskType.TEXT_EMBEDDING.equals(taskType)) {
+        if (TaskType.TEXT_EMBEDDING.equals(taskType) || TaskType.SPARSE_EMBEDDING.equals(taskType)) {
             return ChunkingSettingsBuilder.fromMap(removeFromMap(config, ModelConfigurations.CHUNKING_SETTINGS));
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
@@ -27,16 +27,15 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsOptions;
-import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
-import org.elasticsearch.xpack.core.inference.chunking.SentenceBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
+import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsOptions;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests;
+import org.elasticsearch.xpack.inference.chunking.SentenceBoundaryChunkingSettings;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
 import org.elasticsearch.xpack.inference.services.AbstractInferenceServiceTests;
@@ -794,8 +793,8 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
 
             assertThat(chunkingSettings, instanceOf(SentenceBoundaryChunkingSettings.class));
             assertThat(chunkingSettings.getChunkingStrategy(), equalTo(ChunkingStrategy.SENTENCE));
-            assertThat(chunkingSettings.maxChunkSize(), equalTo(40));
-            assertThat(((SentenceBoundaryChunkingSettings) chunkingSettings).sentenceOverlap(), equalTo(0));
+            assertThat(chunkingSettings.asMap().get(ChunkingSettingsOptions.MAX_CHUNK_SIZE.toString()), equalTo(40));
+            assertThat(chunkingSettings.asMap().get(ChunkingSettingsOptions.SENTENCE_OVERLAP.toString()), equalTo(0));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.ChunkingStrategy;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -26,6 +27,9 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsOptions;
+import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
+import org.elasticsearch.xpack.core.inference.chunking.SentenceBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
@@ -66,6 +70,7 @@ import static org.elasticsearch.xpack.inference.services.custom.response.RerankR
 import static org.elasticsearch.xpack.inference.services.custom.response.SparseEmbeddingResponseParser.SPARSE_EMBEDDING_TOKEN_PATH;
 import static org.elasticsearch.xpack.inference.services.custom.response.SparseEmbeddingResponseParser.SPARSE_EMBEDDING_WEIGHT_PATH;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -291,7 +296,12 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
         );
     }
 
-    private static CustomModel createCustomModel(TaskType taskType, CustomResponseParser customResponseParser, String url) {
+    private static CustomModel createCustomModel(
+        TaskType taskType,
+        CustomResponseParser customResponseParser,
+        String url,
+        @Nullable ChunkingSettings chunkingSettings
+    ) {
         return new CustomModel(
             "model_id",
             taskType,
@@ -306,7 +316,8 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
                 new RateLimitSettings(10_000)
             ),
             new CustomTaskSettings(Map.of("key", "test_value")),
-            new CustomSecretSettings(Map.of("test_key", new SecureString("test_value".toCharArray())))
+            new CustomSecretSettings(Map.of("test_key", new SecureString("test_value".toCharArray()))),
+            chunkingSettings
         );
     }
 
@@ -534,7 +545,8 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
             var model = createCustomModel(
                 TaskType.RERANK,
                 new RerankResponseParser("$.results[*].relevance_score", "$.results[*].index", "$.results[*].document.text"),
-                getUrl(webServer)
+                getUrl(webServer),
+                null
             );
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -605,7 +617,8 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
             var model = createCustomModel(
                 TaskType.COMPLETION,
                 new CompletionResponseParser("$.choices[*].message.content"),
-                getUrl(webServer)
+                getUrl(webServer),
+                null
             );
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -670,7 +683,8 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
                     "$.result.sparse_embeddings[*].embedding[*].tokenId",
                     "$.result.sparse_embeddings[*].embedding[*].weight"
                 ),
-                getUrl(webServer)
+                getUrl(webServer),
+                null
             );
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -741,7 +755,51 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
         }
     }
 
-    public void testChunkedInfer_ChunkingSettingsSet() throws IOException {
+    public void testParseRequestConfig_DoesNotThrow_WhenChunkingSettingsArePresentForSparseEmbeddings() throws IOException {
+        try (var service = createService(threadPool, clientManager)) {
+            Map<String, Object> serviceSettingsMap = new HashMap<>(
+                Map.of(
+                    CustomServiceSettings.URL,
+                    "http://www.abc.com",
+                    CustomServiceSettings.HEADERS,
+                    Map.of("key", "value"),
+                    QueryParameters.QUERY_PARAMETERS,
+                    List.of(List.of("key", "value")),
+                    CustomServiceSettings.REQUEST,
+                    "request body",
+                    CustomServiceSettings.RESPONSE,
+                    new HashMap<>(Map.of(CustomServiceSettings.JSON_PARSER, createResponseParserMap(TaskType.SPARSE_EMBEDDING)))
+                )
+            );
+
+            Map<String, Object> chunkingSettingsMap = new HashMap<>(
+                Map.of(
+                    ChunkingSettingsOptions.STRATEGY.toString(),
+                    "sentence",
+                    ChunkingSettingsOptions.MAX_CHUNK_SIZE.toString(),
+                    40,
+                    ChunkingSettingsOptions.SENTENCE_OVERLAP.toString(),
+                    0
+                )
+            );
+
+            var config = getRequestConfigMap(serviceSettingsMap, createTaskSettingsMap(), chunkingSettingsMap, createSecretSettingsMap());
+            var listener = new PlainActionFuture<Model>();
+
+            service.parseRequestConfig("id", TaskType.SPARSE_EMBEDDING, config, listener);
+
+            // Check chunking settings
+            CustomModel model = (CustomModel) listener.actionGet(TIMEOUT);
+            ChunkingSettings chunkingSettings = model.getConfigurations().getChunkingSettings();
+
+            assertThat(chunkingSettings, instanceOf(SentenceBoundaryChunkingSettings.class));
+            assertThat(chunkingSettings.getChunkingStrategy(), equalTo(ChunkingStrategy.SENTENCE));
+            assertThat(chunkingSettings.maxChunkSize(), equalTo(40));
+            assertThat(((SentenceBoundaryChunkingSettings) chunkingSettings).sentenceOverlap(), equalTo(0));
+        }
+    }
+
+    public void testChunkedInfer_DenseEmbeddings_ChunkingSettingsSet() throws IOException {
         var model = createInternalEmbeddingModel(
             SimilarityMeasure.DOT_PRODUCT,
             new TextEmbeddingResponseParser("$.data[*].embedding"),
@@ -828,7 +886,7 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
         }
     }
 
-    public void testChunkedInfer_ChunkingSettingsNotSet() throws IOException {
+    public void testChunkedInfer_DenseEmbeddings_ChunkingSettingsNotSet() throws IOException {
         var model = createInternalEmbeddingModel(new TextEmbeddingResponseParser("$.data[*].embedding"), getUrl(webServer));
         String responseJson = """
             {
@@ -885,6 +943,231 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap.size(), is(1));
             assertThat(requestMap.get("input"), is(List.of("a")));
+        }
+    }
+
+    public void testChunkedInfer_SparseEmbeddings_ChunkingSettingsSet() throws IOException {
+        var model = createCustomModel(
+            TaskType.SPARSE_EMBEDDING,
+            new SparseEmbeddingResponseParser(
+                "$.result.sparse_embeddings[*].embedding[*].tokenId",
+                "$.result.sparse_embeddings[*].embedding[*].weight"
+            ),
+            getUrl(webServer),
+            ChunkingSettingsTests.createRandomChunkingSettings()
+        );
+
+        String responseJson = """
+                {
+                    "request_id": "75C50B5B-E79E-4930-****-F48DBB392231",
+                    "latency": 22,
+                    "usage": {
+                        "token_count": 11
+                    },
+                    "result": {
+                        "sparse_embeddings": [
+                            {
+                                "index": 0,
+                                "embedding": [
+                                    {
+                                        "tokenId": 6,
+                                        "weight": 0.101
+                                    },
+                                    {
+                                        "tokenId": 163040,
+                                        "weight": 0.28417
+                                    }
+                                ]
+                            },
+                            {
+                                "index": 1,
+                                "embedding": [
+                                    {
+                                        "tokenId": 4,
+                                        "weight": 0.201
+                                    },
+                                    {
+                                        "tokenId": 153040,
+                                        "weight": 0.24417
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            """;
+
+        try (var service = createService(threadPool, clientManager)) {
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+            PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
+            service.chunkedInfer(
+                model,
+                null,
+                List.of(new ChunkInferenceInput("a"), new ChunkInferenceInput("bb")),
+                new HashMap<>(),
+                InputType.INTERNAL_INGEST,
+                InferenceAction.Request.DEFAULT_TIMEOUT,
+                listener
+            );
+
+            var results = listener.actionGet(TIMEOUT);
+            assertThat(results, hasSize(2));
+
+            // Check first embedding
+            {
+                assertThat(results.get(0), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
+                var sparseEmbeddingResult = (ChunkedInferenceEmbedding) results.get(0);
+                assertThat(sparseEmbeddingResult.chunks(), hasSize(1));
+                assertEquals(new ChunkedInference.TextOffset(0, 1), sparseEmbeddingResult.chunks().get(0).offset());
+                assertThat(sparseEmbeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(SparseEmbeddingResults.Embedding.class));
+                assertThat(
+                    ((SparseEmbeddingResults.Embedding) sparseEmbeddingResult.chunks().get(0).embedding()),
+                    equalTo(
+                        new SparseEmbeddingResults.Embedding(
+                            List.of(new WeightedToken("6", 0.101f), new WeightedToken("163040", 0.28417f)),
+                            false
+                        )
+                    )
+                );
+            }
+
+            // Check second embedding
+            {
+                assertThat(results.get(1), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
+                var sparseEmbeddingResult = (ChunkedInferenceEmbedding) results.get(1);
+                assertThat(sparseEmbeddingResult.chunks(), hasSize(1));
+                assertEquals(new ChunkedInference.TextOffset(0, 2), sparseEmbeddingResult.chunks().get(0).offset());
+                assertThat(sparseEmbeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(SparseEmbeddingResults.Embedding.class));
+                assertThat(
+                    ((SparseEmbeddingResults.Embedding) sparseEmbeddingResult.chunks().get(0).embedding()),
+                    equalTo(
+                        new SparseEmbeddingResults.Embedding(
+                            List.of(new WeightedToken("4", 0.201f), new WeightedToken("153040", 0.24417f)),
+                            false
+                        )
+                    )
+                );
+            }
+
+            assertThat(webServer.requests(), hasSize(1));
+
+            var requestMap = entityAsMap(webServer.requests().get(0).getBody());
+            assertThat(requestMap.size(), is(1));
+            assertThat(requestMap.get("input"), is(List.of("a", "bb")));
+        }
+    }
+
+    public void testChunkedInfer_SparseEmbeddings_ChunkingSettingsNotSet() throws IOException {
+        var model = createCustomModel(
+            TaskType.SPARSE_EMBEDDING,
+            new SparseEmbeddingResponseParser(
+                "$.result.sparse_embeddings[*].embedding[*].tokenId",
+                "$.result.sparse_embeddings[*].embedding[*].weight"
+            ),
+            getUrl(webServer),
+            null // chunking not explicitly set
+        );
+
+        String responseJson = """
+                {
+                    "request_id": "75C50B5B-E79E-4930-****-F48DBB392231",
+                    "latency": 22,
+                    "usage": {
+                        "token_count": 11
+                    },
+                    "result": {
+                        "sparse_embeddings": [
+                            {
+                                "index": 0,
+                                "embedding": [
+                                    {
+                                        "tokenId": 6,
+                                        "weight": 0.101
+                                    },
+                                    {
+                                        "tokenId": 163040,
+                                        "weight": 0.28417
+                                    }
+                                ]
+                            },
+                            {
+                                "index": 1,
+                                "embedding": [
+                                    {
+                                        "tokenId": 4,
+                                        "weight": 0.201
+                                    },
+                                    {
+                                        "tokenId": 153040,
+                                        "weight": 0.24417
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            """;
+
+        try (var service = createService(threadPool, clientManager)) {
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+            PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
+            service.chunkedInfer(
+                model,
+                null,
+                List.of(new ChunkInferenceInput("a"), new ChunkInferenceInput("bb")),
+                new HashMap<>(),
+                InputType.INTERNAL_INGEST,
+                InferenceAction.Request.DEFAULT_TIMEOUT,
+                listener
+            );
+
+            var results = listener.actionGet(TIMEOUT);
+            assertThat(results, hasSize(2));
+
+            // Check first embedding
+            {
+                assertThat(results.get(0), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
+                var sparseEmbeddingResult = (ChunkedInferenceEmbedding) results.get(0);
+                assertThat(sparseEmbeddingResult.chunks(), hasSize(1));
+                assertEquals(new ChunkedInference.TextOffset(0, 1), sparseEmbeddingResult.chunks().get(0).offset());
+                assertThat(sparseEmbeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(SparseEmbeddingResults.Embedding.class));
+                assertThat(
+                    ((SparseEmbeddingResults.Embedding) sparseEmbeddingResult.chunks().get(0).embedding()),
+                    equalTo(
+                        new SparseEmbeddingResults.Embedding(
+                            List.of(new WeightedToken("6", 0.101f), new WeightedToken("163040", 0.28417f)),
+                            false
+                        )
+                    )
+                );
+            }
+
+            // Check second embedding
+            {
+                assertThat(results.get(1), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
+                var sparseEmbeddingResult = (ChunkedInferenceEmbedding) results.get(1);
+                assertThat(sparseEmbeddingResult.chunks(), hasSize(1));
+                assertEquals(new ChunkedInference.TextOffset(0, 2), sparseEmbeddingResult.chunks().get(0).offset());
+                assertThat(sparseEmbeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(SparseEmbeddingResults.Embedding.class));
+                assertThat(
+                    ((SparseEmbeddingResults.Embedding) sparseEmbeddingResult.chunks().get(0).embedding()),
+                    equalTo(
+                        new SparseEmbeddingResults.Embedding(
+                            List.of(new WeightedToken("4", 0.201f), new WeightedToken("153040", 0.24417f)),
+                            false
+                        )
+                    )
+                );
+            }
+
+            assertThat(webServer.requests(), hasSize(1));
+
+            // Check request
+            var requestMap = entityAsMap(webServer.requests().get(0).getBody());
+            assertThat(requestMap.size(), is(1));
+            assertThat(requestMap.get("input"), is(List.of("a", "bb")));
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Inference API] Support chunking settings for sparse embeddings in custom service (#138776)](https://github.com/elastic/elasticsearch/pull/138776)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)