### PR TITLE
ESQL: Centralize datasource dependency versions

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -25,6 +25,9 @@ ldapsdk             = 7.0.3
 
 antlr4            = 4.13.1
 iceberg           = 1.10.1
+hadoop            = 3.4.3
+orc               = 2.3.0
+parquet           = 1.17.0
 aircompressor     = 2.0.3
 snappyJava        = 1.1.10.8
 # bouncy castle version for non-fips. fips jars use a different version

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -25,7 +25,6 @@ ldapsdk             = 7.0.3
 
 antlr4            = 4.13.1
 iceberg           = 1.10.1
-hadoop            = 3.4.3
 orc               = 2.3.0
 parquet           = 1.17.0
 aircompressor     = 2.0.3

--- a/x-pack/plugin/esql-datasource-iceberg/build.gradle
+++ b/x-pack/plugin/esql-datasource-iceberg/build.gradle
@@ -9,8 +9,6 @@ apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
 versions << [
-  'hadoop'       : '3.4.3',
-  'parquet'      : '1.17.0',
   'arrow'        : '18.3.0',
   'caffeine'     : '2.9.3',
   'checker_qual' : '3.42.0',
@@ -116,8 +114,8 @@ dependencies {
   // 2. ParquetReadOptions.Builder() constructor creates HadoopParquetConfiguration internally,
   //    which requires the Configuration class to be present even when using non-Hadoop code paths
   // 3. parquet-hadoop-bundle includes shaded Parquet classes but not Hadoop Configuration
-  implementation('org.apache.hadoop:hadoop-client-api:3.4.3')
-  implementation('org.apache.hadoop:hadoop-client-runtime:3.4.3')
+  implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}")
+  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}")
   
   // Arrow dependencies for compile time - provided at runtime by x-pack-esql's arrow module
   compileOnly("org.apache.arrow:arrow-vector:${versions.arrow}")

--- a/x-pack/plugin/esql-datasource-iceberg/build.gradle
+++ b/x-pack/plugin/esql-datasource-iceberg/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
 versions << [
+  'hadoop'       : '3.4.3',
   'arrow'        : '18.3.0',
   'caffeine'     : '2.9.3',
   'checker_qual' : '3.42.0',

--- a/x-pack/plugin/esql-datasource-iceberg/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.checkerframework', module: 'checker-qual'
   }
-  javaRestTestImplementation('org.apache.parquet:parquet-hadoop-bundle:1.17.0')
+  javaRestTestImplementation("org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}")
   javaRestTestImplementation('com.github.ben-manes.caffeine:caffeine:2.9.3') {
     exclude group: 'org.checkerframework', module: 'checker-qual'
   }

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -8,11 +8,6 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
-versions << [
-  'hadoop' : '3.4.3',
-  'orc'    : '2.3.0',
-]
-
 esplugin {
   name = 'esql-datasource-orc'
   description = 'ORC format support for ESQL external data sources'
@@ -53,10 +48,10 @@ dependencies {
 
   // Hadoop dependencies - required because ORC's Reader API uses Hadoop Configuration,
   // Path, and FileSystem in its public interfaces.
-  implementation('org.apache.hadoop:hadoop-client-api:3.4.3') {
+  implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
-  implementation('org.apache.hadoop:hadoop-client-runtime:3.4.3') {
+  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
 

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -8,6 +8,10 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
+versions << [
+  'hadoop' : '3.4.3',
+]
+
 esplugin {
   name = 'esql-datasource-orc'
   description = 'ORC format support for ESQL external data sources'

--- a/x-pack/plugin/esql-datasource-parquet/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/build.gradle
@@ -8,11 +8,6 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
-versions << [
-  'hadoop'  : '3.4.3',
-  'parquet' : '1.17.0',
-]
-
 esplugin {
   name = 'esql-datasource-parquet'
   description = 'Parquet format support for ESQL external data sources'
@@ -42,8 +37,8 @@ dependencies {
   // 2. ParquetReadOptions.Builder() constructor creates HadoopParquetConfiguration internally,
   //    which requires the Configuration class to be present even when using non-Hadoop code paths
   // 3. parquet-hadoop-bundle includes shaded Parquet classes but not Hadoop Configuration
-  implementation('org.apache.hadoop:hadoop-client-api:3.4.3')
-  implementation('org.apache.hadoop:hadoop-client-runtime:3.4.3')
+  implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}")
+  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}")
 
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/esql-datasource-parquet/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/build.gradle
@@ -8,6 +8,10 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 
+versions << [
+  'hadoop' : '3.4.3',
+]
+
 esplugin {
   name = 'esql-datasource-parquet'
   description = 'Parquet format support for ESQL external data sources'

--- a/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   javaRestTestImplementation project(xpackModule('esql-datasource-s3'))
   
   // Parquet support - needed for reading test fixtures
-  javaRestTestImplementation('org.apache.parquet:parquet-hadoop-bundle:1.17.0')
+  javaRestTestImplementation("org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}")
   
   // Repository S3 module for cluster
   clusterModules project(':modules:repository-s3')

--- a/x-pack/plugin/esql/qa/server/build.gradle
+++ b/x-pack/plugin/esql/qa/server/build.gradle
@@ -48,22 +48,22 @@ dependencies {
   implementation "org.apache.commons:commons-compress:${versions.esql_commons_compress}"
 
   // OrcFixtureGenerator: ORC/Hadoop (separate from main to avoid jar hell)
-  orcFixtureGenerator("org.apache.orc:orc-core:2.3.0") { exclude group: 'org.slf4j', module: 'slf4j-api' }
+  orcFixtureGenerator("org.apache.orc:orc-core:${versions.orc}") { exclude group: 'org.slf4j', module: 'slf4j-api' }
   orcFixtureGenerator('org.apache.hive:hive-storage-api:2.8.1')
   orcFixtureGenerator('com.google.protobuf:protobuf-java:3.25.8')
-  orcFixtureGenerator('org.apache.hadoop:hadoop-client-api:3.4.3') { exclude group: 'org.slf4j', module: 'slf4j-api' }
-  orcFixtureGenerator('org.apache.hadoop:hadoop-client-runtime:3.4.3') { exclude group: 'org.slf4j', module: 'slf4j-api' }
+  orcFixtureGenerator("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") { exclude group: 'org.slf4j', module: 'slf4j-api' }
+  orcFixtureGenerator("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") { exclude group: 'org.slf4j', module: 'slf4j-api' }
   orcFixtureGenerator "org.slf4j:slf4j-api:${versions.slf4j}"
   orcFixtureGenerator project(':libs:core')
   orcFixtureGenerator project(xpackModule('esql-datasource-csv'))
 
   // ParquetFixtureGenerator: Parquet/Hadoop (separate from main to avoid jar hell)
-  parquetFixtureGenerator("org.apache.parquet:parquet-hadoop-bundle:1.17.0") {
+  parquetFixtureGenerator("org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}") {
     exclude group: 'org.apache.logging.log4j'
   }
   parquetFixtureGenerator "org.locationtech.jts:jts-core:${versions.jts}"
-  parquetFixtureGenerator('org.apache.hadoop:hadoop-client-api:3.4.3') { exclude group: 'org.apache.logging.log4j' }
-  parquetFixtureGenerator('org.apache.hadoop:hadoop-client-runtime:3.4.3') { exclude group: 'org.apache.logging.log4j' }
+  parquetFixtureGenerator("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") { exclude group: 'org.apache.logging.log4j' }
+  parquetFixtureGenerator("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") { exclude group: 'org.apache.logging.log4j' }
   parquetFixtureGenerator "org.slf4j:slf4j-api:${versions.slf4j}"
   parquetFixtureGenerator project(':libs:core')
   parquetFixtureGenerator project(xpackModule('esql-datasource-csv'))

--- a/x-pack/plugin/esql/qa/server/build.gradle
+++ b/x-pack/plugin/esql/qa/server/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'elasticsearch.java'
 
+versions << [
+  'hadoop' : '3.4.3',
+]
+
 description = 'Integration tests for ESQL'
 
 configurations {


### PR DESCRIPTION
Move orc and parquet version constants into `version.properties` so upgrades require a single-line change instead of editing multiple gradle files.

Hadoop cannot be centralized because `repository-hdfs` mutates the shared `versions` map via `versions <<` which silently downgrades hadoop for all projects. Hadoop version is kept as a per-plugin local override.

Developed with AI-assisted tooling