### PR TITLE
Skip BatchBulkIT on non-snapshot builds

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BatchBulkIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -37,6 +38,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 1)
 public class BatchBulkIT extends ESIntegTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        assumeTrue("batch indexing requires snapshot builds", Build.current().isSnapshot());
+    }
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {


### PR DESCRIPTION
The BATCH_INDEXING setting is snapshot-only, so these tests fail on
release builds. Add a setup check to skip the entire test class.

Fixes #145707.