### PR TITLE
[ESQL] Propagate per-split statistics through FileSplit

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -362,18 +362,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     @SuppressWarnings("rawtypes")
     private static Map<String, Object> buildRowGroupStats(BlockMetaData rowGroup) {
         Map<String, Object> stats = new HashMap<>();
-        stats.put("_stats.row_count", rowGroup.getRowCount());
-        stats.put("_stats.size_bytes", rowGroup.getTotalByteSize());
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowGroup.getRowCount());
+        stats.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, rowGroup.getTotalByteSize());
         for (ColumnChunkMetaData col : rowGroup.getColumns()) {
             String colName = col.getPath().toDotString();
             Statistics colStats = col.getStatistics();
             if (colStats == null || colStats.isEmpty()) {
                 continue;
             }
-            stats.put("_stats.columns." + colName + ".null_count", colStats.getNumNulls());
+            stats.put(SourceStatisticsSerializer.columnNullCountKey(colName), colStats.getNumNulls());
             if (colStats.hasNonNullValue()) {
-                stats.put("_stats.columns." + colName + ".min", colStats.genericGetMin());
-                stats.put("_stats.columns." + colName + ".max", colStats.genericGetMax());
+                stats.put(SourceStatisticsSerializer.columnMinKey(colName), colStats.genericGetMin());
+                stats.put(SourceStatisticsSerializer.columnMaxKey(colName), colStats.genericGetMax());
             }
         }
         return Map.copyOf(stats);
@@ -409,8 +409,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             pendingStats.add(range.statistics());
 
             if (groupEnd - groupStart >= targetBytes) {
-                Map<String, Object> merged = SourceStatisticsSerializer.mergeStatistics(pendingStats);
-                out.add(new SplitRange(groupStart, groupEnd - groupStart, merged != null ? merged : Map.of()));
+                out.add(new SplitRange(groupStart, groupEnd - groupStart, SourceStatisticsSerializer.mergeStatistics(pendingStats)));
                 groupStart = -1;
                 groupEnd = -1;
                 pendingStats.clear();
@@ -418,8 +417,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         if (groupStart >= 0) {
-            Map<String, Object> merged = SourceStatisticsSerializer.mergeStatistics(pendingStats);
-            out.add(new SplitRange(groupStart, groupEnd - groupStart, merged != null ? merged : Map.of()));
+            out.add(new SplitRange(groupStart, groupEnd - groupStart, SourceStatisticsSerializer.mergeStatistics(pendingStats)));
         }
 
         return out;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/README.md
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/README.md
@@ -336,14 +336,11 @@ x-pack/plugin/
 │       ├── GcsDataSourcePlugin.java
 │       └── GcsStorageProvider.java
 │
-<<<<<<< HEAD
 ├── esql-datasource-azure/             # Azure Blob Storage plugin
 │   └── src/main/java/.../azure/
 │       ├── AzureDataSourcePlugin.java
 │       └── AzureStorageProvider.java
 │
-=======
->>>>>>> upstream/main
 └── esql-datasource-iceberg/           # Iceberg table catalog plugin
     ├── build.gradle                   # Iceberg, Arrow, AWS SDK dependencies
     └── src/main/java/.../iceberg/
@@ -381,11 +378,7 @@ Run tests:
 
 ## Future Enhancements
 
-<<<<<<< HEAD
 1. **Additional Storage Providers** - HDFS
-=======
-1. **Additional Storage Providers** - HDFS, Azure Blob
->>>>>>> upstream/main
 2. **Additional Format Readers** - ORC, Avro, JSON Lines
 3. **Additional Table Catalogs** - Delta Lake, Apache Hudi
 4. **Performance Optimizations** - File splitting, parallel reads, caching

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -7,8 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +114,7 @@ public final class SourceStatisticsSerializer {
         if (sourceMetadata == null) {
             return OptionalLong.empty();
         }
-        return toLong(sourceMetadata.get(STATS_COL_PREFIX + columnName + NULL_COUNT_SUFFIX));
+        return toLong(sourceMetadata.get(columnNullCountKey(columnName)));
     }
 
     /**
@@ -122,7 +124,7 @@ public final class SourceStatisticsSerializer {
         if (sourceMetadata == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(sourceMetadata.get(STATS_COL_PREFIX + columnName + MIN_SUFFIX));
+        return Optional.ofNullable(sourceMetadata.get(columnMinKey(columnName)));
     }
 
     /**
@@ -132,14 +134,46 @@ public final class SourceStatisticsSerializer {
         if (sourceMetadata == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(sourceMetadata.get(STATS_COL_PREFIX + columnName + MAX_SUFFIX));
+        return Optional.ofNullable(sourceMetadata.get(columnMaxKey(columnName)));
+    }
+
+    /** Returns the flat key used for a column's null count statistic. */
+    public static String columnNullCountKey(String columnName) {
+        return STATS_COL_PREFIX + columnName + NULL_COUNT_SUFFIX;
+    }
+
+    /** Returns the flat key used for a column's min statistic. */
+    public static String columnMinKey(String columnName) {
+        return STATS_COL_PREFIX + columnName + MIN_SUFFIX;
+    }
+
+    /** Returns the flat key used for a column's max statistic. */
+    public static String columnMaxKey(String columnName) {
+        return STATS_COL_PREFIX + columnName + MAX_SUFFIX;
     }
 
     /**
-     * Merges per-split statistics maps into a single aggregate statistics map.
-     * Sums row counts, size bytes, and null counts; computes min-of-mins and max-of-maxes.
-     * Returns {@code null} if any split lacks a row count (indicating incomplete stats).
+     * Resolves the effective metadata for a set of splits. For single-split queries returns
+     * the given sourceMetadata directly; for multi-split queries merges per-split statistics
+     * from each {@link FileSplit}. Returns {@code null} if any split is not a {@code FileSplit}
+     * or if {@link #mergeStatistics} cannot produce a valid merged result (e.g. missing or
+     * non-numeric row counts).
      */
+    public static Map<String, Object> resolveEffectiveMetadata(List<? extends ExternalSplit> splits, Map<String, Object> sourceMetadata) {
+        if (splits.size() <= 1) {
+            return sourceMetadata;
+        }
+        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
+        for (ExternalSplit split : splits) {
+            if (split instanceof FileSplit fileSplit) {
+                splitStats.add(fileSplit.statistics());
+            } else {
+                return null;
+            }
+        }
+        return mergeStatistics(splitStats);
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static Map<String, Object> mergeStatistics(List<Map<String, Object>> splitStats) {
         if (splitStats == null || splitStats.isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -14,11 +14,9 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
-import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
-import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
@@ -87,7 +85,10 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec;
         }
 
-        Map<String, Object> sourceMetadata = resolveEffectiveMetadata(externalExec);
+        Map<String, Object> sourceMetadata = SourceStatisticsSerializer.resolveEffectiveMetadata(
+            externalExec.splits(),
+            externalExec.sourceMetadata()
+        );
         if (sourceMetadata == null) {
             return aggregateExec;
         }
@@ -220,22 +221,6 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         } else {
             return blockFactory.newConstantNullBlock(1);
         }
-    }
-
-    private static Map<String, Object> resolveEffectiveMetadata(ExternalSourceExec externalExec) {
-        List<? extends ExternalSplit> splits = externalExec.splits();
-        if (splits.size() <= 1) {
-            return externalExec.sourceMetadata();
-        }
-        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
-        for (ExternalSplit split : splits) {
-            if (split instanceof FileSplit fileSplit) {
-                splitStats.add(fileSplit.statistics());
-            } else {
-                return null;
-            }
-        }
-        return SourceStatisticsSerializer.mergeStatistics(splitStats);
     }
 
     private List<Expression> extractAggregateFunctions(List<? extends NamedExpression> aggregates) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
-import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
@@ -80,7 +79,10 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             return aggregateExec;
         }
 
-        Map<String, Object> sourceMetadata = resolveEffectiveMetadata(externalExec);
+        Map<String, Object> sourceMetadata = SourceStatisticsSerializer.resolveEffectiveMetadata(
+            externalExec.splits(),
+            externalExec.sourceMetadata()
+        );
         if (sourceMetadata == null) {
             return aggregateExec;
         }
@@ -162,22 +164,6 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             return maxVal.orElse(null);
         }
         return null;
-    }
-
-    private static Map<String, Object> resolveEffectiveMetadata(ExternalSourceExec externalExec) {
-        List<? extends ExternalSplit> splits = externalExec.splits();
-        if (splits.size() <= 1) {
-            return externalExec.sourceMetadata();
-        }
-        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
-        for (ExternalSplit split : splits) {
-            if (split instanceof FileSplit fileSplit) {
-                splitStats.add(fileSplit.statistics());
-            } else {
-                return null;
-            }
-        }
-        return SourceStatisticsSerializer.mergeStatistics(splitStats);
     }
 
     private static Block[] buildBlocks(List<Object> values) {


### PR DESCRIPTION
Enable metadata-only aggregates (COUNT(*), MIN, MAX) for multi-split external
source queries. When row-group parallelism creates multiple splits per file,
each split now carries per-row-group statistics extracted from Parquet metadata.
The optimizer rules merge these per-split statistics instead of falling back to
a full scan, enabling zero-I/O aggregate resolution across splits.

Developed with AI-assisted tooling