### PR TITLE
[9.3] Prevent invalid polygons from being used in the test (#145129)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownCartesianShapeIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownCartesianShapeIT.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.esql.spatial;
 
+import org.apache.lucene.document.XYShape;
 import org.apache.lucene.geo.XYEncodingUtils;
+import org.elasticsearch.common.geo.LuceneGeometriesUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
 
 public class SpatialPushDownCartesianShapeIT extends SpatialPushDownShapeTestCase {
 
@@ -21,7 +25,35 @@ public class SpatialPushDownCartesianShapeIT extends SpatialPushDownShapeTestCas
 
     @Override
     protected Geometry getIndexGeometry() {
-        return ShapeTestUtils.randomGeometryWithoutCircle(false);
+        return randomValueOtherThanMany(
+            SpatialPushDownCartesianShapeIT::isInvalid,
+            () -> ShapeTestUtils.randomGeometryWithoutCircle(false)
+        );
+    }
+
+    static boolean isInvalid(Geometry geometry) {
+        return switch (geometry) {
+            case Polygon p -> isInvalid(p);
+            case MultiPolygon m -> isInvalid(m);
+            default -> false;
+        };
+    }
+
+    static boolean isInvalid(Polygon polygon) {
+        try {
+            XYShape.createIndexableFields("test", LuceneGeometriesUtils.toXYPolygon(polygon), true);
+            return false;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    static boolean isInvalid(MultiPolygon mulitPolygon) {
+        boolean inValid = false;
+        for (Polygon p : mulitPolygon) {
+            inValid |= isInvalid(p);
+        }
+        return inValid;
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Prevent invalid polygons from being used in the test (#145129)