### PR TITLE
[ESQL] Per-file filter pushdown awareness

### DIFF
--- a/docs/changelog/145755.yaml
+++ b/docs/changelog/145755.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145755
+summary: Per-file filter pushdown awareness
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFilterPushdownSupport.java
@@ -47,7 +47,7 @@ public class OrcFilterPushdownSupport implements FilterPushdownSupport {
         }
 
         logger.debug("ORC filter pushdown: validated {} of {} expressions for pushdown", pushed.size(), filters.size());
-        return new PushdownResult(new OrcPushedExpressions(pushed), remainder);
+        return new PushdownResult(new OrcPushedExpressions(pushed), pushed, remainder);
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -83,7 +83,7 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         }
 
         logger.debug("Parquet filter pushdown: validated {} of {} expressions for pushdown", pushed.size(), filters.size());
-        return new PushdownResult(new ParquetPushedExpressions(pushed), remainder);
+        return new PushdownResult(new ParquetPushedExpressions(pushed), pushed, remainder);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -13,11 +13,15 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
@@ -30,6 +34,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +83,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final ErrorPolicy errorPolicy;
     private final int parsingParallelism;
     private final TimeValue drainTimeout;
+    private final List<Expression> pushedExpressions;
+    private final FilterPushdownSupport pushdownSupport;
 
     public AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
@@ -93,7 +101,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ExternalSliceQueue sliceQueue,
         ErrorPolicy errorPolicy,
         int parsingParallelism,
-        TimeValue drainTimeout
+        TimeValue drainTimeout,
+        @Nullable List<Expression> pushedExpressions,
+        @Nullable FilterPushdownSupport pushdownSupport
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -132,6 +142,46 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.errorPolicy = errorPolicy != null ? errorPolicy : formatReader.defaultErrorPolicy();
         this.parsingParallelism = Math.max(1, parsingParallelism);
         this.drainTimeout = drainTimeout != null ? drainTimeout : ExternalSourceDrainUtils.DEFAULT_DRAIN_TIMEOUT;
+        this.pushedExpressions = pushedExpressions != null ? pushedExpressions : List.of();
+        this.pushdownSupport = pushdownSupport;
+    }
+
+    public AsyncExternalSourceOperatorFactory(
+        StorageProvider storageProvider,
+        FormatReader formatReader,
+        StoragePath path,
+        List<Attribute> attributes,
+        int batchSize,
+        int maxBufferSize,
+        int rowLimit,
+        Executor executor,
+        FileList fileList,
+        Set<String> partitionColumnNames,
+        Map<String, Object> partitionValues,
+        ExternalSliceQueue sliceQueue,
+        ErrorPolicy errorPolicy,
+        int parsingParallelism,
+        TimeValue drainTimeout
+    ) {
+        this(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            batchSize,
+            maxBufferSize,
+            rowLimit,
+            executor,
+            fileList,
+            partitionColumnNames,
+            partitionValues,
+            sliceQueue,
+            errorPolicy,
+            parsingParallelism,
+            drainTimeout,
+            null,
+            null
+        );
     }
 
     public AsyncExternalSourceOperatorFactory(
@@ -165,6 +215,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             sliceQueue,
             errorPolicy,
             parsingParallelism,
+            null,
+            null,
             null
         );
     }
@@ -199,6 +251,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             sliceQueue,
             errorPolicy,
             1,
+            null,
+            null,
             null
         );
     }
@@ -232,6 +286,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             sliceQueue,
             null,
             1,
+            null,
+            null,
             null
         );
     }
@@ -264,6 +320,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             sliceQueue,
             null,
             1,
+            null,
+            null,
             null
         );
     }
@@ -295,6 +353,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             null,
             1,
+            null,
+            null,
             null
         );
     }
@@ -324,6 +384,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             null,
             1,
+            null,
+            null,
             null
         );
     }
@@ -352,6 +414,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             null,
             1,
+            null,
+            null,
             null
         );
     }
@@ -412,6 +476,65 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return new SchemaAdaptingIterator(pages, dataColumns, mapping, driverContext.blockFactory());
     }
 
+    /**
+     * Returns a format reader with an adapted pushed filter for this file, or the original reader
+     * if no adaptation is needed. Adaptation is needed when the file has missing columns and
+     * pushed expressions reference those columns.
+     */
+    private FormatReader readerForFile(FileSplit fileSplit) {
+        if (pushedExpressions.isEmpty() || pushdownSupport == null) {
+            return formatReader;
+        }
+        SchemaReconciliation.ColumnMapping mapping = fileSplit.columnMapping();
+        if (mapping == null || (mapping.hasMissingColumns() == false && mapping.hasCasts() == false)) {
+            return formatReader;
+        }
+        Set<String> fileColumnNames = new LinkedHashSet<>();
+        Map<String, DataType> fileColumnTypes = new HashMap<>();
+        assert mapping.columnCount() <= attributes.size()
+            : "column mapping count [" + mapping.columnCount() + "] exceeds attributes size [" + attributes.size() + "]";
+        for (int i = 0; i < mapping.columnCount(); i++) {
+            if (mapping.localIndex(i) != -1) {
+                String name = attributes.get(i).name();
+                fileColumnNames.add(name);
+                DataType castTarget = mapping.cast(i);
+                if (castTarget != null) {
+                    DataType fileType = inferFileType(attributes.get(i).dataType(), castTarget);
+                    if (fileType != null) {
+                        fileColumnTypes.put(name, fileType);
+                    }
+                }
+            }
+        }
+        List<Expression> adapted = FilterAdaptation.adaptFilterForFile(pushedExpressions, fileColumnNames, fileColumnTypes);
+        if (adapted.isEmpty()) {
+            return formatReader.withPushedFilter(null);
+        }
+        FilterPushdownSupport.PushdownResult result = pushdownSupport.pushFilters(adapted);
+        if (result.hasPushedFilter()) {
+            return formatReader.withPushedFilter(result.pushedFilter());
+        }
+        return formatReader.withPushedFilter(null);
+    }
+
+    /**
+     * Infers the file's native type from the unified attribute type and the cast target.
+     * The cast target is the unified (wider) type; the file has the narrower type.
+     */
+    /**
+     * Infers the file's native type from the cast target. Only returns a narrower type when
+     * the adaptation is safe for integral comparisons (LONG→INTEGER). DOUBLE→INTEGER narrowing
+     * is not supported because literal truncation can cause incorrect predicate semantics.
+     */
+    private static DataType inferFileType(DataType unifiedType, DataType castTarget) {
+        if (castTarget == DataType.LONG) {
+            return DataType.INTEGER;
+        }
+        // DOUBLE→INTEGER narrowing is intentionally not supported: Number.longValue() truncates
+        // fractional values, which can change comparison semantics (e.g., col < 2.7 vs col < 2).
+        return null;
+    }
+
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
         executor.execute(() -> {
             try {
@@ -437,9 +560,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                             }
                             List<String> cols = projectedColumns(injector);
 
+                            FormatReader fileReader = readerForFile(fileSplit);
                             boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
                             CloseableIterator<Page> pages;
-                            if (isRangeSplit && formatReader instanceof RangeAwareFormatReader rangeReader) {
+                            if (isRangeSplit && fileReader instanceof RangeAwareFormatReader rangeReader) {
                                 String fileLengthStr = (String) fileSplit.config().get(FileSplitProvider.FILE_LENGTH_KEY);
                                 StorageObject fullObj = fileLengthStr != null
                                     ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
@@ -470,7 +594,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                                     .firstSplit(firstSplit)
                                     .lastSplit(lastSplit)
                                     .build();
-                                pages = formatReader.read(obj, ctx);
+                                pages = fileReader.read(obj, ctx);
                             }
                             CloseableIterator<Page> adaptedPages = adaptSchema(pages, fileSplit.columnMapping(), driverContext);
                             try (adaptedPages) {
@@ -493,6 +617,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         });
     }
 
+    /**
+     * Multi-file read path (legacy, non-slice-queue). Per-file filter adaptation is not applied
+     * here because this path does not carry {@link FileSplit} with {@link SchemaReconciliation.ColumnMapping};
+     * UNION_BY_NAME queries use the slice-queue path ({@link #startSliceQueueRead}) instead.
+     */
     private void startMultiFileRead(
         List<String> projectedColumns,
         AsyncExternalSourceBuffer buffer,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -8,9 +8,11 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
@@ -20,6 +22,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -138,6 +141,11 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 partitionValues = fileSplit.partitionValues();
             }
 
+            List<Expression> pushedExpressions = context.pushedExpressions();
+            FilterPushdownSupport pushdownSupport = (pushedExpressions != null && pushedExpressions.isEmpty() == false)
+                ? format.filterPushdownSupport()
+                : null;
+
             return new AsyncExternalSourceOperatorFactory(
                 storage,
                 format,
@@ -153,7 +161,9 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 context.sliceQueue(),
                 errorPolicy,
                 context.parsingParallelism(),
-                null
+                null,
+                pushedExpressions,
+                pushdownSupport
             );
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
@@ -32,6 +33,8 @@ import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
@@ -146,9 +149,22 @@ public class FileSplitProvider implements SplitProvider {
                 }
             }
 
-            if (projectedDataColumns.isEmpty() == false && schemaInfo != null) {
-                SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(filePath);
-                if (info != null && hasNoProjectedColumns(info.fileSchema(), projectedDataColumns)) {
+            SchemaReconciliation.FileSchemaInfo fileSchemaInfo = schemaInfo != null ? schemaInfo.get(filePath) : null;
+
+            if (projectedDataColumns.isEmpty() == false && fileSchemaInfo != null) {
+                if (skipIfNoColumnOverlap(fileSchemaInfo.fileSchema(), projectedDataColumns)) {
+                    continue;
+                }
+            }
+
+            if (filterHints.isEmpty() == false && fileSchemaInfo != null) {
+                Set<String> fileColumnNames = new LinkedHashSet<>();
+                for (Attribute attr : fileSchemaInfo.fileSchema()) {
+                    fileColumnNames.add(attr.name());
+                }
+                // Partition columns are always available (values come from paths, not file data)
+                fileColumnNames.addAll(partitionValues.keySet());
+                if (skipIfFilterOnMissingColumns(filterHints, fileColumnNames)) {
                     continue;
                 }
             }
@@ -534,13 +550,77 @@ public class FileSplitProvider implements SplitProvider {
      * Returns {@code true} when the file's data columns have zero overlap with the projected set,
      * meaning this file would produce only NULL rows for all needed columns.
      */
-    static boolean hasNoProjectedColumns(List<Attribute> fileSchema, Set<String> projectedDataColumns) {
+    static boolean skipIfNoColumnOverlap(List<Attribute> fileSchema, Set<String> projectedDataColumns) {
         for (Attribute attr : fileSchema) {
             if (projectedDataColumns.contains(attr.name())) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Returns {@code true} when the file can be skipped because a filter conjunct references a
+     * column absent from the file and evaluates to UNKNOWN (which becomes FALSE in WHERE context).
+     * <p>
+     * Only simple leaf predicates are checked: comparisons ({@code =, !=, <, >, <=, >=}),
+     * {@link In}, and {@link IsNotNull}. These all evaluate to UNKNOWN/FALSE for a missing column.
+     * {@link IsNull} on a missing column evaluates to TRUE (all rows match), so it does NOT
+     * trigger a skip.
+     * <p>
+     * Compound expressions (OR, NOT) and multi-column expressions are conservatively kept.
+     *
+     * @param filterHints AND-separated filter conjuncts from ancestor FilterExec nodes
+     * @param fileColumnNames names of columns present in this file's schema
+     * @return {@code true} if the file can be safely skipped
+     */
+    static boolean skipIfFilterOnMissingColumns(List<Expression> filterHints, Set<String> fileColumnNames) {
+        for (Expression conjunct : filterHints) {
+            String columnName = extractFilterColumnName(conjunct);
+            if (columnName == null) {
+                continue;
+            }
+            if (fileColumnNames.contains(columnName)) {
+                continue;
+            }
+            // Column is missing from this file — determine the skip decision based on predicate type
+            if (conjunct instanceof IsNull) {
+                // IS NULL on missing column → TRUE (all rows match) → do NOT skip
+                continue;
+            }
+            // All other recognized leaf predicates evaluate to UNKNOWN → FALSE in WHERE context → skip
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Extracts the single column name from a simple leaf predicate, or {@code null} for
+     * compound/multi-column expressions that cannot be evaluated for file skipping.
+     */
+    private static String extractFilterColumnName(Expression expr) {
+        if (expr instanceof BinaryComparison bc) {
+            String left = extractColumnName(bc.left());
+            String right = extractColumnName(bc.right());
+            // Only handle single-column leaf predicates (column op literal)
+            if (left != null && bc.right() instanceof Literal) {
+                return left;
+            }
+            if (right != null && bc.left() instanceof Literal) {
+                return right;
+            }
+            return null;
+        }
+        if (expr instanceof In in) {
+            return extractColumnName(in.value());
+        }
+        if (expr instanceof IsNull isNull) {
+            return extractColumnName(isNull.field());
+        }
+        if (expr instanceof IsNotNull isNotNull) {
+            return extractColumnName(isNotNull.field());
+        }
+        return null;
     }
 
     static boolean matchesPartitionFilters(Map<String, Object> partitionValues, List<Expression> filters) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterAdaptation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterAdaptation.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Format-agnostic utility for adapting pushed filter expressions to a specific file's column set.
+ * <p>
+ * In UNION_BY_NAME scenarios, different files may have different columns. When a pushed filter
+ * references a column absent from a file, the predicate must be simplified before re-translation
+ * to the format-specific filter (Parquet {@code FilterPredicate}, ORC {@code SearchArgument}).
+ * <p>
+ * Adaptation rules for missing columns (SQL three-valued logic):
+ * <ul>
+ *   <li>Value comparison on missing column → UNKNOWN → FALSE in WHERE → remove conjunct</li>
+ *   <li>{@code IS NULL} on missing column → TRUE (all rows match) → remove conjunct (always true)</li>
+ *   <li>{@code IS NOT NULL} on missing column → FALSE → remove conjunct (entire AND is false)</li>
+ *   <li>{@code AND(A, B)}: if either is null (FALSE) → null; if either is TRUE → other side</li>
+ *   <li>{@code OR(A, B)}: if either is TRUE → TRUE; if one is null → other side</li>
+ *   <li>{@code NOT(child)}: if child is null → TRUE; if child is TRUE → null</li>
+ * </ul>
+ * <p>
+ * RECHECK semantics guarantee correctness: the adapted filter only affects I/O optimization
+ * (row-group/stripe skipping), never row-level correctness.
+ */
+public final class FilterAdaptation {
+
+    private FilterAdaptation() {}
+
+    /**
+     * Adapts pushed filter conjuncts for a specific file's column set.
+     * Removes or simplifies predicates on columns absent from the file.
+     *
+     * @param filterConjuncts AND-separated pushed expressions (same contract as
+     *        {@link org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport#pushFilters} input)
+     * @param fileColumnNames names of columns present in this file's schema
+     * @return adapted conjuncts; empty list means no pushdown for this file
+     */
+    public static List<Expression> adaptFilterForFile(List<Expression> filterConjuncts, Set<String> fileColumnNames) {
+        return adaptFilterForFile(filterConjuncts, fileColumnNames, Map.of());
+    }
+
+    /**
+     * Adapts pushed filter conjuncts for a specific file's column set and types.
+     * Handles both missing columns and type-widened columns.
+     * <p>
+     * When a column exists in the file with a narrower type than the unified schema (e.g., INTEGER
+     * in file vs LONG in unified), filter literals are downcast to the file's native type for
+     * optimal row-group/stripe skipping. Literals that overflow the narrower range are statically
+     * resolved based on the comparison operator.
+     *
+     * @param filterConjuncts AND-separated pushed expressions
+     * @param fileColumnNames names of columns present in this file's schema
+     * @param fileColumnTypes file-local types for columns that differ from the unified schema;
+     *        columns not in this map are assumed to match the unified type
+     * @return adapted conjuncts; empty list means no pushdown for this file
+     */
+    public static List<Expression> adaptFilterForFile(
+        List<Expression> filterConjuncts,
+        Set<String> fileColumnNames,
+        Map<String, DataType> fileColumnTypes
+    ) {
+        List<Expression> adapted = new ArrayList<>(filterConjuncts.size());
+        for (Expression conjunct : filterConjuncts) {
+            Expression result = adaptExpression(conjunct, fileColumnNames, fileColumnTypes);
+            if (result == null) {
+                return List.of();
+            }
+            if (result != TRUE_SENTINEL) {
+                adapted.add(result);
+            }
+        }
+        return adapted;
+    }
+
+    /**
+     * Sentinel value indicating an expression that evaluates to TRUE for all rows.
+     * Used internally to distinguish TRUE (remove from AND) from null (FALSE, remove entire AND).
+     */
+    private static final Expression TRUE_SENTINEL = new Literal(Source.EMPTY, Boolean.TRUE, DataType.BOOLEAN);
+
+    /**
+     * Recursively adapts a single expression for the file's column set and types.
+     * <p>
+     * Uses conservative pruning semantics (not strict SQL three-valued logic):
+     * a missing column yields "no constraint" (TRUE_SENTINEL) or "unsatisfiable" (null)
+     * depending on the predicate. Under RECHECK, correctness is guaranteed by the
+     * retained FilterExec; this only affects I/O-level skipping.
+     * <p>
+     * Unrecognized expression types (functions, casts, etc.) are returned unchanged.
+     * This is safe because {@code pushFilters} will reject or ignore any sub-expression
+     * it cannot translate, and RECHECK ensures row-level correctness regardless.
+     *
+     * @return the adapted expression, {@link #TRUE_SENTINEL} if always true, or {@code null} if always false/unknown
+     */
+    private static Expression adaptExpression(Expression expr, Set<String> fileColumnNames, Map<String, DataType> fileColumnTypes) {
+        if (expr instanceof BinaryComparison bc) {
+            return adaptComparison(bc, fileColumnNames, fileColumnTypes);
+        }
+        if (expr instanceof In in) {
+            String colName = extractColumnName(in.value());
+            if (colName != null && fileColumnNames.contains(colName) == false) {
+                return null; // UNKNOWN → FALSE
+            }
+            return expr;
+        }
+        if (expr instanceof IsNull isNull) {
+            String colName = extractColumnName(isNull.field());
+            if (colName != null && fileColumnNames.contains(colName) == false) {
+                return TRUE_SENTINEL; // missing column is always null → IS NULL is TRUE
+            }
+            return expr;
+        }
+        if (expr instanceof IsNotNull isNotNull) {
+            String colName = extractColumnName(isNotNull.field());
+            if (colName != null && fileColumnNames.contains(colName) == false) {
+                return null; // missing column is always null → IS NOT NULL is FALSE
+            }
+            return expr;
+        }
+        if (expr instanceof And and) {
+            Expression left = adaptExpression(and.left(), fileColumnNames, fileColumnTypes);
+            Expression right = adaptExpression(and.right(), fileColumnNames, fileColumnTypes);
+            if (left == null || right == null) {
+                return null;
+            }
+            if (left == TRUE_SENTINEL) {
+                return right;
+            }
+            if (right == TRUE_SENTINEL) {
+                return left;
+            }
+            if (left == and.left() && right == and.right()) {
+                return expr;
+            }
+            return new And(and.source(), left, right);
+        }
+        if (expr instanceof Or or) {
+            Expression left = adaptExpression(or.left(), fileColumnNames, fileColumnTypes);
+            Expression right = adaptExpression(or.right(), fileColumnNames, fileColumnTypes);
+            if (left == TRUE_SENTINEL || right == TRUE_SENTINEL) {
+                return TRUE_SENTINEL;
+            }
+            if (left == null && right == null) {
+                return null;
+            }
+            if (left == null) {
+                return right;
+            }
+            if (right == null) {
+                return left;
+            }
+            if (left == or.left() && right == or.right()) {
+                return expr;
+            }
+            return new Or(or.source(), left, right);
+        }
+        if (expr instanceof Not not) {
+            Expression child = adaptExpression(not.field(), fileColumnNames, fileColumnTypes);
+            if (child == null) {
+                return TRUE_SENTINEL; // NOT(unsatisfiable) → no constraint on this file
+            }
+            if (child == TRUE_SENTINEL) {
+                return null; // NOT(always-true) → unsatisfiable
+            }
+            if (child == not.field()) {
+                return expr;
+            }
+            return new Not(not.source(), child);
+        }
+        return expr;
+    }
+
+    /**
+     * Adapts a binary comparison for missing columns and type narrowing.
+     * Returns null if the column is missing, TRUE_SENTINEL/null for overflow resolution,
+     * or a rebuilt expression with the narrower type literal if the value fits.
+     */
+    private static Expression adaptComparison(BinaryComparison bc, Set<String> fileColumnNames, Map<String, DataType> fileColumnTypes) {
+        String leftCol = extractColumnName(bc.left());
+        String rightCol = extractColumnName(bc.right());
+        if (leftCol != null && fileColumnNames.contains(leftCol) == false) {
+            return null;
+        }
+        if (rightCol != null && fileColumnNames.contains(rightCol) == false) {
+            return null;
+        }
+        if (fileColumnTypes.isEmpty()) {
+            return bc;
+        }
+        // Type adaptation: column on left, literal on right (standard form from pushdown)
+        if (leftCol != null && bc.right().foldable()) {
+            DataType fileType = fileColumnTypes.get(leftCol);
+            if (fileType != null) {
+                return adaptComparisonType(bc, leftCol, fileType);
+            }
+        }
+        return bc;
+    }
+
+    /**
+     * Adapts a comparison when the file column has a narrower type than the unified schema.
+     * Tries to downcast the literal; resolves statically on overflow/underflow.
+     */
+    private static Expression adaptComparisonType(BinaryComparison bc, String columnName, DataType fileType) {
+        Object literalValue = bc.right() instanceof Literal lit ? lit.value() : null;
+        if (literalValue == null) {
+            return bc;
+        }
+        if (fileType == DataType.INTEGER && literalValue instanceof Number num) {
+            return adaptLongToInt(bc, columnName, num.longValue());
+        }
+        // Other narrowing pairs (LONG→INTEGER for DOUBLE unified, DATETIME→DATE_NANOS) are not
+        // common in filter pushdown and are left unchanged (safe under RECHECK).
+        return bc;
+    }
+
+    /**
+     * Adapts a LONG comparison to INTEGER when the file column is INT32.
+     * If the literal fits in int range, rebuilds with INTEGER types.
+     * If it overflows, statically resolves based on the comparison operator.
+     */
+    private static Expression adaptLongToInt(BinaryComparison bc, String columnName, long value) {
+        if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+            return rebuildComparison(bc, columnName, DataType.INTEGER, (int) value);
+        }
+        return resolveOverflow(bc, value > Integer.MAX_VALUE);
+    }
+
+    /**
+     * Rebuilds a comparison with a new column type and downcast literal value.
+     */
+    private static Expression rebuildComparison(BinaryComparison bc, String columnName, DataType newType, Object newValue) {
+        NamedExpression origCol = (NamedExpression) bc.left();
+        Expression newCol = new FieldAttribute(
+            origCol.source(),
+            columnName,
+            new EsField(columnName, newType, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Literal newLiteral = new Literal(bc.right().source(), newValue, newType);
+        return switch (bc) {
+            case Equals ignored -> new Equals(bc.source(), newCol, newLiteral);
+            case NotEquals ignored -> new NotEquals(bc.source(), newCol, newLiteral);
+            case GreaterThan ignored -> new GreaterThan(bc.source(), newCol, newLiteral, null);
+            case GreaterThanOrEqual ignored -> new GreaterThanOrEqual(bc.source(), newCol, newLiteral, null);
+            case LessThan ignored -> new LessThan(bc.source(), newCol, newLiteral, null);
+            case LessThanOrEqual ignored -> new LessThanOrEqual(bc.source(), newCol, newLiteral, null);
+            default -> bc;
+        };
+    }
+
+    /**
+     * Statically resolves a comparison when the literal overflows the file's narrower type.
+     *
+     * @param overflowHigh true if the literal is above the max value, false if below the min value
+     * @return TRUE_SENTINEL if the comparison is always true for all file values, null if always false
+     */
+    private static Expression resolveOverflow(BinaryComparison bc, boolean overflowHigh) {
+        // When literal overflows high (e.g., 3_000_000_000L vs INT32 max 2_147_483_647):
+        // col > 3B → always FALSE (no int can be > 3B)
+        // col >= 3B → always FALSE
+        // col < 3B → always TRUE (all ints are < 3B)
+        // col <= 3B → always TRUE
+        // col = 3B → always FALSE
+        // col != 3B → always TRUE
+        // When literal underflows low (e.g., -3_000_000_000L vs INT32 min -2_147_483_648):
+        // col > -3B → always TRUE
+        // col >= -3B → always TRUE
+        // col < -3B → always FALSE
+        // col <= -3B → always FALSE
+        // col = -3B → always FALSE
+        // col != -3B → always TRUE
+        return switch (bc) {
+            case Equals ignored -> null;
+            case NotEquals ignored -> TRUE_SENTINEL;
+            case GreaterThan ignored -> overflowHigh ? null : TRUE_SENTINEL;
+            case GreaterThanOrEqual ignored -> overflowHigh ? null : TRUE_SENTINEL;
+            case LessThan ignored -> overflowHigh ? TRUE_SENTINEL : null;
+            case LessThanOrEqual ignored -> overflowHigh ? TRUE_SENTINEL : null;
+            default -> bc;
+        };
+    }
+
+    private static String extractColumnName(Expression expr) {
+        if (expr instanceof NamedExpression ne) {
+            return ne.name();
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FilterPushdownSupport.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FilterPushdownSupport.java
@@ -87,9 +87,19 @@ public interface FilterPushdownSupport {
      * Result of attempting to push filters to a data source.
      *
      * @param pushedFilter source-specific filter object (opaque to core), or null if nothing was pushed
+     * @param pushedExpressions the original ESQL expressions that were successfully translated into
+     *        the pushed filter. Carried through the pipeline so per-file filter adaptation can
+     *        re-translate them for files with different schemas (UNION_BY_NAME).
      * @param remainder expressions that could not be pushed and must remain in FilterExec
      */
-    record PushdownResult(Object pushedFilter, List<Expression> remainder) {
+    record PushdownResult(Object pushedFilter, List<Expression> pushedExpressions, List<Expression> remainder) {
+
+        /**
+         * Backward-compatible constructor for implementations that do not track pushed expressions.
+         */
+        public PushdownResult(Object pushedFilter, List<Expression> remainder) {
+            this(pushedFilter, List.of(), remainder);
+        }
 
         /**
          * Creates a result indicating no filters could be pushed.
@@ -98,7 +108,7 @@ public interface FilterPushdownSupport {
          * @return a PushdownResult with null pushed filter and all expressions as remainder
          */
         public static PushdownResult none(List<Expression> all) {
-            return new PushdownResult(null, all);
+            return new PushdownResult(null, List.of(), all);
         }
 
         /**
@@ -108,7 +118,7 @@ public interface FilterPushdownSupport {
          * @return a PushdownResult with the pushed filter and empty remainder
          */
         public static PushdownResult all(Object pushedFilter) {
-            return new PushdownResult(pushedFilter, List.of());
+            return new PushdownResult(pushedFilter, List.of(), List.of());
         }
 
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceOperatorContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceOperatorContext.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
 
@@ -49,6 +50,7 @@ public record SourceOperatorContext(
     Map<String, Object> config,
     Map<String, Object> sourceMetadata,
     Object pushedFilter,
+    List<Expression> pushedExpressions,
     FileList fileList,
     @Nullable ExternalSplit split,
     Set<String> partitionColumnNames,
@@ -62,6 +64,7 @@ public record SourceOperatorContext(
         attributes = attributes != null ? List.copyOf(attributes) : List.of();
         config = config != null ? Map.copyOf(config) : Map.of();
         sourceMetadata = sourceMetadata != null ? Map.copyOf(sourceMetadata) : Map.of();
+        pushedExpressions = pushedExpressions != null ? List.copyOf(pushedExpressions) : List.of();
         partitionColumnNames = partitionColumnNames != null && partitionColumnNames.isEmpty() == false
             ? Collections.unmodifiableSet(new LinkedHashSet<>(partitionColumnNames))
             : Set.of();
@@ -103,6 +106,7 @@ public record SourceOperatorContext(
             config,
             sourceMetadata,
             pushedFilter,
+            null,
             fileList,
             split,
             null,
@@ -136,6 +140,7 @@ public record SourceOperatorContext(
             config,
             sourceMetadata,
             pushedFilter,
+            null,
             fileList,
             null,
             null,
@@ -172,6 +177,7 @@ public record SourceOperatorContext(
             null,
             null,
             null,
+            null,
             1
         );
     }
@@ -202,6 +208,7 @@ public record SourceOperatorContext(
             null,
             null,
             null,
+            null,
             1
         );
     }
@@ -222,6 +229,7 @@ public record SourceOperatorContext(
         private Map<String, Object> config;
         private Map<String, Object> sourceMetadata;
         private Object pushedFilter;
+        private List<Expression> pushedExpressions;
         private FileList fileList;
         private ExternalSplit split;
         private Set<String> partitionColumnNames;
@@ -283,6 +291,11 @@ public record SourceOperatorContext(
             return this;
         }
 
+        public Builder pushedExpressions(List<Expression> pushedExpressions) {
+            this.pushedExpressions = pushedExpressions;
+            return this;
+        }
+
         public Builder fileList(FileList fileList) {
             this.fileList = fileList;
             return this;
@@ -321,6 +334,7 @@ public record SourceOperatorContext(
                 config,
                 sourceMetadata,
                 pushedFilter,
+                pushedExpressions,
                 fileList,
                 split,
                 partitionColumnNames,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -264,8 +264,11 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
         FilterPushdownSupport.PushdownResult result = pushdownSupport.pushFilters(filters);
 
         if (result.hasPushedFilter()) {
-            // Create new ExternalSourceExec with pushed filter
-            ExternalSourceExec newExternalExec = externalExec.withPushedFilter(result.pushedFilter());
+            // Create new ExternalSourceExec with pushed filter and the original ESQL expressions
+            ExternalSourceExec newExternalExec = externalExec.withPushedFilterAndExpressions(
+                result.pushedFilter(),
+                result.pushedExpressions()
+            );
 
             // If there are non-pushable filters, keep FilterExec
             if (result.hasRemainder()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -61,6 +62,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
     private final Map<String, Object> config;
     private final Map<String, Object> sourceMetadata;
     private final Object pushedFilter; // Opaque filter - NOT serialized, created locally on data nodes
+    private final List<Expression> pushedExpressions; // NOT serialized - ESQL expressions for per-file re-translation
     private final int pushedLimit; // NOT serialized, set locally on data nodes
     private final Integer estimatedRowSize;
     private final FileList fileList; // NOT serialized - resolved on coordinator, null on data nodes
@@ -105,6 +107,36 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         FileList fileList,
         List<ExternalSplit> splits
     ) {
+        this(
+            source,
+            sourcePath,
+            sourceType,
+            attributes,
+            config,
+            sourceMetadata,
+            pushedFilter,
+            List.of(),
+            pushedLimit,
+            estimatedRowSize,
+            fileList,
+            splits
+        );
+    }
+
+    public ExternalSourceExec(
+        Source source,
+        String sourcePath,
+        String sourceType,
+        List<Attribute> attributes,
+        Map<String, Object> config,
+        Map<String, Object> sourceMetadata,
+        Object pushedFilter,
+        List<Expression> pushedExpressions,
+        int pushedLimit,
+        Integer estimatedRowSize,
+        FileList fileList,
+        List<ExternalSplit> splits
+    ) {
         super(source);
         if (sourcePath == null) {
             throw new IllegalArgumentException("sourcePath must not be null");
@@ -121,6 +153,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         this.config = config != null ? Map.copyOf(config) : Map.of();
         this.sourceMetadata = sourceMetadata != null ? Map.copyOf(sourceMetadata) : Map.of();
         this.pushedFilter = pushedFilter;
+        this.pushedExpressions = pushedExpressions != null ? List.copyOf(pushedExpressions) : List.of();
         this.pushedLimit = pushedLimit;
         this.estimatedRowSize = estimatedRowSize;
         this.fileList = fileList;
@@ -249,6 +282,10 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         return pushedFilter;
     }
 
+    public List<Expression> pushedExpressions() {
+        return pushedExpressions;
+    }
+
     public int pushedLimit() {
         return pushedLimit;
     }
@@ -274,6 +311,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             pushedFilter,
+            pushedExpressions,
             pushedLimit,
             estimatedRowSize,
             fileList,
@@ -290,6 +328,24 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             newFilter,
+            pushedExpressions,
+            pushedLimit,
+            estimatedRowSize,
+            fileList,
+            splits
+        );
+    }
+
+    public ExternalSourceExec withPushedFilterAndExpressions(Object newFilter, List<Expression> newPushedExpressions) {
+        return new ExternalSourceExec(
+            source(),
+            sourcePath,
+            sourceType,
+            attributes,
+            config,
+            sourceMetadata,
+            newFilter,
+            newPushedExpressions,
             pushedLimit,
             estimatedRowSize,
             fileList,
@@ -306,6 +362,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             pushedFilter,
+            pushedExpressions,
             newLimit,
             estimatedRowSize,
             fileList,
@@ -329,6 +386,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             pushedFilter,
+            pushedExpressions,
             pushedLimit,
             newEstimatedRowSize,
             fileList,
@@ -347,6 +405,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             pushedFilter,
+            pushedExpressions,
             pushedLimit,
             estimatedRowSize,
             fileList,
@@ -363,6 +422,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             config,
             sourceMetadata,
             pushedFilter,
+            pushedExpressions,
             pushedLimit,
             estimatedRowSize,
             fileList,
@@ -387,6 +447,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             && Objects.equals(config, other.config)
             && Objects.equals(sourceMetadata, other.sourceMetadata)
             && Objects.equals(pushedFilter, other.pushedFilter)
+            && Objects.equals(pushedExpressions, other.pushedExpressions)
             && pushedLimit == other.pushedLimit
             && Objects.equals(estimatedRowSize, other.estimatedRowSize)
             && Objects.equals(fileList, other.fileList)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1397,6 +1397,7 @@ public class LocalExecutionPlanner {
             .config(externalSource.config())
             .sourceMetadata(externalSource.sourceMetadata())
             .pushedFilter(externalSource.pushedFilter())
+            .pushedExpressions(externalSource.pushedExpressions())
             .fileList(fileList)
             .partitionColumnNames(partitionColumnNames)
             .sliceQueue(sliceQueue)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -35,7 +35,10 @@ import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
@@ -988,6 +991,152 @@ public class FileSplitProviderTests extends ESTestCase {
 
         // pathC pruned by partition filter (year=2023), pathB pruned by column skipping (only 'bonus')
         assertEquals(1, splits.size());
+        assertEquals(pathA, ((FileSplit) splits.get(0)).path());
+    }
+
+    // -- filter-based file skipping --
+
+    public void testSkipIfFilterOnMissingColumn_comparison() {
+        Expression filter = new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null);
+        assertTrue(
+            "File missing 'price' column should be skipped for price > 100",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name", "id"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_isNull() {
+        Expression filter = new IsNull(SRC, fieldAttr("price"));
+        assertFalse(
+            "IS NULL on missing column evaluates to TRUE — file should NOT be skipped",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name", "id"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_isNotNull() {
+        Expression filter = new IsNotNull(SRC, fieldAttr("price"));
+        assertTrue(
+            "IS NOT NULL on missing column evaluates to FALSE — file should be skipped",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name", "id"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_columnPresent() {
+        Expression filter = new Equals(SRC, fieldAttr("price"), intLiteral(100));
+        assertFalse(
+            "Column exists in file — should NOT be skipped",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("price", "name"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_noSchemaInfoIntegration() {
+        // When no schema info is available, discoverSplits does not call skipIfFilterOnMissingColumns
+        StoragePath pathA = StoragePath.of("s3://b/a.parquet");
+        FileList fileList = GlobExpander.fileListOf(List.of(new StorageEntry(pathA, 100, Instant.EPOCH)), "s3://b/*.parquet");
+
+        Expression filter = new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null);
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of(filter));
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals("File without schema info should NOT be skipped (conservative)", 1, splits.size());
+    }
+
+    public void testSkipIfFilterOnMissingColumn_literalOnlyConjunct() {
+        Expression filter = new Literal(SRC, true, DataType.BOOLEAN);
+        assertFalse(
+            "Unrecognized expression should be conservative — should NOT skip",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_literalOpColumn() {
+        // Literal on the left: 100 < price (equivalent to price > 100)
+        Expression filter = new GreaterThan(SRC, intLiteral(100), fieldAttr("price"), null);
+        assertTrue(
+            "Literal-op-column form with missing column should also skip",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_equalsMissing() {
+        Expression filter = new Equals(SRC, fieldAttr("status"), intLiteral(1));
+        assertTrue("Equals on missing column should skip", FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name")));
+    }
+
+    public void testSkipIfFilterOnMissingColumn_partitionColumnNotTreatedAsMissing() {
+        // Partition column 'year' is not in fileSchema but is in partitionValues
+        StoragePath pathA = StoragePath.of("s3://b/year=2024/a.parquet");
+        FileList fileList = GlobExpander.fileListOf(List.of(new StorageEntry(pathA, 100, Instant.EPOCH)), "s3://b/year=*/*.parquet");
+
+        PartitionMetadata partitions = new PartitionMetadata(Map.of("year", DataType.INTEGER), Map.of(pathA, Map.of("year", 2024)));
+
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = new HashMap<>();
+        schemaInfo.put(pathA, new SchemaReconciliation.FileSchemaInfo(List.of(refAttr("id"), refAttr("name")), null, null));
+        fileList = GlobExpander.withSchemaInfo(fileList, schemaInfo);
+
+        Expression yearFilter = new Equals(SRC, fieldAttr("year"), intLiteral(2024));
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), partitions, List.of(yearFilter), Set.of("id"));
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals("Partition column should not be treated as missing — file should NOT be skipped", 1, splits.size());
+    }
+
+    public void testSkipIfFilterOnMissingColumn_inExpression() {
+        Expression filter = new In(SRC, fieldAttr("status"), List.of(intLiteral(1), intLiteral(2)));
+        assertTrue("IN on missing column should skip", FileSplitProvider.skipIfFilterOnMissingColumns(List.of(filter), Set.of("name")));
+    }
+
+    public void testSkipIfFilterOnMissingColumn_multipleConjuncts() {
+        Expression priceFilter = new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null);
+        Expression nameFilter = new Equals(SRC, fieldAttr("name"), new Literal(SRC, new BytesRef("test"), DataType.KEYWORD));
+        // price is missing, name is present — should skip because price > 100 is UNKNOWN → FALSE
+        assertTrue(
+            "Any conjunct on missing column should trigger skip",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(priceFilter, nameFilter), Set.of("name", "id"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_allConjunctsPresent() {
+        Expression priceFilter = new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null);
+        Expression nameFilter = new Equals(SRC, fieldAttr("name"), new Literal(SRC, new BytesRef("test"), DataType.KEYWORD));
+        assertFalse(
+            "All filter columns present — should NOT skip",
+            FileSplitProvider.skipIfFilterOnMissingColumns(List.of(priceFilter, nameFilter), Set.of("price", "name"))
+        );
+    }
+
+    public void testSkipIfFilterOnMissingColumn_combinedWithPartitionPruning() {
+        StoragePath pathA = StoragePath.of("s3://b/year=2024/a.parquet");
+        StoragePath pathB = StoragePath.of("s3://b/year=2024/b.parquet");
+        StoragePath pathC = StoragePath.of("s3://b/year=2023/c.parquet");
+        FileList fileList = GlobExpander.fileListOf(
+            List.of(
+                new StorageEntry(pathA, 100, Instant.EPOCH),
+                new StorageEntry(pathB, 200, Instant.EPOCH),
+                new StorageEntry(pathC, 300, Instant.EPOCH)
+            ),
+            "s3://b/year=*/*.parquet"
+        );
+
+        PartitionMetadata partitions = new PartitionMetadata(
+            Map.of("year", DataType.INTEGER),
+            Map.of(pathA, Map.of("year", 2024), pathB, Map.of("year", 2024), pathC, Map.of("year", 2023))
+        );
+
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = new HashMap<>();
+        schemaInfo.put(pathA, new SchemaReconciliation.FileSchemaInfo(List.of(refAttr("id"), refAttr("price")), null, null));
+        schemaInfo.put(pathB, new SchemaReconciliation.FileSchemaInfo(List.of(refAttr("id")), null, null));
+        schemaInfo.put(pathC, new SchemaReconciliation.FileSchemaInfo(List.of(refAttr("id"), refAttr("price")), null, null));
+        fileList = GlobExpander.withSchemaInfo(fileList, schemaInfo);
+
+        // year=2024 filter prunes pathC; price > 100 filter prunes pathB (missing 'price')
+        List<Expression> filters = List.of(
+            new Equals(SRC, fieldAttr("year"), intLiteral(2024)),
+            new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null)
+        );
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), partitions, filters, Set.of("id", "price"));
+        List<ExternalSplit> splits = provider.discoverSplits(ctx);
+
+        assertEquals("Only pathA should survive partition + filter-column pruning", 1, splits.size());
         assertEquals(pathA, ((FileSplit) splits.get(0)).path());
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterAdaptationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterAdaptationTests.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FilterAdaptationTests extends ESTestCase {
+
+    private static final Source SRC = Source.EMPTY;
+
+    public void testAdaptFilter_leafComparison_missingColumn() {
+        Expression filter = gt("price", 100);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("name", "id"));
+        assertTrue("Comparison on missing column should be removed (entire AND is false)", result.isEmpty());
+    }
+
+    public void testAdaptFilter_leafComparison_presentColumn() {
+        Expression filter = gt("price", 100);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price", "name"));
+        assertEquals("Comparison on present column should be unchanged", 1, result.size());
+        assertSame(filter, result.get(0));
+    }
+
+    public void testAdaptFilter_isNull_missingColumn() {
+        Expression filter = new IsNull(SRC, fieldAttr("price"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("name"));
+        assertTrue("IS NULL on missing column is TRUE — conjunct removed (always true)", result.isEmpty());
+    }
+
+    public void testAdaptFilter_isNotNull_missingColumn() {
+        Expression filter = new IsNotNull(SRC, fieldAttr("price"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("name"));
+        assertTrue("IS NOT NULL on missing column is FALSE — entire AND is false", result.isEmpty());
+    }
+
+    public void testAdaptFilter_and_oneMissing() {
+        // price > 100 AND name = 'x' — price is missing
+        Expression and = new And(SRC, gt("price", 100), eq("name", "x"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(and), Set.of("name"));
+        // price > 100 is UNKNOWN → AND(UNKNOWN, X) = UNKNOWN → entire conjunct is false
+        assertTrue("AND with one missing-column child should be removed", result.isEmpty());
+    }
+
+    public void testAdaptFilter_and_bothMissing() {
+        Expression and = new And(SRC, gt("price", 100), gt("quantity", 5));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(and), Set.of("name"));
+        assertTrue("AND with both children missing should be removed", result.isEmpty());
+    }
+
+    public void testAdaptFilter_or_oneMissing() {
+        // price > 100 OR name = 'x' — price is missing
+        Expression or = new Or(SRC, gt("price", 100), eq("name", "x"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(or), Set.of("name"));
+        assertEquals("OR with one missing child should keep the other side", 1, result.size());
+        assertThat(result.get(0), org.hamcrest.Matchers.instanceOf(Equals.class));
+    }
+
+    public void testAdaptFilter_or_isNullMissing() {
+        // price IS NULL OR name = 'x' — price is missing → IS NULL is TRUE → OR(TRUE, X) = TRUE
+        Expression or = new Or(SRC, new IsNull(SRC, fieldAttr("price")), eq("name", "x"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(or), Set.of("name"));
+        assertTrue("OR with IS NULL on missing column → TRUE → entire conjunct is always true", result.isEmpty());
+    }
+
+    public void testAdaptFilter_not_missingColumn() {
+        // NOT(price > 100) — price is missing → NOT(UNKNOWN) = UNKNOWN → FALSE
+        Expression not = new Not(SRC, gt("price", 100));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(not), Set.of("name"));
+        // NOT(null) → TRUE_SENTINEL (always true), so it should be removed from conjuncts
+        assertTrue("NOT on missing column comparison should be removed (always true)", result.isEmpty());
+    }
+
+    public void testAdaptFilter_allPresent_unchanged() {
+        Expression f1 = gt("price", 100);
+        Expression f2 = eq("name", "x");
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(f1, f2), Set.of("price", "name"));
+        assertEquals(2, result.size());
+        assertSame(f1, result.get(0));
+        assertSame(f2, result.get(1));
+    }
+
+    public void testAdaptFilter_multipleConjuncts_mixedMissing() {
+        // [price > 100, name = 'x'] — price is missing
+        Expression f1 = gt("price", 100);
+        Expression f2 = eq("name", "x");
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(f1, f2), Set.of("name"));
+        // price > 100 on missing column → null → entire AND is false → empty
+        assertTrue("Any conjunct on missing column makes entire AND false", result.isEmpty());
+    }
+
+    public void testAdaptFilter_inExpression_missingColumn() {
+        Expression filter = new In(SRC, fieldAttr("status"), List.of(intLiteral(1), intLiteral(2)));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("name"));
+        assertTrue("IN on missing column should make entire AND false", result.isEmpty());
+    }
+
+    public void testAdaptFilter_or_bothMissing() {
+        // price > 100 OR quantity > 5 — both missing
+        Expression or = new Or(SRC, gt("price", 100), gt("quantity", 5));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(or), Set.of("name"));
+        assertTrue("OR with both sides missing should be removed (entire AND is false)", result.isEmpty());
+    }
+
+    public void testAdaptFilter_nestedAndOr() {
+        // AND(OR(price > 100, name = 'x'), id = 1) — price is missing, name and id present
+        Expression or = new Or(SRC, gt("price", 100), eq("name", "x"));
+        Expression and = new And(SRC, or, eq("id", "1"));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(and), Set.of("name", "id"));
+        assertEquals("Nested AND(OR(missing, present), present) should simplify", 1, result.size());
+        assertThat(result.get(0), org.hamcrest.Matchers.instanceOf(And.class));
+    }
+
+    public void testAdaptFilter_notIsNull_missingColumn() {
+        // NOT(IS NULL price) — price is missing → IS NULL is TRUE → NOT(TRUE) → FALSE
+        Expression not = new Not(SRC, new IsNull(SRC, fieldAttr("price")));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(not), Set.of("name"));
+        assertTrue("NOT(IS NULL missing) should be unsatisfiable", result.isEmpty());
+    }
+
+    public void testAdaptFilter_notIsNotNull_missingColumn() {
+        // NOT(IS NOT NULL price) — price is missing → IS NOT NULL is FALSE → NOT(FALSE) → TRUE
+        Expression not = new Not(SRC, new IsNotNull(SRC, fieldAttr("price")));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(not), Set.of("name"));
+        assertTrue("NOT(IS NOT NULL missing) should be always true (removed from conjuncts)", result.isEmpty());
+    }
+
+    public void testAdaptFilter_emptyConjuncts() {
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(), Set.of("name"));
+        assertTrue("Empty conjuncts should return empty list", result.isEmpty());
+    }
+
+    // -- type adaptation tests --
+
+    public void testAdaptType_longToInt_literalFits() {
+        Expression filter = gtLong("price", 100L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertEquals(1, result.size());
+        assertThat(result.get(0), org.hamcrest.Matchers.instanceOf(GreaterThan.class));
+        GreaterThan adapted = (GreaterThan) result.get(0);
+        assertEquals(DataType.INTEGER, ((FieldAttribute) adapted.left()).dataType());
+        assertEquals(100, ((Literal) adapted.right()).value());
+        assertEquals(DataType.INTEGER, adapted.right().dataType());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_greaterThan() {
+        Expression filter = gtLong("price", 3_000_000_000L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price > 3B with INT32 column → always FALSE → empty", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_lessThan() {
+        Expression filter = ltLong("price", 3_000_000_000L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price < 3B with INT32 column → always TRUE → removed from conjuncts", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_equals() {
+        Expression filter = eqLong("price", 3_000_000_000L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price = 3B with INT32 column → always FALSE → empty", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_underflowLow_greaterThan() {
+        Expression filter = gtLong("price", -3_000_000_000L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price > -3B with INT32 column → always TRUE → removed from conjuncts", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_underflowLow_lessThan() {
+        Expression filter = ltLong("price", -3_000_000_000L);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price < -3B with INT32 column → always FALSE → empty", result.isEmpty());
+    }
+
+    public void testAdaptType_noTypeChange_unchanged() {
+        Expression filter = gt("price", 100);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of());
+        assertEquals(1, result.size());
+        assertSame("No type info → expression unchanged", filter, result.get(0));
+    }
+
+    public void testAdaptType_longToInt_intBoundaryMax() {
+        Expression filter = eqLong("price", (long) Integer.MAX_VALUE);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertEquals(1, result.size());
+        Equals adapted = (Equals) result.get(0);
+        assertEquals(Integer.MAX_VALUE, ((Literal) adapted.right()).value());
+        assertEquals(DataType.INTEGER, adapted.right().dataType());
+    }
+
+    public void testAdaptType_longToInt_intBoundaryMin() {
+        Expression filter = eqLong("price", (long) Integer.MIN_VALUE);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertEquals(1, result.size());
+        Equals adapted = (Equals) result.get(0);
+        assertEquals(Integer.MIN_VALUE, ((Literal) adapted.right()).value());
+        assertEquals(DataType.INTEGER, adapted.right().dataType());
+    }
+
+    public void testAdaptType_longToInt_justAboveMax() {
+        Expression filter = eqLong("price", (long) Integer.MAX_VALUE + 1);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("Literal just above Integer.MAX_VALUE → overflow → FALSE for equals", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_greaterThanOrEqual() {
+        Expression filter = new GreaterThanOrEqual(SRC, longFieldAttr("price"), longLiteral(3_000_000_000L), null);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price >= 3B with INT32 → always FALSE → empty", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_lessThanOrEqual() {
+        Expression filter = new LessThanOrEqual(SRC, longFieldAttr("price"), longLiteral(3_000_000_000L), null);
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price <= 3B with INT32 → always TRUE → removed from conjuncts", result.isEmpty());
+    }
+
+    public void testAdaptType_longToInt_overflowHigh_notEquals() {
+        Expression filter = new NotEquals(SRC, longFieldAttr("price"), longLiteral(3_000_000_000L));
+        List<Expression> result = FilterAdaptation.adaptFilterForFile(List.of(filter), Set.of("price"), Map.of("price", DataType.INTEGER));
+        assertTrue("price != 3B with INT32 → always TRUE → removed from conjuncts", result.isEmpty());
+    }
+
+    // -- helpers --
+
+    private static FieldAttribute fieldAttr(String name) {
+        return new FieldAttribute(SRC, name, new EsField(name, DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static Literal intLiteral(int value) {
+        return new Literal(SRC, value, DataType.INTEGER);
+    }
+
+    private static Expression gt(String column, int value) {
+        return new GreaterThan(SRC, fieldAttr(column), intLiteral(value), null);
+    }
+
+    private static Expression eq(String column, String value) {
+        return new Equals(SRC, fieldAttr(column), new Literal(SRC, new org.apache.lucene.util.BytesRef(value), DataType.KEYWORD));
+    }
+
+    private static FieldAttribute longFieldAttr(String name) {
+        return new FieldAttribute(SRC, name, new EsField(name, DataType.LONG, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static Literal longLiteral(long value) {
+        return new Literal(SRC, value, DataType.LONG);
+    }
+
+    private static Expression gtLong(String column, long value) {
+        return new GreaterThan(SRC, longFieldAttr(column), longLiteral(value), null);
+    }
+
+    private static Expression ltLong(String column, long value) {
+        return new LessThan(SRC, longFieldAttr(column), longLiteral(value), null);
+    }
+
+    private static Expression eqLong(String column, long value) {
+        return new Equals(SRC, longFieldAttr(column), longLiteral(value));
+    }
+}


### PR DESCRIPTION
Make filter pushdown aware of per-file column availability and
types in UNION_BY_NAME scenarios. Files whose filter columns are
entirely absent are skipped at split discovery time. For files
that do contain the columns, pushed ESQL expressions are adapted
to the file's column set and re-translated to format-native
filters. Type-widened columns (e.g. INTEGER file vs LONG unified)
have their filter literals downcast with overflow detection.

Developed with AI-assisted tooling