### PR TITLE
[ESQL] Push STARTS_WITH/LIKE prefix to Parquet and ORC

### DIFF
--- a/docs/changelog/145640.yaml
+++ b/docs/changelog/145640.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145640
+summary: Push STARTS_WITH/LIKE prefix to Parquet and ORC
+type: enhancement

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
@@ -222,6 +222,22 @@ public final class StringUtils {
     }
 
     /**
+     * Escapes Lucene wildcard metacharacters ({@code *}, {@code ?}, {@code \}) in a literal string
+     * so it can be safely embedded in a Lucene wildcard pattern.
+     */
+    public static String escapeWildcardLiteral(String literal) {
+        StringBuilder sb = new StringBuilder(literal.length());
+        for (int i = 0; i < literal.length(); i++) {
+            char c = literal.charAt(i);
+            if (c == '*' || c == '?' || c == '\\') {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /**
      * Translates a like pattern to a Lucene wildcard.
      * This methods pays attention to the custom escape char which gets converted into \ (used by Lucene).
      * <pre>

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/StringUtilsTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/StringUtilsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.core.util;
 
 import org.elasticsearch.test.ESTestCase;
 
+import static org.elasticsearch.xpack.esql.core.util.StringUtils.escapeWildcardLiteral;
 import static org.elasticsearch.xpack.esql.core.util.StringUtils.luceneWildcardToRegExp;
 import static org.elasticsearch.xpack.esql.core.util.StringUtils.wildcardToJavaPattern;
 import static org.hamcrest.Matchers.is;
@@ -56,6 +57,15 @@ public class StringUtilsTests extends ESTestCase {
 
     public void testEscapedEscape() {
         assertEquals("^\\\\\\\\$", wildcardToJavaPattern("\\\\\\\\", '\\'));
+    }
+
+    public void testEscapeWildcardLiteral() {
+        assertThat(escapeWildcardLiteral("foo"), is("foo"));
+        assertThat(escapeWildcardLiteral(""), is(""));
+        assertThat(escapeWildcardLiteral("foo*bar"), is("foo\\*bar"));
+        assertThat(escapeWildcardLiteral("foo?bar"), is("foo\\?bar"));
+        assertThat(escapeWildcardLiteral("foo\\bar"), is("foo\\\\bar"));
+        assertThat(escapeWildcardLiteral("*?\\"), is("\\*\\?\\\\"));
     }
 
     public void testLuceneWildcardToRegExp() {

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFilters.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFilters.java
@@ -97,9 +97,7 @@ final class OrcPushdownFilters {
             return canConvert(not.field());
         }
         if (expr instanceof StartsWith sw) {
-            return sw.singleValueField() instanceof NamedExpression ne
-                && (ne.dataType() == DataType.KEYWORD || ne.dataType() == DataType.TEXT)
-                && sw.prefix().foldable();
+            return PushdownPredicates.isStartsWith(sw, dt -> dt == DataType.KEYWORD || dt == DataType.TEXT);
         }
         return false;
     }

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFilters.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFilters.java
@@ -10,11 +10,14 @@ package org.elasticsearch.xpack.esql.datasource.orc;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.pushdown.PushdownPredicates;
+import org.elasticsearch.xpack.esql.datasources.pushdown.StringPrefixUtils;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -92,6 +95,11 @@ final class OrcPushdownFilters {
         }
         if (expr instanceof Not not) {
             return canConvert(not.field());
+        }
+        if (expr instanceof StartsWith sw) {
+            return sw.singleValueField() instanceof NamedExpression ne
+                && (ne.dataType() == DataType.KEYWORD || ne.dataType() == DataType.TEXT)
+                && sw.prefix().foldable();
         }
         return false;
     }
@@ -237,6 +245,28 @@ final class OrcPushdownFilters {
             builder.startNot();
             buildPredicate(builder, not.field());
             builder.end();
+            return;
+        }
+
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne && sw.prefix().foldable()) {
+            Object prefixValue = literalValueOf(sw.prefix());
+            if (prefixValue == null) {
+                return;
+            }
+            String name = ne.name();
+            PredicateLeaf.Type type = resolveType(ne.dataType());
+            String prefix = BytesRefs.toString(prefixValue);
+            BytesRef upperBytes = StringPrefixUtils.nextPrefixUpperBound(new BytesRef(prefix));
+
+            if (upperBytes != null) {
+                String upper = upperBytes.utf8ToString();
+                builder.startAnd();
+                builder.startNot().lessThan(name, type, prefix).end();
+                builder.lessThan(name, type, upper);
+                builder.end();
+            } else {
+                builder.startNot().lessThan(name, type, prefix).end();
+            }
             return;
         }
 

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFiltersTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcPushdownFiltersTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -310,6 +311,57 @@ public class OrcPushdownFiltersTests extends ESTestCase {
 
     public void testConvertLiteralNull() {
         assertNull(OrcPushdownFilters.convertLiteral(null, DataType.INTEGER));
+    }
+
+    // --- StartsWith tests ---
+
+    public void testCanConvertStartsWithKeyword() {
+        FieldAttribute f = field("name", DataType.KEYWORD);
+        Expression sw = new StartsWith(SOURCE, f, literal("alice", DataType.KEYWORD));
+        assertTrue(OrcPushdownFilters.canConvert(sw));
+    }
+
+    public void testCanConvertStartsWithText() {
+        FieldAttribute f = field("description", DataType.TEXT);
+        Expression sw = new StartsWith(SOURCE, f, literal("hello", DataType.TEXT));
+        assertTrue(OrcPushdownFilters.canConvert(sw));
+    }
+
+    public void testCanConvertStartsWithInteger() {
+        FieldAttribute f = field("age", DataType.INTEGER);
+        Expression sw = new StartsWith(SOURCE, f, literal(10, DataType.INTEGER));
+        assertFalse(OrcPushdownFilters.canConvert(sw));
+    }
+
+    public void testCanConvertStartsWithNonFoldable() {
+        FieldAttribute f = field("name", DataType.KEYWORD);
+        FieldAttribute prefix = field("prefix", DataType.KEYWORD);
+        Expression sw = new StartsWith(SOURCE, f, prefix);
+        assertFalse(OrcPushdownFilters.canConvert(sw));
+    }
+
+    public void testBuildSearchArgumentStartsWith() {
+        FieldAttribute f = field("name", DataType.KEYWORD);
+        Expression sw = new StartsWith(SOURCE, f, literal("alice", DataType.KEYWORD));
+        SearchArgument sarg = OrcPushdownFilters.buildSearchArgument(List.of(sw));
+        assertNotNull(sarg);
+        assertEquals(2, sarg.getLeaves().size());
+        PredicateLeaf lowerLeaf = sarg.getLeaves().get(0);
+        assertEquals("name", lowerLeaf.getColumnName());
+        assertEquals(PredicateLeaf.Type.STRING, lowerLeaf.getType());
+        assertEquals(PredicateLeaf.Operator.LESS_THAN, lowerLeaf.getOperator());
+        assertEquals("alice", lowerLeaf.getLiteral());
+    }
+
+    public void testStartsWithInAndExpression() {
+        FieldAttribute nameField = field("name", DataType.KEYWORD);
+        FieldAttribute ageField = field("age", DataType.INTEGER);
+        Expression sw = new StartsWith(SOURCE, nameField, literal("alice", DataType.KEYWORD));
+        Expression eqExpr = eq("age", DataType.INTEGER, 30);
+        And and = new And(SOURCE, sw, eqExpr);
+        SearchArgument sarg = OrcPushdownFilters.buildSearchArgument(List.of(and));
+        assertNotNull(sarg);
+        assertTrue(sarg.getLeaves().size() >= 2);
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -158,7 +158,7 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
             return canConvert(not.field());
         }
         if (expr instanceof StartsWith sw) {
-            return sw.singleValueField() instanceof NamedExpression ne && ne.dataType() == DataType.KEYWORD && sw.prefix().foldable();
+            return PushdownPredicates.isStartsWith(sw, dt -> dt == DataType.KEYWORD);
         }
         return false;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -19,7 +19,9 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.pushdown.PushdownPredicates;
+import org.elasticsearch.xpack.esql.datasources.pushdown.StringPrefixUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -155,6 +157,9 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         if (expr instanceof Not not) {
             return canConvert(not.field());
         }
+        if (expr instanceof StartsWith sw) {
+            return sw.singleValueField() instanceof NamedExpression ne && ne.dataType() == DataType.KEYWORD && sw.prefix().foldable();
+        }
         return false;
     }
 
@@ -211,6 +216,20 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         }
         if (expr instanceof Not not) {
             return FilterApi.not(translateExpression(not.field()));
+        }
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne && sw.prefix().foldable()) {
+            Object prefixValue = literalValueOf(sw.prefix());
+            if (prefixValue == null) {
+                return null;
+            }
+            BytesRef prefix = (BytesRef) prefixValue;
+            var col = FilterApi.binaryColumn(ne.name());
+            FilterPredicate lower = FilterApi.gtEq(col, toBinary(prefix));
+            BytesRef upper = StringPrefixUtils.nextPrefixUpperBound(prefix);
+            if (upper != null) {
+                return FilterApi.and(lower, FilterApi.lt(col, toBinary(upper)));
+            }
+            return lower;
         }
         return null;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -544,6 +545,67 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         Expression filter = new Range(Source.EMPTY, col, boolLit(false), true, boolLit(true), true, ZoneOffset.UTC);
 
         assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    // --- StartsWith tests ---
+
+    public void testStartsWithKeywordPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new StartsWith(Source.EMPTY, col, keywordLit("alice"));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testStartsWithNonKeywordNotPushed() {
+        Attribute col = attr("age", DataType.INTEGER);
+        Expression filter = new StartsWith(Source.EMPTY, col, intLit(10));
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testStartsWithNonFoldableNotPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Attribute prefix = attr("prefix", DataType.KEYWORD);
+        Expression filter = new StartsWith(Source.EMPTY, col, prefix);
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testStartsWithNullPrefixNotPushed() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new StartsWith(Source.EMPTY, col, new Literal(Source.EMPTY, null, DataType.KEYWORD));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertFalse(result.hasPushedFilter());
+    }
+
+    public void testStartsWithCombinedWithEquals() {
+        Attribute name = attr("name", DataType.KEYWORD);
+        Attribute age = attr("age", DataType.INTEGER);
+        Expression sw = new StartsWith(Source.EMPTY, name, keywordLit("alice"));
+        Expression eq = new Equals(Source.EMPTY, age, intLit(30), null);
+        Expression filter = new And(Source.EMPTY, sw, eq);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testStartsWithInOr() {
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression sw = new StartsWith(Source.EMPTY, col, keywordLit("a"));
+        Expression eq = new Equals(Source.EMPTY, col, keywordLit("z"), null);
+        Expression filter = new Or(Source.EMPTY, sw, eq);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2427,6 +2427,11 @@ public class EsqlCapabilities {
 
         KEYWORDS_MV_COUNT_AS_SINGLE_VALUE_FIX,
 
+        /**
+         * Parquet and ORC filter pushdown for StartsWith (prefix range predicates).
+         */
+        PARQUET_ORC_STARTS_WITH_PUSHDOWN,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/AbstractStringPattern.java
@@ -12,8 +12,12 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 public abstract class AbstractStringPattern implements StringPattern {
+
+    private static final Logger logger = LogManager.getLogger(AbstractStringPattern.class);
 
     private Automaton automaton;
 
@@ -47,5 +51,57 @@ public abstract class AbstractStringPattern implements StringPattern {
         }
         IntsRef singleton = Operations.getSingleton(a);
         return singleton != null ? UnicodeUtil.newString(singleton.ints, singleton.offset, singleton.length) : null;
+    }
+
+    /**
+     * Returns the longest string that prefixes every string accepted by this pattern,
+     * using Lucene's {@link Operations#getCommonPrefix}. Returns {@code null} if the
+     * common prefix is empty (e.g. the pattern starts with a wildcard).
+     */
+    public String extractPrefix() {
+        Automaton a = automaton();
+        if (a.getNumStates() == 0) {
+            return null;
+        }
+        Automaton clean = Operations.removeDeadStates(a);
+        if (clean.getNumStates() == 0) {
+            return null;
+        }
+        String prefix = Operations.getCommonPrefix(clean);
+        return prefix.isEmpty() ? null : prefix;
+    }
+
+    /**
+     * Returns the longest string that suffixes every string accepted by this pattern.
+     * Computed by reversing the automaton and extracting the common prefix of the reversed
+     * language, then reversing the result. Returns {@code null} if the common suffix is empty
+     * or the reversed automaton is too complex to determinize.
+     */
+    public String extractSuffix() {
+        Automaton a = automaton();
+        if (a.getNumStates() == 0) {
+            return null;
+        }
+        Automaton reversed;
+        try {
+            reversed = Operations.determinize(Operations.reverse(a), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        } catch (TooComplexToDeterminizeException e) {
+            logger.debug("reversed automaton too complex to determinize for suffix extraction", e);
+            return null;
+        }
+        reversed = Operations.removeDeadStates(reversed);
+        if (reversed.getNumStates() == 0) {
+            return null;
+        }
+        String reversedPrefix = Operations.getCommonPrefix(reversed);
+        if (reversedPrefix.isEmpty()) {
+            return null;
+        }
+        int[] codePoints = reversedPrefix.codePoints().toArray();
+        StringBuilder sb = new StringBuilder();
+        for (int i = codePoints.length - 1; i >= 0; i--) {
+            sb.appendCodePoint(codePoints[i]);
+        }
+        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
@@ -82,56 +82,6 @@ public class WildcardPattern extends AbstractStringPattern implements Writeable 
         return wildcard;
     }
 
-    /**
-     * Extracts the fixed literal prefix before the first unescaped wildcard ({@code *} or {@code ?}).
-     * Escaped wildcards ({@code \*}, {@code \?}) are treated as literal characters.
-     * Returns {@code null} if the prefix is empty (pattern starts with a wildcard or is empty).
-     */
-    public String extractPrefix() {
-        StringBuilder prefix = new StringBuilder();
-        for (int i = 0; i < wildcard.length(); i++) {
-            char c = wildcard.charAt(i);
-            if (c == '\\' && i + 1 < wildcard.length()) {
-                prefix.append(wildcard.charAt(i + 1));
-                i++;
-            } else if (c == '*' || c == '?') {
-                break;
-            } else {
-                prefix.append(c);
-            }
-        }
-        return prefix.isEmpty() ? null : prefix.toString();
-    }
-
-    /**
-     * Extracts the fixed literal suffix after the last unescaped wildcard ({@code *} or {@code ?}).
-     * Escaped wildcards ({@code \*}, {@code \?}) are treated as literal characters.
-     * Returns {@code null} if the suffix is empty (pattern ends with a wildcard or is empty).
-     */
-    public String extractSuffix() {
-        int lastWildcard = -1;
-        for (int i = 0; i < wildcard.length(); i++) {
-            char c = wildcard.charAt(i);
-            if (c == '\\' && i + 1 < wildcard.length()) {
-                i++;
-            } else if (c == '*' || c == '?') {
-                lastWildcard = i;
-            }
-        }
-        int start = lastWildcard + 1;
-        StringBuilder suffix = new StringBuilder();
-        for (int i = start; i < wildcard.length(); i++) {
-            char c = wildcard.charAt(i);
-            if (c == '\\' && i + 1 < wildcard.length()) {
-                suffix.append(wildcard.charAt(i + 1));
-                i++;
-            } else {
-                suffix.append(c);
-            }
-        }
-        return suffix.isEmpty() ? null : suffix.toString();
-    }
-
     @Override
     public int hashCode() {
         return Objects.hash(wildcard);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/WildcardPattern.java
@@ -82,6 +82,56 @@ public class WildcardPattern extends AbstractStringPattern implements Writeable 
         return wildcard;
     }
 
+    /**
+     * Extracts the fixed literal prefix before the first unescaped wildcard ({@code *} or {@code ?}).
+     * Escaped wildcards ({@code \*}, {@code \?}) are treated as literal characters.
+     * Returns {@code null} if the prefix is empty (pattern starts with a wildcard or is empty).
+     */
+    public String extractPrefix() {
+        StringBuilder prefix = new StringBuilder();
+        for (int i = 0; i < wildcard.length(); i++) {
+            char c = wildcard.charAt(i);
+            if (c == '\\' && i + 1 < wildcard.length()) {
+                prefix.append(wildcard.charAt(i + 1));
+                i++;
+            } else if (c == '*' || c == '?') {
+                break;
+            } else {
+                prefix.append(c);
+            }
+        }
+        return prefix.isEmpty() ? null : prefix.toString();
+    }
+
+    /**
+     * Extracts the fixed literal suffix after the last unescaped wildcard ({@code *} or {@code ?}).
+     * Escaped wildcards ({@code \*}, {@code \?}) are treated as literal characters.
+     * Returns {@code null} if the suffix is empty (pattern ends with a wildcard or is empty).
+     */
+    public String extractSuffix() {
+        int lastWildcard = -1;
+        for (int i = 0; i < wildcard.length(); i++) {
+            char c = wildcard.charAt(i);
+            if (c == '\\' && i + 1 < wildcard.length()) {
+                i++;
+            } else if (c == '*' || c == '?') {
+                lastWildcard = i;
+            }
+        }
+        int start = lastWildcard + 1;
+        StringBuilder suffix = new StringBuilder();
+        for (int i = start; i < wildcard.length(); i++) {
+            char c = wildcard.charAt(i);
+            if (c == '\\' && i + 1 < wildcard.length()) {
+                suffix.append(wildcard.charAt(i + 1));
+                i++;
+            } else {
+                suffix.append(c);
+            }
+        }
+        return suffix.isEmpty() ? null : suffix.toString();
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(wildcard);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/PushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/PushdownPredicates.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.pushdown;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
@@ -104,5 +105,13 @@ public final class PushdownPredicates {
             && typeSupported.test(ne.dataType())
             && range.lower().foldable()
             && range.upper().foldable();
+    }
+
+    /**
+     * Checks if a StartsWith expression can be pushed down: field is a single-value
+     * named expression with a supported data type, and the prefix is foldable.
+     */
+    public static boolean isStartsWith(StartsWith sw, Predicate<DataType> typeSupported) {
+        return sw.singleValueField() instanceof NamedExpression ne && typeSupported.test(ne.dataType()) && sw.prefix().foldable();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/StringPrefixUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/StringPrefixUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Utility for computing the exclusive upper bound of a UTF-8 string prefix range.
+ * Used by Parquet and ORC pushdown to translate {@code StartsWith(col, prefix)} into
+ * {@code col >= prefix AND col < nextPrefixUpperBound(prefix)} for row-group/stripe skipping.
+ */
+public final class StringPrefixUtils {
+
+    private StringPrefixUtils() {}
+
+    public static BytesRef nextPrefixUpperBound(BytesRef prefix) {
+        if (prefix == null || prefix.length == 0) {
+            return null;
+        }
+
+        String s = prefix.utf8ToString();
+        int len = s.length();
+        while (len > 0) {
+            int cp = s.codePointBefore(len);
+            int cpLen = Character.charCount(cp);
+
+            int nextCp = cp + 1;
+            if (nextCp >= Character.MIN_SURROGATE && nextCp <= Character.MAX_SURROGATE) {
+                nextCp = Character.MAX_SURROGATE + 1;
+            }
+
+            if (nextCp > Character.MAX_CODE_POINT) {
+                len -= cpLen;
+                continue;
+            }
+
+            StringBuilder sb = new StringBuilder(len - cpLen + 2);
+            sb.append(s, 0, len - cpLen);
+            sb.appendCodePoint(nextCp);
+            return new BytesRef(sb.toString());
+        }
+
+        return null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
@@ -26,7 +26,10 @@ import org.elasticsearch.xpack.esql.parser.ParsingException;
 public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionRule<RegexMatch<?>> {
 
     public ReplaceRegexMatch() {
-        super(OptimizerRules.TransformDirection.DOWN);
+        // UP: when this rule rewrites WildcardLike → And(StartsWith, WildcardLike),
+        // the inner WildcardLike child was already visited, preventing re-entry.
+        // DOWN would descend into the new WildcardLike child and loop infinitely.
+        super(OptimizerRules.TransformDirection.UP);
     }
 
     @Override
@@ -70,12 +73,12 @@ public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionR
     private static Expression decomposeWildcardLike(WildcardLike wl) {
         WildcardPattern wp = wl.pattern();
         String prefix = wp.extractPrefix();
-        String suffix = wp.extractSuffix();
         String raw = wp.pattern();
 
         if (prefix != null && raw.equals(StringUtils.escapeWildcardLiteral(prefix) + "*")) {
             return new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix));
         }
+        String suffix = wp.extractSuffix();
         if (suffix != null && raw.equals("*" + StringUtils.escapeWildcardLiteral(suffix))) {
             return new EndsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), suffix));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
@@ -11,6 +11,12 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.StringPattern;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.ChangeCase;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
@@ -44,12 +50,49 @@ public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionR
             if (match != null) {
                 Literal literal = Literal.keyword(regexMatch.source(), match);
                 e = regexToEquals(regexMatch, literal);
-            }
+            } else if (regexMatch instanceof WildcardLike wl
+                && wl.caseInsensitive() == false
+                && (wl.field() instanceof ChangeCase) == false) {
+                    Expression decomposed = decomposeWildcardLike(wl);
+                    if (decomposed != null) {
+                        e = decomposed;
+                    }
+                }
         }
         return e;
     }
 
     protected Expression regexToEquals(RegexMatch<?> regexMatch, Literal literal) {
         return new Equals(regexMatch.source(), regexMatch.field(), literal);
+    }
+
+    private static Expression decomposeWildcardLike(WildcardLike wl) {
+        WildcardPattern wp = wl.pattern();
+        String prefix = wp.extractPrefix();
+        String suffix = wp.extractSuffix();
+        String raw = wp.pattern();
+
+        if (prefix != null && raw.equals(escapeWildcard(prefix) + "*")) {
+            return new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix));
+        }
+        if (suffix != null && raw.equals("*" + escapeWildcard(suffix))) {
+            return new EndsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), suffix));
+        }
+        if (prefix != null) {
+            return new And(wl.source(), new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix)), wl);
+        }
+        return null;
+    }
+
+    private static String escapeWildcard(String literal) {
+        StringBuilder sb = new StringBuilder(literal.length());
+        for (int i = 0; i < literal.length(); i++) {
+            char c = literal.charAt(i);
+            if (c == '*' || c == '?' || c == '\\') {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.StringPattern;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
+import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ChangeCase;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
@@ -72,27 +73,15 @@ public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionR
         String suffix = wp.extractSuffix();
         String raw = wp.pattern();
 
-        if (prefix != null && raw.equals(escapeWildcard(prefix) + "*")) {
+        if (prefix != null && raw.equals(StringUtils.escapeWildcardLiteral(prefix) + "*")) {
             return new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix));
         }
-        if (suffix != null && raw.equals("*" + escapeWildcard(suffix))) {
+        if (suffix != null && raw.equals("*" + StringUtils.escapeWildcardLiteral(suffix))) {
             return new EndsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), suffix));
         }
         if (prefix != null) {
             return new And(wl.source(), new StartsWith(wl.source(), wl.field(), Literal.keyword(wl.source(), prefix)), wl);
         }
         return null;
-    }
-
-    private static String escapeWildcard(String literal) {
-        StringBuilder sb = new StringBuilder(literal.length());
-        for (int i = 0; i < literal.length(); i++) {
-            char c = literal.charAt(i);
-            if (c == '*' || c == '?' || c == '\\') {
-                sb.append('\\');
-            }
-            sb.append(c);
-        }
-        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/StringPatternTests.java
@@ -107,6 +107,30 @@ public class StringPatternTests extends ESTestCase {
         assertNotNull(exactMatchRLike("foo|#"));
     }
 
+    public void testWildcardExtractPrefix() {
+        assertEquals("foo", like("foo*").extractPrefix());
+        assertNull(like("*bar").extractPrefix());
+        assertEquals("foo", like("foo*bar").extractPrefix());
+        assertEquals("foo*bar", like("foo\\*bar*").extractPrefix());
+        assertNull(like("*").extractPrefix());
+        assertEquals("exact", like("exact").extractPrefix());
+        assertEquals("foo", like("foo?bar*").extractPrefix());
+        assertNull(like("").extractPrefix());
+        assertEquals("*", like("\\*").extractPrefix());
+    }
+
+    public void testWildcardExtractSuffix() {
+        assertNull(like("foo*").extractSuffix());
+        assertEquals("bar", like("*bar").extractSuffix());
+        assertEquals("bar", like("foo*bar").extractSuffix());
+        assertNull(like("foo\\*bar*").extractSuffix());
+        assertNull(like("*").extractSuffix());
+        assertEquals("exact", like("exact").extractSuffix());
+        assertNull(like("foo?bar*").extractSuffix());
+        assertNull(like("").extractSuffix());
+        assertEquals("*", like("\\*").extractSuffix());
+    }
+
     public void testTooComplexPattern() {
         var e = expectThrows(IllegalArgumentException.class, () -> rlike("(a|b)*a(a|b){13}").createAutomaton(false));
         assertEquals("Pattern was too complex to determinize", e.getMessage());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/StringPrefixUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/StringPrefixUtilsTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+public class StringPrefixUtilsTests extends ESTestCase {
+
+    public void testAsciiIncrement() {
+        assertEquals(new BytesRef("abd"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("abc")));
+    }
+
+    public void testSingleCharAscii() {
+        assertEquals(new BytesRef("{"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("z")));
+    }
+
+    public void testEmptyPrefix() {
+        assertNull(StringPrefixUtils.nextPrefixUpperBound(new BytesRef("")));
+    }
+
+    public void testNullPrefix() {
+        assertNull(StringPrefixUtils.nextPrefixUpperBound(null));
+    }
+
+    public void testCombiningAccent() {
+        // U+0301 (combining acute accent) increments to U+0302
+        assertEquals(new BytesRef("cafe\u0302"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("cafe\u0301")));
+    }
+
+    public void testLastBeforeSurrogateRange() {
+        // U+D7FF is the last code point before the surrogate range; incrementing skips surrogates to U+E000
+        assertEquals(new BytesRef("hello\uE000"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("hello\uD7FF")));
+    }
+
+    public void testTwoByteCharIncrement() {
+        // U+00FF (2-byte in UTF-8) increments to U+0100 (also 2-byte)
+        assertEquals(new BytesRef("\u0100"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("\u00FF")));
+    }
+
+    public void testFourByteEmojiIncrement() {
+        // U+1F600 (grinning face) should increment to U+1F601
+        String emoji = new String(Character.toChars(0x1F600));
+        String next = new String(Character.toChars(0x1F601));
+        assertEquals(new BytesRef(next), StringPrefixUtils.nextPrefixUpperBound(new BytesRef(emoji)));
+    }
+
+    public void testMaxCodePointTrimAndRetry() {
+        // U+10FFFF is max; can't increment, so trim and increment preceding code point
+        String maxCp = new String(Character.toChars(Character.MAX_CODE_POINT));
+        assertEquals(new BytesRef("b"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("a" + maxCp)));
+    }
+
+    public void testAllMaxCodePointsReturnsNull() {
+        String maxCp = new String(Character.toChars(Character.MAX_CODE_POINT));
+        assertNull(StringPrefixUtils.nextPrefixUpperBound(new BytesRef(maxCp)));
+        assertNull(StringPrefixUtils.nextPrefixUpperBound(new BytesRef(maxCp + maxCp)));
+    }
+
+    public void testMultiBytePrefix() {
+        // "héllo" → last char 'o' increments to 'p' → "héllp"
+        assertEquals(new BytesRef("h\u00e9llp"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("h\u00e9llo")));
+    }
+
+    public void testSingleAsciiA() {
+        assertEquals(new BytesRef("b"), StringPrefixUtils.nextPrefixUpperBound(new BytesRef("a")));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -87,8 +87,8 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSum;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Concat;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToLower;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -5251,11 +5251,11 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
     /**
      * Limit[1000[INTEGER],false]
-     * \_Filter[LIKE(language_name{f}#18, "French*", false)]
+     * \_Filter[StartsWith(language_name{f}#18, "French")]
      *   \_Join[LEFT,[languages{f}#9],[language_code{f}#17],languages{f}#9 == language_code{f}#17 AND MATCH(language_name{f}#18,
      * English[KEYWORD])]
      *     |_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
-     *     \_Filter[LIKE(language_name{f}#18, "French*", false)]
+     *     \_Filter[StartsWith(language_name{f}#18, "French")]
      *       \_EsRelation[languages_lookup][LOOKUP][language_code{f}#17, language_name{f}#18]
      */
     public void testLookupJoinRightFilterMatchWithWhereClause() {
@@ -5272,12 +5272,11 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         var join = as(topFilter.child(), Join.class);
         assertEquals("ON languages == language_code and MATCH(language_name,\"English\")", join.config().joinOnConditions().toString());
 
-        // Check that the LIKE condition is pushed down as a right pre-join filter
+        // LIKE "French*" is decomposed to StartsWith by ReplaceRegexMatch
         var rightFilter = as(join.right(), Filter.class);
-        var likeCondition = as(rightFilter.condition(), WildcardLike.class);
-        var field = as(likeCondition.field(), FieldAttribute.class);
+        var startsWithCondition = as(rightFilter.condition(), StartsWith.class);
+        var field = as(startsWithCondition.children().get(0), FieldAttribute.class);
         assertEquals("language_name", field.name());
-        assertEquals("French*", likeCondition.pattern().pattern());
 
         as(rightFilter.child(), EsRelation.class);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
@@ -103,27 +103,25 @@ public class ReplaceRegexMatchTests extends ESTestCase {
     }
 
     public void testLikeMixedPatternAddsStartsWithConjunct() {
-        WildcardPattern pattern = new WildcardPattern("foo*bar*");
-        FieldAttribute fa = getFieldAttribute();
-        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
-        Expression e = replaceRegexMatch(wl);
-        assertEquals(And.class, e.getClass());
-        And and = (And) e;
-        assertEquals(StartsWith.class, and.left().getClass());
-        assertEquals(WildcardLike.class, and.right().getClass());
-        StartsWith sw = (StartsWith) and.left();
-        assertEquals(fa, sw.children().get(0));
-        assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
+        for (String s : asList("foo*bar*", "foo?bar*", "prefix?")) {
+            WildcardPattern pattern = new WildcardPattern(s);
+            FieldAttribute fa = getFieldAttribute();
+            WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+            Expression e = replaceRegexMatch(wl);
+            assertEquals(And.class, e.getClass());
+            And and = (And) e;
+            assertEquals(StartsWith.class, and.left().getClass());
+            assertEquals(WildcardLike.class, and.right().getClass());
+        }
     }
 
-    public void testLikeSingleCharWildcardStopsPrefix() {
-        WildcardPattern pattern = new WildcardPattern("foo?bar*");
+    public void testLikeMixedPatternWithSuffix() {
+        WildcardPattern pattern = new WildcardPattern("foo*bar");
         FieldAttribute fa = getFieldAttribute();
         WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
         Expression e = replaceRegexMatch(wl);
         assertEquals(And.class, e.getClass());
         And and = (And) e;
-        assertEquals(StartsWith.class, and.left().getClass());
         StartsWith sw = (StartsWith) and.left();
         assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatchTests.java
@@ -16,8 +16,11 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLike;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 
@@ -75,6 +78,80 @@ public class ReplaceRegexMatchTests extends ESTestCase {
         Equals eq = (Equals) e;
         assertEquals(fa, eq.left());
         assertEquals("abc", BytesRefs.toString(eq.right().fold(FoldContext.small())));
+    }
+
+    public void testLikePrefixDecomposesToStartsWith() {
+        WildcardPattern pattern = new WildcardPattern("foo*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(StartsWith.class, e.getClass());
+        StartsWith sw = (StartsWith) e;
+        assertEquals(fa, sw.children().get(0));
+        assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeSuffixDecomposesToEndsWith() {
+        WildcardPattern pattern = new WildcardPattern("*bar");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(EndsWith.class, e.getClass());
+        EndsWith ew = (EndsWith) e;
+        assertEquals(fa, ew.children().get(0));
+        assertEquals("bar", BytesRefs.toString(ew.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeMixedPatternAddsStartsWithConjunct() {
+        WildcardPattern pattern = new WildcardPattern("foo*bar*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(And.class, e.getClass());
+        And and = (And) e;
+        assertEquals(StartsWith.class, and.left().getClass());
+        assertEquals(WildcardLike.class, and.right().getClass());
+        StartsWith sw = (StartsWith) and.left();
+        assertEquals(fa, sw.children().get(0));
+        assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeSingleCharWildcardStopsPrefix() {
+        WildcardPattern pattern = new WildcardPattern("foo?bar*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(And.class, e.getClass());
+        And and = (And) e;
+        assertEquals(StartsWith.class, and.left().getClass());
+        StartsWith sw = (StartsWith) and.left();
+        assertEquals("foo", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testLikeNoFixedPrefixUnchanged() {
+        WildcardPattern pattern = new WildcardPattern("*foo*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(WildcardLike.class, e.getClass());
+    }
+
+    public void testLikeEscapedWildcard() {
+        WildcardPattern pattern = new WildcardPattern("foo\\*bar*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(StartsWith.class, e.getClass());
+        StartsWith sw = (StartsWith) e;
+        assertEquals("foo*bar", BytesRefs.toString(sw.children().get(1).fold(FoldContext.small())));
+    }
+
+    public void testCaseInsensitiveLikeNotDecomposed() {
+        WildcardPattern pattern = new WildcardPattern("foo*");
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike wl = new WildcardLike(EMPTY, fa, pattern, true);
+        Expression e = replaceRegexMatch(wl);
+        assertEquals(WildcardLike.class, e.getClass());
     }
 
 }


### PR DESCRIPTION
Decompose LIKE 'prefix*' to StartsWith in the logical optimizer
and translate prefix predicates to range filters for Parquet
(FilterApi.gtEq/lt) and ORC (SearchArgument between). This
enables row-group and stripe skipping via min/max statistics
for prefix string patterns.

Uses Lucene automaton infrastructure (Operations.getCommonPrefix
and reverse-automaton) for robust prefix/suffix extraction from
wildcard patterns, replacing hand-rolled syntactic parsing.

Developed with AI-assisted tooling