### PR TITLE
[9.2] Remove Security Manager usage from x-pack ESQL (#145481)

### DIFF
--- a/x-pack/plugin/esql/arrow/src/main/java/org/elasticsearch/xpack/esql/arrow/AllocationManagerShim.java
+++ b/x-pack/plugin/esql/arrow/src/main/java/org/elasticsearch/xpack/esql/arrow/AllocationManagerShim.java
@@ -16,8 +16,6 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
 import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * An Arrow memory allocation manager that always fails.
@@ -44,16 +42,13 @@ public class AllocationManagerShim implements AllocationManager.Factory {
             logger.info("We're in tests, not disabling Arrow memory manager so we can use a real runtime for testing");
         } catch (ClassNotFoundException notfound) {
             logger.debug("Disabling Arrow's allocation manager");
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                try {
-                    Field field = DefaultAllocationManagerOption.class.getDeclaredField("DEFAULT_ALLOCATION_MANAGER_FACTORY");
-                    field.setAccessible(true);
-                    field.set(null, new AllocationManagerShim());
-                } catch (Exception e) {
-                    throw new AssertionError("Can't init Arrow", e);
-                }
-                return null;
-            });
+            try {
+                Field field = DefaultAllocationManagerOption.class.getDeclaredField("DEFAULT_ALLOCATION_MANAGER_FACTORY");
+                field.setAccessible(true);
+                field.set(null, new AllocationManagerShim());
+            } catch (Exception e) {
+                throw new AssertionError("Can't init Arrow", e);
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -783,9 +783,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             int rootLength = root.toString().length() + 1;
 
             // load classes from jar files
-            // NIO FileSystem API is not used since it trips the SecurityManager
-            // https://bugs.openjdk.java.net/browse/JDK-8160798
-            // so iterate the jar "by hand"
+            // iterate the jar "by hand"
             if (path.endsWith(".jar") && path.contains(ESQL_CORE_JAR_LOCATION_SUBSTRING)) {
                 try (JarInputStream jar = jarStream(root)) {
                     JarEntry je = null;


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Remove Security Manager usage from x-pack ESQL (#145481)