### PR TITLE
[Draft] Prevent reindex task quick back-to-back relocation

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
@@ -118,6 +119,12 @@ public abstract class AbstractAsyncBulkByScrollAction<
      * in order to compute a correct scroll keep alive time.
      */
     private final AtomicInteger totalBatchSizeInSingleScrollResponse = new AtomicInteger();
+    /**
+     * Minimum time a relocated task must run before it can be relocated again.
+     * Prevents quick back-to-back relocations that could cause issues with tasks endpoints,
+     * as of writing, mainly race condition in list where a two-listing approach could hit two relocations and have missing results.
+     */
+    private final long relocationCooldownNanos;
 
     AbstractAsyncBulkByScrollAction(
         BulkByScrollTask task,
@@ -130,7 +137,8 @@ public abstract class AbstractAsyncBulkByScrollAction<
         Request mainRequest,
         ActionListener<BulkByScrollResponse> listener,
         @Nullable ScriptService scriptService,
-        @Nullable ReindexSslConfig sslConfig
+        @Nullable ReindexSslConfig sslConfig,
+        TimeValue maxTaskShutdownGracePeriod
     ) {
         this(
             task,
@@ -144,7 +152,8 @@ public abstract class AbstractAsyncBulkByScrollAction<
             mainRequest,
             listener,
             scriptService,
-            sslConfig
+            sslConfig,
+            maxTaskShutdownGracePeriod
         );
     }
 
@@ -160,7 +169,8 @@ public abstract class AbstractAsyncBulkByScrollAction<
         Request mainRequest,
         ActionListener<BulkByScrollResponse> listener,
         @Nullable ScriptService scriptService,
-        @Nullable ReindexSslConfig sslConfig
+        @Nullable ReindexSslConfig sslConfig,
+        TimeValue maxTaskShutdownGracePeriod
     ) {
         this.task = task;
         this.scriptService = scriptService;
@@ -175,6 +185,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
         this.bulkClient = bulkClient;
         this.threadPool = threadPool;
         this.mainRequest = mainRequest;
+        this.relocationCooldownNanos = computeMinRelocationAgeNanos(maxTaskShutdownGracePeriod);
         this.listener = listener;
         BackoffPolicy backoffPolicy = buildBackoffPolicy();
         bulkRetry = new Retry(BackoffPolicy.wrap(backoffPolicy, worker::countBulkRetry), threadPool);
@@ -183,6 +194,13 @@ public abstract class AbstractAsyncBulkByScrollAction<
             prepareSearchRequest(mainRequest, needsSourceDocumentVersions, needsSourceDocumentSeqNoAndPrimaryTerm, needsVectors)
         );
         scriptApplier = Objects.requireNonNull(buildScriptApplier(), "script applier must not be null");
+    }
+
+    /** Computes the minimum time a relocated task must run before it can be relocated again. Visible for testing. */
+    static long computeMinRelocationAgeNanos(TimeValue maxTaskShutdownGracePeriod) {
+        assert maxTaskShutdownGracePeriod.nanos() >= 0 : "shutdownTimeout must be non-negative"; // implicit nullcheck
+        // no point of going above 30 seconds since it solves our issue with race conditions in list
+        return Math.min(maxTaskShutdownGracePeriod.nanos() / 2, TimeUnit.SECONDS.toNanos(30));
     }
 
     /**
@@ -556,39 +574,45 @@ public abstract class AbstractAsyncBulkByScrollAction<
             return;
         }
         if (task.isRelocationRequested()) {
-            final Optional<String> nodeToRelocateTo = worker.getNodeToRelocateTo();
-            if (nodeToRelocateTo.isPresent()) {
-                final String scrollId = asyncResponse.response().getScrollId();
-                final Version remoteVersion = paginatedHitSource instanceof RemoteScrollablePaginatedHitSource s
-                    ? s.remoteVersion().orElseThrow(() -> new IllegalStateException("Remote scroll version should be set"))
-                    : null;
-                final var workerResumeInfo = new ResumeInfo.ScrollWorkerResumeInfo(
-                    scrollId,
-                    startTimeEpochMillis.get(),
-                    worker.getStatus(),
-                    remoteVersion
-                );
-                final ResumeInfo resumeInfo = new ResumeInfo(task.relocationOrigin(), workerResumeInfo, null);
-                // This response is a local carrier for resumeInfo — for higher-level code to handle relocation and then discard.
-                // However, status must be accurate for sliced tasks only, the leader state stores this response and derives
-                // its own combined status from it to serialize to .tasks index.
-                // For non-sliced, status is unused (comes from the worker state).
-                final BulkByScrollResponse response = new BulkByScrollResponse(
-                    TimeValue.MINUS_ONE,
-                    task.getStatus(),
-                    List.of(),
-                    List.of(),
-                    false,
-                    resumeInfo
-                );
-                // Don't call finishHim — it clears the pagination which the relocated task needs.
-                // Do close local resources (e.g. the remote REST client) that won't be reused.
-                paginatedHitSource.cleanupWithoutClosingPagination(
-                    threadPool.getThreadContext().preserveContext(() -> listener.onResponse(response))
-                );
-                return;
+            final boolean tooYoungToRelocateAgain = task.isRelocatedTask()
+                && (System.nanoTime() - task.getStartTimeNanos()) < relocationCooldownNanos;
+            if (tooYoungToRelocateAgain) {
+                logger.debug("skipping re-relocation for recently-relocated task [{}]", task.getId());
+            } else {
+                final Optional<String> nodeToRelocateTo = worker.getNodeToRelocateTo();
+                if (nodeToRelocateTo.isPresent()) {
+                    final String scrollId = asyncResponse.response().getScrollId();
+                    final Version remoteVersion = paginatedHitSource instanceof RemoteScrollablePaginatedHitSource s
+                        ? s.remoteVersion().orElseThrow(() -> new IllegalStateException("Remote scroll version should be set"))
+                        : null;
+                    final var workerResumeInfo = new ResumeInfo.ScrollWorkerResumeInfo(
+                        scrollId,
+                        startTimeEpochMillis.get(),
+                        worker.getStatus(),
+                        remoteVersion
+                    );
+                    final ResumeInfo resumeInfo = new ResumeInfo(task.relocationOrigin(), workerResumeInfo, null);
+                    // This response is a local carrier for resumeInfo — for higher-level code to handle relocation and then discard.
+                    // However, status must be accurate for sliced tasks only, the leader state stores this response and derives
+                    // its own combined status from it to serialize to .tasks index.
+                    // For non-sliced, status is unused (comes from the worker state).
+                    final BulkByScrollResponse response = new BulkByScrollResponse(
+                        TimeValue.MINUS_ONE,
+                        task.getStatus(),
+                        List.of(),
+                        List.of(),
+                        false,
+                        resumeInfo
+                    );
+                    // Don't call finishHim — it clears the pagination which the relocated task needs.
+                    // Do close local resources (e.g. the remote REST client) that won't be reused.
+                    paginatedHitSource.cleanupWithoutClosingPagination(
+                        threadPool.getThreadContext().preserveContext(() -> listener.onResponse(response))
+                    );
+                    return;
+                }
             }
-            // if the task has no node to relocate to, continue. it might finish before shutdown or a suitable node might join the cluster.
+            // if we can't relocate, continue. we could still finish gracefully, or eventually meet the conditions for relocation.
         }
 
         int totalBatchSize = totalBatchSizeInSingleScrollResponse.getAndSet(0);

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
@@ -31,9 +32,10 @@ public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<De
         ThreadPool threadPool,
         DeleteByQueryRequest request,
         ScriptService scriptService,
-        ActionListener<BulkByScrollResponse> listener
+        ActionListener<BulkByScrollResponse> listener,
+        TimeValue maxTaskShutdownGracePeriod
     ) {
-        super(task, false, true, false, logger, client, threadPool, request, listener, scriptService, null);
+        super(task, false, true, false, logger, client, threadPool, request, listener, scriptService, null, maxTaskShutdownGracePeriod);
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -66,6 +66,7 @@ import org.elasticsearch.index.reindex.ResumeBulkByScrollRequest;
 import org.elasticsearch.index.reindex.ResumeBulkByScrollResponse;
 import org.elasticsearch.index.reindex.ResumeReindexAction;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
+import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.reindex.remote.RemoteReindexingUtils;
 import org.elasticsearch.reindex.remote.RemoteScrollablePaginatedHitSource;
 import org.elasticsearch.script.CtxMap;
@@ -121,6 +122,7 @@ public class Reindexer {
     private final TransportService transportService;
     private final ReindexRelocationNodePicker relocationNodePicker;
     private final FeatureService featureService;
+    private final TimeValue reindexShutdownGracePeriod;
 
     Reindexer(
         ClusterService clusterService,
@@ -145,6 +147,7 @@ public class Reindexer {
         this.transportService = transportService;
         this.relocationNodePicker = Objects.requireNonNull(relocationNodePicker);
         this.featureService = featureService;
+        this.reindexShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
     }
 
     public void initTask(BulkByScrollTask task, ReindexRequest request, ActionListener<Void> listener) {
@@ -210,7 +213,8 @@ public class Reindexer {
                 reindexSslConfig,
                 request,
                 listener,
-                remoteVersion
+                remoteVersion,
+                reindexShutdownGracePeriod
             );
             searchAction.start();
         };
@@ -689,7 +693,8 @@ public class Reindexer {
             ReindexSslConfig sslConfig,
             ReindexRequest request,
             ActionListener<BulkByScrollResponse> listener,
-            @Nullable Version remoteVersion
+            @Nullable Version remoteVersion,
+            TimeValue maxTaskShutdownGracePeriod
         ) {
             super(
                 task,
@@ -707,7 +712,8 @@ public class Reindexer {
                 request,
                 listener,
                 scriptService,
-                sslConfig
+                sslConfig,
+                maxTaskShutdownGracePeriod
             );
             this.destinationIndexIdMapper = destinationIndexMode(state).idFieldMapperWithoutFieldData();
             this.remoteVersion = remoteVersion;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
@@ -17,11 +17,13 @@ import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -36,6 +38,7 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
     private final ScriptService scriptService;
     private final ClusterService clusterService;
     private final DeleteByQueryMetrics deleteByQueryMetrics;
+    private final TimeValue taskShutdownGracePeriod;
 
     @Inject
     public TransportDeleteByQueryAction(
@@ -53,6 +56,8 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
         this.scriptService = scriptService;
         this.clusterService = clusterService;
         this.deleteByQueryMetrics = deleteByQueryMetrics;
+        // todo: this is added to have a safer default in the future, if relocations are added to delete-by-query, and this isn't updated.
+        this.taskShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
     }
 
     @Override
@@ -84,7 +89,8 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
                         if (deleteByQueryMetrics != null) {
                             deleteByQueryMetrics.recordTookTime(elapsedTime);
                         }
-                    })
+                    }),
+                    taskShutdownGracePeriod
                 ).start();
             }
         );

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
@@ -19,12 +19,14 @@ import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.UpdateByQueryAction;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.script.CtxMap;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
@@ -46,6 +48,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
     private final ScriptService scriptService;
     private final ClusterService clusterService;
     private final UpdateByQueryMetrics updateByQueryMetrics;
+    private final TimeValue taskShutdownGracePeriod;
 
     @Inject
     public TransportUpdateByQueryAction(
@@ -63,6 +66,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         this.scriptService = scriptService;
         this.clusterService = clusterService;
         this.updateByQueryMetrics = updateByQueryMetrics;
+        // todo: this is added to have a safer default in the future, if relocations are added to update-by-query, and this isn't updated.
+        this.taskShutdownGracePeriod = ShutdownPrepareService.MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(clusterService.getSettings());
     }
 
     @Override
@@ -94,7 +99,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
                         if (updateByQueryMetrics != null) {
                             updateByQueryMetrics.recordTookTime(elapsedTime);
                         }
-                    })
+                    }),
+                    taskShutdownGracePeriod
                 ).start();
             }
         );
@@ -112,7 +118,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
             ThreadPool threadPool,
             ScriptService scriptService,
             UpdateByQueryRequest request,
-            ActionListener<BulkByScrollResponse> listener
+            ActionListener<BulkByScrollResponse> listener,
+            TimeValue maxTaskShutdownGracePeriod
         ) {
             super(
                 task,
@@ -126,7 +133,8 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
                 request,
                 listener,
                 scriptService,
-                null
+                null,
+                maxTaskShutdownGracePeriod
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.reindex;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -109,6 +110,7 @@ import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
 import static org.elasticsearch.common.BackoffPolicy.constantBackoff;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
+import static org.elasticsearch.reindex.AbstractAsyncBulkByScrollAction.computeMinRelocationAgeNanos;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
@@ -992,6 +994,125 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         assertTrue("asyncResponse.done() should be called for normal flow", doneCalled.get());
     }
 
+    public void testComputeMinRelocationAgeNanosUsesTimeout() {
+        // When shutdown timeout / 2 <= 30s, use timeout / 2
+        final TimeValue timeout = TimeValue.timeValueSeconds(between(0, 60));
+        final long timeoutDividedByHalf = timeout.nanos() / 2;
+        assertThat(computeMinRelocationAgeNanos(timeout), equalTo(timeoutDividedByHalf));
+    }
+
+    public void testComputeMinRelocationAgeNanosLargeTimeoutIsCapped() {
+        // 61 since it's the first value to go above 30s if divided by 2
+        final long timeoutNanos = randomLongBetween(TimeUnit.SECONDS.toNanos(61), Long.MAX_VALUE);
+        // When shutdown timeout / 2 > 30s, cap at 30s
+        assertThat(computeMinRelocationAgeNanos(TimeValue.timeValueNanos(timeoutNanos)), equalTo(TimeUnit.SECONDS.toNanos(30)));
+    }
+
+    public void testNotifyDoneSkipsReRelocationForRecentlyRelocatedTask() {
+        // Re-register with a relocated task
+        taskManager.unregister(testTask);
+        testRequest.setResumeInfo(
+            new ResumeInfo(
+                new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong()),
+                randomResumeInfo(),
+                null
+            )
+        );
+        testTask = (BulkByScrollTask) taskManager.register("don'tcare", "hereeither", testRequest);
+        testTask.setWorker(testRequest.getRequestsPerSecond(), null);
+        worker = testTask.getWorkerState();
+        assertTrue(testTask.isRelocatedTask());
+
+        testTask.requestRelocation();
+        worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
+
+        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
+
+        final AtomicBoolean doneCalled = new AtomicBoolean();
+        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            @Override
+            public PaginatedHitSource.Response response() {
+                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId());
+            }
+
+            @Override
+            public void done(final TimeValue extraKeepAlive) {
+                doneCalled.set(true);
+            }
+        });
+        action.notifyDone(System.nanoTime(), asyncResponse, 0);
+
+        assertTrue("asyncResponse.done() should be called because re-relocation was skipped", doneCalled.get());
+    }
+
+    public void testNotifyDoneAllowsRelocationForOldRelocatedTask() {
+        // Re-register with a relocated task
+        taskManager.unregister(testTask);
+        testRequest.setResumeInfo(
+            new ResumeInfo(
+                new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong()),
+                randomResumeInfo(),
+                null
+            )
+        );
+        testTask = (BulkByScrollTask) taskManager.register("don'tcare", "hereeither", testRequest);
+        testTask.setWorker(testRequest.getRequestsPerSecond(), null);
+        worker = testTask.getWorkerState();
+        assertTrue(testTask.isRelocatedTask());
+
+        testTask.requestRelocation();
+        worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
+
+        final String expectedScrollId = scrollId();
+        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.ZERO);
+        action.setScroll(expectedScrollId);
+
+        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            @Override
+            public PaginatedHitSource.Response response() {
+                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
+            }
+
+            @Override
+            public void done(final TimeValue extraKeepAlive) {
+                fail("done() should not be called because relocation should proceed");
+            }
+        });
+        action.notifyDone(System.nanoTime(), asyncResponse, 0);
+
+        assertTrue(listener.isDone());
+        final BulkByScrollResponse response = listener.actionGet();
+        assertTrue(response.getTaskResumeInfo().isPresent());
+    }
+
+    public void testNotifyDoneCooldownDoesNotApplyToNonRelocatedTask() {
+        // Use a non-relocated task (the default testTask has null relocationOrigin)
+        testTask.requestRelocation();
+        worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
+
+        final String expectedScrollId = scrollId();
+        // Large cooldown, but task is not relocated so it should not apply
+        final DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction(TimeValue.timeValueHours(1));
+        action.setScroll(expectedScrollId);
+
+        final var asyncResponse = new AbstractAsyncBulkByScrollAction.ScrollConsumableHitsResponse(new PaginatedHitSource.AsyncResponse() {
+            @Override
+            public PaginatedHitSource.Response response() {
+                return new PaginatedHitSource.Response(false, emptyList(), 0, emptyList(), scrollId);
+            }
+
+            @Override
+            public void done(final TimeValue extraKeepAlive) {
+                fail("done() should not be called because relocation should proceed");
+            }
+        });
+        action.notifyDone(System.nanoTime(), asyncResponse, 0);
+
+        assertTrue(listener.isDone());
+        final BulkByScrollResponse response = listener.actionGet();
+        assertTrue(response.getTaskResumeInfo().isPresent());
+    }
+
     public void testNotifyDoneIgnoresRelocationWhenNotRequested() throws Exception {
         // do NOT call testTask.requestRelocation()
         worker.setNodeToRelocateToSupplier(() -> Optional.of("target-node"));
@@ -1085,6 +1206,10 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         DummyAbstractBulkByScrollRequest,
         DummyTransportAsyncBulkByScrollAction> {
         DummyAsyncBulkByScrollAction() {
+            this(TimeValue.ZERO);
+        }
+
+        DummyAsyncBulkByScrollAction(TimeValue maxTaskShutdownGracePeriod) {
             super(
                 testTask,
                 randomBoolean(),
@@ -1096,7 +1221,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 testRequest,
                 listener,
                 null,
-                null
+                null,
+                maxTaskShutdownGracePeriod
             );
         }
 
@@ -1324,5 +1450,29 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         AtomicBoolean called = new AtomicBoolean();
         consumer.accept(() -> assertTrue(called.compareAndSet(false, true)));
         assertBusy(() -> assertTrue(called.get()));
+    }
+
+    private ResumeInfo.ScrollWorkerResumeInfo randomResumeInfo() {
+        return new ResumeInfo.ScrollWorkerResumeInfo(
+            randomAlphaOfLength(10),
+            randomLong(),
+            new BulkByScrollTask.Status(
+                randomNonNegativeInt(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeInt(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomTimeValue(),
+                randomFloat(),
+                randomBoolean() ? null : randomAlphaOfLength(10),
+                randomTimeValue()
+            ),
+            randomBoolean() ? null : Version.CURRENT
+        );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -120,7 +120,8 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
             null,
             request(),
             listener(),
-            randomBoolean() ? null : Version.CURRENT
+            randomBoolean() ? null : Version.CURRENT,
+            randomPositiveTimeValue()
         );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -84,7 +84,8 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
                 null,
                 request(),
                 listener(),
-                randomBoolean() ? null : Version.CURRENT
+                randomBoolean() ? null : Version.CURRENT,
+                randomPositiveTimeValue()
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -103,7 +103,8 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
             sslConfig,
             request,
             listener(),
-            randomBoolean() ? null : Version.CURRENT
+            randomBoolean() ? null : Version.CURRENT,
+            randomPositiveTimeValue()
         );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -547,6 +547,7 @@ public class ReindexerTests extends ESTestCase {
             final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
             when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
             when(clusterService.localNode()).thenReturn(localNode);
+            when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
             final ProjectResolver projectResolver = mock(ProjectResolver.class);
             when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -616,6 +617,7 @@ public class ReindexerTests extends ESTestCase {
                 final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
                 when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
                 when(clusterService.localNode()).thenReturn(localNode);
+                when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
                 final ProjectResolver projectResolver = mock(ProjectResolver.class);
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -694,6 +696,7 @@ public class ReindexerTests extends ESTestCase {
                 final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
                 when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
                 when(clusterService.localNode()).thenReturn(localNode);
+                when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
                 final ProjectResolver projectResolver = mock(ProjectResolver.class);
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -766,6 +769,7 @@ public class ReindexerTests extends ESTestCase {
                 final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
                 when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
                 when(clusterService.localNode()).thenReturn(localNode);
+                when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
                 final ProjectResolver projectResolver = mock(ProjectResolver.class);
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -840,6 +844,7 @@ public class ReindexerTests extends ESTestCase {
                 final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
                 when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
                 when(clusterService.localNode()).thenReturn(localNode);
+                when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
                 final ProjectResolver projectResolver = mock(ProjectResolver.class);
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -914,6 +919,7 @@ public class ReindexerTests extends ESTestCase {
                 final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
                 when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
                 when(clusterService.localNode()).thenReturn(localNode);
+                when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
                 final ProjectResolver projectResolver = mock(ProjectResolver.class);
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -1189,6 +1195,7 @@ public class ReindexerTests extends ESTestCase {
         DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
         when(clusterService.localNode()).thenReturn(localNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
         ProjectResolver projectResolver = mock(ProjectResolver.class);
         when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
@@ -1344,6 +1351,7 @@ public class ReindexerTests extends ESTestCase {
     private static Reindexer reindexerWithRelocation(ClusterService clusterService, TransportService transportService) {
         final ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.generic()).thenReturn(mock(ExecutorService.class));
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         return new Reindexer(
             clusterService,
             mock(ProjectResolver.class),

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
@@ -43,7 +43,8 @@ public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionM
                 UpdateByQueryMetadataTests.this.threadPool,
                 null,
                 request(),
-                listener()
+                listener(),
+                randomPositiveTimeValue()
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
@@ -53,7 +53,8 @@ public class UpdateByQueryVersionTests extends AbstractAsyncBulkByScrollActionMe
                 UpdateByQueryVersionTests.this.threadPool,
                 null,
                 request(),
-                listener()
+                listener(),
+                randomPositiveTimeValue()
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.script.ScriptService;
@@ -53,6 +55,8 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
     protected TransportUpdateByQueryAction.AsyncIndexBySearchAction action(ScriptService scriptService, UpdateByQueryRequest request) {
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
         TransportUpdateByQueryAction transportAction = new TransportUpdateByQueryAction(
             threadPool,
@@ -60,7 +64,7 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
             null,
             transportService,
             scriptService,
-            null,
+            clusterService,
             null
         );
         return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(
@@ -70,7 +74,8 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
             threadPool,
             scriptService,
             request,
-            listener()
+            listener(),
+            randomPositiveTimeValue()
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -56,6 +56,7 @@ import static org.elasticsearch.core.TimeValue.timeValueNanos;
 public class BulkByScrollTask extends CancellableTask {
 
     private final boolean eligibleForRelocationOnShutdown;
+    private final boolean relocatedTask;
     // if task is a slice, RelocationOrigin won't be correct because it won't be the leader here, but it's overridden in the leader state
     private final ResumeInfo.RelocationOrigin relocationOrigin;
     private volatile LeaderBulkByScrollTaskState leaderState;
@@ -74,6 +75,7 @@ public class BulkByScrollTask extends CancellableTask {
     ) {
         super(taskId.getId(), type, action, description, parentTaskId, headers);
         this.eligibleForRelocationOnShutdown = eligibleForRelocationOnShutdown;
+        this.relocatedTask = relocationOrigin != null;
         this.relocationOrigin = relocationOrigin != null ? relocationOrigin : new ResumeInfo.RelocationOrigin(taskId, this.startTime);
     }
 
@@ -229,6 +231,11 @@ public class BulkByScrollTask extends CancellableTask {
     /** Returns the relocation origin if this task is a relocated continuation. */
     public ResumeInfo.RelocationOrigin relocationOrigin() {
         return relocationOrigin;
+    }
+
+    /** Returns true if this task was created via relocation from another node. */
+    public boolean isRelocatedTask() {
+        return relocatedTask;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskTests.java
@@ -28,6 +28,7 @@ import static java.lang.Math.min;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueNanos;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class BulkByScrollTaskTests extends ESTestCase {
 
@@ -37,15 +38,19 @@ public class BulkByScrollTaskTests extends ESTestCase {
      * {@link BulkByScrollTask#setWorker(float, Integer)} is called.
      */
     private static BulkByScrollTask createTask(boolean eligibleForRelocationOnShutdown) {
+        return createTask(eligibleForRelocationOnShutdown, randomBoolean());
+    }
+
+    private static BulkByScrollTask createTask(boolean eligibleForRelocationOnShutdown, boolean isRelocated) {
         TaskId taskId = randomTaskId();
         String type = randomAlphaOfLengthBetween(1, 10);
         String action = randomAlphaOfLengthBetween(1, 10);
         String description = randomAlphaOfLengthBetween(0, 20);
         TaskId parentTaskId = randomTaskId();
         Map<String, String> headers = randomBoolean() ? Collections.emptyMap() : Map.of("header", randomAlphaOfLength(5));
-        ResumeInfo.RelocationOrigin origin = randomBoolean()
-            ? null
-            : new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong());
+        ResumeInfo.RelocationOrigin origin = isRelocated
+            ? new ResumeInfo.RelocationOrigin(new TaskId(randomAlphaOfLength(5), randomNonNegativeLong()), randomNonNegativeLong())
+            : null;
         return new BulkByScrollTask(taskId, type, action, description, parentTaskId, headers, eligibleForRelocationOnShutdown, origin);
     }
 
@@ -474,6 +479,12 @@ public class BulkByScrollTaskTests extends ESTestCase {
             () -> task.taskInfoGivenSubtaskInfo(localNodeId, sliceInfoList)
         );
         assertThat(exception.getMessage(), containsString("not set to be a leader"));
+    }
+
+    public void testTaskIsRelocatedIfRelocationOriginIsSet() {
+        final boolean isRelocated = randomBoolean();
+        final BulkByScrollTask task = createTask(randomBoolean(), isRelocated);
+        assertThat(task.isRelocatedTask(), equalTo(isRelocated));
     }
 
     private static float randomFloatBetween(float min, float max) {


### PR DESCRIPTION
- Relocated reindex doesn't relocate again for a short time period, to reduce changes of race conditions in `GET _reindex` endpoint with new approach to handle race conditions
- Ran each added test for 10k iterations