### PR TITLE
[8.19] Remove Security Manager usage from x-pack ml (#145043)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
@@ -21,8 +21,6 @@ import org.ojalgo.structure.Access1D;
 import org.ojalgo.type.CalendarDateDuration;
 import org.ojalgo.type.CalendarDateUnit;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -325,7 +323,7 @@ class LinearProgrammingPlanSolver {
                 .setLinearFactors(allocations, Access1D.wrap(modelMemories));
         }
 
-        Optimisation.Result result = privilegedModelMaximise(model);
+        Optimisation.Result result = model.maximise();
 
         if (result.getState().isFeasible() == false) {
             logger.debug("Linear programming solution state [{}] is not feasible", result.getState());
@@ -345,11 +343,6 @@ class LinearProgrammingPlanSolver {
         }
         logger.debug(() -> "LP solver result =\n" + prettyPrintSolverResult(assignmentValues, allocationValues));
         return true;
-    }
-
-    @SuppressWarnings("removal")
-    private static Optimisation.Result privilegedModelMaximise(ExpressionsBasedModel model) {
-        return AccessController.doPrivileged((PrivilegedAction<Optimisation.Result>) () -> model.maximise());
     }
 
     private int memoryComplexity() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
@@ -12,8 +12,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -82,21 +80,19 @@ public final class DomainSplitFunction {
         );
 
         static {
-            exact = AccessController.doPrivileged((PrivilegedAction<Map<String, String>>) () -> {
-                try (
-                    var stream = DomainSplitFunction.class.getClassLoader()
-                        .getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
-                ) {
-                    return Streams.readAllLines(stream)
-                        .stream()
-                        .map(line -> line.split("="))
-                        .collect(
-                            Collectors.<String[], String, String>toUnmodifiableMap(split -> split[0].intern(), split -> split[1].intern())
-                        );
-                } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
+            try (
+                var stream = DomainSplitFunction.class.getClassLoader()
+                    .getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
+            ) {
+                exact = Streams.readAllLines(stream)
+                    .stream()
+                    .map(line -> line.split("="))
+                    .collect(
+                        Collectors.<String[], String, String>toUnmodifiableMap(split -> split[0].intern(), split -> split[1].intern())
+                    );
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
@@ -171,15 +167,11 @@ public final class DomainSplitFunction {
     }
 
     public static List<String> domainSplit(String host, Map<String, Object> params) {
-        // NOTE: we don't check SpecialPermission because this will be called (indirectly) from scripts
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            deprecationLogger.warn(
-                DeprecationCategory.API,
-                "domainSplit",
-                "Method [domainSplit] taking params is deprecated. Remove the params argument."
-            );
-            return null;
-        });
+        deprecationLogger.warn(
+            DeprecationCategory.API,
+            "domainSplit",
+            "Method [domainSplit] taking params is deprecated. Remove the params argument."
+        );
         return domainSplit(host);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.ml.utils;
 
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
@@ -21,8 +19,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.Duration;
 
 /**
@@ -61,9 +57,8 @@ public class NamedPipeHelper {
     }
 
     /**
-     * The default path where named pipes will be created.  On *nix they can be created elsewhere
-     * (subject to security manager constraints), but on Windows this is the ONLY place they can
-     * be created.
+     * The default path where named pipes will be created.  On *nix they can be created elsewhere,
+     * but on Windows this is the ONLY place they can be created.
      * @return The directory prefix as a string.
      */
     public String getDefaultPipeDirectoryPrefix(Environment env) {
@@ -104,6 +99,7 @@ public class NamedPipeHelper {
      * @return A stream opened to read from the named pipe.
      * @throws IOException if the named pipe cannot be opened.
      */
+    @SuppressForbidden(reason = "Files.newInputStream doesn't work with Windows named pipes")
     public InputStream openNamedPipeInputStream(Path file, Duration timeout) throws IOException {
         long timeoutMillisRemaining = timeout.toMillis();
 
@@ -111,11 +107,6 @@ public class NamedPipeHelper {
         // but luckily there's an even simpler check (that's not possible on *nix)
         if (Constants.WINDOWS && file.toString().startsWith(WIN_PIPE_PREFIX) == false) {
             throw new IOException(file + " is not a named pipe");
-        }
-
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
         }
 
         // Try to open the file periodically until the timeout expires, then, if
@@ -126,11 +117,10 @@ public class NamedPipeHelper {
                 throw new IOException(file + " is not a named pipe");
             }
             try {
-                PrivilegedInputPipeOpener privilegedInputPipeOpener = new PrivilegedInputPipeOpener(file);
-                return AccessController.doPrivileged(privilegedInputPipeOpener);
-            } catch (RuntimeException e) {
+                return new FileInputStream(file.toString());
+            } catch (IOException e) {
                 if (timeoutMillisRemaining <= 0) {
-                    propagatePrivilegedException(e);
+                    throw e;
                 }
                 long thisSleep = Math.min(timeoutMillisRemaining, PAUSE_TIME_MS);
                 timeoutMillisRemaining -= thisSleep;
@@ -138,7 +128,7 @@ public class NamedPipeHelper {
                     Thread.sleep(thisSleep);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    propagatePrivilegedException(e);
+                    throw e;
                 }
             }
         }
@@ -182,6 +172,7 @@ public class NamedPipeHelper {
      * @return A stream opened to read from the named pipe.
      * @throws IOException if the named pipe cannot be opened.
      */
+    @SuppressForbidden(reason = "Files.newOutputStream doesn't work with Windows named pipes")
     private static OutputStream openNamedPipeOutputStreamWindows(Path file, Duration timeout) throws IOException {
         long timeoutMillisRemaining = timeout.toMillis();
 
@@ -190,20 +181,14 @@ public class NamedPipeHelper {
             throw new IOException(file + " is not a named pipe");
         }
 
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
-        }
-
         // Try to open the file periodically until the timeout expires, then, if
         // it's still not available throw the exception from FileOutputStream
         while (true) {
             try {
-                PrivilegedOutputPipeOpener privilegedOutputPipeOpener = new PrivilegedOutputPipeOpener(file);
-                return AccessController.doPrivileged(privilegedOutputPipeOpener);
-            } catch (RuntimeException e) {
+                return new FileOutputStream(file.toString());
+            } catch (IOException e) {
                 if (timeoutMillisRemaining <= 0) {
-                    propagatePrivilegedException(e);
+                    throw e;
                 }
                 long thisSleep = Math.min(timeoutMillisRemaining, PAUSE_TIME_MS);
                 timeoutMillisRemaining -= thisSleep;
@@ -211,7 +196,7 @@ public class NamedPipeHelper {
                     Thread.sleep(thisSleep);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    propagatePrivilegedException(e);
+                    throw e;
                 }
             }
         }
@@ -256,62 +241,4 @@ public class NamedPipeHelper {
         return Files.newOutputStream(file);
     }
 
-    /**
-     * To work around the limitation that privileged actions cannot throw checked exceptions the classes
-     * below wrap IOExceptions in RuntimeExceptions.  If such an exception needs to be propagated back
-     * to a user of this class then it's nice if they get the original IOException rather than having
-     * it wrapped in a RuntimeException.  However, the privileged calls could also possibly throw other
-     * RuntimeExceptions, so this method accounts for this case too.
-     */
-    private static void propagatePrivilegedException(RuntimeException e) throws IOException {
-        Throwable ioe = ExceptionsHelper.unwrap(e, IOException.class);
-        if (ioe != null) {
-            throw (IOException) ioe;
-        }
-        throw e;
-    }
-
-    /**
-     * Used to work around the limitation that privileged actions cannot throw checked exceptions.
-     */
-    private static class PrivilegedInputPipeOpener implements PrivilegedAction<InputStream> {
-
-        private final Path file;
-
-        PrivilegedInputPipeOpener(Path file) {
-            this.file = file;
-        }
-
-        @SuppressForbidden(reason = "Files.newInputStream doesn't work with Windows named pipes")
-        public InputStream run() {
-            try {
-                return new FileInputStream(file.toString());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-    }
-
-    /**
-     * Used to work around the limitation that privileged actions cannot throw checked exceptions.
-     */
-    private static class PrivilegedOutputPipeOpener implements PrivilegedAction<OutputStream> {
-
-        private final Path file;
-
-        PrivilegedOutputPipeOpener(Path file) {
-            this.file = file;
-        }
-
-        @SuppressForbidden(reason = "Files.newOutputStream doesn't work with Windows named pipes")
-        public OutputStream run() {
-            try {
-                return new FileOutputStream(file.toString());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-    }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove Security Manager usage from x-pack ml (#145043)