### PR TITLE
[QVec] Provide index sort to the force merge step

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -452,12 +452,10 @@ public class KnnIndexTester {
     }
 
     /**
-     * Bundles the vector reader, document factory, total doc count, and optional index sort
+     * Bundles the vector reader, document factory and total doc count
      * needed to create an index. Created via {@link DataGenerator#createIndexingSetup()}.
      */
-    public record IndexingSetup(IndexVectorReader reader, KnnIndexer.DocumentFactory factory, int totalDocs, Sort sort)
-        implements
-            Closeable {
+    public record IndexingSetup(IndexVectorReader reader, KnnIndexer.DocumentFactory factory, int totalDocs) implements Closeable {
 
         @Override
         public void close() throws IOException {
@@ -504,7 +502,14 @@ public class KnnIndexTester {
                 if (testConfiguration.reindex()) {
                     Directory writeDir = sharedDir != null ? sharedDir : dirConfig.factory().create(indexPath);
                     try (var setup = dataGenerator.createIndexingSetup()) {
-                        knnIndexer.createIndex(indexResults, writeDir, setup.reader(), setup.factory(), setup.totalDocs(), setup.sort());
+                        knnIndexer.createIndex(
+                            indexResults,
+                            writeDir,
+                            setup.reader(),
+                            setup.factory(),
+                            setup.totalDocs(),
+                            dataGenerator.getIndexSort()
+                        );
                     } finally {
                         if (writeDir != sharedDir) {
                             writeDir.close();
@@ -514,7 +519,7 @@ public class KnnIndexTester {
                     throw new IllegalArgumentException("Index path does not exist: " + indexPath);
                 }
                 if (testConfiguration.forceMerge()) {
-                    forceMerge(knnIndexer, indexResults, sharedDir, testConfiguration);
+                    forceMerge(knnIndexer, indexResults, sharedDir, testConfiguration, dataGenerator.getIndexSort());
                 }
             }
             numSegments(indexPath, indexResults, sharedDir);
@@ -543,12 +548,17 @@ public class KnnIndexTester {
         }
     }
 
-    static void forceMerge(KnnIndexer knnIndexer, Results indexResults, Directory sharedDir, TestConfiguration testConfiguration)
-        throws Exception {
+    static void forceMerge(
+        KnnIndexer knnIndexer,
+        Results indexResults,
+        Directory sharedDir,
+        TestConfiguration testConfiguration,
+        Sort indexSort
+    ) throws Exception {
         if (sharedDir != null) {
-            knnIndexer.forceMerge(indexResults, testConfiguration.forceMergeMaxNumSegments(), sharedDir);
+            knnIndexer.forceMerge(indexResults, testConfiguration.forceMergeMaxNumSegments(), sharedDir, indexSort);
         } else {
-            knnIndexer.forceMerge(indexResults, testConfiguration.forceMergeMaxNumSegments());
+            knnIndexer.forceMerge(indexResults, testConfiguration.forceMergeMaxNumSegments(), indexSort);
         }
     }
 

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
@@ -227,14 +227,17 @@ public class KnnIndexer {
         return iwc;
     }
 
-    void forceMerge(KnnIndexTester.Results results, int maxNumSegments) throws Exception {
+    void forceMerge(KnnIndexTester.Results results, int maxNumSegments, Sort indexSort) throws Exception {
         try (Directory dir = getDirectory(indexPath)) {
-            forceMerge(results, maxNumSegments, dir);
+            forceMerge(results, maxNumSegments, dir, indexSort);
         }
     }
 
-    void forceMerge(KnnIndexTester.Results results, int maxNumSegments, Directory dir) throws Exception {
+    void forceMerge(KnnIndexTester.Results results, int maxNumSegments, Directory dir, Sort indexSort) throws Exception {
         IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+        if (indexSort != null) {
+            iwc.setIndexSort(indexSort);
+        }
         iwc.setInfoStream(new PrintStreamInfoStream(System.out) {
             @Override
             public boolean isEnabled(String component) {

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/data/DataGenerator.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/data/DataGenerator.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.test.knn.data;
 
+import org.apache.lucene.search.Sort;
 import org.elasticsearch.test.knn.KnnIndexTester;
 import org.elasticsearch.test.knn.KnnSearcher;
 import org.elasticsearch.test.knn.SearchParameters;
@@ -24,7 +25,7 @@ import java.io.IOException;
 public interface DataGenerator {
 
     /**
-     * Creates the indexing setup (vector reader, document factory, doc count, sort) for this dataset.
+     * Creates the indexing setup (vector reader, document factory, doc count) for this dataset.
      */
     KnnIndexTester.IndexingSetup createIndexingSetup() throws IOException;
 
@@ -37,4 +38,9 @@ public interface DataGenerator {
      * Whether this generator can provide query vectors for searching.
      */
     boolean hasQueries();
+
+    /**
+     * Returns the index sort or null if these data does not require one.
+     */
+    Sort getIndexSort();
 }

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/data/FileDataGenerator.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/data/FileDataGenerator.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.test.knn.data;
 
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.Channels;
 import org.elasticsearch.test.knn.IndexVectorReader;
@@ -47,7 +48,7 @@ public class FileDataGenerator implements DataGenerator {
             config.vectorEncoding().luceneEncoding(),
             config.numDocs()
         );
-        return new KnnIndexTester.IndexingSetup(reader, new KnnIndexer.DefaultDocumentFactory(), reader.totalDocs(), null);
+        return new KnnIndexTester.IndexingSetup(reader, new KnnIndexer.DefaultDocumentFactory(), reader.totalDocs());
     }
 
     @Override
@@ -125,5 +126,10 @@ public class FileDataGenerator implements DataGenerator {
     @Override
     public boolean hasQueries() {
         return config.queryVectors() != null;
+    }
+
+    @Override
+    public Sort getIndexSort() {
+        return null;
     }
 }

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/data/PartitionDataGenerator.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/data/PartitionDataGenerator.java
@@ -123,8 +123,7 @@ public class PartitionDataGenerator implements DataGenerator {
             partitionAssignments.docPartitionIds(),
             partitionAssignments.docOrdinals()
         );
-        Sort indexSort = new Sort(new SortField(KnnIndexer.PARTITION_ID_FIELD, SortField.Type.STRING, false));
-        return new KnnIndexTester.IndexingSetup(vectorReader, documentFactory, totalDocs, indexSort);
+        return new KnnIndexTester.IndexingSetup(vectorReader, documentFactory, totalDocs);
     }
 
     @Override
@@ -172,6 +171,11 @@ public class PartitionDataGenerator implements DataGenerator {
     @Override
     public boolean hasQueries() {
         return true;
+    }
+
+    @Override
+    public Sort getIndexSort() {
+        return new Sort(new SortField(KnnIndexer.PARTITION_ID_FIELD, SortField.Type.STRING, false));
     }
 
     private PartitionAssignmentInfo computePartitionAssignments() {


### PR DESCRIPTION
The Indexwriter on force merge needs to be configured with the same index sort as when creating the index or it will just force merge the segments wothout any sorting.