### PR TITLE
Unmute EsqlNodeSubclassTests - fixed by #145597

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -419,9 +419,6 @@ tests:
 - class: org.elasticsearch.indices.IndexingMemoryControllerIT
   method: testDeletesAloneCanTriggerRefresh
   issue: https://github.com/elastic/elasticsearch/issues/145609
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.logical.fuse.Fuse}
-  issue: https://github.com/elastic/elasticsearch/issues/145616
 
 # Examples:
 #


### PR DESCRIPTION
Unmutes `EsqlNodeSubclassTests` failures caused by the `output() called on unresolved plan` assertion that was reverted in #145597.

Fixes #145616