### PR TITLE
Revert "PromQL: assert output() is called on resolved plans in AcrossSeriesAggregate (#145525)"

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -404,18 +404,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidLongWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145580
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.MergeExec}
-  issue: https://github.com/elastic/elasticsearch/issues/145581
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.Filter}
-  issue: https://github.com/elastic/elasticsearch/issues/145583
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
-  issue: https://github.com/elastic/elasticsearch/issues/145584
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.ExchangeExec}
-  issue: https://github.com/elastic/elasticsearch/issues/145585
 - class: org.elasticsearch.xpack.esql.CsvTests
   method: test {csv-spec:stats_percentile.percentileOfLong}
   issue: https://github.com/elastic/elasticsearch/issues/145589
@@ -425,18 +413,9 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcFetchSizeIT
   method: testScrollWithDatetimeAndTimezoneParam
   issue: https://github.com/elastic/elasticsearch/issues/145592
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin}
-  issue: https://github.com/elastic/elasticsearch/issues/145594
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.logical.Dissect}
-  issue: https://github.com/elastic/elasticsearch/issues/145595
 - class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
   method: testLicenseCheck
   issue: https://github.com/elastic/elasticsearch/issues/145600
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.logical.local.ResolvingProject}
-  issue: https://github.com/elastic/elasticsearch/issues/145601
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/AcrossSeriesAggregate.java
@@ -113,8 +113,7 @@ public final class AcrossSeriesAggregate extends PromqlFunctionCall {
         if (grouping == Grouping.WITHOUT) {
             return List.of(timeseriesAttribute);
         }
-        assert expressionsResolved() : "output() called on unresolved plan";
-        return groupings.stream().filter(a -> a.dataType() != DataType.NULL).toList();
+        return groupings.stream().filter(a -> a.resolved() == false || a.dataType() != DataType.NULL).toList();
     }
 
     @Override


### PR DESCRIPTION
Reverts #145525 and unmutes the tests that were muted as a consequence.

The assert caused `EsqlNodeSubclassTests` to fail because those tests call `output()` on plans with unresolved children by design (structural tree testing). Restores the original `resolved() == false` guard in the filter.

Fixes #145581, #145583, #145584, #145585, #145594, #145595, #145601, #145603, #145604, #145606