### PR TITLE
Simplify MMRResultDiversificationTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversificationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversificationTests.java
@@ -9,9 +9,6 @@
 
 package org.elasticsearch.search.diversification.mmr;
 
-import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.mapper.MapperBuilderContext;
-import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.vectors.VectorData;
 import org.elasticsearch.test.ESTestCase;
@@ -61,18 +58,6 @@ public class MMRResultDiversificationTests extends ESTestCase {
     }
 
     private MMRResultDiversificationContext getRandomFloatContext(List<Integer> expectedDocIds) {
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
-
-        DenseVectorFieldMapper mapper = new DenseVectorFieldMapper.Builder(
-            "dense_vector_field",
-            IndexVersion.current(),
-            false,
-            false,
-            List.of()
-        ).elementType(DenseVectorFieldMapper.ElementType.FLOAT).dimensions(4).build(context);
-
-        DenseVectorFieldMapper.Builder builder = (DenseVectorFieldMapper.Builder) mapper.getMergeBuilder();
-        builder.elementType(DenseVectorFieldMapper.ElementType.FLOAT);
 
         Supplier<VectorData> queryVectorData = () -> new VectorData(new float[] { 0.5f, 0.2f, 0.4f, 0.4f });
         var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
@@ -99,18 +84,6 @@ public class MMRResultDiversificationTests extends ESTestCase {
     }
 
     private MMRResultDiversificationContext getRandomByteContext(List<Integer> expectedDocIds) {
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
-
-        DenseVectorFieldMapper mapper = new DenseVectorFieldMapper.Builder(
-            "dense_vector_field",
-            IndexVersion.current(),
-            false,
-            false,
-            List.of()
-        ).elementType(DenseVectorFieldMapper.ElementType.BYTE).dimensions(4).build(context);
-
-        DenseVectorFieldMapper.Builder builder = (DenseVectorFieldMapper.Builder) mapper.getMergeBuilder();
-        builder.elementType(DenseVectorFieldMapper.ElementType.BYTE);
 
         Supplier<VectorData> queryVectorData = () -> new VectorData(new byte[] { 0x50, 0x20, 0x40, 0x40 });
         var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
@@ -137,19 +110,6 @@ public class MMRResultDiversificationTests extends ESTestCase {
     }
 
     public void testMMRDiversificationIfNoSearchHits() throws IOException {
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
-
-        DenseVectorFieldMapper mapper = new DenseVectorFieldMapper.Builder(
-            "dense_vector_field",
-            IndexVersion.current(),
-            false,
-            false,
-            List.of()
-        ).elementType(DenseVectorFieldMapper.ElementType.FLOAT).dimensions(4).build(context);
-
-        // Change the element type to byte, which is incompatible with int8 HNSW index options
-        DenseVectorFieldMapper.Builder builder = (DenseVectorFieldMapper.Builder) mapper.getMergeBuilder();
-        builder.elementType(DenseVectorFieldMapper.ElementType.FLOAT);
 
         Supplier<VectorData> queryVectorData = () -> new VectorData(new float[] { 0.5f, 0.2f, 0.4f, 0.4f });
         var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.6f, 10, queryVectorData);


### PR DESCRIPTION
These currently build a DenseVectorFieldMapper, but don't actually use it anywhere, so we can just remove it.
