### PR TITLE
Extract PIT wiring into convertSearchRequestToUsePit

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -74,7 +74,6 @@ import org.elasticsearch.script.ReindexMetadata;
 import org.elasticsearch.script.ReindexScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
@@ -294,15 +293,7 @@ public class Reindexer {
         // NB this is a local request, so we call the TransportAction rather than issuing a REST call
         client.execute(TransportOpenPointInTimeAction.TYPE, pitRequest, listener.delegateFailureAndWrap((l, pitResponse) -> {
             BytesReference pitId = pitResponse.getPointInTimeId();
-            // Inject PIT into the search request so workers can use it; PIT and scroll are mutually exclusive
-            searchRequest.source().pointInTimeBuilder(new PointInTimeBuilder(pitId).setKeepAlive(pitKeepAlive(request)));
-            searchRequest.scroll(null);
-            // PIT defines the index context; indices must not be set on the search request.
-            // Preserve source indices for task description (toString) since searchRequest.indices() will be empty.
-            request.setSourceIndicesForDescription(indices);
-            searchRequest.indices(Strings.EMPTY_ARRAY);
-            // Project routing is fixed at open-PIT time; it must not remain on the SearchRequest with PIT
-            searchRequest.clearProjectRouting();
+            request.convertSearchRequestToUsePit(pitId, pitKeepAlive(request));
             ActionListener<BulkByScrollResponse> listenerWithClosePit = wrapListenerWithClosePit(
                 pitId,
                 l,
@@ -498,15 +489,7 @@ public class Reindexer {
         String[] indices = searchRequest.indices();
         // Sends a REST request to the remote node to open a PIT
         openPit(searchRequest, indices, pitKeepAlive(request), RejectAwareActionListener.wrap(pitId -> {
-            // Inject PIT into the search request so workers can use it; PIT and scroll are mutually exclusive
-            searchRequest.source().pointInTimeBuilder(new PointInTimeBuilder(pitId).setKeepAlive(pitKeepAlive(request)));
-            searchRequest.scroll(null);
-            // PIT defines the index context; indices must not be set on the search request.
-            // Preserve source indices for task description (toString) since searchRequest.indices() will be empty.
-            request.setSourceIndicesForDescription(indices);
-            searchRequest.indices(Strings.EMPTY_ARRAY);
-            // Project routing is fixed at open-PIT time; it must not remain on the SearchRequest with PIT
-            searchRequest.clearProjectRouting();
+            request.convertSearchRequestToUsePit(pitId, pitKeepAlive(request));
             ActionListener<BulkByScrollResponse> listenerWithClosePit = wrapListenerWithClosePit(
                 pitId,
                 listenerWithRelocations,

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -157,6 +158,32 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             this.getSearchRequest().indices(sourceIndices);
         }
         return this;
+    }
+
+    /**
+     * After opening a point-in-time, mutates this request's {@link SearchRequest} to use that PIT for pagination.
+     * <p>
+     * This method:
+     * <ol>
+     *     <li>Sets the PIT on the search source</li>
+     *     <li>Clears the scroll since PIT and scroll are mutually exclusive</li>
+     *     <li>Copies the current {@link SearchRequest#indices()} to {@link #setSourceIndicesForDescription} so the
+     *     task descriptions remain correct</li>
+     *     <li>Clears indices on the search request (the PIT defines index context)</li>
+     *     <li>Clears project routing since it is fixed at open-PIT time</li>
+     * </ol>
+     *
+     * @param pitId      encoded PIT identifier from {@code open_point_in_time}
+     * @param keepAlive  keep-alive for the PIT on the search request
+     */
+    public void convertSearchRequestToUsePit(BytesReference pitId, TimeValue keepAlive) {
+        SearchRequest searchRequest = getSearchRequest();
+        String[] indices = searchRequest.indices();
+        searchRequest.source().pointInTimeBuilder(new PointInTimeBuilder(pitId).setKeepAlive(keepAlive));
+        searchRequest.scroll(null);
+        setSourceIndicesForDescription(indices);
+        searchRequest.indices(Strings.EMPTY_ARRAY);
+        searchRequest.clearProjectRouting();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Tests some of the validation of {@linkplain ReindexRequest}. See reindex's rest tests for much more.
@@ -634,6 +635,26 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
         ActionRequestValidationException validationException = request.validate();
         assertNotNull(validationException);
         assertEquals(List.of("from is not supported in this context"), validationException.validationErrors());
+    }
+
+    /** Verifies {@link ReindexRequest#convertSearchRequestToUsePit} wires PIT, description indices, and clears routing. */
+    public void testConvertSearchRequestToUsePit() {
+        ReindexRequest request = new ReindexRequest();
+        request.setDestIndex("dest");
+        request.setSourceIndices("idx-a", "idx-b");
+        request.getSearchRequest().source(new SearchSourceBuilder().query(matchAllQuery()));
+        request.getSearchRequest().setProjectRouting("_alias:foo");
+
+        BytesReference pitId = new BytesArray("new-pit-id");
+        TimeValue keepAlive = TimeValue.timeValueMinutes(5);
+        request.convertSearchRequestToUsePit(pitId, keepAlive);
+
+        assertEquals(pitId, request.getSearchRequest().source().pointInTimeBuilder().getEncodedId());
+        assertEquals(keepAlive, request.getSearchRequest().source().pointInTimeBuilder().getKeepAlive());
+        assertNull(request.getSearchRequest().scroll());
+        assertArrayEquals(new String[] { "idx-a", "idx-b" }, request.getSourceIndicesForDescription());
+        assertEquals(0, request.getSearchRequest().indices().length);
+        assertNull(request.getSearchRequest().getProjectRouting());
     }
 
     public void testValidateGivenRemoteIndex() throws IOException {


### PR DESCRIPTION
Moves logic to convert a search request from using scroll to using pit into a dedicated method, rather than adhoc in the reindexer.

Relates: https://github.com/elastic/elasticsearch/pull/144339

