### PR TITLE
Ensure MetricsInfo and TsInfo hold reference to _doc

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -392,12 +392,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidBigDecimalFromBooleanWithoutCasting
   issue: https://github.com/elastic/elasticsearch/issues/145702
-- class: org.elasticsearch.xpack.esql.action.MetricsAndTSInfoIT
-  method: testTsInfo
-  issue: https://github.com/elastic/elasticsearch/issues/145720
-- class: org.elasticsearch.xpack.esql.action.MetricsAndTSInfoIT
-  method: testMetricsInfo
-  issue: https://github.com/elastic/elasticsearch/issues/145719
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidIntegerWithCasting
   issue: https://github.com/elastic/elasticsearch/issues/145735

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/MetricsAndTSInfoIT.java
@@ -66,7 +66,9 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
                     "request_count",
                     "type=integer,time_series_metric=counter",
                     "extra-field-1",
-                    "type=keyword"
+                    "type=keyword",
+                    "extra-dimension-1",
+                    "type=keyword,time_series_dimension=true"
                 )
                 .get();
         }
@@ -91,7 +93,9 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
                     "request_count",
                     "type=integer,time_series_metric=counter",
                     "extra-field-2",
-                    "type=keyword"
+                    "type=keyword",
+                    "extra-dimension-2",
+                    "type=keyword,time_series_dimension=true"
                 )
                 .get();
         }
@@ -149,29 +153,53 @@ public class MetricsAndTSInfoIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMetricsInfo() {
-        for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
-            EsqlQueryRequest request = new EsqlQueryRequest();
-            request.query("TS " + index + " | METRICS_INFO");
-            if (canUseQueryPragmas()) {
-                request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
-            }
-            try (var resp = run(request)) {
-                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
-                assertThat(rows, not(empty()));
+        List<String> statements = List.of(
+            "| WHERE @timestamp > \"1970-01-01\" ",
+            "| EVAL t = to_long(@timestamp) | WHERE t > 0 ",
+            "| EVAL t = to_long(@timestamp)",
+            "| DROP @timestamp",
+            "| EVAL t = @timestamp | DROP @timestamp",
+            ""
+        );
+        for (var statement : statements) {
+            for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
+                EsqlQueryRequest request = new EsqlQueryRequest();
+                request.query("TS " + index + statement + " | METRICS_INFO");
+                if (canUseQueryPragmas()) {
+                    request.pragmas(
+                        new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build())
+                    );
+                }
+                try (var resp = run(request)) {
+                    List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+                    assertThat(rows, not(empty()));
+                }
             }
         }
     }
 
     public void testTsInfo() {
-        for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
-            EsqlQueryRequest request = new EsqlQueryRequest();
-            request.query("TS " + index + " | TS_INFO");
-            if (canUseQueryPragmas()) {
-                request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
-            }
-            try (var resp = run(request)) {
-                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
-                assertThat(rows, not(empty()));
+        List<String> statements = List.of(
+            "| WHERE @timestamp > \"1970-01-01\" ",
+            "| EVAL t = to_long(@timestamp) | WHERE t > 0 ",
+            "| EVAL t = to_long(@timestamp)",
+            "| DROP @timestamp",
+            "| EVAL t = @timestamp | DROP @timestamp",
+            ""
+        );
+        for (var statement : statements) {
+            for (String index : List.of("index-1", "index-2", "index-1,index-2")) {
+                EsqlQueryRequest request = new EsqlQueryRequest();
+                request.query("TS " + index + statement + " | TS_INFO");
+                if (canUseQueryPragmas()) {
+                    request.pragmas(
+                        new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build())
+                    );
+                }
+                try (var resp = run(request)) {
+                    List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+                    assertThat(rows, not(empty()));
+                }
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
@@ -36,6 +36,7 @@ public class MetadataAttribute extends TypedAttribute {
     public static final String INDEX = "_index";
     public static final String TIMESERIES = "_timeseries";
     public static final String SIZE = "_size";
+    public static final String DOC = "_doc";
 
     static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Attribute.class,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
@@ -90,7 +90,7 @@ public class InsertFieldExtraction extends PhysicalOptimizerRules.ParameterizedO
         // This is also correct for LookupJoinExec, where we only need field extraction on the left fields used to match, since the right
         // side is always materialized.
         p.references().forEach(f -> {
-            if (f instanceof FieldAttribute || f instanceof MetadataAttribute) {
+            if ((f instanceof FieldAttribute || f instanceof MetadataAttribute) && EsQueryExec.isDocAttribute(f) == false) {
                 if (input.contains(f) == false) {
                     missing.add(f);
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1485,14 +1485,35 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         );
     }
 
+    private static LogicalPlan injectDocAttribute(Source source, LogicalPlan input) {
+        return input.transformDown(r -> {
+            if (r instanceof UnresolvedRelation unresolved) {
+                List<NamedExpression> metadataFields = unresolved.metadataFields();
+                for (NamedExpression field : metadataFields) {
+                    if (field.name().equals(MetadataAttribute.DOC)) {
+                        return r;
+                    }
+                }
+                return unresolved.addMetadataField(new MetadataAttribute(source, MetadataAttribute.DOC, DataType.DOC_DATA_TYPE, false));
+            }
+            return r;
+        });
+    }
+
     @Override
     public PlanFactory visitMetricsInfoCommand(EsqlBaseParser.MetricsInfoCommandContext ctx) {
-        return input -> new MetricsInfo(source(ctx), input);
+        return input -> {
+            Source source = source(ctx);
+            return new MetricsInfo(source, injectDocAttribute(source, input));
+        };
     }
 
     @Override
     public PlanFactory visitTsInfoCommand(EsqlBaseParser.TsInfoCommandContext ctx) {
-        return input -> new TsInfo(source(ctx), input);
+        return input -> {
+            var source = source(ctx);
+            return new TsInfo(source, injectDocAttribute(source, input));
+        };
     }
 
     private String getValueColumnName(EsqlBaseParser.ValueNameContext ctx, String promqlQuery) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,6 +102,11 @@ public class MetricsInfo extends UnaryPlan implements TelemetryAware, PostAnalys
 
     @Override
     protected AttributeSet computeReferences() {
+        for (Attribute attribute : child().outputSet()) {
+            if (EsQueryExec.isDocAttribute(attribute)) {
+                return AttributeSet.of(attribute);
+            }
+        }
         return child().outputSet();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,6 +102,11 @@ public class TsInfo extends UnaryPlan implements TelemetryAware, PostAnalysisVer
 
     @Override
     protected AttributeSet computeReferences() {
+        for (Attribute attribute : child().outputSet()) {
+            if (EsQueryExec.isDocAttribute(attribute)) {
+                return AttributeSet.of(attribute);
+            }
+        }
         return child().outputSet();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
@@ -12,12 +12,14 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.core.capabilities.Unresolvable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.telemetry.PlanTelemetry;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -136,6 +138,12 @@ public class UnresolvedRelation extends LeafPlan implements Unresolvable, Teleme
 
     public List<NamedExpression> metadataFields() {
         return metadataFields;
+    }
+
+    public UnresolvedRelation addMetadataField(MetadataAttribute newField) {
+        ArrayList<NamedExpression> newFields = new ArrayList<>(metadataFields);
+        newFields.add(newField);
+        return new UnresolvedRelation(source(), indexPattern, frozen, newFields, indexMode, unresolvedMsg, commandName);
     }
 
     public IndexMode indexMode() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -166,6 +166,7 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize, DataSourc
         throw new UnsupportedOperationException("not serialized");
     }
 
+    // TODO: Move this to DataType
     public static boolean isDocAttribute(Attribute attr) {
         // While the user can create columns with the same name as DOC_ID_FIELD, they cannot create a field with the DOC_DATA_TYPE.
         return attr.typeResolved().resolved() && attr.dataType() == DataType.DOC_DATA_TYPE;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MetricsInfoExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MetricsInfoExec.java
@@ -144,7 +144,15 @@ public class MetricsInfoExec extends UnaryExec {
 
     @Override
     protected AttributeSet computeReferences() {
-        return child().outputSet();
+        if (mode.inputPartial) {
+            return super.computeReferences();
+        }
+        for (Attribute attribute : child().outputSet()) {
+            if (EsQueryExec.isDocAttribute(attribute)) {
+                return AttributeSet.of(attribute);
+            }
+        }
+        return AttributeSet.EMPTY;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TsInfoExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TsInfoExec.java
@@ -138,7 +138,15 @@ public class TsInfoExec extends UnaryExec {
 
     @Override
     protected AttributeSet computeReferences() {
-        return child().outputSet();
+        if (mode.inputPartial) {
+            return super.computeReferences();
+        }
+        for (Attribute attribute : child().outputSet()) {
+            if (EsQueryExec.isDocAttribute(attribute)) {
+                return AttributeSet.of(attribute);
+            }
+        }
+        return AttributeSet.EMPTY;
     }
 
     @Override


### PR DESCRIPTION
Both the logical and physical plans for MetricsInfo and TsInfo require _doc at runtime to extract fields. However, neither plan declared a reference to it, which allowed optimizers to drop it. For example, when a dimension field has conflicting types across indices, the optimizer can inject an Eval+Project that strips _doc from the plan.

This change introduces _doc as a metadata attribute injected at parse time for MetricsInfo and TsInfo, and updates `computeReferences` to declare it. This ensures optimizers preserve _doc while still pruning unused document fields. 