### PR TITLE
Fix waiting for enrich policy execution for users without the `monitor` privilege 

### DIFF
--- a/docs/changelog/145751.yaml
+++ b/docs/changelog/145751.yaml
@@ -1,0 +1,5 @@
+area: Ingest Node
+issues: []
+pr: 145751
+summary: Fix waiting for enrich policy execution for users without the `monitor` privilege
+type: bug

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -36,6 +37,8 @@ import org.elasticsearch.xpack.enrich.action.InternalExecutePolicyAction.Request
 
 import java.util.concurrent.Semaphore;
 import java.util.function.LongSupplier;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 
 public class EnrichPolicyExecutor {
 
@@ -167,7 +170,8 @@ public class EnrichPolicyExecutor {
         final String enrichIndexName
     ) {
         GetTaskRequest getTaskRequest = new GetTaskRequest().setTaskId(taskId).setWaitForCompletion(true).setTimeout(TimeValue.MAX_VALUE);
-        client.admin().cluster().getTask(getTaskRequest, new ActionListener<>() {
+        // it is not required for the user to have security privileges to retrieve tasks
+        new OriginSettingClient(client, ENRICH_ORIGIN).admin().cluster().getTask(getTaskRequest, new ActionListener<>() {
             @Override
             public void onResponse(GetTaskResponse getTaskResponse) {
                 policyLock.close();

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
@@ -46,7 +46,10 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.common.util.concurrent.ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME;
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -411,6 +414,56 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
             () -> testExecutor.runPolicyLocally(projectId, task, "my-policy", ".enrich-my-policy-123456789", null)
         );
         assertThat(e.getMessage(), equalTo("policy [my-policy] does not exist"));
+    }
+
+    public void testWaitForTaskUsesEnrichOrigin() throws Exception {
+        String testPolicyName = "test_policy";
+        String testTaskId = randomAlphaOfLength(10) + ":" + randomIntBetween(100, 300);
+
+        AtomicReference<String> capturedOrigin = new AtomicReference<>();
+        CountDownLatch getTaskCalled = new CountDownLatch(1);
+
+        Client client = new NoOpClient(testThreadPool) {
+            @Override
+            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                testThreadPool.generic().execute(() -> {
+                    if (TransportGetTaskAction.TYPE.equals(action)) {
+                        capturedOrigin.set(testThreadPool.getThreadContext().getTransient(ACTION_ORIGIN_TRANSIENT_NAME));
+                        getTaskCalled.countDown();
+                        listener.onResponse(null);
+                    } else if (InternalExecutePolicyAction.INSTANCE.equals(action)) {
+                        @SuppressWarnings("unchecked")
+                        Response response = (Response) new ExecuteEnrichPolicyAction.Response(new TaskId(testTaskId));
+                        listener.onResponse(response);
+                    } else {
+                        listener.onResponse(null);
+                    }
+                });
+            }
+        };
+
+        final EnrichPolicyExecutor testExecutor = new EnrichPolicyExecutor(
+            Settings.EMPTY,
+            null,
+            null,
+            client,
+            testThreadPool,
+            TestIndexNameExpressionResolver.newInstance(testThreadPool.getThreadContext()),
+            new EnrichPolicyLocks(),
+            ESTestCase::randomNonNegativeLong
+        );
+
+        testExecutor.coordinatePolicyExecution(
+            new ExecuteEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, testPolicyName).setWaitForCompletion(false),
+            ActionListener.noop()
+        );
+
+        assertTrue("Expected GetTask to be called", getTaskCalled.await(3, TimeUnit.SECONDS));
+        assertThat(capturedOrigin.get(), equalTo(ENRICH_ORIGIN));
     }
 
     private Client getClient(CountDownLatch latch) {


### PR DESCRIPTION
Fix waiting for enrich policy execution for users without the monitor privilege.