### PR TITLE
Fix/jdbc search context flaky

### DIFF
--- a/docs/changelog/145721.yaml
+++ b/docs/changelog/145721.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145721
+summary: Skip MetricsAndTSInfoIT tests in release builds where pragmas are disallowed
+type: bug

--- a/docs/changelog/145738.yaml
+++ b/docs/changelog/145738.yaml
@@ -1,0 +1,5 @@
+area: SQL
+issues: []
+pr: 145738
+summary: "Fix flaky JDBC QA test by retrying search context cleanup"
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.Before;
+import org.elasticsearch.Build;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,6 +25,7 @@ import java.util.Map;
 import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeTrue;
 
 public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
 
@@ -149,6 +151,8 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMetricsInfo() {
+        assumeTrue("pragma only allowed in snapshot builds", Build.current().isSnapshot());
+
         for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
             EsqlQueryRequest request = new EsqlQueryRequest();
             request.query("TS " + index + " | METRICS_INFO");
@@ -161,6 +165,8 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testTsInfo() {
+        assumeTrue("pragma only allowed in snapshot builds", Build.current().isSnapshot());
+
         for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
             EsqlQueryRequest request = new EsqlQueryRequest();
             request.query("TS " + index + " | TS_INFO");

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
@@ -34,12 +34,14 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.elasticsearch.test.ESTestCase.assertBusy;
+
 public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
 
     public static final String JDBC_ES_URL_PREFIX = "jdbc:es://";
 
     @After
-    public void checkSearchContent() throws IOException {
+    public void checkSearchContent() throws Exception {
         // Some context might linger due to fire and forget nature of PIT cleanup
         assertNoSearchContexts();
     }
@@ -157,15 +159,17 @@ public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
         return (Integer) stats.get("open_contexts");
     }
 
-    static void assertNoSearchContexts() throws IOException {
-        Map<String, Object> stats = searchStats();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> indicesStats = (Map<String, Object>) stats.get("indices");
-        for (String index : indicesStats.keySet()) {
-            if (index.startsWith(".") == false) { // We are not interested in internal indices
-                assertEquals(index + " should have no search contexts", 0, getOpenContexts(stats, index));
+    static void assertNoSearchContexts() throws Exception {
+        assertBusy(() -> {
+            Map<String, Object> stats = searchStats();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> indicesStats = (Map<String, Object>) stats.get("indices");
+            for (String index : indicesStats.keySet()) {
+                if (index.startsWith(".") == false) {
+                    assertEquals(index + " should have no search contexts", 0, getOpenContexts(stats, index));
+                }
             }
-        }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Summary
Fix flaky JDBC QA test caused by asynchronous search context cleanup.

## Problem
The test asserted that there are zero open search contexts immediately after execution.
However, PIT/scroll cleanup is asynchronous (fire-and-forget), which can lead to transient
failures where `open_contexts` is temporarily non-zero.

## Solution
Wrap the assertion in `assertBusy` to retry until cleanup completes, aligning behavior
with other QA tests and eliminating flakiness.

## Impact
- Stabilizes JDBC QA tests in BWC pipelines
- No functional changes, only test reliability improvement

## Risk
Low – change only affects test assertions and introduces retry logic.