### PR TITLE
[ESQL] Implement RangeAwareFormatReader for ORC

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -27,6 +27,8 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.StringColumnStatistics;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -41,8 +43,11 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
@@ -61,20 +66,25 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 /**
- * {@link FormatReader} implementation for Apache ORC files.
+ * {@link RangeAwareFormatReader} implementation for Apache ORC files.
  *
  * <p>Uses ORC's vectorized reader ({@link VectorizedRowBatch}) which maps naturally to
  * ESQL's columnar {@link Block}/{@link Page} model. Each ORC {@link ColumnVector} is
  * converted directly to the corresponding ESQL Block type.
+ *
+ * <p>Supports stripe-level split parallelism: {@link #discoverSplitRanges} exposes
+ * per-stripe byte ranges, and {@link #readRange} restricts reading to stripes within
+ * a given byte range via ORC's {@code Reader.Options.range()}.
  *
  * <p>Key features:
  * <ul>
  *   <li>Works with any StorageProvider (HTTP, S3, local) via {@link OrcStorageObjectAdapter}</li>
  *   <li>Efficient columnar reading with column projection</li>
  *   <li>Direct conversion from ORC VectorizedRowBatch to ESQL Page</li>
+ *   <li>Stripe-level split parallelism for multi-stripe files</li>
  * </ul>
  */
-public class OrcFormatReader implements FormatReader {
+public class OrcFormatReader implements RangeAwareFormatReader {
 
     private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
 
@@ -221,45 +231,148 @@ public class OrcFormatReader implements FormatReader {
 
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        OrcFile.ReaderOptions readerOptions = orcReaderOptions(fs);
-        Reader reader = OrcFile.createReader(path, readerOptions);
-
+        Reader reader = OrcFile.createReader(path, orcReaderOptions(fs));
         TypeDescription schema = reader.getSchema();
         List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
 
-        List<Attribute> projectedAttributes;
-        boolean[] include = null;
-        if (projectedColumns == null || projectedColumns.isEmpty()) {
-            projectedAttributes = attributes;
-        } else {
-            projectedAttributes = new ArrayList<>();
-            Map<String, Integer> nameToIndex = new HashMap<>();
-            List<String> fieldNames = schema.getFieldNames();
-            for (int i = 0; i < fieldNames.size(); i++) {
-                nameToIndex.put(fieldNames.get(i), i);
+        List<Attribute> projectedAttributes = resolveProjection(attributes, projectedColumns);
+        boolean[] include = buildIncludeMask(schema, projectedColumns);
+
+        Reader.Options readOptions = configureReadOptions(reader, batchSize, include);
+        RecordReader rows = reader.rows(readOptions);
+
+        CloseableIterator<Page> iter = new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
+        return rowLimit != NO_LIMIT ? new RowLimitingIterator(iter, rowLimit) : iter;
+    }
+
+    @Override
+    public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
+        OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
+        Path path = new Path(object.path().toString());
+        try (Reader reader = OrcFile.createReader(path, orcReaderOptions(fs))) {
+            List<StripeInformation> stripes = reader.getStripes();
+            if (stripes.size() <= 1) {
+                return List.of();
             }
-            // ORC include array: index 0 is the root struct, then 1..N for each field
-            include = new boolean[schema.getMaximumId() + 1];
-            include[0] = true;
-            Map<String, Attribute> attributeMap = new HashMap<>();
-            for (Attribute attr : attributes) {
-                attributeMap.put(attr.name(), attr);
+            List<StripeStatistics> stripeStats = reader.getStripeStatistics();
+            TypeDescription schema = reader.getSchema();
+            List<SplitRange> ranges = new ArrayList<>(stripes.size());
+            for (int i = 0; i < stripes.size(); i++) {
+                StripeInformation stripe = stripes.get(i);
+                Map<String, Object> stats = (i < stripeStats.size()) ? buildStripeStats(stripe, stripeStats.get(i), schema) : Map.of();
+                ranges.add(new SplitRange(stripe.getOffset(), stripe.getLength(), stats));
             }
-            for (String columnName : projectedColumns) {
-                Attribute attr = attributeMap.get(columnName);
-                if (attr != null) {
-                    Integer idx = nameToIndex.get(columnName);
-                    if (idx != null) {
-                        TypeDescription child = schema.getChildren().get(idx);
-                        includeColumnForType(include, child);
-                    }
-                } else {
-                    attr = new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL);
-                }
-                projectedAttributes.add(attr);
+            return ranges;
+        }
+    }
+
+    private static Map<String, Object> buildStripeStats(StripeInformation stripe, StripeStatistics stats, TypeDescription schema) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("_stats.row_count", stripe.getNumberOfRows());
+        map.put("_stats.size_bytes", stripe.getLength());
+        List<String> fieldNames = schema.getFieldNames();
+        List<TypeDescription> children = schema.getChildren();
+        ColumnStatistics[] colStats = stats.getColumnStatistics();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            String colName = fieldNames.get(i);
+            int colId = children.get(i).getId();
+            if (colId >= colStats.length) {
+                continue;
+            }
+            ColumnStatistics cs = colStats[colId];
+            if (cs == null) {
+                continue;
+            }
+            long totalValues = cs.getNumberOfValues();
+            long nullCount = stripe.getNumberOfRows() - totalValues;
+            map.put("_stats.columns." + colName + ".null_count", nullCount);
+            Object minVal = extractOrcMin(cs);
+            Object maxVal = extractOrcMax(cs);
+            if (minVal != null) {
+                map.put("_stats.columns." + colName + ".min", minVal);
+            }
+            if (maxVal != null) {
+                map.put("_stats.columns." + colName + ".max", maxVal);
             }
         }
+        return Map.copyOf(map);
+    }
 
+    /**
+     * Reads only the stripes whose byte range falls within {@code [rangeStart, rangeEnd)}.
+     * {@code errorPolicy} is accepted for interface compliance but not applied — ORC errors are
+     * structural (corrupt stripe, schema mismatch) rather than row-level.
+     */
+    @Override
+    public CloseableIterator<Page> readRange(
+        StorageObject object,
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        if (rangeEnd <= rangeStart) {
+            throw new IllegalArgumentException("rangeEnd [" + rangeEnd + "] must be greater than rangeStart [" + rangeStart + "]");
+        }
+        OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
+        Path path = new Path(object.path().toString());
+        Reader reader = OrcFile.createReader(path, orcReaderOptions(fs));
+        TypeDescription schema = reader.getSchema();
+
+        final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
+            ? resolvedAttributes
+            : convertOrcSchemaToAttributes(schema);
+
+        List<Attribute> projectedAttributes = resolveProjection(attributes, projectedColumns);
+        boolean[] include = buildIncludeMask(schema, projectedColumns);
+
+        Reader.Options readOptions = configureReadOptions(reader, batchSize, include);
+        readOptions.range(rangeStart, rangeEnd - rangeStart);
+        RecordReader rows = reader.rows(readOptions);
+
+        return new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
+    }
+
+    private static List<Attribute> resolveProjection(List<Attribute> attributes, List<String> projectedColumns) {
+        if (projectedColumns == null || projectedColumns.isEmpty()) {
+            return attributes;
+        }
+        List<Attribute> projected = new ArrayList<>();
+        Map<String, Attribute> attributeMap = new HashMap<>();
+        for (Attribute attr : attributes) {
+            attributeMap.put(attr.name(), attr);
+        }
+        for (String columnName : projectedColumns) {
+            Attribute attr = attributeMap.get(columnName);
+            projected.add(attr != null ? attr : new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL));
+        }
+        return projected;
+    }
+
+    private static boolean[] buildIncludeMask(TypeDescription schema, List<String> projectedColumns) {
+        if (projectedColumns == null || projectedColumns.isEmpty()) {
+            return null;
+        }
+        Map<String, Integer> nameToIndex = new HashMap<>();
+        List<String> fieldNames = schema.getFieldNames();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            nameToIndex.put(fieldNames.get(i), i);
+        }
+        boolean[] include = new boolean[schema.getMaximumId() + 1];
+        include[0] = true;
+        for (String columnName : projectedColumns) {
+            Integer idx = nameToIndex.get(columnName);
+            if (idx != null) {
+                TypeDescription child = schema.getChildren().get(idx);
+                includeColumnForType(include, child);
+            }
+        }
+        return include;
+    }
+
+    private Reader.Options configureReadOptions(Reader reader, int batchSize, boolean[] include) {
         Reader.Options readOptions = reader.options().rowBatchSize(batchSize);
         if (include != null) {
             readOptions.include(include);
@@ -272,10 +385,7 @@ public class OrcFormatReader implements FormatReader {
             }
             readOptions.searchArgument(pushedFilter, nameSet.toArray(new String[0]));
         }
-        RecordReader rows = reader.rows(readOptions);
-
-        CloseableIterator<Page> iter = new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
-        return rowLimit != NO_LIMIT ? new RowLimitingIterator(iter, rowLimit) : iter;
+        return readOptions;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -37,11 +37,13 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -94,7 +96,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             LongColumnVector activeCol = (LongColumnVector) batch.cols[3];
 
             idCol.vector[0] = 1L;
-            nameCol.setVal(0, "Alice".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(0, "Alice".getBytes(StandardCharsets.UTF_8));
             ageCol.vector[0] = 30;
             activeCol.vector[0] = 1;
         });
@@ -133,25 +135,22 @@ public class OrcFormatReaderTests extends ESTestCase {
             DoubleColumnVector scoreCol = (DoubleColumnVector) batch.cols[2];
 
             idCol.vector[0] = 1L;
-            nameCol.setVal(0, "Alice".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(0, "Alice".getBytes(StandardCharsets.UTF_8));
             scoreCol.vector[0] = 95.5;
 
             idCol.vector[1] = 2L;
-            nameCol.setVal(1, "Bob".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(1, "Bob".getBytes(StandardCharsets.UTF_8));
             scoreCol.vector[1] = 87.3;
 
             idCol.vector[2] = 3L;
-            nameCol.setVal(2, "Charlie".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(2, "Charlie".getBytes(StandardCharsets.UTF_8));
             scoreCol.vector[2] = 92.1;
         });
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
             assertEquals(3, page.getBlockCount());
 
@@ -166,9 +165,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
             assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(2, new BytesRef()));
             assertEquals(92.1, ((DoubleBlock) page.getBlock(2)).getDouble(2), 0.001);
-
-            assertFalse(iterator.hasNext());
-        }
+        });
     }
 
     public void testReadWithColumnProjection() throws Exception {
@@ -184,21 +181,18 @@ public class OrcFormatReaderTests extends ESTestCase {
             DoubleColumnVector scoreCol = (DoubleColumnVector) batch.cols[2];
 
             idCol.vector[0] = 1L;
-            nameCol.setVal(0, "Alice".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(0, "Alice".getBytes(StandardCharsets.UTF_8));
             scoreCol.vector[0] = 95.5;
 
             idCol.vector[1] = 2L;
-            nameCol.setVal(1, "Bob".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            nameCol.setVal(1, "Bob".getBytes(StandardCharsets.UTF_8));
             scoreCol.vector[1] = 87.3;
         });
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, List.of("name", "score"), 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, List.of("name", "score"), page -> {
             assertEquals(2, page.getPositionCount());
             assertEquals(2, page.getBlockCount());
 
@@ -207,7 +201,7 @@ public class OrcFormatReaderTests extends ESTestCase {
 
             assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(0)).getBytesRef(1, new BytesRef()));
             assertEquals(87.3, ((DoubleBlock) page.getBlock(1)).getDouble(1), 0.001);
-        }
+        });
     }
 
     public void testProjectedColumnMissingFromFileReturnsNullBlock() throws Exception {
@@ -234,10 +228,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, List.of("id", "nonexistent", "score"), 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, List.of("id", "nonexistent", "score"), page -> {
             assertEquals(2, page.getPositionCount());
             assertEquals(3, page.getBlockCount());
 
@@ -248,7 +239,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
             assertTrue(page.getBlock(1).isNull(1));
             assertEquals(87.3, ((DoubleBlock) page.getBlock(2)).getDouble(1), 0.001);
-        }
+        });
     }
 
     public void testReadWithBatching() throws Exception {
@@ -269,15 +260,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        int totalRows = 0;
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
-            while (iterator.hasNext()) {
-                Page page = iterator.next();
-                totalRows += page.getPositionCount();
-            }
-        }
-
-        assertEquals(25, totalRows);
+        assertEquals(25, countRows(reader, storageObject, null, 10));
     }
 
     public void testReadBooleanColumn() throws Exception {
@@ -300,15 +283,11 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             assertTrue(((BooleanBlock) page.getBlock(1)).getBoolean(0));
             assertFalse(((BooleanBlock) page.getBlock(1)).getBoolean(1));
-        }
+        });
     }
 
     public void testReadIntegerColumn() throws Exception {
@@ -325,16 +304,12 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
-
             assertEquals(100, ((IntBlock) page.getBlock(0)).getInt(0));
             assertEquals(200, ((IntBlock) page.getBlock(0)).getInt(1));
             assertEquals(300, ((IntBlock) page.getBlock(0)).getInt(2));
-        }
+        });
     }
 
     public void testReadFloatColumn() throws Exception {
@@ -350,15 +325,11 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             assertEquals(98.6, ((DoubleBlock) page.getBlock(0)).getDouble(0), 0.1);
             assertEquals(37.0, ((DoubleBlock) page.getBlock(0)).getDouble(1), 0.1);
-        }
+        });
     }
 
     public void testMetadataReturnsCorrectSourceType() throws Exception {
@@ -407,10 +378,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
 
             LongBlock idBlock = (LongBlock) page.getBlock(0);
@@ -427,7 +395,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(95.5, scoreBlock.getDouble(0), 0.001);
             assertTrue(scoreBlock.isNull(1));
             assertEquals(92.1, scoreBlock.getDouble(2), 0.001);
-        }
+        });
     }
 
     public void testReadRepeatingVectors() throws Exception {
@@ -450,10 +418,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(5, page.getPositionCount());
 
             LongBlock idBlock = (LongBlock) page.getBlock(0);
@@ -465,7 +430,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             for (int i = 0; i < 5; i++) {
                 assertEquals(42, constantBlock.getInt(i));
             }
-        }
+        });
     }
 
     public void testReadTimestampColumn() throws Exception {
@@ -495,16 +460,12 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             LongBlock tsBlock = (LongBlock) page.getBlock(1);
             assertEquals(epochMillis, tsBlock.getLong(0));
             assertEquals(epochMillis + 3600_000, tsBlock.getLong(1));
-        }
+        });
     }
 
     public void testReadTimestampColumnWithNulls() throws Exception {
@@ -535,17 +496,13 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
-
             LongBlock tsBlock = (LongBlock) page.getBlock(1);
             assertEquals(epochMillis, tsBlock.getLong(0));
             assertTrue(tsBlock.isNull(1));
             assertEquals(epochMillis + 7200_000, tsBlock.getLong(2));
-        }
+        });
     }
 
     public void testReadDateColumn() throws Exception {
@@ -570,18 +527,12 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             LongBlock dateBlock = (LongBlock) page.getBlock(1);
-            long expectedMillis0 = daysSinceEpoch * 86_400_000L;
-            long expectedMillis1 = (daysSinceEpoch + 1) * 86_400_000L;
-            assertEquals(expectedMillis0, dateBlock.getLong(0));
-            assertEquals(expectedMillis1, dateBlock.getLong(1));
-        }
+            assertEquals(daysSinceEpoch * 86_400_000L, dateBlock.getLong(0));
+            assertEquals((daysSinceEpoch + 1) * 86_400_000L, dateBlock.getLong(1));
+        });
     }
 
     public void testReadListColumnAsMultiValue() throws Exception {
@@ -613,13 +564,9 @@ public class OrcFormatReaderTests extends ESTestCase {
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
         SourceMetadata metadata = reader.metadata(storageObject);
-        List<Attribute> attributes = metadata.schema();
-        assertEquals(DataType.KEYWORD, attributes.get(1).dataType());
+        assertEquals(DataType.KEYWORD, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
             assertEquals(2, page.getBlockCount());
 
@@ -633,7 +580,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(new BytesRef("b"), tagsBlock.getBytesRef(1, new BytesRef()));
             assertEquals(1, tagsBlock.getValueCount(1));
             assertEquals(new BytesRef("x"), tagsBlock.getBytesRef(2, new BytesRef()));
-        }
+        });
     }
 
     public void testIteratorCloseReleasesResourcesOnPartialRead() throws Exception {
@@ -685,7 +632,6 @@ public class OrcFormatReaderTests extends ESTestCase {
     }
 
     public void testReadWithPushedFilterMatchingAll() throws Exception {
-        // Create ORC file with values 1-5, push filter that matches all (id > 0)
         TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 5;
@@ -699,16 +645,10 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
         StorageObject storageObject = createStorageObject(orcData);
-        try (CloseableIterator<Page> iter = reader.read(storageObject, null, 1024)) {
-            assertTrue(iter.hasNext());
-            Page page = iter.next();
-            // All rows should be returned since filter matches all
-            assertEquals(5, page.getPositionCount());
-        }
+        readFirstPage(reader, storageObject, null, page -> assertEquals(5, page.getPositionCount()));
     }
 
     public void testReadWithPushedFilterMatchingNone() throws Exception {
-        // Create ORC file with values 1-5, push filter that matches none (id > 100)
         TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 5;
@@ -718,7 +658,6 @@ public class OrcFormatReaderTests extends ESTestCase {
             }
         });
 
-        // id > 100 → NOT(id <= 100) — file stats have max=5, so entire file is skipped
         SearchArgument sarg = SearchArgumentFactory.newBuilder()
             .startNot()
             .lessThanEquals("id", PredicateLeaf.Type.LONG, 100L)
@@ -728,7 +667,6 @@ public class OrcFormatReaderTests extends ESTestCase {
         OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
         StorageObject storageObject = createStorageObject(orcData);
         try (CloseableIterator<Page> iter = reader.read(storageObject, null, 1024)) {
-            // File-level stats should show max=5 < 100, so all stripes should be skipped
             assertFalse("No rows should match the filter", iter.hasNext());
         }
     }
@@ -750,19 +688,16 @@ public class OrcFormatReaderTests extends ESTestCase {
             nameCol.setVal(2, "Charlie".getBytes(StandardCharsets.UTF_8));
         });
 
-        // Filter id >= 1 (matches all — just testing that filter + projection work together)
         SearchArgument sarg = SearchArgumentFactory.newBuilder().startNot().lessThan("id", PredicateLeaf.Type.LONG, 1L).end().build();
 
         OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
         StorageObject storageObject = createStorageObject(orcData);
-        try (CloseableIterator<Page> iter = reader.read(storageObject, List.of("name"), 1024)) {
-            assertTrue(iter.hasNext());
-            Page page = iter.next();
+        readFirstPage(reader, storageObject, List.of("name"), page -> {
             assertEquals(3, page.getPositionCount());
             assertEquals(1, page.getBlockCount());
             BytesRefBlock nameBlock = (BytesRefBlock) page.getBlock(0);
             assertEquals("Alice", nameBlock.getBytesRef(0, new BytesRef()).utf8ToString());
-        }
+        });
     }
 
     public void testTimestampTruncatesToMillisPrecision() throws Exception {
@@ -773,10 +708,8 @@ public class OrcFormatReaderTests extends ESTestCase {
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 2;
             TimestampColumnVector tsCol = (TimestampColumnVector) batch.cols[0];
-
             tsCol.time[0] = epochMillis;
             tsCol.nanos[0] = 123_456_789;
-
             tsCol.time[1] = epochMillis;
             tsCol.nanos[1] = 123_000_000;
         });
@@ -784,16 +717,12 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
             LongBlock tsBlock = (LongBlock) page.getBlock(0);
-
             assertEquals(epochMillis, tsBlock.getLong(0));
             assertEquals(epochMillis, tsBlock.getLong(1));
-        }
+        });
     }
 
     public void testPreEpochTimestamp() throws Exception {
@@ -824,17 +753,13 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             LongBlock tsBlock = (LongBlock) page.getBlock(1);
             assertTrue("pre-epoch millis should be negative", tsBlock.getLong(0) < 0);
             assertEquals(preEpochMillis, tsBlock.getLong(0));
             assertEquals(postEpochMillis, tsBlock.getLong(1));
-        }
+        });
     }
 
     public void testReadListTimestampColumn() throws Exception {
@@ -874,12 +799,8 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             LongBlock eventsBlock = (LongBlock) page.getBlock(1);
             assertEquals(2, eventsBlock.getValueCount(0));
             assertEquals(ts1, eventsBlock.getLong(0));
@@ -887,7 +808,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(1, eventsBlock.getValueCount(1));
             assertTrue("pre-epoch list element should be negative", eventsBlock.getLong(2) < 0);
             assertEquals(ts3, eventsBlock.getLong(2));
-        }
+        });
     }
 
     public void testBinaryMapsToUnsupported() throws Exception {
@@ -908,14 +829,11 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.UNSUPPORTED, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(1, page.getPositionCount());
             assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
             assertTrue(page.getBlock(1).isNull(0));
-        }
+        });
     }
 
     public void testReadDecimalColumn() throws Exception {
@@ -944,17 +862,13 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DOUBLE, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
-
             DoubleBlock priceBlock = (DoubleBlock) page.getBlock(1);
             assertEquals(123.45, priceBlock.getDouble(0), 0.001);
             assertEquals(0.01, priceBlock.getDouble(1), 0.001);
             assertEquals(99999.99, priceBlock.getDouble(2), 0.001);
-        }
+        });
     }
 
     public void testReadDecimalColumnWithNulls() throws Exception {
@@ -964,29 +878,22 @@ public class OrcFormatReaderTests extends ESTestCase {
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 3;
             DecimalColumnVector amountCol = (DecimalColumnVector) batch.cols[0];
-
             amountCol.set(0, new HiveDecimalWritable("42.50"));
-
             amountCol.noNulls = false;
             amountCol.isNull[1] = true;
-
             amountCol.set(2, new HiveDecimalWritable("100.00"));
         });
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(3, page.getPositionCount());
-
             DoubleBlock block = (DoubleBlock) page.getBlock(0);
             assertEquals(42.50, block.getDouble(0), 0.001);
             assertTrue(block.isNull(1));
             assertEquals(100.00, block.getDouble(2), 0.001);
-        }
+        });
     }
 
     public void testReadDecimalHighPrecision() throws Exception {
@@ -996,7 +903,6 @@ public class OrcFormatReaderTests extends ESTestCase {
         byte[] orcData = createOrcFile(schema, batch -> {
             batch.size = 2;
             DecimalColumnVector valCol = (DecimalColumnVector) batch.cols[0];
-
             valCol.set(0, new HiveDecimalWritable("1234567890.1234567890"));
             valCol.set(1, new HiveDecimalWritable("-9876543210.0000000001"));
         });
@@ -1004,16 +910,12 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             DoubleBlock block = (DoubleBlock) page.getBlock(0);
             assertEquals(1234567890.1234567890, block.getDouble(0), 0.01);
             assertEquals(-9876543210.0000000001, block.getDouble(1), 0.01);
-        }
+        });
     }
 
     public void testReadListDecimalColumn() throws Exception {
@@ -1046,19 +948,292 @@ public class OrcFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DOUBLE, metadata.schema().get(1).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 1024)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-
+        readFirstPage(reader, storageObject, null, page -> {
             assertEquals(2, page.getPositionCount());
-
             DoubleBlock pricesBlock = (DoubleBlock) page.getBlock(1);
             assertEquals(2, pricesBlock.getValueCount(0));
             assertEquals(10.50, pricesBlock.getDouble(0), 0.001);
             assertEquals(20.99, pricesBlock.getDouble(1), 0.001);
             assertEquals(1, pricesBlock.getValueCount(1));
             assertEquals(99.00, pricesBlock.getDouble(2), 0.001);
+        });
+    }
+
+    // --- Range-aware (stripe-level split) tests ---
+
+    public void testDiscoverSplitRanges_singleStripe() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 3;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            idCol.vector[0] = 1L;
+            idCol.vector[1] = 2L;
+            idCol.vector[2] = 3L;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertEquals("Single-stripe file should return empty list", 0, ranges.size());
+    }
+
+    public void testDiscoverSplitRanges_multiStripeFile() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("name", TypeDescription.createString());
+
+        byte[] orcData = createMultiStripeOrcFile(schema, 3, batchIndex -> {
+            VectorizedRowBatch batch = schema.createRowBatch();
+            batch.size = 100;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            BytesColumnVector nameCol = (BytesColumnVector) batch.cols[1];
+            for (int i = 0; i < 100; i++) {
+                idCol.vector[i] = batchIndex * 100L + i;
+                nameCol.setVal(i, ("name_" + (batchIndex * 100 + i)).getBytes(StandardCharsets.UTF_8));
+            }
+            return batch;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+
+        assertTrue("Multi-stripe file should return non-empty ranges", ranges.size() >= 2);
+        for (SplitRange range : ranges) {
+            assertTrue("Offset should be non-negative", range.offset() >= 0);
+            assertTrue("Length should be positive", range.length() > 0);
+            assertNotNull("Per-stripe statistics should be present", range.statistics());
+            assertTrue("Statistics should contain row count", range.statistics().containsKey("_stats.row_count"));
+            assertEquals("Each stripe should have 100 rows", 100L, range.statistics().get("_stats.row_count"));
+            assertTrue("Statistics should contain size bytes", range.statistics().containsKey("_stats.size_bytes"));
+            assertTrue("Statistics should contain per-column stats", range.statistics().containsKey("_stats.columns.id.null_count"));
         }
+        for (int i = 1; i < ranges.size(); i++) {
+            assertTrue("Ranges should be in ascending offset order", ranges.get(i).offset() > ranges.get(i - 1).offset());
+        }
+    }
+
+    public void testReadRange_readsOnlyAssignedStripes() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("value", TypeDescription.createInt());
+
+        int rowsPerStripe = 100;
+        int stripeCount = 3;
+        byte[] orcData = createMultiStripeOrcFile(schema, stripeCount, batchIndex -> {
+            VectorizedRowBatch batch = schema.createRowBatch();
+            batch.size = rowsPerStripe;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            LongColumnVector valueCol = (LongColumnVector) batch.cols[1];
+            for (int i = 0; i < rowsPerStripe; i++) {
+                idCol.vector[i] = batchIndex * rowsPerStripe + i;
+                valueCol.vector[i] = batchIndex;
+            }
+            return batch;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Should have multiple stripes", ranges.size() >= 2);
+
+        // First stripe: all values should be 0
+        int firstStripeRows = countRangeRows(reader, storageObject, ranges.get(0), page -> {
+            IntBlock valueBlock = (IntBlock) page.getBlock(1);
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                assertEquals("All rows in first stripe should have value=0", 0, valueBlock.getInt(i));
+            }
+        });
+        assertEquals("First stripe should contain exactly " + rowsPerStripe + " rows", rowsPerStripe, firstStripeRows);
+
+        // Second stripe: all values should be 1
+        if (ranges.size() >= 3) {
+            forEachRangePage(reader, storageObject, ranges.get(1), page -> {
+                IntBlock valueBlock = (IntBlock) page.getBlock(1);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    assertEquals("All rows in second stripe should have value=1", 1, valueBlock.getInt(i));
+                }
+            });
+        }
+
+        // Sum of all range reads should equal total rows
+        int fullTotal = 0;
+        for (SplitRange range : ranges) {
+            fullTotal += countRangeRows(reader, storageObject, range);
+        }
+        assertEquals("Sum of all range reads should equal total rows", rowsPerStripe * stripeCount, fullTotal);
+    }
+
+    public void testReadRange_withProjection() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("name", TypeDescription.createString())
+            .addField("score", TypeDescription.createDouble());
+
+        byte[] orcData = createMultiStripeOrcFile(schema, 2, batchIndex -> {
+            VectorizedRowBatch batch = schema.createRowBatch();
+            batch.size = 100;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            BytesColumnVector nameCol = (BytesColumnVector) batch.cols[1];
+            DoubleColumnVector scoreCol = (DoubleColumnVector) batch.cols[2];
+            for (int i = 0; i < 100; i++) {
+                idCol.vector[i] = batchIndex * 100L + i;
+                nameCol.setVal(i, ("n" + i).getBytes(StandardCharsets.UTF_8));
+                scoreCol.vector[i] = batchIndex * 100.0 + i;
+            }
+            return batch;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Should have multiple stripes", ranges.size() >= 2);
+
+        readFirstRangePage(reader, storageObject, ranges.get(0), List.of("name", "score"), page -> {
+            assertEquals("Projected to 2 columns", 2, page.getBlockCount());
+            assertEquals("First stripe should have 100 rows", 100, page.getPositionCount());
+            BytesRefBlock nameBlock = (BytesRefBlock) page.getBlock(0);
+            assertEquals(new BytesRef("n0"), nameBlock.getBytesRef(0, new BytesRef()));
+            DoubleBlock scoreBlock = (DoubleBlock) page.getBlock(1);
+            assertEquals(0.0, scoreBlock.getDouble(0), 0.001);
+        });
+    }
+
+    public void testReadRange_withPredicate() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+
+        byte[] orcData = createMultiStripeOrcFile(schema, 3, batchIndex -> {
+            VectorizedRowBatch batch = schema.createRowBatch();
+            batch.size = 100;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            for (int i = 0; i < 100; i++) {
+                idCol.vector[i] = batchIndex * 1000L + i;
+            }
+            return batch;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+
+        SearchArgument sarg = SearchArgumentFactory.newBuilder()
+            .startNot()
+            .lessThanEquals("id", PredicateLeaf.Type.LONG, 999999L)
+            .end()
+            .build();
+        OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
+
+        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Should have multiple stripes", ranges.size() >= 2);
+
+        assertEquals("Filter should exclude all rows in this stripe", 0, countRangeRows(reader, storageObject, ranges.get(0)));
+    }
+
+    // --- Read template helpers ---
+
+    private void readFirstPage(
+        OrcFormatReader reader,
+        StorageObject object,
+        List<String> projection,
+        CheckedConsumer<Page, Exception> check
+    ) throws Exception {
+        try (CloseableIterator<Page> iter = reader.read(object, projection, 1024)) {
+            assertTrue(iter.hasNext());
+            check.accept(iter.next());
+        }
+    }
+
+    private int countRows(OrcFormatReader reader, StorageObject object, List<String> projection, int batchSize) throws Exception {
+        int total = 0;
+        try (CloseableIterator<Page> iter = reader.read(object, projection, batchSize)) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                total += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        return total;
+    }
+
+    private void readFirstRangePage(
+        OrcFormatReader reader,
+        StorageObject object,
+        SplitRange range,
+        List<String> projection,
+        CheckedConsumer<Page, Exception> check
+    ) throws Exception {
+        try (
+            CloseableIterator<Page> iter = reader.readRange(
+                object,
+                projection,
+                1024,
+                range.offset(),
+                range.offset() + range.length(),
+                List.of(),
+                null
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            check.accept(page);
+            page.releaseBlocks();
+        }
+    }
+
+    private void forEachRangePage(OrcFormatReader reader, StorageObject object, SplitRange range, CheckedConsumer<Page, Exception> check)
+        throws Exception {
+        try (
+            CloseableIterator<Page> iter = reader.readRange(
+                object,
+                null,
+                1024,
+                range.offset(),
+                range.offset() + range.length(),
+                List.of(),
+                null
+            )
+        ) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                check.accept(page);
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    private int countRangeRows(OrcFormatReader reader, StorageObject object, SplitRange range) throws Exception {
+        return countRangeRows(reader, object, range, page -> {});
+    }
+
+    private int countRangeRows(OrcFormatReader reader, StorageObject object, SplitRange range, CheckedConsumer<Page, Exception> check)
+        throws Exception {
+        int total = 0;
+        try (
+            CloseableIterator<Page> iter = reader.readRange(
+                object,
+                null,
+                1024,
+                range.offset(),
+                range.offset() + range.length(),
+                List.of(),
+                null
+            )
+        ) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                check.accept(page);
+                total += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        return total;
+    }
+
+    // --- ORC file creation helpers ---
+
+    @FunctionalInterface
+    private interface StripeBatchProducer {
+        VectorizedRowBatch produce(int stripeIndex) throws IOException;
     }
 
     @FunctionalInterface
@@ -1067,16 +1242,12 @@ public class OrcFormatReaderTests extends ESTestCase {
     }
 
     private byte[] createOrcFile(TypeDescription schema, BatchPopulator populator) throws IOException {
-        java.nio.file.Path tempFile = createTempFile();
+        var tempFile = createTempFile();
         Files.delete(tempFile);
         Path orcPath = new Path(tempFile.toUri());
 
         Configuration conf = new Configuration(false);
-        // Use in-memory key provider to avoid Hadoop's Shell class initialization, which
-        // attempts to start a process (blocked by entitlements as "never entitled")
         conf.set("orc.key.provider", "memory");
-        // Use a minimal FileSystem that avoids Hadoop's UserGroupInformation (Subject.getSubject()
-        // is unsupported on Java 25+) and doesn't call chmod (blocked by entitlements)
         NoPermissionLocalFileSystem localFs = new NoPermissionLocalFileSystem();
         localFs.setConf(conf);
         OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(conf)
@@ -1088,6 +1259,32 @@ public class OrcFormatReaderTests extends ESTestCase {
             VectorizedRowBatch batch = schema.createRowBatch();
             populator.populate(batch);
             writer.addRowBatch(batch);
+        }
+
+        return Files.readAllBytes(tempFile);
+    }
+
+    private byte[] createMultiStripeOrcFile(TypeDescription schema, int stripeCount, StripeBatchProducer producer) throws IOException {
+        var tempFile = createTempFile();
+        Files.delete(tempFile);
+        Path orcPath = new Path(tempFile.toUri());
+
+        Configuration conf = new Configuration(false);
+        conf.set("orc.key.provider", "memory");
+        NoPermissionLocalFileSystem localFs = new NoPermissionLocalFileSystem();
+        localFs.setConf(conf);
+        OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(conf)
+            .setSchema(schema)
+            .fileSystem(localFs)
+            .compress(CompressionKind.NONE)
+            .stripeSize(512);
+
+        try (Writer writer = OrcFile.createWriter(orcPath, writerOptions)) {
+            for (int s = 0; s < stripeCount; s++) {
+                VectorizedRowBatch batch = producer.produce(s);
+                writer.addRowBatch(batch);
+                writer.writeIntermediateFooter();
+            }
         }
 
         return Files.readAllBytes(tempFile);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -405,7 +406,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             pendingStats.add(range.statistics());
 
             if (groupEnd - groupStart >= targetBytes) {
-                out.add(new SplitRange(groupStart, groupEnd - groupStart, mergeStatsMaps(pendingStats)));
+                Map<String, Object> merged = SourceStatisticsSerializer.mergeStatistics(pendingStats);
+                out.add(new SplitRange(groupStart, groupEnd - groupStart, merged != null ? merged : Map.of()));
                 groupStart = -1;
                 groupEnd = -1;
                 pendingStats.clear();
@@ -413,69 +415,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         if (groupStart >= 0) {
-            out.add(new SplitRange(groupStart, groupEnd - groupStart, mergeStatsMaps(pendingStats)));
+            Map<String, Object> merged = SourceStatisticsSerializer.mergeStatistics(pendingStats);
+            out.add(new SplitRange(groupStart, groupEnd - groupStart, merged != null ? merged : Map.of()));
         }
 
         return out;
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    private static Map<String, Object> mergeStatsMaps(List<Map<String, Object>> statsList) {
-        if (statsList.isEmpty()) {
-            return Map.of();
-        }
-        if (statsList.size() == 1) {
-            return statsList.get(0);
-        }
-        long totalRows = 0;
-        long totalSize = 0;
-        Map<String, long[]> nullCounts = new HashMap<>();
-        Map<String, Comparable[]> mins = new HashMap<>();
-        Map<String, Comparable[]> maxs = new HashMap<>();
-
-        for (Map<String, Object> stats : statsList) {
-            Object rc = stats.get("_stats.row_count");
-            if (rc instanceof Number rcNum) {
-                totalRows += rcNum.longValue();
-            }
-            Object sb = stats.get("_stats.size_bytes");
-            if (sb instanceof Number sbNum) {
-                totalSize += sbNum.longValue();
-            }
-
-            for (Map.Entry<String, Object> entry : stats.entrySet()) {
-                String key = entry.getKey();
-                if (key.startsWith("_stats.columns.") == false) continue;
-                if (key.endsWith(".null_count") && entry.getValue() instanceof Number ncNum) {
-                    nullCounts.merge(key, new long[] { ncNum.longValue() }, (a, b) -> {
-                        a[0] += b[0];
-                        return a;
-                    });
-                } else if (key.endsWith(".min") && entry.getValue() instanceof Comparable c) {
-                    mins.merge(key, new Comparable[] { c }, (a, b) -> {
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp > 0) a[0] = b[0];
-                        return a;
-                    });
-                } else if (key.endsWith(".max") && entry.getValue() instanceof Comparable c) {
-                    maxs.merge(key, new Comparable[] { c }, (a, b) -> {
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp < 0) a[0] = b[0];
-                        return a;
-                    });
-                }
-            }
-        }
-
-        Map<String, Object> merged = new HashMap<>();
-        merged.put("_stats.row_count", totalRows);
-        if (totalSize > 0) {
-            merged.put("_stats.size_bytes", totalSize);
-        }
-        nullCounts.forEach((k, v) -> merged.put(k, v[0]));
-        mins.forEach((k, v) -> merged.put(k, v[0]));
-        maxs.forEach((k, v) -> merged.put(k, v[0]));
-        return Map.copyOf(merged);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
@@ -336,7 +337,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     }
 
     @Override
-    public List<long[]> discoverSplitRanges(StorageObject object) throws IOException {
+    public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
         InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetReadOptions options = readOptionsBuilder().build();
         try (ParquetFileReader reader = openParquetFile(object, parquetInputFile, options)) {
@@ -344,18 +345,37 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             if (rowGroups.size() <= 1) {
                 return List.of();
             }
-            List<long[]> ranges = new ArrayList<>(rowGroups.size());
+            List<SplitRange> ranges = new ArrayList<>(rowGroups.size());
             for (BlockMetaData block : rowGroups) {
-                ranges.add(new long[] { block.getStartingPos(), block.getTotalByteSize() });
+                Map<String, Object> stats = buildRowGroupStats(block);
+                ranges.add(new SplitRange(block.getStartingPos(), block.getTotalByteSize(), stats));
             }
-            List<long[]> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
-            // If the whole file fits into a single macro-split target, keep row-group split granularity
-            // (i.e. return the original ranges) to preserve parallelism.
+            List<SplitRange> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
             return coalesced.size() < 2 ? ranges : coalesced;
         }
     }
 
-    static List<long[]> coalesceRowGroupRanges(List<long[]> rowGroupRanges, long targetBytes) {
+    @SuppressWarnings("rawtypes")
+    private static Map<String, Object> buildRowGroupStats(BlockMetaData rowGroup) {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("_stats.row_count", rowGroup.getRowCount());
+        stats.put("_stats.size_bytes", rowGroup.getTotalByteSize());
+        for (ColumnChunkMetaData col : rowGroup.getColumns()) {
+            String colName = col.getPath().toDotString();
+            Statistics colStats = col.getStatistics();
+            if (colStats == null || colStats.isEmpty()) {
+                continue;
+            }
+            stats.put("_stats.columns." + colName + ".null_count", colStats.getNumNulls());
+            if (colStats.hasNonNullValue()) {
+                stats.put("_stats.columns." + colName + ".min", colStats.genericGetMin());
+                stats.put("_stats.columns." + colName + ".max", colStats.genericGetMax());
+            }
+        }
+        return Map.copyOf(stats);
+    }
+
+    static List<SplitRange> coalesceRowGroupRanges(List<SplitRange> rowGroupRanges, long targetBytes) {
         if (rowGroupRanges == null || rowGroupRanges.size() <= 1) {
             return List.of();
         }
@@ -363,16 +383,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return List.copyOf(rowGroupRanges);
         }
 
-        List<long[]> sorted = new ArrayList<>(rowGroupRanges);
-        sorted.sort(Comparator.comparingLong(a -> a[0]));
+        List<SplitRange> sorted = new ArrayList<>(rowGroupRanges);
+        sorted.sort(Comparator.comparingLong(SplitRange::offset));
 
-        List<long[]> out = new ArrayList<>();
+        List<SplitRange> out = new ArrayList<>();
         long groupStart = -1;
         long groupEnd = -1;
+        List<Map<String, Object>> pendingStats = new ArrayList<>();
 
-        for (long[] range : sorted) {
-            long start = range[0];
-            long length = range[1];
+        for (SplitRange range : sorted) {
+            long start = range.offset();
+            long length = range.length();
             long end = start + length;
 
             if (groupStart < 0) {
@@ -381,19 +402,80 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             } else {
                 groupEnd = Math.max(groupEnd, end);
             }
+            pendingStats.add(range.statistics());
 
             if (groupEnd - groupStart >= targetBytes) {
-                out.add(new long[] { groupStart, groupEnd - groupStart });
+                out.add(new SplitRange(groupStart, groupEnd - groupStart, mergeStatsMaps(pendingStats)));
                 groupStart = -1;
                 groupEnd = -1;
+                pendingStats.clear();
             }
         }
 
         if (groupStart >= 0) {
-            out.add(new long[] { groupStart, groupEnd - groupStart });
+            out.add(new SplitRange(groupStart, groupEnd - groupStart, mergeStatsMaps(pendingStats)));
         }
 
         return out;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Map<String, Object> mergeStatsMaps(List<Map<String, Object>> statsList) {
+        if (statsList.isEmpty()) {
+            return Map.of();
+        }
+        if (statsList.size() == 1) {
+            return statsList.get(0);
+        }
+        long totalRows = 0;
+        long totalSize = 0;
+        Map<String, long[]> nullCounts = new HashMap<>();
+        Map<String, Comparable[]> mins = new HashMap<>();
+        Map<String, Comparable[]> maxs = new HashMap<>();
+
+        for (Map<String, Object> stats : statsList) {
+            Object rc = stats.get("_stats.row_count");
+            if (rc instanceof Number rcNum) {
+                totalRows += rcNum.longValue();
+            }
+            Object sb = stats.get("_stats.size_bytes");
+            if (sb instanceof Number sbNum) {
+                totalSize += sbNum.longValue();
+            }
+
+            for (Map.Entry<String, Object> entry : stats.entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith("_stats.columns.") == false) continue;
+                if (key.endsWith(".null_count") && entry.getValue() instanceof Number ncNum) {
+                    nullCounts.merge(key, new long[] { ncNum.longValue() }, (a, b) -> {
+                        a[0] += b[0];
+                        return a;
+                    });
+                } else if (key.endsWith(".min") && entry.getValue() instanceof Comparable c) {
+                    mins.merge(key, new Comparable[] { c }, (a, b) -> {
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp > 0) a[0] = b[0];
+                        return a;
+                    });
+                } else if (key.endsWith(".max") && entry.getValue() instanceof Comparable c) {
+                    maxs.merge(key, new Comparable[] { c }, (a, b) -> {
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp < 0) a[0] = b[0];
+                        return a;
+                    });
+                }
+            }
+        }
+
+        Map<String, Object> merged = new HashMap<>();
+        merged.put("_stats.row_count", totalRows);
+        if (totalSize > 0) {
+            merged.put("_stats.size_bytes", totalSize);
+        }
+        nullCounts.forEach((k, v) -> merged.put(k, v[0]));
+        mins.forEach((k, v) -> merged.put(k, v[0]));
+        maxs.forEach((k, v) -> merged.put(k, v[0]));
+        return Map.copyOf(merged);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -1226,12 +1227,14 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
         assertTrue("Expected multiple ranges for multi-row-group file, got " + ranges.size(), ranges.size() > 1);
 
-        for (long[] range : ranges) {
-            assertTrue("Range offset must be non-negative", range[0] >= 0);
-            assertTrue("Range length must be positive", range[1] > 0);
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            assertTrue("Range offset must be non-negative", range.offset() >= 0);
+            assertTrue("Range length must be positive", range.length() > 0);
+            assertNotNull("Per-row-group statistics should be present", range.statistics());
+            assertTrue("Statistics should contain row count", range.statistics().containsKey("_stats.row_count"));
         }
     }
 
@@ -1247,7 +1250,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
         assertTrue("Single row group file should return empty ranges", ranges.isEmpty());
     }
 
@@ -1459,13 +1462,13 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<long[]> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
         assertTrue("Need at least 2 ranges for this test, got " + ranges.size(), ranges.size() >= 2);
 
         int totalRowsFromRanges = 0;
-        for (long[] range : ranges) {
-            long rangeStart = range[0];
-            long rangeEnd = rangeStart + range[1];
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            long rangeStart = range.offset();
+            long rangeEnd = rangeStart + range.length();
             try (
                 CloseableIterator<Page> iterator = reader.readRange(
                     storageObject,
@@ -1514,7 +1517,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         byte[] unscaledBytes = BigInteger.valueOf(unscaledValue).toByteArray();
         byte[] padded = new byte[fixedLen];
         byte fill = unscaledValue < 0 ? (byte) 0xFF : (byte) 0x00;
-        java.util.Arrays.fill(padded, fill);
+        Arrays.fill(padded, fill);
         System.arraycopy(unscaledBytes, 0, padded, fixedLen - unscaledBytes.length, unscaledBytes.length);
         return padded;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
@@ -8,25 +8,27 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class ParquetSplitCoalescingTests extends ESTestCase {
 
     public void testCoalesceProducesFewerRangesAndPreservesCoverage() {
-        List<long[]> ranges = new ArrayList<>();
-        ranges.add(new long[] { 0, 10 });
-        ranges.add(new long[] { 10, 10 });
-        ranges.add(new long[] { 20, 10 });
-        ranges.add(new long[] { 30, 10 });
-        ranges.add(new long[] { 40, 10 });
+        List<SplitRange> ranges = new ArrayList<>();
+        ranges.add(new SplitRange(0, 10, Map.of("_stats.row_count", 10L)));
+        ranges.add(new SplitRange(10, 10, Map.of("_stats.row_count", 10L)));
+        ranges.add(new SplitRange(20, 10, Map.of("_stats.row_count", 10L)));
+        ranges.add(new SplitRange(30, 10, Map.of("_stats.row_count", 10L)));
+        ranges.add(new SplitRange(40, 10, Map.of("_stats.row_count", 10L)));
 
-        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
         assertTrue(coalesced.size() < ranges.size());
 
-        for (long[] original : ranges) {
-            long start = original[0];
+        for (SplitRange original : ranges) {
+            long start = original.offset();
             assertTrue("Missing coverage for start=" + start, isCoveredByAny(coalesced, start));
         }
 
@@ -34,27 +36,33 @@ public class ParquetSplitCoalescingTests extends ESTestCase {
     }
 
     public void testCoalesceWithLargeTargetProducesSingleRange() {
-        List<long[]> ranges = List.of(new long[] { 0, 10 }, new long[] { 10, 10 }, new long[] { 20, 10 });
-        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 1024 * 1024);
+        List<SplitRange> ranges = List.of(
+            new SplitRange(0, 10, Map.of("_stats.row_count", 5L)),
+            new SplitRange(10, 10, Map.of("_stats.row_count", 5L)),
+            new SplitRange(20, 10, Map.of("_stats.row_count", 5L))
+        );
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 1024 * 1024);
         assertEquals(1, coalesced.size());
-        assertEquals(0, coalesced.get(0)[0]);
-        assertEquals(30, coalesced.get(0)[1]);
+        assertEquals(0, coalesced.get(0).offset());
+        assertEquals(30, coalesced.get(0).length());
+        assertEquals(15L, coalesced.get(0).statistics().get("_stats.row_count"));
         assertSortedNonOverlapping(coalesced);
     }
 
     public void testCoalesceWithNonPositiveTargetReturnsOriginal() {
-        List<long[]> ranges = List.of(new long[] { 20, 10 }, new long[] { 0, 10 }, new long[] { 10, 10 });
-        List<long[]> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 0);
+        List<SplitRange> ranges = List.of(new SplitRange(20, 10), new SplitRange(0, 10), new SplitRange(10, 10));
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 0);
         assertEquals(ranges.size(), coalesced.size());
         for (int i = 0; i < ranges.size(); i++) {
-            assertArrayEquals(ranges.get(i), coalesced.get(i));
+            assertEquals(ranges.get(i).offset(), coalesced.get(i).offset());
+            assertEquals(ranges.get(i).length(), coalesced.get(i).length());
         }
     }
 
-    private static boolean isCoveredByAny(List<long[]> coalesced, long start) {
-        for (long[] group : coalesced) {
-            long groupStart = group[0];
-            long groupEnd = groupStart + group[1];
+    private static boolean isCoveredByAny(List<SplitRange> coalesced, long start) {
+        for (SplitRange group : coalesced) {
+            long groupStart = group.offset();
+            long groupEnd = groupStart + group.length();
             if (start >= groupStart && start < groupEnd) {
                 return true;
             }
@@ -62,12 +70,12 @@ public class ParquetSplitCoalescingTests extends ESTestCase {
         return false;
     }
 
-    private static void assertSortedNonOverlapping(List<long[]> ranges) {
+    private static void assertSortedNonOverlapping(List<SplitRange> ranges) {
         long lastEnd = Long.MIN_VALUE;
-        for (long[] r : ranges) {
-            assertTrue("length must be > 0", r[1] > 0);
-            assertTrue("ranges must be sorted and non-overlapping", r[0] >= lastEnd);
-            lastEnd = r[0] + r[1];
+        for (SplitRange r : ranges) {
+            assertTrue("length must be > 0", r.length() > 0);
+            assertTrue("ranges must be sorted and non-overlapping", r.offset() >= lastEnd);
+            lastEnd = r.offset() + r.length();
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
@@ -42,6 +42,8 @@ public class FileSplit implements ExternalSplit {
     private final Map<String, Object> partitionValues;
     @Nullable
     private final SchemaReconciliation.ColumnMapping columnMapping;
+    @Nullable
+    private final Map<String, Object> statistics;
 
     public FileSplit(
         String sourceType,
@@ -52,7 +54,7 @@ public class FileSplit implements ExternalSplit {
         Map<String, Object> config,
         Map<String, Object> partitionValues
     ) {
-        this(sourceType, path, offset, length, format, config, partitionValues, null);
+        this(sourceType, path, offset, length, format, config, partitionValues, null, null);
     }
 
     public FileSplit(
@@ -64,6 +66,20 @@ public class FileSplit implements ExternalSplit {
         Map<String, Object> config,
         Map<String, Object> partitionValues,
         @Nullable SchemaReconciliation.ColumnMapping columnMapping
+    ) {
+        this(sourceType, path, offset, length, format, config, partitionValues, columnMapping, null);
+    }
+
+    public FileSplit(
+        String sourceType,
+        StoragePath path,
+        long offset,
+        long length,
+        String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
+        @Nullable Map<String, Object> statistics
     ) {
         if (sourceType == null) {
             throw new IllegalArgumentException("sourceType cannot be null");
@@ -81,6 +97,7 @@ public class FileSplit implements ExternalSplit {
             ? Collections.unmodifiableMap(new LinkedHashMap<>(partitionValues))
             : Map.of();
         this.columnMapping = columnMapping;
+        this.statistics = statistics != null ? Map.copyOf(statistics) : null;
     }
 
     public FileSplit(StreamInput in) throws IOException {
@@ -96,6 +113,11 @@ public class FileSplit implements ExternalSplit {
         } else {
             this.columnMapping = null;
         }
+        if (in.readBoolean()) {
+            this.statistics = Map.copyOf(in.readGenericMap());
+        } else {
+            this.statistics = null;
+        }
     }
 
     @Override
@@ -110,6 +132,12 @@ public class FileSplit implements ExternalSplit {
         if (columnMapping != null) {
             out.writeBoolean(true);
             columnMapping.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (statistics != null) {
+            out.writeBoolean(true);
+            out.writeGenericMap(statistics);
         } else {
             out.writeBoolean(false);
         }
@@ -154,6 +182,11 @@ public class FileSplit implements ExternalSplit {
         return columnMapping;
     }
 
+    @Nullable
+    public Map<String, Object> statistics() {
+        return statistics;
+    }
+
     @Override
     public long estimatedSizeInBytes() {
         return length;
@@ -175,12 +208,13 @@ public class FileSplit implements ExternalSplit {
             && Objects.equals(format, that.format)
             && Objects.equals(config, that.config)
             && Objects.equals(partitionValues, that.partitionValues)
-            && Objects.equals(columnMapping, that.columnMapping);
+            && Objects.equals(columnMapping, that.columnMapping)
+            && Objects.equals(statistics, that.statistics);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceType, path, offset, length, format, config, partitionValues, columnMapping);
+        return Objects.hash(sourceType, path, offset, length, format, config, partitionValues, columnMapping, statistics);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FrameIndex;
 import org.elasticsearch.xpack.esql.datasources.spi.IndexedDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
@@ -314,7 +315,7 @@ public class FileSplitProvider implements SplitProvider {
             }
             StorageObject object = provider.newObject(filePath, fileLength);
 
-            List<long[]> ranges = rangeReader.discoverSplitRanges(object);
+            List<SplitRange> ranges = rangeReader.discoverSplitRanges(object);
             if (ranges.isEmpty()) {
                 return false;
             }
@@ -323,10 +324,21 @@ public class FileSplitProvider implements SplitProvider {
             splitConfig.put(RANGE_SPLIT_KEY, "true");
             splitConfig.put(FILE_LENGTH_KEY, Long.toString(fileLength));
 
-            for (long[] range : ranges) {
-                long offset = range[0];
-                long length = range[1];
-                splits.add(new FileSplit("file", filePath, offset, length, format, splitConfig, partitionValues, columnMapping));
+            for (SplitRange range : ranges) {
+                Map<String, Object> rangeStats = range.statistics().isEmpty() ? null : range.statistics();
+                splits.add(
+                    new FileSplit(
+                        "file",
+                        filePath,
+                        range.offset(),
+                        range.length(),
+                        format,
+                        splitConfig,
+                        partitionValues,
+                        columnMapping,
+                        rangeStats
+                    )
+                );
             }
             return true;
         } catch (IOException e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -132,6 +133,75 @@ public final class SourceStatisticsSerializer {
             return Optional.empty();
         }
         return Optional.ofNullable(sourceMetadata.get(STATS_COL_PREFIX + columnName + MAX_SUFFIX));
+    }
+
+    /**
+     * Merges per-split statistics maps into a single aggregate statistics map.
+     * Sums row counts, size bytes, and null counts; computes min-of-mins and max-of-maxes.
+     * Returns {@code null} if any split lacks a row count (indicating incomplete stats).
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static Map<String, Object> mergeStatistics(List<Map<String, Object>> splitStats) {
+        if (splitStats == null || splitStats.isEmpty()) {
+            return null;
+        }
+        if (splitStats.size() == 1) {
+            Map<String, Object> single = splitStats.get(0);
+            return single != null && single.get(STATS_ROW_COUNT) instanceof Number ? single : null;
+        }
+
+        long totalRows = 0;
+        long totalSize = 0;
+        Map<String, long[]> nullCounts = new HashMap<>();
+        Map<String, Comparable[]> mins = new HashMap<>();
+        Map<String, Comparable[]> maxs = new HashMap<>();
+
+        for (Map<String, Object> stats : splitStats) {
+            if (stats == null || stats.containsKey(STATS_ROW_COUNT) == false) {
+                return null;
+            }
+            Object rc = stats.get(STATS_ROW_COUNT);
+            if (rc instanceof Number rcNum) {
+                totalRows += rcNum.longValue();
+            } else {
+                return null;
+            }
+            Object sb = stats.get(STATS_SIZE_BYTES);
+            if (sb instanceof Number sbNum) totalSize += sbNum.longValue();
+
+            for (Map.Entry<String, Object> entry : stats.entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith(STATS_COL_PREFIX) == false) continue;
+                if (key.endsWith(NULL_COUNT_SUFFIX) && entry.getValue() instanceof Number ncNum) {
+                    nullCounts.merge(key, new long[] { ncNum.longValue() }, (a, b) -> {
+                        a[0] += b[0];
+                        return a;
+                    });
+                } else if (key.endsWith(MIN_SUFFIX) && entry.getValue() instanceof Comparable c) {
+                    mins.merge(key, new Comparable[] { c }, (a, b) -> {
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp > 0) a[0] = b[0];
+                        return a;
+                    });
+                } else if (key.endsWith(MAX_SUFFIX) && entry.getValue() instanceof Comparable c) {
+                    maxs.merge(key, new Comparable[] { c }, (a, b) -> {
+                        int cmp = a[0].compareTo(b[0]);
+                        if (cmp < 0) a[0] = b[0];
+                        return a;
+                    });
+                }
+            }
+        }
+
+        Map<String, Object> merged = new HashMap<>();
+        merged.put(STATS_ROW_COUNT, totalRows);
+        if (totalSize > 0) {
+            merged.put(STATS_SIZE_BYTES, totalSize);
+        }
+        nullCounts.forEach((k, v) -> merged.put(k, v[0]));
+        mins.forEach((k, v) -> merged.put(k, v[0]));
+        maxs.forEach((k, v) -> merged.put(k, v[0]));
+        return merged;
     }
 
     private static OptionalLong toLong(Object value) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Extension of {@link FormatReader} for columnar formats (Parquet, ORC) that support
@@ -36,16 +37,33 @@ import java.util.List;
 public interface RangeAwareFormatReader extends FormatReader {
 
     /**
+     * A byte range within a file with optional per-range statistics (e.g. per-row-group
+     * Parquet statistics). Statistics use the same {@code _stats.*} key convention as
+     * {@code sourceMetadata} for consistency with {@code SourceStatisticsSerializer}.
+     */
+    record SplitRange(long offset, long length, Map<String, Object> statistics) {
+        public SplitRange {
+            if (statistics == null) {
+                statistics = Map.of();
+            }
+        }
+
+        public SplitRange(long offset, long length) {
+            this(offset, length, Map.of());
+        }
+    }
+
+    /**
      * Discovers independently readable byte ranges within a file by reading its metadata.
      * Each range typically corresponds to one row group (Parquet) or stripe (ORC).
      * <p>
-     * Returns a list of {@code [startOffset, length]} pairs. An empty list means the
+     * Returns a list of {@link SplitRange} objects. An empty list means the
      * file cannot be split (e.g. single row group) and should be read as a whole.
      *
      * @param object the storage object representing the full file
-     * @return list of byte ranges, each as {@code [offset, length]}
+     * @return list of split ranges with optional per-range statistics
      */
-    List<long[]> discoverSplitRanges(StorageObject object) throws IOException;
+    List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException;
 
     /**
      * Reads only the row groups / stripes that fall within the given byte range.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -14,9 +14,11 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
@@ -45,9 +47,9 @@ import java.util.OptionalLong;
  * The coordinator's FINAL AggregateExec is never touched — it merges intermediate values from all
  * data nodes regardless of whether each data node pushed down or scanned.
  * <p>
- * Statistics come from {@code ExternalSourceExec.sourceMetadata()} which is populated at planning time.
- * In Phase 2 (union-by-name), per-split statistics in {@code FileSplit.statistics()} will enable
- * pushdown even when per-query metadata only has first-file stats.
+ * Statistics come from {@code ExternalSourceExec.sourceMetadata()} for single-split queries, or
+ * from merged per-split statistics in {@code FileSplit.statistics()} for multi-split queries.
+ * Falls back to normal execution when any split lacks statistics.
  */
 public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
     AggregateExec,
@@ -85,8 +87,10 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec;
         }
 
-        // Try to resolve all aggregate values from sourceMetadata
-        Map<String, Object> sourceMetadata = externalExec.sourceMetadata();
+        Map<String, Object> sourceMetadata = resolveEffectiveMetadata(externalExec);
+        if (sourceMetadata == null) {
+            return aggregateExec;
+        }
         List<Object> values = resolveAggregateValues(aggregateExec.aggregates(), sourceMetadata);
         if (values == null) {
             return aggregateExec; // Some aggregate couldn't be resolved from metadata
@@ -216,6 +220,22 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         } else {
             return blockFactory.newConstantNullBlock(1);
         }
+    }
+
+    private static Map<String, Object> resolveEffectiveMetadata(ExternalSourceExec externalExec) {
+        List<? extends ExternalSplit> splits = externalExec.splits();
+        if (splits.size() <= 1) {
+            return externalExec.sourceMetadata();
+        }
+        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
+        for (ExternalSplit split : splits) {
+            if (split instanceof FileSplit fileSplit) {
+                splitStats.add(fileSplit.statistics());
+            } else {
+                return null;
+            }
+        }
+        return SourceStatisticsSerializer.mergeStatistics(splitStats);
     }
 
     private List<Expression> extractAggregateFunctions(List<? extends NamedExpression> aggregates) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -16,7 +16,9 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
@@ -45,8 +47,9 @@ import java.util.OptionalLong;
  * the aggregate and external source by resolving aliased attribute names back to the
  * original column names before metadata lookup.
  * <p>
- * Currently supports single-file queries only (no splits or exactly one split).
- * Multi-file queries fall through to normal execution.
+ * Supports multi-split queries when per-split statistics are available in
+ * {@link FileSplit#statistics()}. Statistics are merged across splits (sum row counts,
+ * min-of-mins, max-of-maxes). Falls back to normal execution when any split lacks stats.
  * <p>
  * Note: MIN/MAX pushdown uses raw values from file metadata. For DATE/TIMESTAMP columns,
  * the raw values may not match ESQL's millisecond representation. A future enhancement
@@ -76,11 +79,11 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         if (aggregateExec.groupings().isEmpty() == false) {
             return aggregateExec;
         }
-        if (externalExec.splits().size() > 1) {
+
+        Map<String, Object> sourceMetadata = resolveEffectiveMetadata(externalExec);
+        if (sourceMetadata == null) {
             return aggregateExec;
         }
-
-        Map<String, Object> sourceMetadata = externalExec.sourceMetadata();
         List<? extends NamedExpression> aggregates = aggregateExec.aggregates();
 
         List<Object> values = new ArrayList<>(aggregates.size());
@@ -159,6 +162,22 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             return maxVal.orElse(null);
         }
         return null;
+    }
+
+    private static Map<String, Object> resolveEffectiveMetadata(ExternalSourceExec externalExec) {
+        List<? extends ExternalSplit> splits = externalExec.splits();
+        if (splits.size() <= 1) {
+            return externalExec.sourceMetadata();
+        }
+        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
+        for (ExternalSplit split : splits) {
+            if (split instanceof FileSplit fileSplit) {
+                splitStats.add(fileSplit.statistics());
+            } else {
+                return null;
+            }
+        }
+        return SourceStatisticsSerializer.mergeStatistics(splitStats);
     }
 
     private static Block[] buildBlocks(List<Object> values) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
@@ -452,7 +453,10 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testRangeAwareSplitsForParquet() {
-        long[][] fakeRanges = { { 100, 500 }, { 700, 600 }, { 1400, 400 } };
+        SplitRange[] fakeRanges = {
+            new SplitRange(100, 500, Map.of("_stats.row_count", 100L)),
+            new SplitRange(700, 600, Map.of("_stats.row_count", 200L)),
+            new SplitRange(1400, 400, Map.of("_stats.row_count", 300L)) };
 
         RangeAwareFormatReader mockReader = createMockRangeReader(List.of(fakeRanges[0], fakeRanges[1], fakeRanges[2]));
 
@@ -479,15 +483,17 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(3, splits.size());
         for (int i = 0; i < splits.size(); i++) {
             FileSplit fs = (FileSplit) splits.get(i);
-            assertEquals(fakeRanges[i][0], fs.offset());
-            assertEquals(fakeRanges[i][1], fs.length());
+            assertEquals(fakeRanges[i].offset(), fs.offset());
+            assertEquals(fakeRanges[i].length(), fs.length());
             assertEquals("true", fs.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
             assertEquals("2000", fs.config().get(FileSplitProvider.FILE_LENGTH_KEY));
+            assertNotNull(fs.statistics());
+            assertEquals(fakeRanges[i].statistics().get("_stats.row_count"), fs.statistics().get("_stats.row_count"));
         }
     }
 
     public void testRangeAwareFallbackForSingleRowGroup() {
-        RangeAwareFormatReader mockReader = createMockRangeReader(List.of());
+        RangeAwareFormatReader mockReader = createMockRangeReader(List.<SplitRange>of());
 
         FormatReaderRegistry formatRegistry = new FormatReaderRegistry(new DecompressionCodecRegistry());
         formatRegistry.registerLazy("parquet", (s, bf) -> mockReader, Settings.EMPTY, null);
@@ -516,10 +522,10 @@ public class FileSplitProviderTests extends ESTestCase {
         assertNull("Single split should not have RANGE_SPLIT_KEY", fs.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
     }
 
-    private static RangeAwareFormatReader createMockRangeReader(List<long[]> ranges) {
+    private static RangeAwareFormatReader createMockRangeReader(List<SplitRange> ranges) {
         return new RangeAwareFormatReader() {
             @Override
-            public List<long[]> discoverSplitRanges(StorageObject object) {
+            public List<SplitRange> discoverSplitRanges(StorageObject object) {
                 return ranges;
             }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitTests.java
@@ -119,4 +119,48 @@ public class FileSplitTests extends ESTestCase {
         assertTrue(str.contains("s3://bucket/file.parquet"));
         assertTrue(str.contains("year"));
     }
+
+    public void testNamedWriteableRoundTripWithStatistics() throws IOException {
+        StoragePath path = StoragePath.of("s3://bucket/data/file.parquet");
+        Map<String, Object> stats = Map.of("_stats.row_count", 1000L, "_stats.columns.age.null_count", 50L);
+        FileSplit original = new FileSplit("file", path, 0, 2048, ".parquet", Map.of(), Map.of(), null, stats);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteable(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        FileSplit deserialized = (FileSplit) in.readNamedWriteable(ExternalSplit.class);
+
+        assertEquals(original, deserialized);
+        assertEquals(original.hashCode(), deserialized.hashCode());
+        assertNotNull(deserialized.statistics());
+        assertEquals(1000L, deserialized.statistics().get("_stats.row_count"));
+        assertEquals(50L, deserialized.statistics().get("_stats.columns.age.null_count"));
+    }
+
+    public void testNamedWriteableRoundTripWithNullStatistics() throws IOException {
+        StoragePath path = StoragePath.of("s3://bucket/data/file.parquet");
+        FileSplit original = new FileSplit("file", path, 0, 2048, ".parquet", Map.of(), Map.of(), null, null);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeNamedWriteable(original);
+
+        StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
+        FileSplit deserialized = (FileSplit) in.readNamedWriteable(ExternalSplit.class);
+
+        assertEquals(original, deserialized);
+        assertNull(deserialized.statistics());
+    }
+
+    public void testEqualityWithStatistics() {
+        StoragePath path = StoragePath.of("s3://bucket/file.parquet");
+        Map<String, Object> stats = Map.of("_stats.row_count", 100L);
+        FileSplit a = new FileSplit("file", path, 0, 100, ".parquet", Map.of(), Map.of(), null, stats);
+        FileSplit b = new FileSplit("file", path, 0, 100, ".parquet", Map.of(), Map.of(), null, stats);
+        FileSplit c = new FileSplit("file", path, 0, 100, ".parquet", Map.of(), Map.of(), null, null);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SourceStatisticsSerializerTests extends ESTestCase {
+
+    public void testMergeStatisticsEmpty() {
+        assertNull(SourceStatisticsSerializer.mergeStatistics(null));
+        assertNull(SourceStatisticsSerializer.mergeStatistics(List.of()));
+    }
+
+    public void testMergeStatisticsSingleSplit() {
+        Map<String, Object> stats = Map.of(
+            SourceStatisticsSerializer.STATS_ROW_COUNT,
+            100L,
+            SourceStatisticsSerializer.STATS_SIZE_BYTES,
+            5000L
+        );
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(stats));
+        assertNotNull(result);
+        assertEquals(100L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    public void testMergeStatisticsSingleSplitWithoutRowCount() {
+        Map<String, Object> stats = Map.of(SourceStatisticsSerializer.STATS_SIZE_BYTES, 5000L);
+        assertNull(SourceStatisticsSerializer.mergeStatistics(List.of(stats)));
+    }
+
+    public void testMergeStatisticsMultipleSplits() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, 5000L);
+        s1.put("_stats.columns.age.null_count", 10L);
+        s1.put("_stats.columns.age.min", 18);
+        s1.put("_stats.columns.age.max", 50);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, 8000L);
+        s2.put("_stats.columns.age.null_count", 5L);
+        s2.put("_stats.columns.age.min", 22);
+        s2.put("_stats.columns.age.max", 65);
+
+        Map<String, Object> s3 = new HashMap<>();
+        s3.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 300L);
+        s3.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, 12000L);
+        s3.put("_stats.columns.age.null_count", 0L);
+        s3.put("_stats.columns.age.min", 25);
+        s3.put("_stats.columns.age.max", 40);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2, s3));
+        assertNotNull(result);
+        assertEquals(600L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals(25000L, result.get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
+        assertEquals(15L, result.get("_stats.columns.age.null_count"));
+        assertEquals(18, result.get("_stats.columns.age.min"));
+        assertEquals(65, result.get("_stats.columns.age.max"));
+    }
+
+    public void testMergeStatisticsMissingSplitReturnsNull() {
+        Map<String, Object> s1 = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        Map<String, Object> s2 = Map.of(SourceStatisticsSerializer.STATS_SIZE_BYTES, 5000L);
+
+        assertNull(SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2)));
+    }
+
+    public void testMergeStatisticsNullSplitReturnsNull() {
+        Map<String, Object> s1 = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        List<Map<String, Object>> list = new ArrayList<>();
+        list.add(s1);
+        list.add(null);
+
+        assertNull(SourceStatisticsSerializer.mergeStatistics(list));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
@@ -21,6 +22,8 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
@@ -33,9 +36,12 @@ import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -153,25 +159,9 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertThat(result, instanceOf(AggregateExec.class));
     }
 
-    public void testNotPushedWithMultipleSplits() {
+    public void testNotPushedWithMultipleSplitsWithoutStats() {
         Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        List<Attribute> attrs = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
-        ExternalSourceExec ext = new ExternalSourceExec(
-            Source.EMPTY,
-            "file:///test.parquet",
-            "parquet",
-            attrs,
-            Map.of(),
-            metadata,
-            null,
-            -1,
-            null,
-            null,
-            List.of(
-                new FileSplit("parquet", StoragePath.of("file:///split1.parquet"), 0, 100, "parquet", Map.of(), Map.of()),
-                new FileSplit("parquet", StoragePath.of("file:///split2.parquet"), 0, 100, "parquet", Map.of(), Map.of())
-            )
-        );
+        ExternalSourceExec ext = externalSourceWithSplits(metadata, null, null);
         AggregateExec agg = aggregateExec(ext, countStarAlias());
 
         PhysicalPlan result = applyRule(agg);
@@ -179,22 +169,62 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertThat(result, instanceOf(AggregateExec.class));
     }
 
+    public void testPushedWithMultipleSplitsWithStats() {
+        Map<String, Object> stats1 = statsMetadata(100L, null, null, null);
+        Map<String, Object> stats2 = statsMetadata(200L, null, null, null);
+        Map<String, Object> stats3 = statsMetadata(300L, null, null, null);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, stats2, stats3);
+        AggregateExec agg = aggregateExec(ext, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        Page page = local.supplier().get();
+        assertEquals(600L, ((LongBlock) page.getBlock(0)).getLong(0));
+    }
+
+    public void testNotPushedWithMixedStatsAndNoStats() {
+        Map<String, Object> stats1 = statsMetadata(100L, null, null, null);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, null);
+        AggregateExec agg = aggregateExec(ext, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(AggregateExec.class));
+    }
+
+    public void testMinMaxPushedWithMultipleSplitsWithStats() {
+        Map<String, Object> stats1 = statsMetadata(100L, "age", 5L, null);
+        stats1.put("_stats.columns.age.min", 18);
+        stats1.put("_stats.columns.age.max", 50);
+
+        Map<String, Object> stats2 = statsMetadata(200L, "age", 10L, null);
+        stats2.put("_stats.columns.age.min", 22);
+        stats2.put("_stats.columns.age.max", 65);
+
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, stats2);
+
+        ReferenceAttribute ageField = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        AggregateExec agg = aggregateExec(
+            ext,
+            new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, ageField)),
+            new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, ageField))
+        );
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        assertEquals(2, local.output().size());
+        Page page = local.supplier().get();
+        assertEquals(18, ((IntBlock) page.getBlock(0)).getInt(0));
+        assertEquals(65, ((IntBlock) page.getBlock(1)).getInt(0));
+    }
+
     public void testPushedWithSingleSplit() {
         Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        List<Attribute> attrs = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
-        ExternalSourceExec ext = new ExternalSourceExec(
-            Source.EMPTY,
-            "file:///test.parquet",
-            "parquet",
-            attrs,
-            Map.of(),
-            metadata,
-            null,
-            -1,
-            null,
-            null,
-            List.of(new FileSplit("parquet", StoragePath.of("file:///test.parquet"), 0, 100, "parquet", Map.of(), Map.of()))
-        );
+        ExternalSourceExec ext = externalSourceWithSplits(metadata, (Map<String, Object>) null);
         AggregateExec agg = aggregateExec(ext, countStarAlias());
 
         PhysicalPlan result = applyRule(agg);
@@ -228,57 +258,50 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         Map<String, Object> original = new HashMap<>();
         original.put("existing_key", "value");
 
-        Map<String, Object> enriched = SourceStatisticsSerializer.embedStatistics(
-            original,
-            new org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics() {
-                @Override
-                public java.util.OptionalLong rowCount() {
-                    return java.util.OptionalLong.of(42);
-                }
-
-                @Override
-                public java.util.OptionalLong sizeInBytes() {
-                    return java.util.OptionalLong.of(1024);
-                }
-
-                @Override
-                public
-                    java.util.Optional<Map<String, org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics.ColumnStatistics>>
-                    columnStatistics() {
-                    return java.util.Optional.of(
-                        Map.of("col1", new org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics.ColumnStatistics() {
-                            @Override
-                            public java.util.OptionalLong nullCount() {
-                                return java.util.OptionalLong.of(5);
-                            }
-
-                            @Override
-                            public java.util.OptionalLong distinctCount() {
-                                return java.util.OptionalLong.empty();
-                            }
-
-                            @Override
-                            public java.util.Optional<Object> minValue() {
-                                return java.util.Optional.of(10);
-                            }
-
-                            @Override
-                            public java.util.Optional<Object> maxValue() {
-                                return java.util.Optional.of(100);
-                            }
-                        })
-                    );
-                }
+        Map<String, Object> enriched = SourceStatisticsSerializer.embedStatistics(original, new SourceStatistics() {
+            @Override
+            public OptionalLong rowCount() {
+                return OptionalLong.of(42);
             }
-        );
+
+            @Override
+            public OptionalLong sizeInBytes() {
+                return OptionalLong.of(1024);
+            }
+
+            @Override
+            public Optional<Map<String, SourceStatistics.ColumnStatistics>> columnStatistics() {
+                return Optional.of(Map.of("col1", new SourceStatistics.ColumnStatistics() {
+                    @Override
+                    public OptionalLong nullCount() {
+                        return OptionalLong.of(5);
+                    }
+
+                    @Override
+                    public OptionalLong distinctCount() {
+                        return OptionalLong.empty();
+                    }
+
+                    @Override
+                    public Optional<Object> minValue() {
+                        return Optional.of(10);
+                    }
+
+                    @Override
+                    public Optional<Object> maxValue() {
+                        return Optional.of(100);
+                    }
+                }));
+            }
+        });
 
         assertEquals("value", enriched.get("existing_key"));
         assertEquals(42L, enriched.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
         assertEquals(1024L, enriched.get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
-        assertEquals(java.util.OptionalLong.of(42), SourceStatisticsSerializer.extractRowCount(enriched));
-        assertEquals(java.util.OptionalLong.of(5), SourceStatisticsSerializer.extractColumnNullCount(enriched, "col1"));
-        assertEquals(java.util.Optional.of(10), SourceStatisticsSerializer.extractColumnMin(enriched, "col1"));
-        assertEquals(java.util.Optional.of(100), SourceStatisticsSerializer.extractColumnMax(enriched, "col1"));
+        assertEquals(OptionalLong.of(42), SourceStatisticsSerializer.extractRowCount(enriched));
+        assertEquals(OptionalLong.of(5), SourceStatisticsSerializer.extractColumnNullCount(enriched, "col1"));
+        assertEquals(Optional.of(10), SourceStatisticsSerializer.extractColumnMin(enriched, "col1"));
+        assertEquals(Optional.of(100), SourceStatisticsSerializer.extractColumnMax(enriched, "col1"));
     }
 
     // --- EvalExec intermediate node tests ---
@@ -495,6 +518,44 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     }
 
     // --- helpers ---
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private static ExternalSourceExec externalSourceWithSplits(Map<String, Object> sourceMetadata, Map<String, Object>... perSplitStats) {
+        List<Attribute> attrs = List.of(
+            new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER)
+        );
+        List<ExternalSplit> splits = new ArrayList<>(perSplitStats.length);
+        for (int i = 0; i < perSplitStats.length; i++) {
+            splits.add(
+                new FileSplit(
+                    "parquet",
+                    StoragePath.of("file:///split" + (i + 1) + ".parquet"),
+                    0,
+                    100,
+                    "parquet",
+                    Map.of(),
+                    Map.of(),
+                    null,
+                    perSplitStats[i]
+                )
+            );
+        }
+        return new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            attrs,
+            Map.of(),
+            sourceMetadata,
+            null,
+            -1,
+            null,
+            null,
+            splits
+        );
+    }
 
     private static ExternalSourceExec externalSource(Map<String, Object> sourceMetadata) {
         List<Attribute> attrs = List.of(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
@@ -56,6 +56,9 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
 
     static FileSplit randomFileSplit() {
         StoragePath path = StoragePath.of("s3://bucket/data/" + randomAlphaOfLength(6) + ".parquet");
+        Map<String, Object> statistics = randomBoolean()
+            ? null
+            : Map.of("_stats.row_count", (long) randomIntBetween(100, 10000), "_stats.size_bytes", (long) randomIntBetween(1000, 100000));
         return new FileSplit(
             "file",
             path,
@@ -63,7 +66,9 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
             randomLongBetween(1, 10000),
             ".parquet",
             Map.of(),
-            randomBoolean() ? Map.of() : Map.of("year", randomIntBetween(2020, 2026))
+            randomBoolean() ? Map.of() : Map.of("year", randomIntBetween(2020, 2026)),
+            null,
+            statistics
         );
     }
 


### PR DESCRIPTION
Enable stripe-level split parallelism for ORC files by implementing
RangeAwareFormatReader. `discoverSplitRanges()` returns per-stripe byte
ranges with statistics (row count, size, per-column min/max/null count),
and `readRange()` restricts reading to stripes within a given byte range
via ORC's `Reader.Options.range()`. Refactors shared read configuration
into reusable helpers for consistency between `read()` and `readRange()`.

Builds on top of #145579 which introduced the same for Parquet and the
`SplitRange` record with per-split statistics support.

Developed with AI-assisted tooling