### PR TITLE
[TEST] Update testTSDBWithMultiplePrefixByte with latest format

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,9 +354,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvTests
   method: test {csv-spec:floats.values}
   issue: https://github.com/elastic/elasticsearch/issues/145524
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testContainsIterator
-  issue: https://github.com/elastic/elasticsearch/issues/145532
 - class: org.elasticsearch.xpack.esql.CsvTests
   method: test {csv-spec:ints.convertStringToBaseIndexGroup6}
   issue: https://github.com/elastic/elasticsearch/issues/145540
@@ -407,18 +404,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
   method: testTopNByKeyEncoderTooMuchMemory
   issue: https://github.com/elastic/elasticsearch/issues/145627
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testBlockWiseBinarySmallValues
-  issue: https://github.com/elastic/elasticsearch/issues/145635
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/145654
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/145655
-- class: org.elasticsearch.index.codec.tsdb.es819.TSDBDocValuesFormatSingleNodeTests
-  method: testTSDBWithMultiplePrefixByte
-  issue: https://github.com/elastic/elasticsearch/issues/145668
 - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
   method: testRecreateTemplateWhenDeleted
   issue: https://github.com/elastic/elasticsearch/issues/123232

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/TSDBDocValuesFormatSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/TSDBDocValuesFormatSingleNodeTests.java
@@ -112,7 +112,7 @@ public class TSDBDocValuesFormatSingleNodeTests extends ESSingleNodeTestCase {
         Set<String> expectedFields = Set.of("@timestamp", "hostname", "gauge", "_tsid", "_ts_routing_hash");
         assertDocValuesFormat(
             indexName,
-            ES819TSDBDocValuesFormatFactory.ES_819_3_TSDB_DOC_VALUES_FORMAT_LARGE_NUMERIC_BLOCK,
+            ES819TSDBDocValuesFormatFactory.ES_819_3_TSDB_DOC_VALUES_FORMAT_LARGE_NUMERIC_AND_BINARY_BLOCK,
             expectedFields
         );
         var indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(resolveIndex(indexName));


### PR DESCRIPTION
The default format for TSDB was updated in https://github.com/elastic/elasticsearch/pull/145216

Fixes #145668