### PR TITLE
[TEST] Always merge segments in PruningMergePolicyTests.testPruneAll

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -406,9 +406,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidBigDecimalFromBooleanWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145702
-- class: org.elasticsearch.index.engine.PruningMergePolicyTests
-  method: testPruneAll
-  issue: https://github.com/elastic/elasticsearch/issues/145704
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
@@ -112,7 +112,7 @@ public class PruningMergePolicyTests extends ESTestCase {
                         try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                             final int nbDocs = randomIntBetween(10, 100);
                             for (int i = 0; i < nbDocs; i++) {
-                                if (i > 0 && randomBoolean()) {
+                                if (i > 0 && (randomBoolean() || i == nbDocs / 2)) {
                                     writer.flush();
                                 }
                                 Document doc = new Document();


### PR DESCRIPTION
Pruning happens during segment merging, so we need more than one segments to test.

Fixes #145704 