### PR TITLE
Unmark indices for frozen conversion after unrecoverable exception

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutor.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutor.java
@@ -7,7 +7,12 @@
 
 package org.elasticsearch.xpack.dlm.frozen;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -46,6 +51,7 @@ class DLMFrozenTransitionExecutor implements Closeable {
     private final int maxQueueSize;
     private final ClusterService clusterService;
     private final DataStreamLifecycleErrorStore errorStore;
+    private final MasterServiceTaskQueue<UnmarkIndexForFrozenTask> unmarkIndexForDlmFrozenConversionQueue;
     private volatile int errorRetryInterval;
 
     DLMFrozenTransitionExecutor(
@@ -70,6 +76,11 @@ class DLMFrozenTransitionExecutor implements Closeable {
         this.clusterService = clusterService;
         this.errorStore = errorStore;
         this.errorRetryInterval = DataStreamLifecycleErrorStore.DATA_STREAM_SIGNALLING_ERROR_RETRY_INTERVAL_SETTING.get(settings);
+        this.unmarkIndexForDlmFrozenConversionQueue = clusterService.createTaskQueue(
+            "dlm-unmark-index-for-frozen",
+            Priority.LOW,
+            new UnmarkIndexForDLMFrozenExecutor()
+        );
     }
 
     public void init() {
@@ -120,6 +131,23 @@ class DLMFrozenTransitionExecutor implements Closeable {
         ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
     }
 
+    public static class UnmarkIndexForDLMFrozenExecutor implements ClusterStateTaskExecutor<UnmarkIndexForFrozenTask> {
+        @Override
+        public ClusterState execute(BatchExecutionContext<UnmarkIndexForFrozenTask> batchExecutionContext) {
+            var state = batchExecutionContext.initialState();
+            for (final var taskContext : batchExecutionContext.taskContexts()) {
+                try {
+                    final UnmarkIndexForFrozenTask task = taskContext.getTask();
+                    state = task.execute(state);
+                    taskContext.success(task);
+                } catch (Exception e) {
+                    taskContext.onFailure(e);
+                }
+            }
+            return state;
+        }
+    }
+
     private class WrappedDlmFrozenTransitionRunnable implements Runnable {
         private final DLMFrozenTransitionRunnable task;
 
@@ -137,6 +165,32 @@ class DLMFrozenTransitionExecutor implements Closeable {
                     : "expected the previous value to exist and be false, but it was " + previousValue;
                 task.run();
                 logger.debug("Transition completed for index [{}]", indexName);
+            } catch (DLMUnrecoverableException err) {
+                logger.debug(
+                    "DLM encountered an unrecoverable error while converting [{}] "
+                        + "to a frozen index, submitting task to unmark it for conversion",
+                    indexName
+                );
+                unmarkIndexForDlmFrozenConversionQueue.submitTask(
+                    "dlm-unmark-frozen-" + indexName,
+                    new UnmarkIndexForFrozenTask(
+                        task.getProjectId(),
+                        task.getIndexName(),
+                        ActionListener.wrap(
+                            resp -> logger.debug("DLM successfully unmarked index [{}] for frozen conversion", indexName),
+                            exception -> {
+                                errorStore.recordAndLogError(
+                                    task.getProjectId(),
+                                    indexName,
+                                    exception,
+                                    Strings.format("Error unmarking index [%s] for conversion to frozen index", indexName),
+                                    errorRetryInterval
+                                );
+                            }
+                        )
+                    ),
+                    null
+                );
             } catch (Exception ex) {
                 errorStore.recordAndLogError(
                     task.getProjectId(),

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/UnmarkIndexForFrozenTask.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/UnmarkIndexForFrozenTask.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.dlm.frozen;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.AckedBatchedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.datastreams.DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY;
+
+/**
+ * Task to update the cluster state to remove the frozen conversion flag from an index
+ */
+public class UnmarkIndexForFrozenTask extends AckedBatchedClusterStateUpdateTask implements ClusterStateTaskListener {
+    private final ActionListener<AcknowledgedResponse> listener;
+    private final ProjectId projectId;
+    private final String indexName;
+    private final Logger logger = LogManager.getLogger(UnmarkIndexForFrozenTask.class);
+
+    UnmarkIndexForFrozenTask(ProjectId projectId, String indexName, ActionListener<AcknowledgedResponse> listener) {
+        super(TimeValue.THIRTY_SECONDS, listener);
+        this.listener = listener;
+        this.projectId = projectId;
+        this.indexName = indexName;
+    }
+
+    ClusterState execute(ClusterState currentState) {
+        ProjectMetadata projectMetadata = currentState.metadata().getProject(this.projectId);
+        if (projectMetadata == null) {
+            return currentState;
+        }
+        IndexMetadata originalIndexMetadata = projectMetadata.index(indexName);
+        if (originalIndexMetadata == null) {
+            logger.debug("DLM attempted to unmark index [{}] for frozen conversion, but index no longer exists", indexName);
+            return currentState;
+        }
+
+        Map<String, String> existingCustomMetadata = originalIndexMetadata.getCustomData(LIFECYCLE_CUSTOM_INDEX_METADATA_KEY);
+        Map<String, String> customMetadata = new HashMap<>();
+        if (existingCustomMetadata != null) {
+            if (existingCustomMetadata.containsKey(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY) == false) {
+                // Index is already unmarked, no update needed
+                return currentState;
+            }
+            customMetadata.putAll(existingCustomMetadata);
+        }
+        customMetadata.remove(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY);
+
+        IndexMetadata updatedOriginalIndexMetadata = new IndexMetadata.Builder(originalIndexMetadata).putCustom(
+            LIFECYCLE_CUSTOM_INDEX_METADATA_KEY,
+            customMetadata
+        ).build();
+
+        final ProjectMetadata.Builder updatedProject = ProjectMetadata.builder(currentState.metadata().getProject(projectId))
+            .put(updatedOriginalIndexMetadata, true);
+        return ClusterState.builder(currentState).putProjectMetadata(updatedProject).build();
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        listener.onFailure(e);
+    }
+}

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutorTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionExecutorTests.java
@@ -7,11 +7,19 @@
 
 package org.elasticsearch.xpack.dlm.frozen;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.datastreams.lifecycle.ErrorEntry;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.WrappedRunnable;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService;
 import org.elasticsearch.dlm.DataStreamLifecycleErrorStore;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -23,6 +31,7 @@ import org.junit.Before;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -93,6 +102,56 @@ public class DLMFrozenTransitionExecutorTests extends ESTestCase {
             ErrorEntry err = errorStore.getError(ProjectId.DEFAULT, "exception-index");
             assertNotNull("expected an error to be recorded in the error store", err);
             assertThat(err.error(), containsString("simulated failure"));
+        }
+    }
+
+    public void testIndexUnmarkedAfterUnrecoverableFailure() throws Exception {
+        var errorStore = makeErrorStore();
+        String indexName = "exception-index";
+        try (var executor = new DLMFrozenTransitionExecutor(clusterService, 2, 100, Settings.EMPTY, errorStore)) {
+            ClusterServiceUtils.setState(
+                clusterService,
+                ClusterState.builder(ClusterState.EMPTY_STATE)
+                    .nodes(
+                        DiscoveryNodes.builder().add(DiscoveryNodeUtils.create("local")).localNodeId("local").masterNodeId("local").build()
+                    )
+                    .putProjectMetadata(
+                        ProjectMetadata.builder(ProjectId.DEFAULT)
+                            .put(
+                                IndexMetadata.builder(indexName)
+                                    .settings(
+                                        Settings.builder()
+                                            .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5))
+                                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                                            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                                            .build()
+                                    )
+                                    .putCustom(
+                                        DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY,
+                                        Map.of(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY, "myrepo")
+                                    )
+                            )
+                    )
+            );
+            var runtimeTask = new TestDLMFrozenTransitionRunnable(indexName);
+            runtimeTask.throwOnRun = new DLMUnrecoverableException(indexName, "simulated unrecoverable failure");
+            executor.submit(runtimeTask).get(10, TimeUnit.SECONDS);
+            assertFalse(executor.transitionSubmitted(indexName));
+            assertNull(errorStore.getError(ProjectId.DEFAULT, indexName));
+
+            // Check that the cluster state has been updated with the index having its mark removed
+            ClusterServiceUtils.awaitClusterState(cs -> {
+                IndexMetadata index = clusterService.state().projectState(ProjectId.DEFAULT).metadata().index(indexName);
+                if (index == null) {
+                    fail("index should always exist");
+                }
+                Map<String, String> custom = index.getCustomData(DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY);
+                if (custom.containsKey(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY)) {
+                    return false;
+                }
+                return custom.get(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY) == null;
+            }, clusterService);
         }
     }
 

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/UnmarkIndexForFrozenTaskTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/UnmarkIndexForFrozenTaskTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.dlm.frozen;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class UnmarkIndexForFrozenTaskTests extends ESTestCase {
+    final ProjectId PROJECT_ID = randomProjectIdOrDefault();
+
+    public void testUnmark() {
+        IndexMetadata vanilla = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("vanilla", 1))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .creationDate(randomNonNegativeLong())
+            .build();
+
+        ClusterState state;
+        state = unmarkAndCheck(vanilla);
+        assertThat(getCustomData(state, vanilla.getIndex().getName()), equalTo(Map.of()));
+
+        IndexMetadata onlyCustom = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("withCustom", 1))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .creationDate(randomNonNegativeLong())
+            .putCustom(DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY, Map.of("other", "thing"))
+            .build();
+
+        state = unmarkAndCheck(onlyCustom);
+        assertThat(getCustomData(state, onlyCustom.getIndex().getName()), equalTo(Map.of("other", "thing")));
+
+        IndexMetadata markedIndex = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("myds", 1))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .creationDate(randomNonNegativeLong())
+            .putCustom(
+                DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY,
+                Map.of(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY, "repo")
+            )
+            .build();
+
+        state = unmarkAndCheck(markedIndex);
+        assertThat(getCustomData(state, markedIndex.getIndex().getName()), equalTo(Map.of()));
+
+        IndexMetadata withOtherCustom = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("withCustom", 1))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .creationDate(randomNonNegativeLong())
+            .putCustom(
+                DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY,
+                Map.of(DataStreamLifecycleService.FROZEN_CANDIDATE_REPOSITORY_METADATA_KEY, "repo", "other", "thing")
+            )
+            .build();
+
+        state = unmarkAndCheck(withOtherCustom);
+        assertThat(getCustomData(state, withOtherCustom.getIndex().getName()), equalTo(Map.of("other", "thing")));
+
+        UnmarkIndexForFrozenTask task = new UnmarkIndexForFrozenTask(PROJECT_ID, "missing-index", ActionListener.noop());
+        var newState = task.execute(state);
+        assertThat(newState, sameInstance(state));
+    }
+
+    private ClusterState unmarkAndCheck(IndexMetadata indexMetadata) {
+        ProjectMetadata projectMetadata = ProjectMetadata.builder(PROJECT_ID).put(indexMetadata, true).build();
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).putProjectMetadata(projectMetadata).build();
+        UnmarkIndexForFrozenTask task = new UnmarkIndexForFrozenTask(PROJECT_ID, indexMetadata.getIndex().getName(), ActionListener.noop());
+
+        ClusterState newState = task.execute(state);
+        assertIndexUnmarked(newState, indexMetadata.getIndex().getName());
+        var anotherState = task.execute(newState);
+        // Check that doing it twice is a no-op
+        assertThat(anotherState, sameInstance(newState));
+        return newState;
+    }
+
+    private void assertIndexUnmarked(ClusterState state, String indexName) {
+        assertTrue(
+            "expected " + indexName + " to be unmarked as ready for frozen, but its custom data was: " + getCustomData(state, indexName),
+            Optional.ofNullable(state.metadata().getProject(PROJECT_ID).index(indexName))
+                .map(im -> DataStreamLifecycleService.indexMarkedForFrozen(im) == false)
+                .orElse(false)
+        );
+    }
+
+    private Map<String, String> getCustomData(ClusterState state, String indexName) {
+        return Optional.ofNullable(state.metadata().getProject(PROJECT_ID).index(indexName))
+            .map(im -> im.getCustomData(DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY))
+            .orElse(Map.of());
+    }
+}


### PR DESCRIPTION
In the event DLM reaches an unrecoverable exception while converting an index, such as the repository being unregistered entirely during execution, we need to unmark the index so that we don't continue to retry converting the index that will never be convertible. This commit adds a check for the `DLMUnrecoverableException` and submits a task to unmark the index for conversion.
