### PR TITLE
[9.3] Skip rest compatibility tests a downsampling test because last value was not supported (#145605)

### DIFF
--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
@@ -1849,8 +1849,13 @@ setup:
 ---
 "Downsample index with multi-value dimensions":
   - requires:
+      test_runner_features: [ "capabilities" ]
       cluster_features: [ "data_stream.downsample.fix_support_multi_value_dimensions" ]
       reason: "Support multi-value dimensions in downsampling (bug fix)"
+      capabilities:
+        - method: POST
+          path: /{index}/_downsample/{target_index}
+          capabilities: [ "downsample.sampling_mode.last_value" ]
 
   - do:
       indices.create:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Skip rest compatibility tests a downsampling test because last value was not supported (#145605)](https://github.com/elastic/elasticsearch/pull/145605)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)