### PR TITLE
[9.3] Fix ScaledFloatMatcher to handle coerced numeric strings (#145757)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/matchers/source/FieldSpecificMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/matchers/source/FieldSpecificMatcher.java
@@ -281,6 +281,14 @@ interface FieldSpecificMatcher {
             if (value instanceof Number n) {
                 return n;
             }
+            // Accept coercible numeric strings
+            if (value instanceof String s) {
+                try {
+                    return Double.parseDouble(s);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }
 
             return null;
         }
@@ -294,6 +302,18 @@ interface FieldSpecificMatcher {
                 .filter(Objects::nonNull)
                 .filter(v -> v instanceof Number == false)
                 .filter(v -> v instanceof String == false || ((String) v).isEmpty() == false)
+                // Exclude coercible numeric strings
+                .filter(v -> {
+                    if (v instanceof String s) {
+                        try {
+                            Double.parseDouble(s);
+                            return false;
+                        } catch (NumberFormatException e) {
+                            return true;
+                        }
+                    }
+                    return true;
+                })
                 .collect(Collectors.toSet());
         }
 

--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
@@ -208,4 +208,25 @@ public class SourceMatcherTests extends ESTestCase {
         var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
         assertTrue(sut.match().isMatch());
     }
+
+    public void testCoercedStringScaledFloatMatchesNumericValue() throws IOException {
+        List<Map<String, Object>> expected = List.of(Map.of("field", "28"));
+        List<Map<String, Object>> actual = List.of(Map.of("field", 28.0));
+
+        var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
+        mapping.startObject();
+        mapping.startObject("_doc");
+        {
+            mapping.startObject("field")
+                .field("type", "scaled_float")
+                .field("scaling_factor", 10)
+                .field("ignore_malformed", true)
+                .endObject();
+        }
+        mapping.endObject();
+        mapping.endObject();
+
+        var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
+        assertTrue(sut.match().isMatch());
+    }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix ScaledFloatMatcher to handle coerced numeric strings (#145757)