### PR TITLE
[9.2] Return false instead of throwing for File.isFile, isDirectory, isHidden (#145626)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -127,19 +127,19 @@ class FileCheckActions {
         return readFile().toFile().exists();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsDirectory() {
-        readFile().toFile().isDirectory();
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "false", expectedDefaultType = boolean.class)
+    static boolean fileIsDirectory() {
+        return readFile().toFile().isDirectory();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsFile() {
-        readFile().toFile().isFile();
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "false", expectedDefaultType = boolean.class)
+    static boolean fileIsFile() {
+        return readFile().toFile().isFile();
     }
 
-    @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsHidden() {
-        readFile().toFile().isHidden();
+    @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "false", expectedDefaultType = boolean.class)
+    static boolean fileIsHidden() {
+        return readFile().toFile().isHidden();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS, expectedDefaultIfDenied = "0", expectedDefaultType = long.class)

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/FileInstrumentation.java
@@ -74,9 +74,9 @@ public class FileInstrumentation implements InstrumentationConfig {
             rule.calling(File::delete).enforce(Policies::fileWrite).elseThrowNotEntitled();
             rule.callingVoid(File::deleteOnExit).enforce(Policies::fileWrite).elseThrowNotEntitled();
             rule.calling(File::exists).enforce(Policies::fileRead).elseReturn(false);
-            rule.calling(File::isDirectory).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.calling(File::isFile).enforce(Policies::fileRead).elseThrowNotEntitled();
-            rule.calling(File::isHidden).enforce(Policies::fileRead).elseThrowNotEntitled();
+            rule.calling(File::isDirectory).enforce(Policies::fileRead).elseReturn(false);
+            rule.calling(File::isFile).enforce(Policies::fileRead).elseReturn(false);
+            rule.calling(File::isHidden).enforce(Policies::fileRead).elseReturn(false);
             rule.calling(File::lastModified).enforce(Policies::fileRead).elseReturn(0L);
             rule.calling(File::length).enforce(Policies::fileRead).elseReturn(0L);
             rule.calling(File::list).enforce(Policies::fileRead).elseReturn(null);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Return false instead of throwing for File.isFile, isDirectory, isHidden (#145626)