### PR TITLE
[9.2] Use query circuit breaker for wildcard/regexp determinization (#145427)

### DIFF
--- a/docs/changelog/145427.yaml
+++ b/docs/changelog/145427.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 145128
+pr: 145427
+summary: Use query circuit breaker for wildcard/regexp determinization
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -108,6 +108,31 @@ public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
         assertQueryMemoryReleasedAfterSearch(new RangeQueryBuilder(KEYWORD_FIELD).gte("key0").lte("key999"));
     }
 
+    public void testCaseInsensitiveWildcardQueryMemoryReleased() throws Exception {
+        WildcardQueryBuilder wildcardQuery = new WildcardQueryBuilder(TEXT_FIELD, "*test*pattern*");
+        wildcardQuery.caseInsensitive(true);
+        assertQueryMemoryReleasedAfterSearch(wildcardQuery);
+    }
+
+    public void testSingleHugeWildcardTripsCircuitBreaker() {
+        createAndPopulateIndex();
+        assertQueryTripsBreaker(new WildcardQueryBuilder(TEXT_FIELD, "*a*b*c*d*e*f*g*h*i*j*k*l*m*n*"));
+    }
+
+    public void testSingleHugeRegexpTripsCircuitBreaker() {
+        createAndPopulateIndex();
+        RegexpQueryBuilder regexpQuery = new RegexpQueryBuilder(TEXT_FIELD, ".*a.*b.*c.*d.*e.*f.*g.*h.*i.*j.*k.*l.*m.*n.*");
+        regexpQuery.maxDeterminizedStates(Integer.MAX_VALUE);
+        assertQueryTripsBreaker(regexpQuery);
+    }
+
+    public void testSingleHugeCaseInsensitiveWildcardTripsCircuitBreaker() {
+        createAndPopulateIndex();
+        WildcardQueryBuilder wildcardQuery = new WildcardQueryBuilder(TEXT_FIELD, "*a*b*c*d*e*f*g*h*i*j*k*l*m*n*");
+        wildcardQuery.caseInsensitive(true);
+        assertQueryTripsBreaker(wildcardQuery);
+    }
+
     private void assertBoolQueryTripsBreaker(int count, IntFunction<QueryBuilder> queryFactory) {
         createAndPopulateIndex();
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -11,10 +11,14 @@ package org.elasticsearch.common.lucene.search;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.AutomatonQuery;
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.lucene.util.automaton.CircuitBreakingOperations;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -67,8 +71,59 @@ public class AutomatonQueries {
     /**
      * Convert Lucene wildcard syntax into an automaton.
      */
-    @SuppressWarnings("fallthrough")
     public static Automaton toCaseInsensitiveWildcardAutomaton(Term wildcardquery) {
+        Automaton nfa = toCaseInsensitiveWildcardNFA(wildcardquery);
+        return Operations.determinize(nfa, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+    }
+
+    /**
+     * Convert Lucene wildcard syntax into an automaton, checking a circuit breaker
+     * during determinization to prevent OOM from huge automatons.
+     */
+    public static Automaton toCaseInsensitiveWildcardAutomaton(Term wildcardquery, CircuitBreaker circuitBreaker) {
+        Automaton nfa = toCaseInsensitiveWildcardNFA(wildcardquery);
+        return CircuitBreakingOperations.determinize(
+            nfa,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            circuitBreaker,
+            "wildcard-ci:" + wildcardquery.field()
+        );
+    }
+
+    /**
+     * Convert Lucene wildcard syntax into a case-sensitive automaton, checking a circuit breaker
+     * during determinization to prevent OOM from huge automatons.
+     */
+    public static Automaton toWildcardAutomaton(Term wildcardquery, CircuitBreaker circuitBreaker) {
+        Automaton nfa = toWildcardNFA(wildcardquery);
+        return CircuitBreakingOperations.determinize(
+            nfa,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            circuitBreaker,
+            "wildcard:" + wildcardquery.field()
+        );
+    }
+
+    /**
+     * Build a deterministic automaton from a regular expression, checking a circuit breaker
+     * during determinization to prevent OOM from huge automatons.
+     */
+    public static Automaton toRegexpAutomaton(
+        Term term,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        CircuitBreaker circuitBreaker
+    ) {
+        Automaton nfa = new RegExp(term.text(), syntaxFlags, matchFlags).toAutomaton();
+        return CircuitBreakingOperations.determinize(nfa, maxDeterminizedStates, circuitBreaker, "regexp:" + term.field());
+    }
+
+    /**
+     * Build the NFA for a case-insensitive wildcard pattern without determinizing.
+     */
+    @SuppressWarnings("fallthrough")
+    static Automaton toCaseInsensitiveWildcardNFA(Term wildcardquery) {
         List<Automaton> automata = new ArrayList<>();
 
         String wildcardText = wildcardquery.text();
@@ -97,7 +152,43 @@ public class AutomatonQueries {
             i += length;
         }
 
-        return Operations.determinize(Operations.concatenate(automata), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        return Operations.concatenate(automata);
+    }
+
+    /**
+     * Build the NFA for a case-sensitive wildcard pattern without determinizing.
+     * This mirrors {@link WildcardQuery#toAutomaton(Term, int)} but stops before the determinize step.
+     */
+    public static Automaton toWildcardNFA(Term wildcardquery) {
+        List<Automaton> automata = new ArrayList<>();
+
+        String wildcardText = wildcardquery.text();
+
+        for (int i = 0; i < wildcardText.length();) {
+            final int c = wildcardText.codePointAt(i);
+            int length = Character.charCount(c);
+            switch (c) {
+                case WILDCARD_STRING:
+                    automata.add(Automata.makeAnyString());
+                    break;
+                case WILDCARD_CHAR:
+                    automata.add(Automata.makeAnyChar());
+                    break;
+                case WILDCARD_ESCAPE:
+                    // add the next codepoint instead, if it exists
+                    if (i + length < wildcardText.length()) {
+                        final int nextChar = wildcardText.codePointAt(i + length);
+                        length += Character.charCount(nextChar);
+                        automata.add(Automata.makeChar(nextChar));
+                        break;
+                    } // else fallthru, lenient parsing with a trailing \
+                default:
+                    automata.add(Automata.makeChar(c));
+            }
+            i += length;
+        }
+
+        return Operations.concatenate(automata);
     }
 
     protected static Automaton toCaseInsensitiveString(BytesRef br) {

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -160,6 +160,7 @@ public class AutomatonQueries {
      * Build the NFA for a case-sensitive wildcard pattern without determinizing.
      * This mirrors {@link WildcardQuery#toAutomaton(Term, int)} but stops before the determinize step.
      */
+    @SuppressWarnings("fallthrough")
     public static Automaton toWildcardNFA(Term wildcardquery) {
         List<Automaton> automata = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -94,6 +94,7 @@ public class AutomatonQueries {
      * Convert Lucene wildcard syntax into a case-sensitive automaton, checking a circuit breaker
      * during determinization to prevent OOM from huge automatons.
      */
+    @SuppressWarnings("fallthrough")
     public static Automaton toWildcardAutomaton(Term wildcardquery, CircuitBreaker circuitBreaker) {
         Automaton nfa = toWildcardNFA(wildcardquery);
         return CircuitBreakingOperations.determinize(

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/CaseInsensitiveWildcardQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/CaseInsensitiveWildcardQuery.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.lucene.search;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.AutomatonQuery;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 
 import static org.elasticsearch.common.lucene.search.AutomatonQueries.toCaseInsensitiveWildcardAutomaton;
 
@@ -26,8 +27,16 @@ public class CaseInsensitiveWildcardQuery extends AutomatonQuery {
         super(term, toCaseInsensitiveWildcardAutomaton(term));
     }
 
+    public CaseInsensitiveWildcardQuery(Term term, CircuitBreaker circuitBreaker) {
+        super(term, toCaseInsensitiveWildcardAutomaton(term, circuitBreaker));
+    }
+
     public CaseInsensitiveWildcardQuery(Term term, boolean isBinary, RewriteMethod rewriteMethod) {
         super(term, toCaseInsensitiveWildcardAutomaton(term), isBinary, rewriteMethod);
+    }
+
+    public CaseInsensitiveWildcardQuery(Term term, boolean isBinary, RewriteMethod rewriteMethod, CircuitBreaker circuitBreaker) {
+        super(term, toCaseInsensitiveWildcardAutomaton(term, circuitBreaker), isBinary, rewriteMethod);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1024,7 +1024,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                     Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
                     return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
                 }
-                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                 
+                return new StringScriptFieldWildcardQuery(
+                    new Script(""),
+                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    name(),
+                    value,
+                    false
+                );
             }
         }
 
@@ -1055,13 +1062,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                     );
                     return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
                 }
-                return new RegexpQuery(
-                    new Term(name(), indexedValueForSearch(value)),
+                return new StringScriptFieldRegexpQuery(
+                    new Script(""),
+                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    name(),
+                    indexedValueForSearch(value).utf8ToString(),
                     syntaxFlags,
                     matchFlags,
-                    RegexpQuery.DEFAULT_PROVIDER,
-                    maxDeterminizedStates,
-                    MultiTermQuery.DOC_VALUES_REWRITE
+                    maxDeterminizedStates
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -996,11 +996,15 @@ public final class KeywordFieldMapper extends FieldMapper {
                         Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
                         return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
                     }
-                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
                 }
 
-                StringFieldScript.LeafFactory leafFactory = ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
-                return new StringScriptFieldWildcardQuery(new Script(""), leafFactory, name(), value, caseInsensitive);
+                return new StringScriptFieldWildcardQuery(
+                    new Script(""),
+                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    name(),
+                    value,
+                    caseInsensitive
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -27,8 +27,11 @@ import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -67,7 +70,6 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldFuzzyQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
-import org.elasticsearch.search.runtime.StringScriptFieldRegexpQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldTermQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 import org.elasticsearch.xcontent.Text;
@@ -988,13 +990,17 @@ public final class KeywordFieldMapper extends FieldMapper {
                 } else {
                     value = indexedValueForSearch(value).utf8ToString();
                 }
-                return new StringScriptFieldWildcardQuery(
-                    new Script(""),
-                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
-                    name(),
-                    value,
-                    caseInsensitive
-                );
+                if (caseInsensitive == false) {
+                    Term term = new Term(name(), value);
+                    if (context.getCircuitBreaker() != null) {
+                        Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
+                        return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                    }
+                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                }
+
+                StringFieldScript.LeafFactory leafFactory = ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
+                return new StringScriptFieldWildcardQuery(new Script(""), leafFactory, name(), value, caseInsensitive);
             }
         }
 
@@ -1009,13 +1015,12 @@ public final class KeywordFieldMapper extends FieldMapper {
                 } else {
                     value = indexedValueForSearch(value).utf8ToString();
                 }
-                return new StringScriptFieldWildcardQuery(
-                    new Script(""),
-                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
-                    name(),
-                    value,
-                    false
-                );
+                Term term = new Term(name(), value);
+                if (context.getCircuitBreaker() != null) {
+                    Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
+                    return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                }
+                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
             }
         }
 
@@ -1035,14 +1040,24 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (matchFlags != 0) {
                     throw new IllegalArgumentException("Match flags not yet implemented [" + matchFlags + "]");
                 }
-                return new StringScriptFieldRegexpQuery(
-                    new Script(""),
-                    ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),
-                    name(),
-                    indexedValueForSearch(value).utf8ToString(),
+                if (context.getCircuitBreaker() != null) {
+                    Term term = new Term(name(), indexedValueForSearch(value));
+                    Automaton dfa = AutomatonQueries.toRegexpAutomaton(
+                        term,
+                        syntaxFlags,
+                        matchFlags,
+                        maxDeterminizedStates,
+                        context.getCircuitBreaker()
+                    );
+                    return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                }
+                return new RegexpQuery(
+                    new Term(name(), indexedValueForSearch(value)),
                     syntaxFlags,
                     matchFlags,
-                    maxDeterminizedStates
+                    RegexpQuery.DEFAULT_PROVIDER,
+                    maxDeterminizedStates,
+                    MultiTermQuery.DOC_VALUES_REWRITE
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -70,6 +70,7 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldFuzzyQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
+import org.elasticsearch.search.runtime.StringScriptFieldRegexpQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldTermQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 import org.elasticsearch.xcontent.Text;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -30,8 +30,6 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.RegexpQuery;
-import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -1024,7 +1022,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
                     return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
                 }
-                 
+
                 return new StringScriptFieldWildcardQuery(
                     new Script(""),
                     ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx),

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -21,13 +21,17 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.lucene.search.CaseInsensitivePrefixQuery;
 import org.elasticsearch.common.lucene.search.CaseInsensitiveWildcardQuery;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Map;
@@ -183,11 +187,28 @@ public abstract class StringFieldType extends TermBasedFieldType {
         } else {
             term = new Term(name(), indexedValueForSearch(value));
         }
+
+        CircuitBreaker circuitBreaker = context.getCircuitBreaker();
         AutomatonQuery query;
-        if (caseInsensitive) {
-            query = method == null ? new CaseInsensitiveWildcardQuery(term) : new CaseInsensitiveWildcardQuery(term, false, method);
+        if (circuitBreaker != null) {
+            if (caseInsensitive) {
+                query = method == null
+                    ? new CaseInsensitiveWildcardQuery(term, circuitBreaker)
+                    : new CaseInsensitiveWildcardQuery(term, false, method, circuitBreaker);
+            } else {
+                Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, circuitBreaker);
+                query = method == null
+                    ? new AutomatonQueryWithDescription(term, dfa, term.text())
+                    : new AutomatonQuery(term, dfa, false, method);
+            }
         } else {
-            query = method == null ? new WildcardQuery(term) : new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
+            if (caseInsensitive) {
+                query = method == null ? new CaseInsensitiveWildcardQuery(term) : new CaseInsensitiveWildcardQuery(term, false, method);
+            } else {
+                query = method == null
+                    ? new WildcardQuery(term)
+                    : new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
+            }
         }
         context.addCircuitBreakerMemory(query.ramBytesUsed(), "wildcard:" + name());
         return query;
@@ -208,16 +229,20 @@ public abstract class StringFieldType extends TermBasedFieldType {
             );
         }
         failIfNotIndexed();
-        AutomatonQuery query = method == null
-            ? new RegexpQuery(new Term(name(), indexedValueForSearch(value)), syntaxFlags, matchFlags, maxDeterminizedStates)
-            : new RegexpQuery(
-                new Term(name(), indexedValueForSearch(value)),
-                syntaxFlags,
-                matchFlags,
-                RegexpQuery.DEFAULT_PROVIDER,
-                maxDeterminizedStates,
-                method
-            );
+
+        AutomatonQuery query;
+        Term term = new Term(name(), indexedValueForSearch(value));
+        CircuitBreaker circuitBreaker = context.getCircuitBreaker();
+        if (circuitBreaker != null) {
+            Automaton dfa = AutomatonQueries.toRegexpAutomaton(term, syntaxFlags, matchFlags, maxDeterminizedStates, circuitBreaker);
+            query = method == null
+                ? new AutomatonQueryWithDescription(term, dfa, "/" + term.text() + "/")
+                : new AutomatonQuery(term, dfa, false, method);
+        } else {
+            query = method == null
+                ? new RegexpQuery(new Term(name(), indexedValueForSearch(value)), syntaxFlags, matchFlags, maxDeterminizedStates)
+                : new RegexpQuery(term, syntaxFlags, matchFlags, RegexpQuery.DEFAULT_PROVIDER, maxDeterminizedStates, method);
+        }
         context.addCircuitBreakerMemory(query.ramBytesUsed(), "regexp:" + name());
         return query;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.TransportVersion;
@@ -22,6 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -286,16 +288,22 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
                 return query;
             }
         }
-        AutomatonQuery query = method == null
-            ? new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates)
-            : new RegexpQuery(
-                new Term(fieldName, BytesRefs.toBytesRef(value)),
+        AutomatonQuery query;
+        Term term = new Term(fieldName, BytesRefs.toBytesRef(value));
+        if (context.getCircuitBreaker() != null) {
+            Automaton dfa = AutomatonQueries.toRegexpAutomaton(
+                term,
                 sanitisedSyntaxFlag,
                 matchFlagsValue,
-                RegexpQuery.DEFAULT_PROVIDER,
                 maxDeterminizedStates,
-                method
+                context.getCircuitBreaker()
             );
+            query = method == null ? new AutomatonQuery(term, dfa) : new AutomatonQuery(term, dfa, false, method);
+        } else {
+            query = method == null
+                ? new RegexpQuery(term, sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates)
+                : new RegexpQuery(term, sanitisedSyntaxFlag, matchFlagsValue, RegexpQuery.DEFAULT_PROVIDER, maxDeterminizedStates, method);
+        }
         context.addCircuitBreakerMemory(query.ramBytesUsed(), "regexp:" + fieldName);
         return query;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -790,6 +790,15 @@ public class SearchExecutionContext extends QueryRewriteContext {
     }
 
     /**
+     * Returns the circuit breaker used for query construction memory accounting, or {@code null}
+     * if none was configured.
+     */
+    @Nullable
+    public CircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    /**
      * Adds memory usage to the circuit breaker for query construction.
      * <p>
      * This method tracks memory used during query construction and enforces circuit breaker limits

--- a/server/src/main/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperations.java
+++ b/server/src/main/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperations.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.util.automaton;
+
+import org.apache.lucene.internal.hppc.BitMixer;
+import org.apache.lucene.internal.hppc.IntCursor;
+import org.apache.lucene.internal.hppc.IntIntHashMap;
+import org.apache.lucene.internal.hppc.IntObjectHashMap;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.apache.lucene.util.automaton.Transition;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides a circuit-breaker-aware variant of {@link Operations#determinize(Automaton, int)}.
+ * <p>
+ * Lucene's {@code Operations.determinize} can allocate memory proportional to the powerset of
+ * the NFA states, which grows exponentially for certain patterns (e.g. {@code .*a.*b.*c.*d.*}).
+ * The standard effort-based work limit ({@code TooComplexToDeterminizeException}) bounds CPU
+ * work but does not directly bound memory. This class periodically estimates the memory consumed
+ * by the growing DFA and intermediate data structures, checking the circuit breaker so that
+ * construction is aborted before an OOM can occur.
+ * <p>
+ * The helper classes below ({@code IntSet}, {@code FrozenIntSet}, {@code StateSet}, etc.) are
+ * copied from Lucene's package-private internals because they cannot be accessed from outside
+ * {@code org.apache.lucene.util.automaton}.
+ *
+ * @see MinimizationOperations
+ */
+public final class CircuitBreakingOperations {
+
+    private CircuitBreakingOperations() {}
+
+    /**
+     * How often (in new-DFA-state increments) we re-estimate memory and check the breaker.
+     * A value of 64 amortizes the per-check overhead while still catching runaway growth early.
+     */
+    private static final int CB_CHECK_INTERVAL = 64;
+
+    /**
+     * Approximate bytes consumed per new DFA state during subset construction. This accounts for:
+     * <ul>
+     *   <li>{@code HashMap.Node}: ~32 bytes (header + hash + key/value/next refs)</li>
+     *   <li>{@code FrozenIntSet}: ~40 bytes (header + int[] ref + state + hashCode) plus the
+     *       backing {@code int[]} whose size depends on the NFA subset size</li>
+     *   <li>{@code Automaton.Builder} per-state storage: 8 bytes (2 ints in {@code states[]})</li>
+     *   <li>Transitions (averaged): ~36 bytes (3 transitions per state × 12 bytes each)</li>
+     * </ul>
+     */
+    private static final long ESTIMATED_BYTES_PER_STATE = 200L;
+
+    /**
+     * Determinizes the given automaton, periodically checking the provided circuit breaker.
+     * <p>
+     * This is functionally equivalent to {@link Operations#determinize(Automaton, int)} but adds
+     * memory accounting. Temporary memory reserved on the breaker during construction is released
+     * before returning (or in the finally block on exception). The caller is responsible for
+     * accounting the final automaton's {@code ramBytesUsed()} separately.
+     *
+     * @param a              the NFA to determinize
+     * @param workLimit      maximum "effort" before throwing {@link TooComplexToDeterminizeException}
+     * @param circuitBreaker the circuit breaker to check (must not be {@code null})
+     * @param label          descriptive label for circuit breaker error messages
+     * @return the determinized automaton
+     * @throws TooComplexToDeterminizeException if effort exceeds {@code workLimit}
+     * @throws org.elasticsearch.common.breaker.CircuitBreakingException if the breaker trips
+     */
+    public static Automaton determinize(Automaton a, int workLimit, CircuitBreaker circuitBreaker, String label) {
+        assert circuitBreaker != null : "circuit breaker must not be null";
+
+        if (a.isDeterministic()) {
+            return a;
+        }
+        if (a.getNumStates() <= 1) {
+            return a;
+        }
+
+        Automaton.Builder b = new Automaton.Builder();
+
+        FrozenIntSet initialset = new FrozenIntSet(new int[] { 0 }, BitMixer.mix(0) + 1, 0);
+
+        b.createState();
+
+        ArrayDeque<FrozenIntSet> worklist = new ArrayDeque<>();
+        Map<IntSet, Integer> newstate = new HashMap<>();
+
+        worklist.add(initialset);
+
+        b.setAccept(0, a.isAccept(0));
+        newstate.put(initialset, 0);
+
+        final PointTransitionSet points = new PointTransitionSet();
+
+        final StateSet statesSet = new StateSet(5);
+
+        Transition t = new Transition();
+
+        long effortSpent = 0;
+
+        // LUCENE-9981: approximate conversion from what used to be a limit on number of states,
+        // to maximum "effort":
+        long effortLimit = workLimit * (long) 10;
+
+        int newStatesCreated = 0;
+        long totalReserved = 0;
+
+        try {
+            while (worklist.size() > 0) {
+                FrozenIntSet s = worklist.removeFirst();
+
+                effortSpent += s.values.length;
+                if (effortSpent >= effortLimit) {
+                    throw new TooComplexToDeterminizeException(a, workLimit);
+                }
+
+                for (int i = 0; i < s.values.length; i++) {
+                    final int s0 = s.values[i];
+                    int numTransitions = a.getNumTransitions(s0);
+                    a.initTransition(s0, t);
+                    for (int j = 0; j < numTransitions; j++) {
+                        a.getNextTransition(t);
+                        points.add(t);
+                    }
+                }
+
+                if (points.count == 0) {
+                    continue;
+                }
+
+                points.sort();
+
+                int lastPoint = -1;
+                int accCount = 0;
+
+                final int r = s.state;
+
+                for (int i = 0; i < points.count; i++) {
+
+                    final int point = points.points[i].point;
+
+                    if (statesSet.size() > 0) {
+                        assert lastPoint != -1;
+
+                        Integer q = newstate.get(statesSet);
+                        if (q == null) {
+                            q = b.createState();
+                            final FrozenIntSet p = statesSet.freeze(q);
+                            worklist.add(p);
+                            b.setAccept(q, accCount > 0);
+                            newstate.put(p, q);
+
+                            newStatesCreated++;
+                            if (newStatesCreated % CB_CHECK_INTERVAL == 0) {
+                                long estimatedNewBytes = CB_CHECK_INTERVAL * ESTIMATED_BYTES_PER_STATE;
+                                circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedNewBytes, label);
+                                totalReserved += estimatedNewBytes;
+                            }
+                        } else {
+                            assert (accCount > 0 ? true : false) == b.isAccept(q)
+                                : "accCount=" + accCount + " vs existing accept=" + b.isAccept(q) + " states=" + statesSet;
+                        }
+
+                        b.addTransition(r, q, lastPoint, point - 1);
+                    }
+
+                    int[] transitions = points.points[i].ends.transitions;
+                    int limit = points.points[i].ends.next;
+                    for (int j = 0; j < limit; j += 3) {
+                        int dest = transitions[j];
+                        statesSet.decr(dest);
+                        accCount -= a.isAccept(dest) ? 1 : 0;
+                    }
+                    points.points[i].ends.next = 0;
+
+                    transitions = points.points[i].starts.transitions;
+                    limit = points.points[i].starts.next;
+                    for (int j = 0; j < limit; j += 3) {
+                        int dest = transitions[j];
+                        statesSet.incr(dest);
+                        accCount += a.isAccept(dest) ? 1 : 0;
+                    }
+                    lastPoint = point;
+                    points.points[i].starts.next = 0;
+                }
+                points.reset();
+                assert statesSet.size() == 0 : "size=" + statesSet.size();
+            }
+        } finally {
+            if (totalReserved > 0) {
+                circuitBreaker.addWithoutBreaking(-totalReserved);
+            }
+        }
+
+        Automaton result = b.finish();
+        assert result.isDeterministic();
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Package-private helper classes copied from Lucene (10.3.2) because
+    // they are not accessible outside org.apache.lucene.util.automaton.
+    // ------------------------------------------------------------------
+
+    abstract static class IntSet {
+        abstract int[] getArray();
+
+        abstract int size();
+
+        abstract long longHashCode();
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(longHashCode());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if ((o instanceof IntSet) == false) return false;
+            IntSet that = (IntSet) o;
+            return longHashCode() == that.longHashCode() && Arrays.equals(getArray(), 0, size(), that.getArray(), 0, that.size());
+        }
+    }
+
+    static final class FrozenIntSet extends IntSet {
+        final int[] values;
+        final int state;
+        final long hashCode;
+
+        FrozenIntSet(int[] values, long hashCode, int state) {
+            this.values = values;
+            this.state = state;
+            this.hashCode = hashCode;
+        }
+
+        @Override
+        int[] getArray() {
+            return values;
+        }
+
+        @Override
+        int size() {
+            return values.length;
+        }
+
+        @Override
+        long longHashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            return Arrays.toString(values);
+        }
+    }
+
+    static final class StateSet extends IntSet {
+        private final IntIntHashMap inner;
+        private long hashCode;
+        private boolean hashUpdated = true;
+        private boolean arrayUpdated = true;
+        private int[] arrayCache = new int[0];
+
+        StateSet(int capacity) {
+            inner = new IntIntHashMap(capacity);
+        }
+
+        void incr(int state) {
+            if (inner.addTo(state, 1) == 1) {
+                keyChanged();
+            }
+        }
+
+        void decr(int state) {
+            assert inner.containsKey(state);
+            int keyIndex = inner.indexOf(state);
+            int count = inner.indexGet(keyIndex) - 1;
+            if (count == 0) {
+                inner.indexRemove(keyIndex);
+                keyChanged();
+            } else {
+                inner.indexReplace(keyIndex, count);
+            }
+        }
+
+        FrozenIntSet freeze(int state) {
+            return new FrozenIntSet(getArray(), longHashCode(), state);
+        }
+
+        private void keyChanged() {
+            hashUpdated = false;
+            arrayUpdated = false;
+        }
+
+        @Override
+        int[] getArray() {
+            if (arrayUpdated) {
+                return arrayCache;
+            }
+            arrayCache = new int[inner.size()];
+            int i = 0;
+            for (IntCursor key : inner.keys()) {
+                arrayCache[i++] = key.value;
+            }
+            Arrays.sort(arrayCache);
+            arrayUpdated = true;
+            return arrayCache;
+        }
+
+        @Override
+        int size() {
+            return inner.size();
+        }
+
+        @Override
+        long longHashCode() {
+            if (hashUpdated) {
+                return hashCode;
+            }
+            hashCode = inner.size();
+            for (IntCursor key : inner.keys()) {
+                hashCode += BitMixer.mix(key.value);
+            }
+            hashUpdated = true;
+            return hashCode;
+        }
+    }
+
+    static final class TransitionList {
+        int[] transitions = new int[3];
+        int next;
+
+        void add(Transition t) {
+            if (transitions.length < next + 3) {
+                transitions = ArrayUtil.grow(transitions, next + 3);
+            }
+            transitions[next] = t.dest;
+            transitions[next + 1] = t.min;
+            transitions[next + 2] = t.max;
+            next += 3;
+        }
+    }
+
+    static final class PointTransitions implements Comparable<PointTransitions> {
+        int point;
+        final TransitionList ends = new TransitionList();
+        final TransitionList starts = new TransitionList();
+
+        @Override
+        public int compareTo(PointTransitions other) {
+            return point - other.point;
+        }
+
+        void reset(int point) {
+            this.point = point;
+            ends.next = 0;
+            starts.next = 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return ((PointTransitions) other).point == point;
+        }
+
+        @Override
+        public int hashCode() {
+            return point;
+        }
+    }
+
+    static final class PointTransitionSet {
+        int count;
+        PointTransitions[] points = new PointTransitions[5];
+
+        private static final int HASHMAP_CUTOVER = 30;
+        private final IntObjectHashMap<PointTransitions> map = new IntObjectHashMap<>();
+        private boolean useHash = false;
+
+        private PointTransitions next(int point) {
+            if (count == points.length) {
+                final PointTransitions[] newArray = new PointTransitions[ArrayUtil.oversize(
+                    1 + count,
+                    RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                )];
+                System.arraycopy(points, 0, newArray, 0, count);
+                points = newArray;
+            }
+            PointTransitions points0 = points[count];
+            if (points0 == null) {
+                points0 = points[count] = new PointTransitions();
+            }
+            points0.reset(point);
+            count++;
+            return points0;
+        }
+
+        private PointTransitions find(int point) {
+            if (useHash) {
+                final Integer pi = point;
+                PointTransitions p = map.get(pi);
+                if (p == null) {
+                    p = next(point);
+                    map.put(pi, p);
+                }
+                return p;
+            } else {
+                for (int i = 0; i < count; i++) {
+                    if (points[i].point == point) {
+                        return points[i];
+                    }
+                }
+
+                final PointTransitions p = next(point);
+                if (count == HASHMAP_CUTOVER) {
+                    assert map.size() == 0;
+                    for (int i = 0; i < count; i++) {
+                        map.put(points[i].point, points[i]);
+                    }
+                    useHash = true;
+                }
+                return p;
+            }
+        }
+
+        void reset() {
+            if (useHash) {
+                map.clear();
+                useHash = false;
+            }
+            count = 0;
+        }
+
+        void sort() {
+            if (count > 1) ArrayUtil.timSort(points, 0, count);
+        }
+
+        void add(Transition t) {
+            find(t.min).starts.add(t);
+            find(1 + t.max).ends.add(t);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperationsTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperationsTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.util.automaton;
+
+import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.lucene.tests.util.automaton.AutomatonTestUtil.subsetOf;
+
+public class CircuitBreakingOperationsTests extends ESTestCase {
+
+    public void testDeterminizeWithNullBreakerThrowsAssertionError() {
+        Automaton a = buildSimpleWildcardNFA("*test*");
+        expectThrows(
+            AssertionError.class,
+            () -> CircuitBreakingOperations.determinize(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, null, "test")
+        );
+    }
+
+    public void testDeterminizeWithLimitedBreakerProducesCorrectResult() {
+        int num = atLeast(50);
+        for (int i = 0; i < num; i++) {
+            Automaton a = AutomatonTestUtil.randomAutomaton(random());
+            Automaton expected = Operations.determinize(a, Integer.MAX_VALUE);
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofGb(1));
+            Automaton actual = CircuitBreakingOperations.determinize(a, Integer.MAX_VALUE, breaker, "test");
+            assertAcceptSameStrings(expected, actual);
+        }
+    }
+
+    public void testDeterminizeWithDeterministicInputReturnsSameInstance() {
+        Automaton a = Automata.makeString("hello");
+        assertTrue(a.isDeterministic());
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+        Automaton result = CircuitBreakingOperations.determinize(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, breaker, "test");
+        assertSame(a, result);
+    }
+
+    public void testDeterminizeWithSingleStateAutomatonReturnsSameInstance() {
+        Automaton a = new Automaton();
+        a.createState();
+        a.finishState();
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+        Automaton result = CircuitBreakingOperations.determinize(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, breaker, "test");
+        assertSame(a, result);
+    }
+
+    public void testDeterminizeExceedingWorkLimitThrowsTooComplex() {
+        Automaton nfa = buildPathologicalNFA(20);
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofGb(1));
+        expectThrows(TooComplexToDeterminizeException.class, () -> CircuitBreakingOperations.determinize(nfa, 10, breaker, "test"));
+    }
+
+    public void testCircuitBreakerTripsOnLargeAutomaton() {
+        Automaton nfa = buildPathologicalNFA(10);
+        CircuitBreaker tripBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(5_000));
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> CircuitBreakingOperations.determinize(nfa, Integer.MAX_VALUE, tripBreaker, "test-label")
+        );
+    }
+
+    public void testBreakerMemoryReleasedOnSuccess() {
+        Automaton nfa = buildSimpleWildcardNFA("*test*");
+        CircuitBreaker trackingBreaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+
+        Automaton result = CircuitBreakingOperations.determinize(nfa, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, trackingBreaker, "test");
+        assertTrue(result.isDeterministic());
+        assertEquals("All temporarily reserved memory should be released after successful determinize", 0, trackingBreaker.getUsed());
+    }
+
+    public void testBreakerMemoryReleasedOnException() {
+        Automaton nfa = buildPathologicalNFA(20);
+        CircuitBreaker tripBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(12_800));
+
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> CircuitBreakingOperations.determinize(nfa, Integer.MAX_VALUE, tripBreaker, "test-label")
+        );
+        assertEquals("All reserved memory should be released after circuit breaker exception", 0, tripBreaker.getUsed());
+    }
+
+    /**
+     * Builds a pathological NFA that causes exponential state blowup during determinization:
+     * .*a.*b.*c.*d... with {@code depth} interleaved wildcards and literals.
+     */
+    private static Automaton buildPathologicalNFA(int depth) {
+        List<Automaton> automata = new ArrayList<>();
+        for (int i = 0; i < depth; i++) {
+            automata.add(Automata.makeAnyString());
+            automata.add(Automata.makeChar('a' + (i % 26)));
+        }
+        automata.add(Automata.makeAnyString());
+        return Operations.concatenate(automata);
+    }
+
+    private static Automaton buildSimpleWildcardNFA(String pattern) {
+        List<Automaton> automata = new ArrayList<>();
+        for (int i = 0; i < pattern.length();) {
+            int c = pattern.codePointAt(i);
+            if (c == '*') {
+                automata.add(Automata.makeAnyString());
+            } else if (c == '?') {
+                automata.add(Automata.makeAnyChar());
+            } else {
+                automata.add(Automata.makeChar(c));
+            }
+            i += Character.charCount(c);
+        }
+        return Operations.concatenate(automata);
+    }
+
+    private static void assertAcceptSameStrings(Automaton expected, Automaton actual) {
+        assertTrue(
+            "Circuit-breaking determinize should produce the same language as Lucene's determinize",
+            subsetOf(expected, actual) && subsetOf(actual, expected)
+        );
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Use query circuit breaker for wildcard/regexp determinization (#145427)](https://github.com/elastic/elasticsearch/pull/145427)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)