### PR TITLE
[9.2] Add runtime constructor validation to ClassMethodBuilder#protectedCtor (#145367)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/ClassMethodBuilder.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/rules/ClassMethodBuilder.java
@@ -77,7 +77,7 @@ public class ClassMethodBuilder<T> {
      * @return a builder for configuring the constructor rule
      */
     public VoidMethodRuleBuilder<T> protectedCtor() {
-        MethodKey methodKey = getConstructorMethodKey();
+        MethodKey methodKey = resolveConstructor(clazz);
         return new VoidMethodRuleBuilder<>(registry, clazz, methodKey);
     }
 
@@ -89,7 +89,7 @@ public class ClassMethodBuilder<T> {
      * @return a builder for configuring the constructor rule
      */
     public <A> VoidMethodRuleBuilder.VoidMethodRuleBuilder1<T, A> protectedCtor(Class<A> arg0) {
-        MethodKey methodKey = getConstructorMethodKey(arg0);
+        MethodKey methodKey = resolveConstructor(clazz, arg0);
         return new VoidMethodRuleBuilder.VoidMethodRuleBuilder1<>(registry, clazz, methodKey);
     }
 
@@ -103,7 +103,7 @@ public class ClassMethodBuilder<T> {
      * @return a builder for configuring the constructor rule
      */
     public <A, B> VoidMethodRuleBuilder.VoidMethodRuleBuilder2<T, A, B> protectedCtor(Class<A> arg0, Class<B> arg1) {
-        MethodKey methodKey = getConstructorMethodKey(arg0, arg1);
+        MethodKey methodKey = resolveConstructor(clazz, arg0, arg1);
         return new VoidMethodRuleBuilder.VoidMethodRuleBuilder2<>(registry, clazz, methodKey);
     }
 
@@ -1199,7 +1199,25 @@ public class ClassMethodBuilder<T> {
         throw new NoSuchMethodException("Method " + methodName + " not found on class hierarchy of " + clazz.getName());
     }
 
-    private MethodKey getConstructorMethodKey(Class<?>... args) {
-        return new MethodKey(clazz.getName().replace(".", "/"), "<init>", Arrays.stream(args).map(Class::getCanonicalName).toList());
+    @SuppressForbidden(reason = "relies on reflection")
+    private static void validateConstructorExists(Class<?> clazz, Class<?>... args) {
+        Class<?>[] resolvedArgs = Arrays.stream(args).map(TypeUtils::toPrimitive).toArray(Class[]::new);
+        try {
+            clazz.getDeclaredConstructor(resolvedArgs);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(
+                "No constructor found on " + clazz.getName() + " with parameter types " + Arrays.stream(args).map(Class::getName).toList(),
+                e
+            );
+        }
+    }
+
+    private static MethodKey resolveConstructor(Class<?> clazz, Class<?>... args) {
+        validateConstructorExists(clazz, args);
+        return new MethodKey(
+            clazz.getName().replace(".", "/"),
+            "<init>",
+            Arrays.stream(args).map(TypeUtils::getParameterTypeName).toList()
+        );
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/EntitlementRulesBuilderTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/rules/EntitlementRulesBuilderTests.java
@@ -151,6 +151,17 @@ public class EntitlementRulesBuilderTests extends ESTestCase {
         assertHasRule(registry, new MethodKey(CONCRETE_INTERNAL, "<init>", List.of("java.lang.String")));
     }
 
+    public void testProtectedCtorThrowsWhenArgTypeMismatch() {
+        expectThrows(IllegalArgumentException.class, () -> newBuilder(newRegistry()).on(Concrete.class).protectedCtor(Integer.class));
+    }
+
+    public void testProtectedCtorThrowsWhenArgCountMismatch() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> newBuilder(newRegistry()).on(Concrete.class).protectedCtor(Integer.class, String.class)
+        );
+    }
+
     public void testTypeTokenParameter() {
         var registry = newRegistry();
         newBuilder(registry).on(DummyWithGeneric.class)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Add runtime constructor validation to ClassMethodBuilder#protectedCtor (#145367)](https://github.com/elastic/elasticsearch/pull/145367)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)