### PR TITLE
[9.2] Validate Watcher Proxy Allowlist (#144759)

### DIFF
--- a/docs/changelog/144759.yaml
+++ b/docs/changelog/144759.yaml
@@ -1,0 +1,5 @@
+area: Watcher
+issues: []
+pr: 144759
+summary: Validate Watcher Proxy Allowlist
+type: bug

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -228,6 +228,7 @@ public class HttpClient implements Closeable {
         }
 
         RequestConfig.Builder config = RequestConfig.custom();
+        validateProxyAgainstWhitelist(request.proxy);
         setProxy(config, request, settingsProxy);
         HttpClientContext localContext = HttpClientContext.create();
         // auth
@@ -420,6 +421,26 @@ public class HttpClient implements Closeable {
 
     private boolean isWhitelisted(String host) {
         return whitelistAutomaton.get().run(host);
+    }
+
+    /**
+     * Validates that a per-request proxy host is whitelisted. System-wide proxies configured via {@code xpack.http.proxy.host} are exempt
+     */
+    private void validateProxyAgainstWhitelist(HttpProxy proxy) {
+        if (proxy == null || proxy.equals(HttpProxy.NO_PROXY)) {
+            return;
+        }
+        HttpHost proxyHost = new HttpHost(proxy.getHost(), proxy.getPort(), proxy.getScheme() != null ? proxy.getScheme().scheme() : null);
+        if (isWhitelisted(proxyHost.toURI()) == false) {
+            throw new ElasticsearchException(
+                "proxy host ["
+                    + proxyHost.toURI()
+                    + "] is not whitelisted in setting ["
+                    + HttpSettings.HOSTS_WHITELIST.getKey()
+                    + "], "
+                    + "will not connect"
+            );
+        }
     }
 
     private static final CharacterRunAutomaton MATCH_ALL_AUTOMATON = new CharacterRunAutomaton(Regex.simpleMatchToAutomaton("*"));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -755,6 +755,72 @@ public class HttpClientTests extends ESTestCase {
         assertThat(automaton.run(randomAlphaOfLength(10)), is(true));
     }
 
+    public void testThatWhiteListBlocksPerRequestProxy() throws Exception {
+        Settings settings = Settings.builder().put(HttpSettings.HOSTS_WHITELIST.getKey(), getWebserverUri()).build();
+
+        try (HttpClient client = new HttpClient(settings, new SSLService(environment), null, mockClusterService())) {
+            HttpRequest request = HttpRequest.builder(webServer.getHostName(), webServer.getPort())
+                .path("/")
+                .proxy(new HttpProxy("not-whitelisted-proxy", randomIntBetween(1000, 5000), randomFrom(Scheme.HTTP, Scheme.HTTPS)))
+                .build();
+            ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> client.execute(request));
+            assertThat(e.getMessage(), containsString("proxy host"));
+            assertThat(e.getMessage(), containsString("not whitelisted"));
+        }
+    }
+
+    public void testThatWhiteListAllowsWhitelistedProxy() throws Exception {
+        try (MockWebServer proxyServer = new MockWebServer()) {
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody("proxiedContent"));
+            proxyServer.start();
+
+            String proxyUri = "http://localhost:" + proxyServer.getPort();
+            Settings settings = Settings.builder().putList(HttpSettings.HOSTS_WHITELIST.getKey(), getWebserverUri(), proxyUri).build();
+
+            try (HttpClient client = new HttpClient(settings, new SSLService(environment), null, mockClusterService())) {
+                HttpRequest request = HttpRequest.builder(webServer.getHostName(), webServer.getPort())
+                    .path("/")
+                    .proxy(new HttpProxy("localhost", proxyServer.getPort()))
+                    .build();
+                HttpResponse response = client.execute(request);
+                assertThat(response.status(), equalTo(200));
+                assertThat(response.body().utf8ToString(), equalTo("proxiedContent"));
+            }
+
+            assertThat(webServer.requests(), hasSize(0));
+            assertThat(proxyServer.requests(), hasSize(1));
+        }
+    }
+
+    public void testThatSystemProxyIsExemptFromWhitelist() throws Exception {
+        try (MockWebServer proxyServer = new MockWebServer()) {
+            proxyServer.enqueue(new MockResponse().setResponseCode(200).setBody("proxiedContent"));
+            proxyServer.start();
+
+            // Whitelist only the target — the system-wide proxy is NOT whitelisted but should still work
+            Settings settings = Settings.builder()
+                .put(environment.settings())
+                .put(HttpSettings.HOSTS_WHITELIST.getKey(), getWebserverUri())
+                .put(HttpSettings.PROXY_HOST.getKey(), "localhost")
+                .put(HttpSettings.PROXY_PORT.getKey(), proxyServer.getPort())
+                .build();
+
+            final SSLService sslService = new SSLService(TestEnvironment.newEnvironment(settings));
+            try (HttpClient client = new HttpClient(settings, sslService, null, mockClusterService())) {
+                HttpRequest request = HttpRequest.builder(webServer.getHostName(), webServer.getPort())
+                    .path("/")
+                    .method(HttpMethod.GET)
+                    .build();
+                HttpResponse response = client.execute(request);
+                assertThat(response.status(), equalTo(200));
+                assertThat(response.body().utf8ToString(), equalTo("proxiedContent"));
+            }
+
+            assertThat(webServer.requests(), hasSize(0));
+            assertThat(proxyServer.requests(), hasSize(1));
+        }
+    }
+
     public void testCreateUri() throws Exception {
         assertCreateUri("https://example.org/foo/", "/foo/");
         assertCreateUri("https://example.org/foo", "/foo");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Validate Watcher Proxy Allowlist (#144759)](https://github.com/elastic/elasticsearch/pull/144759)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)