### PR TITLE
[ESQL] Enable cross-node text file splitting

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -30,6 +31,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
@@ -92,6 +94,7 @@ import java.util.regex.Pattern;
  *   <tr><td>{@code datetime_format}</td><td>ISO-8601 / epoch</td><td>Custom datetime pattern</td></tr>
  *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>OOM protection; max bytes per field</td></tr>
  *   <tr><td>{@code multi_value_syntax}</td><td>{@code brackets}</td><td>Multi-value field syntax</td></tr>
+ *   <tr><td>{@code schema_sample_size}</td><td>20,000</td><td>Number of rows to sample for type inference</td></tr>
  * </table>
  *
  * <h2>Bracket multi-value syntax</h2>
@@ -140,17 +143,18 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private final String format;
     private final List<String> extensions;
     private final List<Attribute> resolvedSchema;
+    private final int schemaSampleSize;
 
     public CsvFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, CsvFormatOptions.DEFAULT, "csv", List.of(".csv", ".tsv"), null);
+        this(blockFactory, CsvFormatOptions.DEFAULT, "csv", List.of(".csv", ".tsv"), null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
     }
 
     public CsvFormatReader(BlockFactory blockFactory, String format, List<String> extensions) {
-        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions, null);
+        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
     }
 
     public CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options, String format, List<String> extensions) {
-        this(blockFactory, options, format, extensions, null);
+        this(blockFactory, options, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
     }
 
     private CsvFormatReader(
@@ -158,13 +162,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
         CsvFormatOptions options,
         String format,
         List<String> extensions,
-        List<Attribute> resolvedSchema
+        List<Attribute> resolvedSchema,
+        int schemaSampleSize
     ) {
         this.blockFactory = blockFactory;
         this.options = options;
         this.format = format;
         this.extensions = extensions;
         this.resolvedSchema = resolvedSchema;
+        this.schemaSampleSize = schemaSampleSize;
         this.sharedCsvMapper = createMapper(options);
     }
 
@@ -295,12 +301,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
-        return new CsvFormatReader(blockFactory, newOptions, format, extensions, resolvedSchema);
+        return new CsvFormatReader(blockFactory, newOptions, format, extensions, resolvedSchema, schemaSampleSize);
     }
 
     @Override
     public CsvFormatReader withSchema(List<Attribute> schema) {
-        return new CsvFormatReader(blockFactory, options, format, extensions, schema);
+        return new CsvFormatReader(blockFactory, options, format, extensions, schema, schemaSampleSize);
     }
 
     @Override
@@ -309,7 +315,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return this;
         }
         CsvFormatOptions parsed = parseOptionsFromConfig(config);
-        return parsed == null ? this : withOptions(parsed);
+        int newSampleSize = parseInt(config.get("schema_sample_size"), schemaSampleSize);
+        Check.isTrue(newSampleSize > 0, "schema_sample_size must be positive, got: {}", newSampleSize);
+        CsvFormatReader result = parsed != null ? withOptions(parsed) : this;
+        if (newSampleSize != result.schemaSampleSize) {
+            result = new CsvFormatReader(
+                result.blockFactory,
+                result.options,
+                result.format,
+                result.extensions,
+                result.resolvedSchema,
+                newSampleSize
+            );
+        }
+        return result;
     }
 
     @Override
@@ -347,8 +366,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private List<Attribute> inferSchemaFromSample(String headerLine, BufferedReader reader) throws IOException {
         String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
         Iterator<List<?>> csvIterator = newCsvIterator(reader);
-        List<String[]> sampleRows = collectSampleRows(csvIterator, options.commentPrefix());
-        return CsvSchemaInferrer.inferSchema(columnNames, sampleRows);
+        CircuitBreaker breaker = blockFactory.breaker();
+        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker);
+        try {
+            return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
+        } finally {
+            breaker.addWithoutBreaking(-sample.reservedBytes());
+        }
     }
 
     private Iterator<List<?>> newCsvIterator(Reader reader) throws IOException {
@@ -360,24 +384,57 @@ public class CsvFormatReader implements SegmentableFormatReader {
         return sharedCsvMapper.readerFor(List.class).with(csvSchema).readValues(reader);
     }
 
-    static List<String[]> collectSampleRows(Iterator<List<?>> csvIterator, String commentPrefix) {
+    /**
+     * Holds sample rows collected for schema inference together with the number of bytes
+     * reserved on the circuit breaker. Callers must release {@link #reservedBytes} via
+     * {@link CircuitBreaker#addWithoutBreaking(long)} when the rows are no longer needed.
+     */
+    record SchemaSample(List<String[]> rows, long reservedBytes) {}
+
+    static SchemaSample collectSampleRows(Iterator<List<?>> csvIterator, String commentPrefix, int sampleSize, CircuitBreaker breaker) {
         List<String[]> sampleRows = new ArrayList<>();
-        boolean hasCommentFilter = commentPrefix != null && commentPrefix.isEmpty() == false;
-        while (sampleRows.size() < CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE && csvIterator.hasNext()) {
-            List<?> rowList = csvIterator.next();
-            String[] row = new String[rowList.size()];
-            for (int i = 0; i < rowList.size(); i++) {
-                Object val = rowList.get(i);
-                row[i] = val != null ? val.toString() : null;
-            }
-            if (hasCommentFilter && row.length > 0 && row[0] != null) {
-                if (row[0].trim().startsWith(commentPrefix)) {
-                    continue;
+        long reservedBytes = 0;
+        boolean success = false;
+        try {
+            boolean hasCommentFilter = commentPrefix != null && commentPrefix.isEmpty() == false;
+            while (sampleRows.size() < sampleSize && csvIterator.hasNext()) {
+                List<?> rowList = csvIterator.next();
+                String[] row = new String[rowList.size()];
+                for (int i = 0; i < rowList.size(); i++) {
+                    Object val = rowList.get(i);
+                    row[i] = val != null ? val.toString() : null;
                 }
+                if (hasCommentFilter && row.length > 0 && row[0] != null) {
+                    if (row[0].trim().startsWith(commentPrefix)) {
+                        continue;
+                    }
+                }
+                long rowBytes = estimateRowBytes(row);
+                breaker.addEstimateBytesAndMaybeBreak(rowBytes, "csv_schema_inference");
+                reservedBytes += rowBytes;
+                sampleRows.add(row);
             }
-            sampleRows.add(row);
+            success = true;
+            return new SchemaSample(sampleRows, reservedBytes);
+        } finally {
+            if (success == false) {
+                breaker.addWithoutBreaking(-reservedBytes);
+            }
         }
-        return sampleRows;
+    }
+
+    /**
+     * Estimates heap usage for a {@code String[]} row: array header + reference slots +
+     * per-string overhead (object header, fields, char storage).
+     */
+    static long estimateRowBytes(String[] row) {
+        long bytes = 16L + (long) row.length * 8;
+        for (String s : row) {
+            if (s != null) {
+                bytes += 40L + (long) s.length() * 2;
+            }
+        }
+        return bytes;
     }
 
     @Override
@@ -555,6 +612,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private Object[] rowBuffer;
         private Iterator<List<?>> csvIterator;
         private List<String[]> prefetchedRows;
+        private long prefetchedRowsBytes;
         private Page nextPage;
         private boolean closed = false;
         private long errorCount = 0;
@@ -614,6 +672,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
         public void close() throws IOException {
             if (closed == false) {
                 closed = true;
+                if (prefetchedRowsBytes > 0) {
+                    blockFactory.breaker().addWithoutBreaking(-prefetchedRowsBytes);
+                    prefetchedRowsBytes = 0;
+                    prefetchedRows = null;
+                }
                 if (modeOrdinal != ErrorPolicy.Mode.FAIL_FAST.ordinal() && errorCount > 0) {
                     logger.info(
                         "CSV parsing completed with [{}] errors out of [{}] rows (policy: {})",
@@ -670,6 +733,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 if (prefetchedRows != null) {
                     rows.addAll(prefetchedRows);
                     prefetchedRows = null;
+                    blockFactory.breaker().addWithoutBreaking(-prefetchedRowsBytes);
+                    prefetchedRowsBytes = 0;
                 }
                 if (csvIterator == null && bracketMultiValues && options.delimiter() == ',') {
                     rows.addAll(readRowsBracketAware(batchSize - rows.size()));
@@ -828,12 +893,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private List<Attribute> inferSchemaFromBatchReader(String headerLine) throws IOException {
             String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
             csvIterator = newCsvIterator(reader);
-            List<String[]> sampleRows = collectSampleRows(csvIterator, options.commentPrefix());
-            if (sampleRows.isEmpty()) {
+            SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, blockFactory.breaker());
+            if (sample.rows().isEmpty()) {
+                blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;
             }
-            prefetchedRows = sampleRows;
-            return CsvSchemaInferrer.inferSchema(columnNames, sampleRows);
+            prefetchedRows = sample.rows();
+            prefetchedRowsBytes = sample.reservedBytes();
+            return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
         }
 
         private void initProjection() {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrer.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrer.java
@@ -43,7 +43,7 @@ import java.util.Locale;
  */
 public class CsvSchemaInferrer {
 
-    static final int DEFAULT_SAMPLE_SIZE = 100;
+    static final int DEFAULT_SAMPLE_SIZE = 20_000;
 
     private static final DataType[] TYPE_CANDIDATES = {
         DataType.BOOLEAN,

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -1417,6 +1418,37 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertTrue(e.getMessage().contains("Failed to parse CSV value"));
     }
 
+    public void testWithConfigSchemaSampleSizeOverride() throws IOException {
+        StringBuilder csv = new StringBuilder();
+        csv.append("id,value\n");
+        for (int i = 0; i < 200; i++) {
+            csv.append(i).append(",text_").append(i).append("\n");
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader configured = baseReader.withConfig(Map.of("schema_sample_size", "50"));
+        try (CloseableIterator<Page> iterator = configured.read(object, null, 1000)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertTrue(page.getPositionCount() > 0);
+        }
+    }
+
+    public void testWithConfigSchemaSampleSizeZeroIsRejected() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "0")));
+    }
+
+    public void testWithConfigSchemaSampleSizeNegativeIsRejected() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "-1")));
+    }
+
+    public void testWithConfigSchemaSampleSizeInvalidIsRejected() {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        expectThrows(IllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "abc")));
+    }
+
     // --- Multi-value bracket syntax tests ---
 
     public void testMultiValueBracketsInteger() throws IOException {
@@ -2125,6 +2157,16 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testFindNextRecordBoundaryEmptyStream() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
         assertEquals(-1, reader.findNextRecordBoundary(new ByteArrayInputStream(new byte[0])));
+    }
+
+    public void testFindNextRecordBoundaryQuotedNewlineAcrossSplitBoundary() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Simulate a split boundary landing inside a quoted field with embedded newlines.
+        // The boundary finder must skip past the quoted field to find the real record boundary.
+        byte[] data = "partial,\"quoted\nfield\nwith\nnewlines\",end\nnext_record,b,c\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        int expected = "partial,\"quoted\nfield\nwith\nnewlines\",end\n".length();
+        assertEquals(expected, boundary);
     }
 
     public void testFindNextRecordBoundaryAtBufferBoundary() throws IOException {

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -12,7 +12,9 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -21,6 +23,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 /**
  * FormatReader implementation for NDJSON files.
@@ -29,25 +32,44 @@ import java.util.List;
 public class NdJsonFormatReader implements SegmentableFormatReader {
 
     public static final String SCHEMA_SAMPLE_SIZE_SETTING = "esql.datasource.ndjson.schema_sample_size";
-    public static final int DEFAULT_SCHEMA_SAMPLE_SIZE = 100;
+    public static final int DEFAULT_SCHEMA_SAMPLE_SIZE = 20_000;
 
     private final BlockFactory blockFactory;
     private final Settings settings;
     private final List<Attribute> resolvedSchema;
+    private final int schemaSampleSize;
 
     public NdJsonFormatReader(Settings settings, BlockFactory blockFactory, List<Attribute> resolvedSchema) {
-        this.blockFactory = blockFactory;
-        this.settings = settings == null ? Settings.EMPTY : settings;
-        this.resolvedSchema = resolvedSchema;
+        this(settings, blockFactory, resolvedSchema, schemaSampleSize(settings));
     }
 
     NdJsonFormatReader(Settings settings, BlockFactory blockFactory) {
         this(settings, blockFactory, null);
     }
 
+    private NdJsonFormatReader(Settings settings, BlockFactory blockFactory, List<Attribute> resolvedSchema, int schemaSampleSize) {
+        this.blockFactory = blockFactory;
+        this.settings = settings == null ? Settings.EMPTY : settings;
+        this.resolvedSchema = resolvedSchema;
+        this.schemaSampleSize = schemaSampleSize;
+    }
+
     @Override
     public NdJsonFormatReader withSchema(List<Attribute> schema) {
-        return new NdJsonFormatReader(settings, blockFactory, schema);
+        return new NdJsonFormatReader(settings, blockFactory, schema, schemaSampleSize);
+    }
+
+    @Override
+    public FormatReader withConfig(Map<String, Object> config) {
+        if (config == null || config.isEmpty()) {
+            return this;
+        }
+        int newSampleSize = parseInt(config.get("schema_sample_size"), schemaSampleSize);
+        Check.isTrue(newSampleSize > 0, "schema_sample_size must be positive, got: {}", newSampleSize);
+        if (newSampleSize == schemaSampleSize) {
+            return this;
+        }
+        return new NdJsonFormatReader(settings, blockFactory, resolvedSchema, newSampleSize);
     }
 
     private List<Attribute> inferSchemaIfNeeded(List<Attribute> attributes, StorageObject object) throws IOException {
@@ -56,19 +78,31 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         }
 
         try (var stream = object.newStream()) {
-            return NdJsonSchemaInferrer.inferSchema(stream, schemaSampleSize(settings));
+            return NdJsonSchemaInferrer.inferSchema(stream, schemaSampleSize);
         }
     }
 
     private static int schemaSampleSize(Settings settings) {
-        return settings.getAsInt(SCHEMA_SAMPLE_SIZE_SETTING, DEFAULT_SCHEMA_SAMPLE_SIZE);
+        Settings resolved = settings == null ? Settings.EMPTY : settings;
+        return resolved.getAsInt(SCHEMA_SAMPLE_SIZE_SETTING, DEFAULT_SCHEMA_SAMPLE_SIZE);
+    }
+
+    private static int parseInt(Object value, int defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid integer value [" + value + "]", e);
+        }
     }
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
         List<Attribute> schema;
         try (var stream = object.newStream()) {
-            schema = NdJsonSchemaInferrer.inferSchema(stream, schemaSampleSize(settings));
+            schema = NdJsonSchemaInferrer.inferSchema(stream, schemaSampleSize);
         }
         return new SimpleSourceMetadata(schema, formatName(), object.path().toString());
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xpack.esql.action.ColumnInfoImpl;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -41,6 +42,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class NdJsonPageIteratorTests extends ESTestCase {
@@ -525,6 +527,33 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         var str = RestResponseUtils.getTextBodyContent(format.format(req, resp));
 
         assertEquals(expected, str);
+    }
+
+    public void testWithConfigSchemaSampleSizeOverride() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        var configured = reader.withConfig(Map.of("schema_sample_size", "50"));
+        assertNotSame(reader, configured);
+    }
+
+    public void testWithConfigSchemaSampleSizeZeroIsRejected() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "0")));
+    }
+
+    public void testWithConfigSchemaSampleSizeNegativeIsRejected() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        expectThrows(QlIllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "-1")));
+    }
+
+    public void testWithConfigSchemaSampleSizeInvalidIsRejected() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        expectThrows(IllegalArgumentException.class, () -> reader.withConfig(Map.of("schema_sample_size", "abc")));
+    }
+
+    public void testWithConfigNullOrEmptyReturnsThis() {
+        NdJsonFormatReader reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        assertSame(reader, reader.withConfig(null));
+        assertSame(reader, reader.withConfig(Map.of()));
     }
 
     private static DataType dataType(Block block) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -15,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -55,13 +57,17 @@ public class FileSplitProvider implements SplitProvider {
 
     private static final Logger LOGGER = LogManager.getLogger(FileSplitProvider.class);
 
-    static final long DEFAULT_TARGET_SPLIT_SIZE = -1;
+    // 64 MB — 2x the maximum compression block target (DEFAULT_MACRO_SPLIT_TARGET) to keep
+    // memory pressure low while still enabling meaningful cross-node parallelism.
+    // DuckDB uses ~32 MB buffers; increase to 128+ MB for high-throughput clusters.
+    static final long DEFAULT_TARGET_SPLIT_SIZE = 64 * 1024 * 1024;
     static final long DEFAULT_MACRO_SPLIT_TARGET = 32 * 1024 * 1024; // 32MB compressed
     static final String FIRST_SPLIT_KEY = "_first_split";
     static final String LAST_SPLIT_KEY = "_last_split";
 
     static final String RANGE_SPLIT_KEY = "_range_split";
     static final String FILE_LENGTH_KEY = "_file_length";
+    static final String CONFIG_TARGET_SPLIT_SIZE = "target_split_size";
 
     private final long targetSplitSizeBytes;
     private final DecompressionCodecRegistry codecRegistry;
@@ -116,6 +122,8 @@ public class FileSplitProvider implements SplitProvider {
         // instance on the coordinator, avoiding redundant allocations.
         Map<SchemaReconciliation.ColumnMapping, SchemaReconciliation.ColumnMapping> mappingCache = new HashMap<>();
 
+        long effectiveSplitSize = resolveTargetSplitSize(config);
+
         for (int i = 0; i < fileList.fileCount(); i++) {
             StoragePath filePath = fileList.path(i);
 
@@ -163,12 +171,22 @@ public class FileSplitProvider implements SplitProvider {
                 continue;
             }
 
-            if (targetSplitSizeBytes > 0 && fileLength > targetSplitSizeBytes && isSplittableFormat(format)) {
+            if (effectiveSplitSize > 0 && fileLength > effectiveSplitSize && isSplittableFormat(format)) {
                 long offset = 0;
+                boolean isFirst = true;
                 while (offset < fileLength) {
-                    long chunkLength = Math.min(targetSplitSizeBytes, fileLength - offset);
-                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, config, partitionValues, columnMapping));
+                    long chunkLength = Math.min(effectiveSplitSize, fileLength - offset);
+                    boolean isLast = (offset + chunkLength >= fileLength);
+                    Map<String, Object> splitConfig = new HashMap<>(config);
+                    if (isFirst) {
+                        splitConfig.put(FIRST_SPLIT_KEY, "true");
+                    }
+                    if (isLast) {
+                        splitConfig.put(LAST_SPLIT_KEY, "true");
+                    }
+                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, splitConfig, partitionValues, columnMapping));
                     offset += chunkLength;
+                    isFirst = false;
                 }
             } else {
                 splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
@@ -447,6 +465,33 @@ public class FileSplitProvider implements SplitProvider {
             case ".csv", ".tsv", ".ndjson", ".jsonl", ".json", ".txt" -> true;
             default -> false;
         };
+    }
+
+    /**
+     * Resolves the effective target split size from the config map, falling back to the
+     * constructor-provided value. Delegates to {@link ByteSizeValue#parseBytesSizeValue} for
+     * unit parsing (accepts {@code "64mb"}, {@code "1gb"}, {@code "1024b"}, etc.).
+     * Unitless values (e.g. {@code "1024"}) are rejected — a unit suffix is always required.
+     *
+     * <p>{@code ByteSizeValue} throws {@link org.elasticsearch.ElasticsearchParseException}
+     * on malformed input — an {@link org.elasticsearch.ElasticsearchException} subclass that
+     * {@code SplitDiscoveryPhase} already handles without wrapping.
+     */
+    private long resolveTargetSplitSize(Map<String, Object> config) {
+        if (config == null) {
+            return targetSplitSizeBytes;
+        }
+        Object value = config.get(CONFIG_TARGET_SPLIT_SIZE);
+        if (value == null) {
+            return targetSplitSizeBytes;
+        }
+        String s = value.toString().trim();
+        if (s.isEmpty()) {
+            return targetSplitSizeBytes;
+        }
+        long result = ByteSizeValue.parseBytesSizeValue(s, CONFIG_TARGET_SPLIT_SIZE).getBytes();
+        Check.isTrue(result > 0, "Invalid value for [{}]: [{}]; must be positive", CONFIG_TARGET_SPLIT_SIZE, value);
+        return result;
     }
 
     static boolean matchesPartitionFilters(Map<String, Object> partitionValues, List<Expression> filters) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -8,10 +8,12 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -369,15 +371,26 @@ public class FileSplitProviderTests extends ESTestCase {
         FileSplit s0 = (FileSplit) splits.get(0);
         assertEquals(0, s0.offset());
         assertEquals(1000, s0.length());
+        assertEquals("true", s0.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(s0.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+
         FileSplit s1 = (FileSplit) splits.get(1);
         assertEquals(1000, s1.offset());
         assertEquals(1000, s1.length());
+        assertNull(s1.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(s1.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+
         FileSplit s2 = (FileSplit) splits.get(2);
         assertEquals(2000, s2.offset());
         assertEquals(1000, s2.length());
+        assertNull(s2.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(s2.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+
         FileSplit s3 = (FileSplit) splits.get(3);
         assertEquals(3000, s3.offset());
         assertEquals(500, s3.length());
+        assertNull(s3.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", s3.config().get(FileSplitProvider.LAST_SPLIT_KEY));
     }
 
     public void testSmallFileIsNotSplit() {
@@ -411,7 +424,7 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(5000, ((FileSplit) splits.get(0)).length());
     }
 
-    public void testDefaultProviderDoesNotSplit() {
+    public void testDefaultProviderDoesNotSplitSmallFile() {
         StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/big.csv"), 10_000_000, Instant.EPOCH);
         FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
 
@@ -420,6 +433,135 @@ public class FileSplitProviderTests extends ESTestCase {
 
         assertEquals(1, splits.size());
         assertEquals(0, ((FileSplit) splits.get(0)).offset());
+    }
+
+    public void testDefaultProviderSplitsLargeTextFile() {
+        long fileSize = 500 * 1024 * 1024L; // 500 MB
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/huge.csv"), fileSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        // 500 MB / 64 MB default = 7.8125 → 8 splits
+        assertEquals(8, splits.size());
+
+        long totalBytes = 0;
+        for (ExternalSplit split : splits) {
+            totalBytes += ((FileSplit) split).length();
+        }
+        assertEquals(fileSize, totalBytes);
+
+        FileSplit first = (FileSplit) splits.get(0);
+        assertEquals(0, first.offset());
+        assertEquals("true", first.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(first.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+
+        FileSplit last = (FileSplit) splits.get(splits.size() - 1);
+        assertNull(last.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", last.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+    }
+
+    public void testTargetSplitSizeConfigOverride() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "1kb");
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals(3, splits.size());
+        long totalBytes = 0;
+        for (ExternalSplit split : splits) {
+            totalBytes += ((FileSplit) split).length();
+        }
+        assertEquals(3000, totalBytes);
+
+        assertEquals("true", ((FileSplit) splits.get(0)).config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(((FileSplit) splits.get(0)).config().get(FileSplitProvider.LAST_SPLIT_KEY));
+        assertNull(((FileSplit) splits.get(1)).config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertNull(((FileSplit) splits.get(1)).config().get(FileSplitProvider.LAST_SPLIT_KEY));
+        assertNull(((FileSplit) splits.get(2)).config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", ((FileSplit) splits.get(2)).config().get(FileSplitProvider.LAST_SPLIT_KEY));
+    }
+
+    public void testTargetSplitSizeConfigOverrideMb() {
+        long fileSize = 300 * 1024 * 1024L; // 300 MB
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), fileSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
+
+        // Use 32mb (half the 64MB default) to verify the override actually changes behavior
+        Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "32mb");
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        // 300MB / 32MB ≈ 9.375 → 10 splits (vs 5 with the 64MB default)
+        assertEquals(10, splits.size());
+        assertEquals("true", ((FileSplit) splits.get(0)).config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", ((FileSplit) splits.get(9)).config().get(FileSplitProvider.LAST_SPLIT_KEY));
+
+        long totalBytes = 0;
+        for (ExternalSplit split : splits) {
+            totalBytes += ((FileSplit) split).length();
+        }
+        assertEquals(fileSize, totalBytes);
+    }
+
+    public void testTargetSplitSizeInvalidValue() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "not_a_number");
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
+        expectThrows(ElasticsearchParseException.class, () -> provider.discoverSplits(ctx));
+    }
+
+    public void testTargetSplitSizeUnitlessIsRejected() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "1024");
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
+        expectThrows(ElasticsearchParseException.class, () -> provider.discoverSplits(ctx));
+    }
+
+    public void testTargetSplitSizeZeroIsRejected() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "0b");
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
+        expectThrows(QlIllegalArgumentException.class, () -> provider.discoverSplits(ctx));
+    }
+
+    public void testFileSizeExactlyEqualsSplitSizeProducesSingleSplit() {
+        long targetSize = 1000;
+        FileSplitProvider splitter = new FileSplitProvider(targetSize);
+
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/exact.csv"), targetSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals("File exactly equal to split size should produce one split", 1, splits.size());
+        FileSplit fs = (FileSplit) splits.get(0);
+        assertEquals(0, fs.offset());
+        assertEquals(targetSize, fs.length());
+    }
+
+    public void testDefaultProviderDoesNotByteRangeSplitLargeParquet() {
+        long fileSize = 500 * 1024 * 1024L; // 500 MB — well above the 64MB default
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/huge.parquet"), fileSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.parquet");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals("Parquet must not be byte-range split even with positive default split size", 1, splits.size());
+        FileSplit fs = (FileSplit) splits.get(0);
+        assertEquals(0, fs.offset());
+        assertEquals(fileSize, fs.length());
     }
 
     public void testIsSplittableFormat() {


### PR DESCRIPTION
Enable byte-range splitting for text formats (CSV, NDJSON, etc.)
by changing the default target split size from disabled (-1) to
64 MB — 2x the max compression block target to keep memory
pressure low. Large files now produce multiple FileSplits
distributed across compute nodes, complementing the existing
intra-node ParallelParsingCoordinator. Byte-range splits carry
FIRST/LAST split markers for correct header and boundary handling.

Also bumps schema inference sample size from 100 to 20,000 rows
for both CSV and NDJSON, reducing type mis-inference risk on files
where data patterns change after the first 100 rows.

New WITH clause options:
- target_split_size: override split size (e.g. "64mb")
- schema_sample_size: override CSV inference sample (e.g. 500)

Developed with AI-assisted tooling