### PR TITLE
Fix metrics_info and ts_info references

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+
+public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
+
+    record Doc(
+        Collection<String> project,
+        String host,
+        String cluster,
+        long timestamp,
+        int requestCount,
+        double cpu,
+        ByteSizeValue memory
+    ) {}
+
+    final List<Doc> docs = new ArrayList<>();
+
+    @Before
+    public void populateIndices() {
+        Settings.Builder settings = Settings.builder().put("mode", "time_series").putList("routing_path", List.of("host", "cluster"));
+        if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean()) {
+            settings.put("index.codec", "default").put("index.number_of_replicas", 0).put(IndexSettings.SYNTHETIC_ID.getKey(), true);
+        }
+        {
+            client().admin()
+                .indices()
+                .prepareCreate("index-1")
+                .setSettings(settings)
+                .setMapping(
+                    "@timestamp",
+                    "type=date",
+                    "project",
+                    "type=keyword",
+                    "host",
+                    "type=keyword,time_series_dimension=true",
+                    "cluster",
+                    "type=keyword,time_series_dimension=true",
+                    "cpu",
+                    "type=double,time_series_metric=gauge",
+                    "memory",
+                    "type=long,time_series_metric=gauge",
+                    "request_count",
+                    "type=integer,time_series_metric=counter",
+                    "extra-field-1",
+                    "type=keyword"
+                )
+                .get();
+        }
+        {
+            client().admin()
+                .indices()
+                .prepareCreate("index-2")
+                .setSettings(settings)
+                .setMapping(
+                    "@timestamp",
+                    "type=date",
+                    "project",
+                    "type=keyword",
+                    "host",
+                    "type=keyword,time_series_dimension=true",
+                    "cluster",
+                    "type=keyword,time_series_dimension=true",
+                    "cpu",
+                    "type=double,time_series_metric=gauge",
+                    "memory",
+                    "type=long,time_series_metric=gauge",
+                    "request_count",
+                    "type=integer,time_series_metric=counter",
+                    "extra-field-2",
+                    "type=keyword"
+                )
+                .get();
+        }
+
+        Map<String, String> hostToClusters = new HashMap<>();
+        for (int i = 0; i < 5; i++) {
+            hostToClusters.put("p" + i, randomFrom("qa", "prod"));
+        }
+        long timestamp = DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-04-15T00:00:00Z");
+        int numDocs = between(20, 100);
+        docs.clear();
+        Map<String, Integer> requestCounts = new HashMap<>();
+        List<String> allProjects = List.of("project-1", "project-2", "project-3");
+        for (int i = 0; i < numDocs; i++) {
+            List<String> hosts = randomSubsetOf(between(1, hostToClusters.size()), hostToClusters.keySet());
+            timestamp += between(1, 10) * 1000L;
+            for (String host : hosts) {
+                var requestCount = requestCounts.compute(host, (k, curr) -> {
+                    if (curr == null || randomInt(100) <= 20) {
+                        return randomIntBetween(0, 10);
+                    } else {
+                        return curr + randomIntBetween(1, 10);
+                    }
+                });
+                int cpu = randomIntBetween(0, 100);
+                ByteSizeValue memory = ByteSizeValue.ofBytes(randomIntBetween(1024, 1024 * 1024));
+                List<String> projects = randomSubsetOf(between(1, 3), allProjects);
+                docs.add(new Doc(projects, host, hostToClusters.get(host), timestamp, requestCount, cpu, memory));
+            }
+        }
+        for (String index : List.of("index-1", "index-2")) {
+            Randomness.shuffle(docs);
+            for (Doc doc : docs) {
+                client().prepareIndex(index)
+                    .setSource(
+                        "@timestamp",
+                        doc.timestamp,
+                        "project",
+                        doc.project,
+                        "host",
+                        doc.host,
+                        "cluster",
+                        doc.cluster,
+                        "cpu",
+                        doc.cpu,
+                        "memory",
+                        doc.memory.getBytes(),
+                        "request_count",
+                        doc.requestCount
+                    )
+                    .get();
+            }
+            client().admin().indices().prepareRefresh(index).get();
+        }
+    }
+
+    public void testMetricsInfo() {
+        for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
+            EsqlQueryRequest request = new EsqlQueryRequest();
+            request.query("TS " + index + " | METRICS_INFO");
+            request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            try (var resp = run(request)) {
+                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+                assertThat(rows, not(empty()));
+            }
+        }
+    }
+
+    public void testTsInfo() {
+        for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
+            EsqlQueryRequest request = new EsqlQueryRequest();
+            request.query("TS " + index + " | TS_INFO");
+            request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            try (var resp = run(request)) {
+                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+                assertThat(rows, not(empty()));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -23,11 +23,9 @@ import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.MetricsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Sample;
-import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
@@ -72,13 +70,6 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
             // TODO: revisit with every new command
             // skip nodes that simply pass the input through and use no references
             if (p instanceof Limit || p instanceof Sample) {
-                return p;
-            }
-
-            // MetricsInfo/TsInfo handle their own field extraction internally;
-            // mark all child attributes as used so nothing below them is pruned.
-            if (p instanceof MetricsInfo || p instanceof TsInfo) {
-                used.addAll(((UnaryPlan) p).child().outputSet());
                 return p;
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
@@ -101,7 +101,7 @@ public class MetricsInfo extends UnaryPlan implements TelemetryAware, PostAnalys
 
     @Override
     protected AttributeSet computeReferences() {
-        return AttributeSet.EMPTY;
+        return child().outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
@@ -101,7 +101,7 @@ public class TsInfo extends UnaryPlan implements TelemetryAware, PostAnalysisVer
 
     @Override
     protected AttributeSet computeReferences() {
-        return AttributeSet.EMPTY;
+        return child().outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MetricsInfoExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MetricsInfoExec.java
@@ -144,10 +144,7 @@ public class MetricsInfoExec extends UnaryExec {
 
     @Override
     protected AttributeSet computeReferences() {
-        if (mode.isInputPartial()) {
-            return AttributeSet.of(intermediateAttributes);
-        }
-        return AttributeSet.EMPTY;
+        return child().outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TsInfoExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TsInfoExec.java
@@ -138,10 +138,7 @@ public class TsInfoExec extends UnaryExec {
 
     @Override
     protected AttributeSet computeReferences() {
-        if (mode.isInputPartial()) {
-            return AttributeSet.of(intermediateAttributes);
-        }
-        return AttributeSet.EMPTY;
+        return child().outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/FieldNameUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/FieldNameUtils.java
@@ -36,12 +36,14 @@ import org.elasticsearch.xpack.esql.plan.logical.Insist;
 import org.elasticsearch.xpack.esql.plan.logical.Keep;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.MetricsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Rename;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
@@ -346,7 +348,10 @@ public class FieldNameUtils {
      * Indicates whether the given plan gives an exact list of fields that we need to collect from field_caps.
      */
     private static boolean shouldCollectReferencedFields(LogicalPlan plan, Set<Aggregate> inlinestatsAggs) {
-        return plan instanceof Project || (plan instanceof Aggregate agg && inlinestatsAggs.contains(agg) == false);
+        return plan instanceof Project || (plan instanceof Aggregate agg && inlinestatsAggs.contains(agg) == false)
+        // no need to collect fields for metrics_info or ts_info
+            || plan instanceof MetricsInfo
+            || plan instanceof TsInfo;
     }
 
     /**


### PR DESCRIPTION
TsInfo and MetricsInfo report no references, so the optimizer is free to prune all fields from the underlying EsRelation. When querying multiple indices with different mappings, ReplaceFieldWithConstantOrNull inserts null-EVALs and projections for missing fields. Because TsInfo/MetricsInfo claim no references, the optimizer then prunes everything and replaces the source with an empty relation - returning no results.

Two changes in this PR:

1. Excludes TsInfo and MetricsInfo from field-caps requests, since they don't need resolved field mappings.
2. Adds a _doc reference to TsInfo and MetricsInfo so the optimizer retains the source relation instead of pruning it.