### PR TITLE
Fix eval description in round_to tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundToTests.java
@@ -347,7 +347,7 @@ public class RoundToTests extends AbstractScalarFunctionTestCase {
                 case DATETIME, DATE_NANOS, LONG -> "Long";
                 default -> throw new UnsupportedOperationException();
             };
-            String spec = forcedSpecialization != null ? forcedSpecialization : specialization(points.size(), fieldType, points);
+            String spec = forcedSpecialization != null ? forcedSpecialization : specialization(points.size(), expectedType, points);
             Matcher<String> expectedEvaluatorName = startsWith("RoundTo" + type + spec + "Evaluator");
             return new TestCaseSupplier.TestCase(params, expectedEvaluatorName, expectedType, equalTo(expected.apply(field, points)));
         });


### PR DESCRIPTION
We should use the expected type in the evaluator description.

Closes #145450