### PR TITLE
Document semantic_text field defaulting to bfloat16

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
@@ -53,16 +53,16 @@ the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/opera
     Learn how to [use dedicated endpoints for ingestion and search](./semantic-text-setup-configuration.md#dedicated-endpoints-for-ingestion-and-search).
 
 `index_options` {applies_to}`stack: ga 9.1`
-:   (Optional, object) Specifies the index options to override default values
-for the field. Currently, `dense_vector` and `sparse_vector` index options are supported. For text embeddings, `index_options` may match any allowed.
+:   (Optional, object) Specifies the index options to override default values for the field.
+`dense_vector` and `sparse_vector` index options are supported.
 
     :::{note}
     This parameter configures vector indexing structures. It is distinct from the [`index_options`](/reference/elasticsearch/mapping-reference/index-options.md) parameter used by term-based fields to control whether term frequencies, positions, and offsets are stored in the inverted index.
     :::
 
-- [dense_vector index options](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-index-options)
+- [dense_vector index options](semantic-text-setup-configuration.md#index-options-dense_vectors)
 
-- [sparse_vector index options](/reference/elasticsearch/mapping-reference/sparse-vector.md#sparse-vectors-params) {applies_to}`stack: ga 9.2`
+- [sparse_vector index options](semantic-text-setup-configuration.md#index-options-sparse_vectors) {applies_to}`stack: ga 9.2`
 
 `chunking_settings` {applies_to}`stack: ga 9.1`
 :   (Optional, object) Settings for chunking text into smaller passages.
@@ -112,9 +112,13 @@ PUT my-index-000004
 3. Disables automatic chunking by setting the chunking strategy to `none`.
 
 ::::{note}
-{applies_to}`stack: ga 9.1`  Newly created indices with `semantic_text` fields using dense embeddings will be
+{applies_to}`serverless: ga` {applies_to}`stack: ga 9.1`  Newly created indices with `semantic_text` fields using dense embeddings will be
 [quantized](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization)
 to `bbq_hnsw` automatically as long as they have a minimum of 64 dimensions.
+
+{applies_to}`serverless: ga` {applies_to}`stack: ga 9.4` Newly created indices with `semantic_text` fields that use dense embeddings with the `float` element type will automatically use the [`bfloat16`](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-element-type) element type.
+This halves the storage required per vector dimension (2 bytes instead of 4) with a negligible impact on search relevance for most use cases.
+You can [override this default](./semantic-text-setup-configuration.md#index-options-dense_vectors-element-type-override) by explicitly setting `element_type` in `index_options`.
 ::::
 
 ## {{infer-cap}} endpoints [configuring-inference-endpoints]

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -341,6 +341,35 @@ For {{infer}} endpoints that produce `float` embeddings, `semantic_text` fields 
 This reduces the storage required per vector dimension from 4 to 2 bytes with a negligible impact on search relevance for the vast majority of use cases.
 
 The `bfloat16` format uses a 2-byte floating-point encoding that maintains the same value range as 4-byte floats, but with reduced precision.
+You can check if your `semantic_text` field is using `bfloat16` by default by inspecting the default `index_options` for the field using the [get field mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-field-mapping):
+
+```console
+GET semantic-embeddings/_mapping/field/content?include_defaults
+```
+
+```console-result
+{
+  "semantic-embeddings": {
+    "mappings": {
+      "content": {
+        "full_name": "content",
+        "mapping": {
+          "content": {
+            "type": "semantic_text",
+            "inference_id": "my-float-embedding-endpoint",
+            "index_options": {
+              "dense_vector": {
+                "element_type": "bfloat16" <1>
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+1. Indicates that the `semantic_text` field defaulted to the `bfloat16` element type.
 
 #### Override the default element type [index-options-dense_vectors-element-type-override]
 
@@ -353,6 +382,7 @@ PUT semantic-embeddings
     "properties": {
       "content": {
         "type": "semantic_text",
+        "inference_id": "my-float-embedding-endpoint"
         "index_options": {
           "dense_vector": {
             "element_type": "float" <1>
@@ -374,6 +404,7 @@ PUT semantic-embeddings
     "properties": {
       "content": {
         "type": "semantic_text",
+        "inference_id": "my-float-embedding-endpoint"
         "index_options": {
           "dense_vector": {
             "element_type": "float",

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -382,7 +382,7 @@ PUT semantic-embeddings
     "properties": {
       "content": {
         "type": "semantic_text",
-        "inference_id": "my-float-embedding-endpoint"
+        "inference_id": "my-float-embedding-endpoint",
         "index_options": {
           "dense_vector": {
             "element_type": "float" <1>
@@ -404,7 +404,7 @@ PUT semantic-embeddings
     "properties": {
       "content": {
         "type": "semantic_text",
-        "inference_id": "my-float-embedding-endpoint"
+        "inference_id": "my-float-embedding-endpoint",
         "index_options": {
           "dense_vector": {
             "element_type": "float",

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -119,7 +119,7 @@ When a query targets indices that use different {{infer}} endpoints, {{es}} must
 
 To mitigate this issue, ensure that indices queried together use the same {{infer}} endpoint. You can do this by:
 
-- explicitly setting the `inference_id` when defining the `semantic_text` field for new indeces, or
+- explicitly setting the `inference_id` when defining the `semantic_text` field for new indices, or
 - by [reindexing](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex) older indices with the desired endpoint.
 
 #### Alerts based on raw relevance scores might stop triggering

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -62,7 +62,7 @@ For details, refer to [potential issues when mixing embedding models across indi
 :::::{dropdown} Potential issues when mixing embedding models across indices
 :name: default-endpoint-considerations
 
-If a `semantic_text` field relies on the default {{infer}} endpoint, the model used to generate embeddings might change across versions or deployments. This can result in indices using different embedding models. 
+If a `semantic_text` field relies on the default {{infer}} endpoint, the model used to generate embeddings might change across versions or deployments. This can result in indices using different embedding models.
 
 For example, if the `semantic_text` field is created without specifying `inference_id`, indices created on {{ecloud}} 9.3 use the `.elser-2-elastic` endpoint by default, while indices created on {{ecloud}} 9.4+ use `.jina-embeddings-v5-text-small`. As a result, older indices contain ELSER embeddings while newer indices contain Jina embeddings.
 
@@ -119,7 +119,7 @@ When a query targets indices that use different {{infer}} endpoints, {{es}} must
 
 To mitigate this issue, ensure that indices queried together use the same {{infer}} endpoint. You can do this by:
 
-- explicitly setting the `inference_id` when defining the `semantic_text` field for new indeces, or 
+- explicitly setting the `inference_id` when defining the `semantic_text` field for new indeces, or
 - by [reindexing](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex) older indices with the desired endpoint.
 
 #### Alerts based on raw relevance scores might stop triggering
@@ -134,7 +134,7 @@ To mitigate this issue, adjust alert thresholds to match the scoring range of th
 
 ### Use preconfigured endpoints [preconfigured-endpoints]
 
-Preconfigured endpoints are {{infer}} endpoints that are automatically available in the deployment or project and do not require manual creation. The available preconfigured endpoints vary across deployment types and versions. 
+Preconfigured endpoints are {{infer}} endpoints that are automatically available in the deployment or project and do not require manual creation. The available preconfigured endpoints vary across deployment types and versions.
 
 To view the list of available preconfigured endpoints for your deployment, go to **{{infer-cap}} endpoints** in {{kib}}.
 
@@ -329,4 +329,66 @@ PUT semantic-embeddings
 1. (Optional) Selects the `int8_hnsw` vector quantization strategy. Learn about [default quantization types](/reference/elasticsearch/mapping-reference/dense-vector.md#default-quantization-types).
 2. (Optional) Sets `m` to 15 to control how many neighbors each node connects to in the HNSW graph. Default is `16`.
 3. (Optional) Sets `ef_construction` to 90 to control how many candidate neighbors are considered during graph construction. Default is `100`.
+
+### Default `bfloat16` element type [index-options-dense_vectors-bfloat16]
+
+```{applies_to}
+stack: ga 9.4
+serverless: ga
+```
+
+For {{infer}} endpoints that produce `float` embeddings, `semantic_text` fields automatically use the [`bfloat16`](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-element-type) element type.
+This reduces the storage required per vector dimension from 4 to 2 bytes with a negligible impact on search relevance for the vast majority of use cases.
+
+The `bfloat16` format uses a 2-byte floating-point encoding that maintains the same value range as 4-byte floats, but with reduced precision.
+
+#### Override the default element type [index-options-dense_vectors-element-type-override]
+
+If your use case requires full `float` precision, you can override the default `bfloat16` element type by specifying `element_type` in `index_options.dense_vector`:
+
+```console
+PUT semantic-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic_text",
+        "index_options": {
+          "dense_vector": {
+            "element_type": "float" <1>
+          }
+        }
+      }
+    }
+  }
+}
+```
+1. Overrides the default `bfloat16` element type to use full-precision `float` (4 bytes per dimension).
+
+You can also combine `element_type` with other index options:
+
+```console
+PUT semantic-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic_text",
+        "index_options": {
+          "dense_vector": {
+            "element_type": "float",
+            "type": "int8_hnsw"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::{note}
+The `element_type` override is only valid for {{infer}} endpoints that produce `float` embeddings.
+For `float` models, valid values are `float` and `bfloat16`.
+For other model element types (such as `byte` or `bit`), the `element_type` must match the model's native element type if specified.
+:::
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/144236, we updated `semantic_text` to default to `bfloat16` in many cases. This PR documents that functionality, as well as how to override it.