### PR TITLE
Enable single prefix byte tsid in release builds

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/TsidBuilder.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/TsidBuilder.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class TsidBuilder {
 
-    public static final boolean SINGLE_PREFIX_BYTE_ENABLED = new FeatureFlag("tsid_layout_single_prefix_byte").isEnabled();
+    private static final boolean SINGLE_PREFIX_BYTE_ENABLED = new FeatureFlag("tsid_layout_single_prefix_byte").isEnabled();
 
     /**
      * The maximum number of fields to use for the value similarity part of the TSID.
@@ -232,7 +232,8 @@ public class TsidBuilder {
     }
 
     public static boolean useSingleBytePrefixLayout(IndexVersion indexVersion) {
-        return SINGLE_PREFIX_BYTE_ENABLED && indexVersion.onOrAfter(IndexVersions.TSID_SINGLE_PREFIX_BYTE_FEATURE_FLAG);
+        return indexVersion.onOrAfter(IndexVersions.TSID_SINGLE_PREFIX_BYTE)
+            || (SINGLE_PREFIX_BYTE_ENABLED && indexVersion.onOrAfter(IndexVersions.TSID_SINGLE_PREFIX_BYTE_FEATURE_FLAG));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -250,6 +250,7 @@ public class IndexVersions {
     public static final IndexVersion SEMANTIC_TEXT_DEFAULTS_TO_BFLOAT16 = def(9_088_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion STORE_IGNORED_FLATTENED_FIELDS_IN_BINARY_DOC_VALUES = def(9_089_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_BEST_COMPRESSION = def(9_090_0_00, Version.LUCENE_10_4_0);
+    public static final IndexVersion TSID_SINGLE_PREFIX_BYTE = def(9_091_0_00, Version.LUCENE_10_4_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/TsidBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/TsidBuilderTests.java
@@ -57,8 +57,9 @@ public class TsidBuilderTests extends ESTestCase {
             HexFormat.of().formatHex(legacyTsid.bytes, legacyTsid.offset, legacyTsid.length),
             equalTo("bfa0a8d66356d2151e7889e42b7a295d065613ded4")
         );
-        BytesRef newTsid = builder.buildTsid(randomSinglePrefixByteVersion());
-        if (TsidBuilder.SINGLE_PREFIX_BYTE_ENABLED) {
+        IndexVersion newVersion = randomSinglePrefixByteVersion();
+        BytesRef newTsid = builder.buildTsid(newVersion);
+        if (TsidBuilder.useSingleBytePrefixLayout(newVersion)) {
             assertThat(
                 HexFormat.of().formatHex(newTsid.bytes, newTsid.offset, newTsid.length),
                 equalTo("bfd2151e7889e42b7a295d065613ded4")
@@ -76,10 +77,11 @@ public class TsidBuilderTests extends ESTestCase {
             builder.addStringDimension("_test_large_array", "value_" + i);
         }
         assertThat(builder.buildTsid(randomMultiplePrefixBytesVersion()).length, equalTo(19));
-        if (TsidBuilder.SINGLE_PREFIX_BYTE_ENABLED) {
-            assertThat(builder.buildTsid(randomSinglePrefixByteVersion()).length, equalTo(16));
+        IndexVersion singleVersion = randomSinglePrefixByteVersion();
+        if (TsidBuilder.useSingleBytePrefixLayout(singleVersion)) {
+            assertThat(builder.buildTsid(singleVersion).length, equalTo(16));
         } else {
-            assertThat(builder.buildTsid(randomSinglePrefixByteVersion()).length, equalTo(19));
+            assertThat(builder.buildTsid(singleVersion).length, equalTo(19));
         }
     }
 
@@ -172,12 +174,13 @@ public class TsidBuilderTests extends ESTestCase {
             .addStringDimension("test_array", "value1")
             .addStringDimension("test_array", "value2");
         BytesRef oldTsid = builder.buildTsid(randomMultiplePrefixBytesVersion());
-        BytesRef newTsid = builder.buildTsid(randomSinglePrefixByteVersion());
+        IndexVersion newVersion = randomSinglePrefixByteVersion();
+        BytesRef newTsid = builder.buildTsid(newVersion);
         assertThat(
             HexFormat.of().formatHex(oldTsid.bytes, oldTsid.offset, oldTsid.length),
             equalTo("01e3a0a8d693dbccd8eed09bb80b82b55d9756c7a6")
         );
-        if (TsidBuilder.SINGLE_PREFIX_BYTE_ENABLED) {
+        if (TsidBuilder.useSingleBytePrefixLayout(newVersion)) {
             assertThat(
                 HexFormat.of().formatHex(newTsid.bytes, newTsid.offset, newTsid.length),
                 equalTo("e3dbccd8eed09bb80b82b55d9756c7a6")
@@ -201,8 +204,9 @@ public class TsidBuilderTests extends ESTestCase {
             HexFormat.of().formatHex(oldTsid.bytes, oldTsid.offset, oldTsid.length),
             equalTo("afe3a0a8d67821311bea0fc3c9cbd40c8047c484aa")
         );
-        BytesRef newTsid = builder.buildTsid(randomSinglePrefixByteVersion());
-        if (TsidBuilder.SINGLE_PREFIX_BYTE_ENABLED) {
+        IndexVersion version = randomSinglePrefixByteVersion();
+        BytesRef newTsid = builder.buildTsid(version);
+        if (TsidBuilder.useSingleBytePrefixLayout(version)) {
             assertThat(
                 HexFormat.of().formatHex(newTsid.bytes, newTsid.offset, newTsid.length),
                 equalTo("e321311bea0fc3c9cbd40c8047c484aa")
@@ -210,5 +214,9 @@ public class TsidBuilderTests extends ESTestCase {
         } else {
             assertThat(newTsid, equalTo(oldTsid));
         }
+    }
+
+    public void testEnableSinglePrefixByte() {
+        assertTrue(TsidBuilder.useSingleBytePrefixLayout(IndexVersion.current()));
     }
 }


### PR DESCRIPTION
This change enables the new layout - single prefix byte for tsid in release builds.  

Relates #143955