### PR TITLE
Fix ScaledFloatMatcher to handle coerced numeric strings

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/matchers/source/FieldSpecificMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/matchers/source/FieldSpecificMatcher.java
@@ -282,6 +282,14 @@ interface FieldSpecificMatcher {
             if (value instanceof Number n) {
                 return n;
             }
+            // Accept coercible numeric strings
+            if (value instanceof String s) {
+                try {
+                    return Double.parseDouble(s);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }
 
             return null;
         }
@@ -295,6 +303,18 @@ interface FieldSpecificMatcher {
                 .filter(Objects::nonNull)
                 .filter(v -> v instanceof Number == false)
                 .filter(v -> v instanceof String == false || ((String) v).isEmpty() == false)
+                // Exclude coercible numeric strings
+                .filter(v -> {
+                    if (v instanceof String s) {
+                        try {
+                            Double.parseDouble(s);
+                            return false;
+                        } catch (NumberFormatException e) {
+                            return true;
+                        }
+                    }
+                    return true;
+                })
                 .collect(Collectors.toSet());
         }
 

--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
@@ -208,4 +208,25 @@ public class SourceMatcherTests extends ESTestCase {
         var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
         assertTrue(sut.match().isMatch());
     }
+
+    public void testCoercedStringScaledFloatMatchesNumericValue() throws IOException {
+        List<Map<String, Object>> expected = List.of(Map.of("field", "28"));
+        List<Map<String, Object>> actual = List.of(Map.of("field", 28.0));
+
+        var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
+        mapping.startObject();
+        mapping.startObject("_doc");
+        {
+            mapping.startObject("field")
+                .field("type", "scaled_float")
+                .field("scaling_factor", 10)
+                .field("ignore_malformed", true)
+                .endObject();
+        }
+        mapping.endObject();
+        mapping.endObject();
+
+        var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
+        assertTrue(sut.match().isMatch());
+    }
 }


### PR DESCRIPTION
Stored source preserves original string values (e.g. "28") while synthetic source reconstructs from doc values as a double (28.0). The matcher now parses coercible strings as numbers so they match their numeric equivalents.


The following test failures which this fixes are on 9.3. But this issues is also on main and just hasn't shown up. (As proved by the failure on main of the attached unit test without the fix.) Since the issue is on main, adding the fix to main and backporting.

Fixes https://github.com/elastic/elasticsearch/issues/145731
Fixes https://github.com/elastic/elasticsearch/issues/145730
Fixes https://github.com/elastic/elasticsearch/issues/145729
