### PR TITLE
SQL JDBC QA: assert search contexts drain

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/SingleNodeJdbcSearchContextCleanupIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/SingleNodeJdbcSearchContextCleanupIT.java
@@ -20,4 +20,3 @@ public class SingleNodeJdbcSearchContextCleanupIT extends SearchContextCleanupTe
         return cluster;
     }
 }
-

--- a/x-pack/plugin/sql/qa/jdbc/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/SingleNodeJdbcSearchContextCleanupIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/SingleNodeJdbcSearchContextCleanupIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.sql.qa.jdbc.single_node;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xpack.sql.qa.jdbc.SearchContextCleanupTestCase;
+import org.junit.ClassRule;
+
+public class SingleNodeJdbcSearchContextCleanupIT extends SearchContextCleanupTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = singleNodeCluster();
+
+    @Override
+    public ElasticsearchCluster getCluster() {
+        return cluster;
+    }
+}
+

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
@@ -39,8 +39,8 @@ public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
     public static final String JDBC_ES_URL_PREFIX = "jdbc:es://";
 
     @After
-    public void checkSearchContent() throws IOException {
-        // Some context might linger due to fire and forget nature of PIT cleanup
+    public void checkSearchContent() throws Exception {
+        // Some context might linger due to the fire-and-forget nature of PIT cleanup
         assertNoSearchContexts();
     }
 
@@ -157,15 +157,17 @@ public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
         return (Integer) stats.get("open_contexts");
     }
 
-    static void assertNoSearchContexts() throws IOException {
-        Map<String, Object> stats = searchStats();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> indicesStats = (Map<String, Object>) stats.get("indices");
-        for (String index : indicesStats.keySet()) {
-            if (index.startsWith(".") == false) { // We are not interested in internal indices
-                assertEquals(index + " should have no search contexts", 0, getOpenContexts(stats, index));
+    static void assertNoSearchContexts() throws Exception {
+        assertBusy(() -> {
+            Map<String, Object> stats = searchStats();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> indicesStats = (Map<String, Object>) stats.get("indices");
+            for (String index : indicesStats.keySet()) {
+                if (index.startsWith(".") == false) { // We are not interested in internal indices
+                    assertEquals(index + " should have no search contexts", 0, getOpenContexts(stats, index));
+                }
             }
-        }
+        });
     }
 
     @Override

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SearchContextCleanupTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SearchContextCleanupTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.sql.qa.jdbc;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Map;
+
+public abstract class SearchContextCleanupTestCase extends JdbcIntegrationTestCase {
+
+    public void testSearchContextCleanupEventually() throws Exception {
+        index("pit-test", builder -> builder.field("foo", "bar"));
+
+        String pitId = null;
+        Response openResponse = null;
+        try {
+            Request open = new Request("POST", "/_pit");
+            open.addParameter("index", "pit-test");
+            open.addParameter("keep_alive", "1m");
+            openResponse = client().performRequest(open);
+            assertOK(openResponse);
+
+            Map<String, Object> openMap = responseAsMap(openResponse);
+            pitId = (String) openMap.get("id");
+            assertNotNull(pitId);
+        } finally {
+            if (pitId != null) {
+                Request close = new Request("DELETE", "/_pit");
+                try (XContentBuilder body = JsonXContent.contentBuilder()) {
+                    body.startObject();
+                    body.field("id", pitId);
+                    body.endObject();
+                    close.setJsonEntity(Strings.toString(body));
+                }
+                assertOK(client().performRequest(close));
+            }
+        }
+
+        assertNoSearchContexts();
+    }
+}
+

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SearchContextCleanupTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SearchContextCleanupTestCase.java
@@ -47,4 +47,3 @@ public abstract class SearchContextCleanupTestCase extends JdbcIntegrationTestCa
         assertNoSearchContexts();
     }
 }
-


### PR DESCRIPTION
## Summary

Make SQL JDBC QA search-context cleanup assertions tolerate eventual server-side cleanup.

#145702

## Changes

- Use `assertBusy` when asserting `open_contexts` is 0 after tests.
- Add a PIT open/close test that asserts search contexts drain.

