### PR TITLE
[9.3] [CI] Move PR CI to n4 (#145639)

### DIFF
--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -23,5 +23,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -23,6 +23,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -16,7 +16,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
@@ -28,7 +29,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
@@ -40,7 +42,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
@@ -52,7 +55,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
@@ -64,7 +68,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
@@ -76,5 +81,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: n1-standard-32
+          machineType: e2-standard-32
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -16,8 +16,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
@@ -29,8 +29,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
@@ -42,8 +42,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
@@ -55,8 +55,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
@@ -68,8 +68,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
@@ -81,6 +81,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: e2-standard-32
-          diskType: pd-ssd
+          machineType: n4-standard-32
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/docs-check.yml
+++ b/.buildkite/pipelines/pull-request/docs-check.yml
@@ -10,6 +10,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/docs-check.yml
+++ b/.buildkite/pipelines/pull-request/docs-check.yml
@@ -10,5 +10,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -5,6 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -5,5 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -14,5 +14,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -14,6 +14,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -11,6 +11,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: e2-custom-32-98304
-          diskType: pd-ssd
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -11,5 +11,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: custom-32-98304
+          machineType: e2-custom-32-98304
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
@@ -22,7 +22,8 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-16-32768
+          machineType: e2-custom-16-32768
+          diskType: pd-ssd
         env:
           USE_PROD_DOCKER_CREDENTIALS: "true"
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
@@ -22,8 +22,8 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: e2-custom-16-32768
-          diskType: pd-ssd
+          machineType: n4-custom-16-32768
+          diskType: hyperdisk-balanced
         env:
           USE_PROD_DOCKER_CREDENTIALS: "true"
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -37,5 +37,5 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: e2-custom-16-32768
-          diskType: pd-ssd
+          machineType: n4-custom-16-32768
+          diskType: hyperdisk-balanced

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -37,4 +37,5 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-16-32768
+          machineType: e2-custom-16-32768
+          diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -18,8 +18,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: e2-custom-32-98304
-          diskType: pd-ssd
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
           diskSizeGb: 350
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -18,7 +18,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: custom-32-98304
+          machineType: e2-custom-32-98304
+          diskType: pd-ssd
           diskType: pd-ssd
           diskSizeGb: 350
         env:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -20,7 +20,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: e2-custom-32-98304
           diskType: pd-ssd
-          diskType: pd-ssd
           diskSizeGb: 350
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -17,8 +17,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: e2-custom-32-98304
-          diskType: pd-ssd
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
           diskSizeGb: 350
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -19,7 +19,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: e2-custom-32-98304
           diskType: pd-ssd
-          diskType: pd-ssd
           diskSizeGb: 350
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -17,7 +17,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: custom-32-98304
+          machineType: e2-custom-32-98304
+          diskType: pd-ssd
           diskType: pd-ssd
           diskSizeGb: 350
         env:

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -16,7 +16,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: custom-16-32768
+          machineType: e2-custom-16-32768
+          diskType: pd-ssd
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -16,8 +16,8 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: e2-custom-16-32768
-          diskType: pd-ssd
+          machineType: n4-custom-16-32768
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-1-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart1

--- a/.buildkite/pipelines/pull-request/part-1-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-1-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart1

--- a/.buildkite/pipelines/pull-request/part-1-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-1-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -7,5 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-2-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart2

--- a/.buildkite/pipelines/pull-request/part-2-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-2-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart2

--- a/.buildkite/pipelines/pull-request/part-2-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-2-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -5,6 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -5,5 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-3-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart3

--- a/.buildkite/pipelines/pull-request/part-3-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-3-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart3

--- a/.buildkite/pipelines/pull-request/part-3-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-3-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -7,5 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: e2-standard-32
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-standard-32
-      diskType: pd-ssd
+      machineType: n4-standard-32
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-4-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart4

--- a/.buildkite/pipelines/pull-request/part-4-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-4-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart4

--- a/.buildkite/pipelines/pull-request/part-4-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-4-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -7,5 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n1-standard-32
+      machineType: e2-standard-32
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-standard-32
-      diskType: pd-ssd
+      machineType: n4-standard-32
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-5-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart5

--- a/.buildkite/pipelines/pull-request/part-5-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-5-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart5

--- a/.buildkite/pipelines/pull-request/part-5-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-5-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -7,5 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -9,5 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -9,6 +9,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-6-windows.yml
@@ -7,8 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart6

--- a/.buildkite/pipelines/pull-request/part-6-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-6-windows.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-windows-2022
       machineType: e2-custom-32-98304
       diskType: pd-ssd
-      diskType: pd-ssd
       diskSizeGb: 350
     env:
       GRADLE_TASK: checkPart6

--- a/.buildkite/pipelines/pull-request/part-6-windows.yml
+++ b/.buildkite/pipelines/pull-request/part-6-windows.yml
@@ -7,7 +7,8 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-windows-2022
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       diskType: pd-ssd
       diskSizeGb: 350
     env:

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -6,6 +6,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -6,5 +6,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -10,6 +10,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -10,5 +10,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/release-tests.yml
+++ b/.buildkite/pipelines/pull-request/release-tests.yml
@@ -20,4 +20,5 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           diskSizeGb: 350
-          machineType: custom-32-98304
+          machineType: e2-custom-32-98304
+          diskType: pd-ssd

--- a/.buildkite/pipelines/pull-request/release-tests.yml
+++ b/.buildkite/pipelines/pull-request/release-tests.yml
@@ -20,5 +20,5 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           diskSizeGb: 350
-          machineType: e2-custom-32-98304
-          diskType: pd-ssd
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -7,5 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -5,6 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: e2-custom-32-98304
-      diskType: pd-ssd
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -5,5 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: custom-32-98304
+      machineType: e2-custom-32-98304
+      diskType: pd-ssd
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -35,7 +35,8 @@ steps:
           agents:
             provider: gcp
             image: family/elasticsearch-ubuntu-2004
-            machineType: n1-standard-32
+            machineType: e2-standard-32
+            diskType: pd-ssd
             buildDirectory: /dev/shm/bk
           matrix:
             setup:

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -35,8 +35,8 @@ steps:
           agents:
             provider: gcp
             image: family/elasticsearch-ubuntu-2004
-            machineType: e2-standard-32
-            diskType: pd-ssd
+            machineType: n4-standard-32
+            diskType: hyperdisk-balanced
             buildDirectory: /dev/shm/bk
           matrix:
             setup:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Move n4 to flexible e2 type (#145639)](https://github.com/elastic/elasticsearch/pull/145639)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)