### PR TITLE
[9.3] Update "search.retrievers/20_knn_retriever/kNN retrieve with visit_percentage" to not check result order (#145636)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -357,9 +357,6 @@ tests:
 - class: org.elasticsearch.indices.IndicesRequestCacheIT
   method: testCanCache
   issue: https://github.com/elastic/elasticsearch/issues/144526
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.retrievers/20_knn_retriever/kNN retrieve with visit_percentage}
-  issue: https://github.com/elastic/elasticsearch/issues/145574
 
 # Examples:
 #

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
@@ -62,6 +62,8 @@ setup:
   - requires:
       cluster_features: "mapper.bbq_disk_support"
       reason: 'bbq disk support required'
+
+  # Test that visit_percentage is accepted even though it is ignored, since the vector field uses int8_hnsw
   - do:
       search:
         index: index1
@@ -75,11 +77,7 @@ setup:
               num_candidates: 3
               visit_percentage: 1.0
 
-  - match: {hits.hits.0._id: "2"}
-  - match: {hits.hits.0.fields.name.0: "moose.jpg"}
-
-  - match: {hits.hits.1._id: "3"}
-  - match: {hits.hits.1.fields.name.0: "rabbit.jpg"}
+  - gt: { hits.total.value: 0 }
 
 ---
 "kNN retriever with filter":


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Update "search.retrievers/20_knn_retriever/kNN retrieve with visit_percentage" to not check result order (#145636)