### PR TITLE
PromQL: assert output() is called on resolved plans in AcrossSeriesAggregate

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
@@ -113,7 +113,8 @@ public final class AcrossSeriesAggregate extends PromqlFunctionCall {
         if (grouping == Grouping.WITHOUT) {
             return List.of(timeseriesAttribute);
         }
-        return groupings.stream().filter(a -> a.resolved() == false || a.dataType() != DataType.NULL).toList();
+        assert expressionsResolved() : "output() called on unresolved plan";
+        return groupings.stream().filter(a -> a.dataType() != DataType.NULL).toList();
     }
 
     @Override


### PR DESCRIPTION
Encodes the contract from `QueryPlan#output()` with an assert rather than silently accepting unresolved attributes in the output stream.

Relates to alex-spies' comment in #145307.