### PR TITLE
[9.3] Update timeout on yaml rest tests because they often exceed 1h (#142715)

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -45,7 +45,7 @@ import static java.util.Collections.singletonMap;
 
 /** Runs rest tests against external cluster */
 // TODO: Remove this timeout increase once this test suite is broken up
-@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = 90 * TimeUnits.MINUTE)
 public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(
         "x_pack_rest_user",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Update timeout on yaml rest tests because they often exceed 1h (#142715)](https://github.com/elastic/elasticsearch/pull/142715)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)