### PR TITLE
Unmute entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -147,9 +147,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointServiceNodeTests
   method: testGetCheckpointStats
   issue: https://github.com/elastic/elasticsearch/issues/141112
-- class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
-  method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
-  issue: https://github.com/elastic/elasticsearch/issues/141200
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:boolean.convertFromIntAndLong}
   issue: https://github.com/elastic/elasticsearch/issues/141375

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
@@ -217,7 +217,7 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
     @Override
     protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (queryVectors == null) {
-            return EMPTY_QUERY_VECTORS;
+            throw new IllegalStateException("query vectors should be set during sparse_vector query rewrite");
         }
 
         final MappedFieldType ft = context.getFieldType(fieldName);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
@@ -217,7 +217,7 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
     @Override
     protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (queryVectors == null) {
-            throw new IllegalStateException("query vectors should be set during sparse_vector query rewrite");
+            return EMPTY_QUERY_VECTORS;
         }
 
         final MappedFieldType ft = context.getFieldType(fieldName);


### PR DESCRIPTION
Unmutes the test muted by https://github.com/elastic/elasticsearch/issues/141200. I cannot reproduce this test failure, so I suggest we unmute it for now and see if it happens again.

~~A timeboxed analysis led me to `SparseVectorQueryBuilder#doToQuery` as the most likely culprit. That method rewrites to (the equivalent of) `MatchNoDocsQuery` when `queryVectors == null`, which may be what's happening here. However, that should never happen and if it does, it should be handled as an error. I changed `doToQuery` to raise an error on this case so that we can catch it in the future. Happy to put this in a separate PR if others feel this should be done independent of unmuting the test.~~ Changing this in a separate PR.

Fixes https://github.com/elastic/elasticsearch/issues/141200
