### PR TITLE
Guard pragmas in MetricsAndTSInfoIT behind canUseQueryPragmas()

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
@@ -152,7 +152,9 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
         for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
             EsqlQueryRequest request = new EsqlQueryRequest();
             request.query("TS " + index + " | METRICS_INFO");
-            request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            if (canUseQueryPragmas()) {
+                request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            }
             try (var resp = run(request)) {
                 List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
                 assertThat(rows, not(empty()));
@@ -164,7 +166,9 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
         for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
             EsqlQueryRequest request = new EsqlQueryRequest();
             request.query("TS " + index + " | TS_INFO");
-            request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            if (canUseQueryPragmas()) {
+                request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+            }
             try (var resp = run(request)) {
                 List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
                 assertThat(rows, not(empty()));


### PR DESCRIPTION
After #145696 was merged, `testMetricsInfo` and `testTsInfo` in `MetricsAndTSInfoIT` uses `QueryPragmas` unconditionally.  
It causes release tests to fail since pragmas are only permitted in snapshot builds. 

Instead, we wrap it like that:

```
if (canUseQueryPragmas()) {
    request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
}
```

Fixes #145719
Fixes #145720