### PR TITLE
Throw a 400 error for malformed parsing input when missing element end

### DIFF
--- a/docs/changelog/145777.yaml
+++ b/docs/changelog/145777.yaml
@@ -1,0 +1,5 @@
+area: "Infra/Core, Search"
+issues: []
+pr: 145777
+summary: Throw a 400 error for malformed parsing input when missing element end
+type: bug

--- a/docs/changelog/145777.yaml
+++ b/docs/changelog/145777.yaml
@@ -1,4 +1,4 @@
-area: "Infra/Core, Search"
+area: "Infra/Core"
 issues: []
 pr: 145777
 summary: Throw a 400 error for malformed parsing input when missing element end

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
@@ -640,7 +640,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                  * for having a cheap test.
                  */
                 if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
-                    throwMustEndOn(currentFieldName, XContentParser.Token.END_OBJECT);
+                    throwMustEndOn(parser, currentFieldName, XContentParser.Token.END_OBJECT);
                 }
             }
             case START_ARRAY -> {
@@ -654,7 +654,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                  * for having a cheap test.
                  */
                 if (parser.currentToken() != XContentParser.Token.END_ARRAY) {
-                    throwMustEndOn(currentFieldName, XContentParser.Token.END_ARRAY);
+                    throwMustEndOn(parser, currentFieldName, XContentParser.Token.END_ARRAY);
                 }
             }
             case END_OBJECT, END_ARRAY, FIELD_NAME -> throw throwUnexpectedToken(parser, token);
@@ -668,8 +668,8 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
         }
     }
 
-    private static void throwMustEndOn(String currentFieldName, XContentParser.Token token) {
-        throw new IllegalStateException("parser for [" + currentFieldName + "] did not end on " + token);
+    private static void throwMustEndOn(XContentParser parser, String currentFieldName, XContentParser.Token token) {
+        throw new XContentParseException(parser.getTokenLocation(), "parser for [" + currentFieldName + "] did not end on " + token);
     }
 
     private XContentParseException throwUnexpectedToken(XContentParser parser, XContentParser.Token token) {

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -763,16 +763,16 @@ public class ObjectParserTests extends ESTestCase {
 
         assertEquals("i", parser.parse(createParser(JsonXContent.jsonXContent, "{\"body\": \"i\"}"), null).get());
         Exception garbageException = expectThrows(
-            IllegalStateException.class,
+            XContentParseException.class,
             () -> parser.parse(createParser(JsonXContent.jsonXContent, """
                 {"noop": {"garbage": "shouldn't"}}
                 """), null)
         );
-        assertEquals("parser for [noop] did not end on END_OBJECT", garbageException.getMessage());
-        Exception sneakyException = expectThrows(IllegalStateException.class, () -> parser.parse(createParser(JsonXContent.jsonXContent, """
+        assertThat(garbageException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
+        Exception sneakyException = expectThrows(XContentParseException.class, () -> parser.parse(createParser(JsonXContent.jsonXContent, """
             {"noop": {"body": "shouldn't"}}
             """), null));
-        assertEquals("parser for [noop] did not end on END_OBJECT", sneakyException.getMessage());
+        assertThat(sneakyException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
     }
 
     public void testNoopDeclareField() throws IOException {
@@ -782,10 +782,10 @@ public class ObjectParserTests extends ESTestCase {
 
         assertEquals("i", parser.parse(createParser(JsonXContent.jsonXContent, "{\"body\": \"i\"}"), null).get());
         Exception e = expectThrows(
-            IllegalStateException.class,
+            XContentParseException.class,
             () -> parser.parse(createParser(JsonXContent.jsonXContent, "{\"noop\": [\"ignored\"]}"), null)
         );
-        assertEquals("parser for [noop] did not end on END_ARRAY", e.getMessage());
+        assertThat(e.getMessage(), containsString("parser for [noop] did not end on END_ARRAY"));
     }
 
     public void testNoopDeclareObjectArray() {

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -769,9 +769,12 @@ public class ObjectParserTests extends ESTestCase {
                 """), null)
         );
         assertThat(garbageException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
-        Exception sneakyException = expectThrows(XContentParseException.class, () -> parser.parse(createParser(JsonXContent.jsonXContent, """
-            {"noop": {"body": "shouldn't"}}
-            """), null));
+        Exception sneakyException = expectThrows(
+            XContentParseException.class,
+            () -> parser.parse(createParser(JsonXContent.jsonXContent, """
+                {"noop": {"body": "shouldn't"}}
+                """), null)
+        );
         assertThat(sneakyException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
     }
 


### PR DESCRIPTION
We can see suppressed rest errors when an end element is missing from parsing. 

Retrievers is one place where this can happen:

```
java.lang.IllegalStateException: parser for [retriever] did not end on END_OBJECT
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.ObjectParser.throwMustEndOn(ObjectParser.java:672)
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.ObjectParser.parseSub(ObjectParser.java:643)
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.ObjectParser.parse(ObjectParser.java:316)
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:159)
	at org.elasticsearch.inference@9.4.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.fromXContent(TextSimilarityRankRetrieverBuilder.java:118)
	at org.elasticsearch.inference@9.4.0/org.elasticsearch.xpack.inference.InferencePlugin.lambda$getRetrievers$27(InferencePlugin.java:840)
	at org.elasticsearch.server@9.4.0/org.elasticsearch.search.SearchModule.lambda$registerRetriever$24(SearchModule.java:1287)
	at org.elasticsearch.xcontent@9.4.0/org.elasticsearch.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:149)
```

This PR changes ObjectParser to throw an XContentParseException in case we're missing an end element (object or array).

Related:
- https://github.com/elastic/elasticsearch/pull/111548
- https://github.com/elastic/elasticsearch/issues/112296