### PR TITLE
Add BulkProcessor2 with retry to SnapshotHistoryStore

### DIFF
--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
@@ -123,7 +123,7 @@ public class SnapshotLifecycle extends Plugin implements ActionPlugin, HealthPlu
             services.xContentRegistry()
         );
         templateRegistry.initialize();
-        snapshotHistoryStore.set(new SnapshotHistoryStore(new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN), clusterService));
+        snapshotHistoryStore.set(new SnapshotHistoryStore(new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN), clusterService, threadPool));
         snapshotLifecycleService.set(
             new SnapshotLifecycleService(
                 settings,

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStore.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStore.java
@@ -14,21 +14,34 @@ import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor2;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.shutdown.PluginShutdownService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.SLM_HISTORY_INDEX_ENABLED_SETTING;
 import static org.elasticsearch.xpack.slm.history.SnapshotLifecycleTemplateRegistry.INDEX_TEMPLATE_VERSION;
 import static org.elasticsearch.xpack.slm.history.SnapshotLifecycleTemplateRegistry.SLM_TEMPLATE_NAME;
@@ -37,20 +50,86 @@ import static org.elasticsearch.xpack.slm.history.SnapshotLifecycleTemplateRegis
  * Records Snapshot Lifecycle Management actions as represented by {@link SnapshotHistoryItem} into an index
  * for the purposes of querying and alerting.
  */
-public class SnapshotHistoryStore {
+public class SnapshotHistoryStore implements Closeable {
     private static final Logger logger = LogManager.getLogger(SnapshotHistoryStore.class);
 
     public static final String SLM_HISTORY_DATA_STREAM = ".slm-history-" + INDEX_TEMPLATE_VERSION;
 
     private final Client client;
     private final ClusterService clusterService;
+    private final BulkProcessor2 processor;
     private volatile boolean slmHistoryEnabled = true;
 
-    public SnapshotHistoryStore(Client client, ClusterService clusterService) {
+    public SnapshotHistoryStore(Client client, ClusterService clusterService, ThreadPool threadPool) {
         this.client = client;
         this.clusterService = clusterService;
         this.setSlmHistoryEnabled(SLM_HISTORY_INDEX_ENABLED_SETTING.get(clusterService.getSettings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(SLM_HISTORY_INDEX_ENABLED_SETTING, this::setSlmHistoryEnabled);
+
+        this.processor = BulkProcessor2.builder(
+            new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN)::bulk,
+            new BulkProcessor2.Listener() {
+                @Override
+                public void beforeBulk(long executionId, BulkRequest request) {
+                    final Metadata metadata = clusterService.state().getMetadata();
+                    if (metadata.getProject().dataStreams().containsKey(SLM_HISTORY_DATA_STREAM) == false
+                        && metadata.getProject().templatesV2().containsKey(SLM_TEMPLATE_NAME) == false) {
+                        logger.error(
+                            () -> format(
+                                "failed to index snapshot history item, data stream [%s] and template [%s] don't exist",
+                                SLM_HISTORY_DATA_STREAM,
+                                SLM_TEMPLATE_NAME
+                            )
+                        );
+                    }
+                }
+
+                @Override
+                public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace(
+                            "indexed [{}] items into SLM history index [{}]",
+                            request.numberOfActions(),
+                            Arrays.stream(response.getItems())
+                                .map(BulkItemResponse::getIndex)
+                                .distinct()
+                                .collect(Collectors.joining(","))
+                        );
+                    }
+                    if (response.hasFailures()) {
+                        var failures = Arrays.stream(response.getItems())
+                            .filter(BulkItemResponse::isFailed)
+                            .collect(
+                                Collectors.toMap(
+                                    BulkItemResponse::getId,
+                                    BulkItemResponse::getFailureMessage,
+                                    (msg1, msg2) -> Objects.equals(msg1, msg2) ? msg1 : msg1 + "," + msg2
+                                )
+                            );
+                        logger.error("failures indexing SLM history: [{}]", failures);
+                    }
+                }
+
+                @Override
+                public void afterBulk(long executionId, BulkRequest request, Exception failure) {
+                    logErrorOrWarning(
+                        logger,
+                        clusterService.state(),
+                        () -> format(
+                            "failed to index [%d] snapshot history items into [%s]",
+                            request.numberOfActions(),
+                            SLM_HISTORY_DATA_STREAM
+                        ),
+                        failure
+                    );
+                }
+            },
+            threadPool
+        )
+            .setBulkActions(-1)
+            .setFlushInterval(TimeValue.timeValueSeconds(5))
+            .setMaxNumberOfRetries(3)
+            .build();
     }
 
     /**
@@ -68,36 +147,10 @@ public class SnapshotHistoryStore {
             return;
         }
         logger.trace("about to index snapshot history item in data stream [{}]: [{}]", SLM_HISTORY_DATA_STREAM, item);
-        Metadata metadata = clusterService.state().getMetadata();
-        if (metadata.getProject().dataStreams().containsKey(SLM_HISTORY_DATA_STREAM) == false
-            && metadata.getProject().templatesV2().containsKey(SLM_TEMPLATE_NAME) == false) {
-            logger.error(
-                () -> format(
-                    "failed to index snapshot history item, data stream [%s] and template [%s] don't exist",
-                    SLM_HISTORY_DATA_STREAM,
-                    SLM_TEMPLATE_NAME
-                )
-            );
-            return;
-        }
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             item.toXContent(builder, ToXContent.EMPTY_PARAMS);
             IndexRequest request = new IndexRequest(SLM_HISTORY_DATA_STREAM).opType(DocWriteRequest.OpType.CREATE).source(builder);
-            client.index(request, ActionListener.wrap(indexResponse -> {
-                logger.debug(
-                    "successfully indexed snapshot history item with id [{}] in data stream [{}]: [{}]",
-                    indexResponse.getId(),
-                    SLM_HISTORY_DATA_STREAM,
-                    item
-                );
-            },
-                exception -> logErrorOrWarning(
-                    logger,
-                    clusterService.state(),
-                    () -> format("failed to index snapshot history item in data stream [%s]: [%s]", SLM_HISTORY_DATA_STREAM, item),
-                    exception
-                )
-            ));
+            processor.add(request);
         } catch (IOException exception) {
             logErrorOrWarning(
                 logger,
@@ -122,6 +175,16 @@ public class SnapshotHistoryStore {
         }
 
         logger.log(level, failureMsgSupplier, exception);
+    }
+
+    @Override
+    public void close() {
+        try {
+            processor.awaitClose(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("failed to shut down SLM history bulk processor after 10 seconds", e);
+            Thread.currentThread().interrupt();
+        }
     }
 
     public void setSlmHistoryEnabled(boolean slmHistoryEnabled) {

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStoreTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStoreTests.java
@@ -69,7 +69,7 @@ public class SnapshotHistoryStoreTests extends ESTestCase {
                 )
             );
         ClusterServiceUtils.setState(clusterService, ClusterState.builder(state).metadata(metadataBuilder).build());
-        historyStore = new SnapshotHistoryStore(client, clusterService);
+        historyStore = new SnapshotHistoryStore(client, clusterService, threadPool);
     }
 
     @After


### PR DESCRIPTION
## Summary

SnapshotHistoryStore currently makes a single indexing attempt and logs an error when it hits `EsRejectedExecutionException` (cluster too busy). This mirrors an issue that was previously fixed in ILMHistoryStore by switching to `BulkProcessor2` with retry support.

This PR updates `SnapshotHistoryStore` to use `BulkProcessor2` with `setMaxNumberOfRetries(3)`, consistent with how `ILMHistoryStore` handles the same scenario.

## Changes

- `SnapshotHistoryStore` now implements `Closeable` and uses `BulkProcessor2`
- Retry count set to 3 (matching ILMHistoryStore)
- Flush interval set to 5 seconds
- Constructor updated to accept `ThreadPool` parameter
- `SnapshotLifecycle.java` updated to pass `ThreadPool` to the store
- Test updated to match new constructor signature

## References

Fixes #141887

/cc @masseyke