### PR TITLE
[9.3] ESQL: Keywords mv count fix (#145390)

### DIFF
--- a/docs/changelog/145390.yaml
+++ b/docs/changelog/145390.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145390
+summary: Keywords mv count fix
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -2422,6 +2422,8 @@ emp_no:integer |  c1:long
 
 simpleCountWithFilteringAndNoGroupingOnFieldWithMultivalues
 required_capability: inline_stats
+required_capability: keywords_mv_count_as_single_value_fix
+
 from employees
 | inline stats c1 = count(job_positions) where emp_no <= 10003
 | keep emp_no, c1

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -2795,6 +2795,7 @@ c1:long
 
 simpleCountWithFilteringAndNoGroupingOnFieldWithMultivalues
 required_capability: per_agg_filtering
+required_capability: keywords_mv_count_as_single_value_fix
 from employees
 | stats c1 = count(job_positions) where emp_no <= 10003
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1949,6 +1949,8 @@ public class EsqlCapabilities {
          */
         FIX_FORK_UNMAPPED_NULLIFY,
 
+        KEYWORDS_MV_COUNT_AS_SINGLE_VALUE_FIX,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -380,7 +380,7 @@ public class SearchContextStats implements SearchStats {
         } else if (fieldType instanceof KeywordFieldType) {
             tester = lr -> {
                 Terms terms = lr.terms(name);
-                return terms == null || terms.size() == terms.getDocCount();
+                return terms == null || terms.getSumDocFreq() == terms.getDocCount();
             };
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -348,7 +348,7 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
      * segment has terms.size()=2, getDocCount()=2 which wrongly reported the field as being single-valued.
      */
     public void testCountPushDownFor_SpecificDistributionOfMVValues() throws IOException {
-        String properties = EsqlTestUtils.loadUtf8TextFile("/index/mappings/mapping-basic.json");
+        String properties = EsqlTestUtils.loadUtf8TextFile("/mapping-basic.json");
         String mapping = "{\"mappings\": " + properties + "}";
         String keywordQuery = """
             from test

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -339,6 +339,33 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
         }
     }
 
+    /**
+     * Keyword MV field: detectSingleValue has a false positive when terms.size() == terms.getDocCount().
+     * See SearchContextStats.detectSingleValue(IndexReader, MappedFieldType, String) where this check was wrong for KeywordFieldType.
+     *
+     * doc1: first_name=["A","B"]
+     * doc2: first_name=["A"]
+     * segment has terms.size()=2, getDocCount()=2 which wrongly reported the field as being single-valued.
+     */
+    public void testCountPushDownFor_SpecificDistributionOfMVValues() throws IOException {
+        String properties = EsqlTestUtils.loadUtf8TextFile("/index/mappings/mapping-basic.json");
+        String mapping = "{\"mappings\": " + properties + "}";
+        String keywordQuery = """
+            from test
+            | stats c = count(first_name)
+            """;
+        List<List<String>> keywordMvCasesWithoutPushdown = List.of(
+            List.of("{ \"first_name\" : [\"A\", \"B\"] }", "{ \"first_name\" : [\"A\"] }")
+        );
+
+        PhysicalPlan plan;
+        for (List<String> docs : keywordMvCasesWithoutPushdown) {
+            plan = planWithMappingAndDocs(keywordQuery, mapping, docs);
+            // No EsSatsQueryExec as leaf of the plan.
+            assertThat(plan.anyMatch(EsQueryExec.class::isInstance), is(true));
+        }
+    }
+
     private PhysicalPlan planWithMappingAndDocs(String query, String mapping, List<String> docs) throws IOException {
         MapperService mapperService = createMapperService(mapping);
         List<ParsedDocument> parsedDocs = docs.stream().map(d -> mapperService.documentMapper().parse(source(d))).toList();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -13,7 +13,10 @@ import org.apache.lucene.document.FloatField;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.common.Rounding;
@@ -238,6 +241,57 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
             assertNotNull(prepared);
         } finally {
             IOUtils.close(toClose);
+        }
+    }
+
+    /**
+     * Verifies that {@code isSingleValue} correctly detects multi-valued keyword fields even when
+     * the number of unique terms equals the number of documents — a case where the old heuristic
+     * ({@code terms.size() == terms.getDocCount()}) produced a false positive.
+     * <p>
+     * Given doc1=["A","B"] and doc2=["A"]:
+     * <ul>
+     *   <li>{@code terms.size()} = 2 (unique terms: A, B)</li>
+     *   <li>{@code terms.getDocCount()} = 2 (docs with the field)</li>
+     *   <li>{@code terms.getSumDocFreq()} = 3 (docFreq("A")=2 + docFreq("B")=1)</li>
+     * </ul>
+     * The old check ({@code size == docCount}) would return {@code true} (single-valued) — wrong.
+     * The new check ({@code sumDocFreq == docCount}) returns {@code false} (multi-valued) — correct.
+     * <p>
+     * When this false positive is visible in a scenario, {@code PushStatsToSource} pushes {@code COUNT(keyword_field)} to Lucene
+     * as a document count ({@code EsStatsQueryExec}), yielding 2 instead of 3.
+     */
+    public void testKeywordMultiValueDetection() throws IOException {
+        final MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
+        final MapperService mapperService = mapperHelper.createMapperService("""
+            { "doc": { "properties": { "kw": { "type": "keyword" } } } }""");
+
+        final Directory dir = newDirectory();
+        final IndexReader reader;
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+            writer.addDocument(List.of(new StringField("kw", "A", Field.Store.NO), new StringField("kw", "B", Field.Store.NO)));
+            writer.addDocument(List.of(new StringField("kw", "A", Field.Store.NO)));
+            writer.forceMerge(1);
+            reader = writer.getReader();
+        }
+
+        try {
+            LeafReader leafReader = ((DirectoryReader) reader).leaves().get(0).reader();
+            Terms terms = leafReader.terms("kw");
+            assertNotNull(terms);
+
+            assertEquals(2, terms.size());
+            assertEquals(2, terms.getDocCount());
+            assertEquals(3, terms.getSumDocFreq());
+
+            SearchExecutionContext ctx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(reader));
+            SearchStats stats = SearchContextStats.from(List.of(ctx));
+            assertFalse(
+                "keyword field with MVs must not be reported as single-valued",
+                stats.isSingleValue(new FieldAttribute.FieldName("kw"))
+            );
+        } finally {
+            IOUtils.close(reader, mapperService, dir);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: Keywords mv count fix (#145390)