### PR TITLE
ESQL: Allow values() limitation related to multi-values fields in generative testing

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -265,7 +265,7 @@ final class PackedValuesBlockHash extends BlockHash {
                         ords.appendInt(Math.toIntExact(found));
                         count++;
                         if (count > Block.MAX_LOOKUP) {
-                            // TODO replace this with a warning and break
+                            // TODO replace this with a warning and break and remove the accepted error from GenerativeRestTest
                             throw new IllegalArgumentException("Found a single entry with " + count + " entries");
                         }
                     }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -85,6 +85,11 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "failed to parse date field \\[.*\\] with format",
         // full-text function trying to parse a non-IP string
         "is not an IP string literal",
+        // a values(<that field>) agg could more than 100,000 values into a single multi-valued field, and a subsequent
+        // inline stats … by <that field> hits the hard limit Block.MAX_LOOKUP = 100_000 in the compute layer
+        // throwing IllegalArgumentException via PackedValuesBlockHash
+        // see https://github.com/elastic/elasticsearch/issues/145694
+        "Found a single entry with .* entries",
 
         // Awaiting fixes for query failure
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/145694