### PR TITLE
mute MultiNodeJdbcPreparedStatementIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -398,6 +398,8 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testScalarOnDates
   issue: https://github.com/elastic/elasticsearch/issues/145667
+- class: org.elasticsearch.xpack.sql.qa.jdbc.multi_node.MultiNodeJdbcPreparedStatementIT
+  issue: https://github.com/elastic/elasticsearch/issues/145448
 
 # Examples:
 #


### PR DESCRIPTION
There are multiple tests failed https://github.com/elastic/elasticsearch/issues/145448, mute MultiNodeJdbcPreparedStatementIT for now.