### PR TITLE
Support String port field in Watcher's HttpRequestTemplate

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -133,9 +133,6 @@ tests:
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
   issue: https://github.com/elastic/elasticsearch/issues/139654
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
-  issue: https://github.com/elastic/elasticsearch/issues/139663
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/140612

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplate.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplate.java
@@ -340,6 +340,8 @@ public class HttpRequestTemplate implements ToXContentObject {
                         builder.method(HttpMethod.parse(parser.text()));
                     } else if (HttpRequest.Field.HOST.match(currentFieldName, parser.getDeprecationHandler())) {
                         builder.host = parser.text();
+                    } else if (HttpRequest.Field.PORT.match(currentFieldName, parser.getDeprecationHandler())) {
+                        builder.port = parseInteger(currentFieldName, parser);
                     } else {
                         throw new ElasticsearchParseException(
                             "could not parse http request template. unexpected string field [{}]",
@@ -378,6 +380,18 @@ public class HttpRequestTemplate implements ToXContentObject {
             }
 
             return builder.build();
+        }
+
+        private static int parseInteger(String fieldName, XContentParser parser) throws IOException {
+            try {
+                return parser.intValue();
+            } catch (NumberFormatException e) {
+                throw new ElasticsearchParseException(
+                    "Could not parse http request template. Invalid {} value [{}]",
+                    fieldName,
+                    parser.text()
+                );
+            }
         }
 
         private static TextTemplate parseFieldTemplate(String field, XContentParser parser) throws IOException {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplateTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplateTests.java
@@ -158,7 +158,7 @@ public class HttpRequestTemplateTests extends ESTestCase {
         int expectedPort = 6667;
         XContentBuilder builder = jsonBuilder().startObject()
             .field("host", "localhost")
-            .field( "port", String.valueOf(expectedPort))
+            .field("port", String.valueOf(expectedPort))
             .endObject();
         XContentParser parser = createParser(builder);
         parser.nextToken();
@@ -168,10 +168,7 @@ public class HttpRequestTemplateTests extends ESTestCase {
     }
 
     public void testParsePortAsStringRejectsNonIntegers() throws Exception {
-        XContentBuilder builder = jsonBuilder().startObject()
-            .field("host", "localhost")
-            .field( "port", "not_a_number")
-            .endObject();
+        XContentBuilder builder = jsonBuilder().startObject().field("host", "localhost").field("port", "not_a_number").endObject();
         XContentParser parser = createParser(builder);
         parser.nextToken();
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplateTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplateTests.java
@@ -60,7 +60,7 @@ public class HttpRequestTemplateTests extends ESTestCase {
             .putHeader("_key2", new TextTemplate("_value2"))
             .build();
 
-        HttpRequest result = template.render(new MockTextTemplateEngine(), Collections.emptyMap());
+        HttpRequest result = template.render(new MockTextTemplateEngine(), emptyMap());
         assertThat(result.body(), equalTo("_body"));
         assertThat(result.path(), equalTo("_path"));
         assertThat(result.params(), equalTo(Collections.singletonMap("_key1", "_value1")));
@@ -152,6 +152,31 @@ public class HttpRequestTemplateTests extends ESTestCase {
         // encoded values
         builder = HttpRequestTemplate.builder("www.example.org", 80).putParam("foo", new TextTemplate(" white space"));
         assertThatManualBuilderEqualsParsingFromUrl("http://www.example.org?foo=%20white%20space", builder);
+    }
+
+    public void testParsePortAsString() throws Exception {
+        int expectedPort = 6667;
+        XContentBuilder builder = jsonBuilder().startObject()
+            .field("host", "localhost")
+            .field( "port", String.valueOf(expectedPort))
+            .endObject();
+        XContentParser parser = createParser(builder);
+        parser.nextToken();
+
+        HttpRequestTemplate template = HttpRequestTemplate.Parser.parse(parser);
+        assertThat(template.port(), is(expectedPort));
+    }
+
+    public void testParsePortAsStringRejectsNonIntegers() throws Exception {
+        XContentBuilder builder = jsonBuilder().startObject()
+            .field("host", "localhost")
+            .field( "port", "not_a_number")
+            .endObject();
+        XContentParser parser = createParser(builder);
+        parser.nextToken();
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> HttpRequestTemplate.Parser.parse(parser));
+        assertThat(e.getMessage(), is("Could not parse http request template. Invalid port value [not_a_number]"));
     }
 
     public void testParsingEmptyUrl() throws Exception {


### PR DESCRIPTION
When the port in the request was passed as a string, the parser was rejecting such value.

Currently, port as string is accepted and converted to integer by the parser. 

Invalid integer values are rejected as previously.

Fixes #139663.

