### PR TITLE
[9.3] Remove Security Manager usage from x-pack SQL (#145480)

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/DriverManagerRegistrationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/DriverManagerRegistrationTests.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.sql.jdbc;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -50,11 +48,8 @@ public class DriverManagerRegistrationTests extends ESTestCase {
 
             c.accept(d);
 
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                // mimic DriverManager and unregister the driver
-                EsDriver.deregister();
-                return null;
-            });
+            // mimic DriverManager and unregister the driver
+            EsDriver.deregister();
 
             SQLException ex = expectThrows(SQLException.class, () -> DriverManager.getDriver(url));
             assertEquals("No suitable driver", ex.getMessage());

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.jdbc;
 
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.SslConfig;
@@ -17,8 +16,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
@@ -323,14 +320,7 @@ public class JdbcConfigurationTests extends ESTestCase {
         Map<String, String> urlPropMap = sslProperties();
         String sslUrlProps = urlPropMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("&"));
 
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new SpecialPermission());
-        }
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            DriverManager.setLogWriter(new java.io.PrintWriter(System.out));
-            return null;
-        });
+        DriverManager.setLogWriter(new java.io.PrintWriter(System.out));
 
         try {
             DriverManager.getDriver(jdbcPrefix() + "test?" + sslUrlProps);

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/HttpClient.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/HttpClient.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.sql.client;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 
-import org.elasticsearch.xpack.sql.client.JreHttpUrlConnection.ResponseOrException;
 import org.elasticsearch.xpack.sql.proto.AbstractSqlRequest;
 import org.elasticsearch.xpack.sql.proto.CoreProtocol;
 import org.elasticsearch.xpack.sql.proto.MainResponse;
@@ -31,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.PrivilegedAction;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -156,17 +154,15 @@ public class HttpClient {
     ) throws SQLException {
         byte[] requestBytes = toContent(request);
         String query = "error_trace";
-        Tuple<Function<String, List<String>>, byte[]> response = java.security.AccessController.doPrivileged(
-            (PrivilegedAction<ResponseOrException<Tuple<Function<String, List<String>>, byte[]>>>) () -> JreHttpUrlConnection.http(
-                path,
-                query,
-                cfg,
-                con -> con.request(
-                    (out) -> out.write(requestBytes),
-                    HttpClient::readFrom,
-                    "POST",
-                    requestBodyContentType.mediaTypeWithoutParameters() // "application/cbor" or "application/json"
-                )
+        Tuple<Function<String, List<String>>, byte[]> response = JreHttpUrlConnection.http(
+            path,
+            query,
+            cfg,
+            con -> con.request(
+                (out) -> out.write(requestBytes),
+                HttpClient::readFrom,
+                "POST",
+                requestBodyContentType.mediaTypeWithoutParameters() // "application/cbor" or "application/json"
             )
         ).getResponseOrThrowException();
         List<String> warnings = response.v1().apply("Warning");
@@ -195,22 +191,18 @@ public class HttpClient {
             cfg.projectRouting()
         );
         try {
-            return java.security.AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) () -> JreHttpUrlConnection.http(path, "error_trace", pingCfg, JreHttpUrlConnection::head)
-            );
+            return JreHttpUrlConnection.http(path, "error_trace", pingCfg, JreHttpUrlConnection::head);
         } catch (ClientException ex) {
             throw new SQLException("Cannot ping server", ex);
         }
     }
 
     private <Response> Response get(String path, CheckedFunction<JsonParser, Response, IOException> responseParser) throws SQLException {
-        Tuple<Function<String, List<String>>, byte[]> response = java.security.AccessController.doPrivileged(
-            (PrivilegedAction<ResponseOrException<Tuple<Function<String, List<String>>, byte[]>>>) () -> JreHttpUrlConnection.http(
-                path,
-                "error_trace",
-                cfg,
-                con -> con.request(null, HttpClient::readFrom, "GET")
-            )
+        Tuple<Function<String, List<String>>, byte[]> response = JreHttpUrlConnection.http(
+            path,
+            "error_trace",
+            cfg,
+            con -> con.request(null, HttpClient::readFrom, "GET")
         ).getResponseOrThrowException();
         return fromContent(contentType(response.v1()), response.v2(), responseParser);
     }

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
@@ -21,8 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
@@ -127,10 +125,7 @@ public class JreHttpUrlConnection implements Closeable {
         if (cfg.sslConfig().isEnabled()) {
             HttpsURLConnection https = (HttpsURLConnection) con;
             SSLSocketFactory factory = cfg.sslConfig().sslSocketFactory();
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                https.setSSLSocketFactory(factory);
-                return null;
-            });
+            https.setSSLSocketFactory(factory);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Remove Security Manager usage from x-pack SQL (#145480)