### PR TITLE
Fix flaky WatcherYamlRestIT test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -97,9 +97,6 @@ tests:
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
   issue: https://github.com/elastic/elasticsearch/issues/139654
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
-  issue: https://github.com/elastic/elasticsearch/issues/139663
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/140612

--- a/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/mustache/10_webhook.yml
+++ b/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/mustache/10_webhook.yml
@@ -20,7 +20,8 @@
         body:
           pipeline:
             description: _description
-            processors: [ grok: { field: host, patterns : ["(?:\\[(?<hostname>[^\\]]+)\\]|(?<hostname>%{IPORHOST})):(?<port>\\d+)"]} ]
+            processors: [ grok: { field: host, patterns: [ "(?:\\[(?<hostname>[^\\]]+)\\]|(?<hostname>%{IPORHOST})):(?<port>\\d+)" ] },
+                          convert: { field: port, type: integer } ]
           docs: [ { _index: index, _id: id, _source: { host: $host } } ]
   - set: { docs.0.doc._source.hostname: hostname }
   - set: { docs.0.doc._source.port: port }
@@ -28,6 +29,7 @@
   - do:
       watcher.put_watch:
         id: "test_watch"
+        active: false
         body:
           trigger:
             schedule:


### PR DESCRIPTION
**Prerequisite fix:** 
Fix the test that broke when being muted

**Fix:**
The test adds a scheduled watch that runs immediately and right after executes the watch.
This scenario is not concurrency-safe. The `TickerScheduleTriggerEngine` does not check whether a processed watch is currently executing (side note: the there is such a check in the execute watch operation). This introduces a possibility of a watch being executed simultaneously and this is what's happening in the test.

Since Execute Watch operation is described [as a testing/debugging tool](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-execute-watch), we may want to leave the functionality as is and just fix the test.

Closes: #139663