### PR TITLE
Enforce using native scorers only when it's possible to get a single segment for the whole input

### DIFF
--- a/libs/simdvec/build.gradle
+++ b/libs/simdvec/build.gradle
@@ -43,9 +43,6 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
   ignoreMissingClasses = true
 }
 
-tasks.named('test').configure {
-  dependsOn 'testJava21'
-}
 
 tasks.withType(CheckForbiddenApisTask).configureEach {
   replaceSignatureFiles 'jdk-signatures'
@@ -55,15 +52,3 @@ def java21Launcher = javaToolchains.launcherFor {
   languageVersion = JavaLanguageVersion.of(21)
 }
 
-tasks.register('testJava21', Test) {
-  description = 'Runs simdvec tests with JDK 21 to verify runtime version guards'
-  group = 'verification'
-  testClassesDirs = sourceSets.test.output.classesDirs
-  classpath = sourceSets.test.runtimeClasspath
-  javaLauncher = java21Launcher
-  executable = java21Launcher.get().executablePath.asFile.absolutePath
-  jvmArgs '--add-modules=jdk.incubator.vector'
-  onlyIf('runtime JDK is not already 21') {
-    buildParams.getRuntimeJavaVersion().get().majorVersion.toInteger() > 21
-  }
-}

--- a/libs/simdvec/build.gradle
+++ b/libs/simdvec/build.gradle
@@ -43,6 +43,9 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
   ignoreMissingClasses = true
 }
 
+tasks.named('test').configure {
+  dependsOn 'testJava21'
+}
 
 tasks.withType(CheckForbiddenApisTask).configureEach {
   replaceSignatureFiles 'jdk-signatures'
@@ -52,3 +55,15 @@ def java21Launcher = javaToolchains.launcherFor {
   languageVersion = JavaLanguageVersion.of(21)
 }
 
+tasks.register('testJava21', Test) {
+  description = 'Runs simdvec tests with JDK 21 to verify runtime version guards'
+  group = 'verification'
+  testClassesDirs = sourceSets.test.output.classesDirs
+  classpath = sourceSets.test.runtimeClasspath
+  javaLauncher = java21Launcher
+  executable = java21Launcher.get().executablePath.asFile.absolutePath
+  jvmArgs '--add-modules=jdk.incubator.vector'
+  onlyIf('runtime JDK is not already 21') {
+    buildParams.getRuntimeJavaVersion().get().majorVersion.toInteger() > 21
+  }
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 
+import java.io.IOException;
 import java.util.Optional;
 
 /** A factory of quantized vector scorers. */
@@ -186,7 +187,7 @@ public interface VectorScorerFactory {
         VectorSimilarityType similarityType,
         IndexInput input,
         org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues values
-    );
+    ) throws IOException;
 
     /**
      * Returns an optional containing an int4 packed-nibble query-time vector scorer
@@ -209,5 +210,5 @@ public interface VectorScorerFactory {
         float upperInterval,
         float additionalCorrection,
         int quantizedComponentSum
-    );
+    ) throws IOException;
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
@@ -25,6 +25,7 @@ import org.elasticsearch.simdvec.internal.ByteVectorScorer;
 import org.elasticsearch.simdvec.internal.ByteVectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.FloatVectorScorer;
 import org.elasticsearch.simdvec.internal.FloatVectorScorerSupplier;
+import org.elasticsearch.simdvec.internal.IndexInputUtils;
 import org.elasticsearch.simdvec.internal.Int4VectorScorer;
 import org.elasticsearch.simdvec.internal.Int4VectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int7SQVectorScorer;
@@ -32,6 +33,7 @@ import org.elasticsearch.simdvec.internal.Int7SQVectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int7uOSQVectorScorer;
 import org.elasticsearch.simdvec.internal.Int7uOSQVectorScorerSupplier;
 
+import java.io.IOException;
 import java.util.Optional;
 
 final class VectorScorerFactoryImpl implements VectorScorerFactory {
@@ -162,6 +164,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
     ) {
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
+        // TODO: remove when we switch to dotProductI7uBulkSparse
         if (input instanceof MemorySegmentAccessInput msInput) {
             checkInvariants(values.size(), values.dimension(), input);
             return switch (similarityType) {
@@ -199,10 +202,14 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         VectorSimilarityType similarityType,
         IndexInput input,
         org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues values
-    ) {
+    ) throws IOException {
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
         checkInvariants(values.size(), values.dimension() / 2, input);
+        // TODO: remove when we switch to dotProductI4BulkSparse
+        if (IndexInputUtils.canGetSingleSegment(input) == false) {
+            return Optional.empty();
+        }
         return Optional.of(new Int4VectorScorerSupplier(input, values, similarityType));
     }
 
@@ -215,7 +222,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         float upperInterval,
         float additionalCorrection,
         int quantizedComponentSum
-    ) {
+    ) throws IOException {
         return Int4VectorScorer.create(
             sim,
             values,

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
@@ -42,8 +42,17 @@ public final class IndexInputUtils {
     /**
      * Returns {@code true} if {@code MemorySegment} slices can be obtained from the specified {@link IndexInput}.
      */
+    @Deprecated
     public static boolean canUseSegmentSlices(IndexInput input) {
         return input instanceof MemorySegmentAccessInput || input instanceof DirectAccessInput;
+    }
+
+    /**
+     * Returns {@code true} if it is possible to obtain a single {@code MemorySegment} slice over the whole specified {@link IndexInput}.
+     */
+    @Deprecated
+    public static boolean canGetSingleSegment(IndexInput input) throws IOException {
+        return input instanceof MemorySegmentAccessInput msai && msai.segmentSliceOrNull(0L, input.length()) != null;
     }
 
     /**

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
@@ -58,13 +58,17 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
         float upperInterval,
         float additionalCorrection,
         int quantizedComponentSum
-    ) {
+    ) throws IOException {
         IndexInput input = values.getSlice();
         if (input == null) {
             return Optional.empty();
         }
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
+        // TODO: remove when we switch to dotProductI4BulkSparse
+        if (IndexInputUtils.canGetSingleSegment(input) == false) {
+            return Optional.empty();
+        }
         return Optional.of(
             new Int4VectorScorer(
                 input,

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorer.java
@@ -58,6 +58,8 @@ public abstract sealed class Int7uOSQVectorScorer extends RandomVectorScorer.Abs
         }
         input = FilterIndexInput.unwrapOnlyTest(input);
         input = MemorySegmentAccessInputAccess.unwrap(input);
+
+        // TODO: remove when we switch to dotProductI7uBulkSparse
         if ((input instanceof MemorySegmentAccessInput) == false) {
             return Optional.empty();
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
@@ -80,11 +80,11 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
     }
 
     @Override
-    public ES92Int7VectorsScorer newES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) {
+    public ES92Int7VectorsScorer newES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) throws IOException {
         IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
         unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
 
-        if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+        if (IndexInputUtils.canGetSingleSegment(unwrappedInput)) {
             return new MemorySegmentES92Int7VectorsScorer(unwrappedInput, dimension, bulkSize);
         }
         return new ES92Int7VectorsScorer(input, dimension, bulkSize);
@@ -96,7 +96,7 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
         if (NATIVE_SUPPORTED) {
             IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
             unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
-            if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
+            if (IndexInputUtils.canGetSingleSegment(unwrappedInput)) {
                 return new NativeBinaryQuantizedVectorScorer(unwrappedInput, dimensions, vectorLengthInBytes);
             }
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
@@ -80,11 +80,11 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
     }
 
     @Override
-    public ES92Int7VectorsScorer newES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) throws IOException {
+    public ES92Int7VectorsScorer newES92Int7VectorsScorer(IndexInput input, int dimension, int bulkSize) {
         IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
         unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);
 
-        if (IndexInputUtils.canGetSingleSegment(unwrappedInput)) {
+        if (IndexInputUtils.canUseSegmentSlices(unwrappedInput)) {
             return new MemorySegmentES92Int7VectorsScorer(unwrappedInput, dimension, bulkSize);
         }
         return new ES92Int7VectorsScorer(input, dimension, bulkSize);

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
@@ -81,7 +81,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         testSimpleImpl(MMapDirectory.DEFAULT_MAX_CHUNK_SIZE);
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testSimpleMaxChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(4, 16);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -155,7 +155,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testRandomNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomNIO"))) {
@@ -163,7 +163,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testRandomMaxChunkSizeSmall() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         long maxChunkSize = randomLongBetween(32, 128);
@@ -246,7 +246,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testRandomScorerNIO() throws IOException {
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomScorerNIO"))) {
             testRandomScorerImpl(dir, FLOAT_ARRAY_RANDOM_FUNC);
@@ -259,7 +259,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testRandomScorerChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -327,7 +327,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testRandomSlice() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         testRandomSliceImpl(30, 64, 1, BYTE_ARRAY_RANDOM_INT4_FUNC);
@@ -430,7 +430,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -484,7 +484,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testBulkNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testBulkNIO"))) {
@@ -540,7 +540,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testBulkWithDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -600,7 +600,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "TODO")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/145779")
     public void testBulkScorerNIO() throws IOException {
         assumeTrue("scorer only supported on JDK 22+", SUPPORTS_HEAP_SEGMENTS);
         assumeTrue(notSupportedMsg(), supported());

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
@@ -81,7 +81,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         testSimpleImpl(MMapDirectory.DEFAULT_MAX_CHUNK_SIZE);
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testSimpleMaxChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(4, 16);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -155,7 +155,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testRandomNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomNIO"))) {
@@ -163,7 +163,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testRandomMaxChunkSizeSmall() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         long maxChunkSize = randomLongBetween(32, 128);
@@ -246,7 +246,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testRandomScorerNIO() throws IOException {
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomScorerNIO"))) {
             testRandomScorerImpl(dir, FLOAT_ARRAY_RANDOM_FUNC);
@@ -259,7 +259,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testRandomScorerChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -327,7 +327,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testRandomSlice() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         testRandomSliceImpl(30, 64, 1, BYTE_ARRAY_RANDOM_INT4_FUNC);
@@ -430,7 +430,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -484,7 +484,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testBulkNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testBulkNIO"))) {
@@ -540,7 +540,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testBulkWithDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -600,7 +600,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl="TODO")
+    @AwaitsFix(bugUrl = "TODO")
     public void testBulkScorerNIO() throws IOException {
         assumeTrue("scorer only supported on JDK 22+", SUPPORTS_HEAP_SEGMENTS);
         assumeTrue(notSupportedMsg(), supported());

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int4VectorScorerFactoryTests.java
@@ -81,6 +81,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         testSimpleImpl(MMapDirectory.DEFAULT_MAX_CHUNK_SIZE);
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testSimpleMaxChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(4, 16);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -154,6 +155,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testRandomNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomNIO"))) {
@@ -161,6 +163,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testRandomMaxChunkSizeSmall() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         long maxChunkSize = randomLongBetween(32, 128);
@@ -243,6 +246,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testRandomScorerNIO() throws IOException {
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomScorerNIO"))) {
             testRandomScorerImpl(dir, FLOAT_ARRAY_RANDOM_FUNC);
@@ -255,6 +259,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testRandomScorerChunkSizeSmall() throws IOException {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
@@ -322,6 +327,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testRandomSlice() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         testRandomSliceImpl(30, 64, 1, BYTE_ARRAY_RANDOM_INT4_FUNC);
@@ -424,6 +430,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -477,6 +484,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testBulkNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testBulkNIO"))) {
@@ -532,6 +540,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testBulkWithDatasetGreaterThanChunkSize() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
@@ -591,6 +600,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl="TODO")
     public void testBulkScorerNIO() throws IOException {
         assumeTrue("scorer only supported on JDK 22+", SUPPORTS_HEAP_SEGMENTS);
         assumeTrue(notSupportedMsg(), supported());
@@ -771,7 +781,6 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         assumeTrue(notSupportedMsg(), supported());
         var factory = AbstractVectorTestCase.factory.get();
 
-        final long maxChunkSize = 32;
         final int dims = 34;
         final float[] centroid = FLOAT_ARRAY_RANDOM_FUNC.apply(dims);
         final float centroidDP = VectorUtil.dotProduct(centroid, centroid);
@@ -783,7 +792,7 @@ public class Int4VectorScorerFactoryTests extends AbstractVectorTestCase {
         byte[] packed2 = packNibbles(unpacked2);
         var correction1 = randomCorrectionPacked(packed1);
         var correction2 = randomCorrectionPacked(packed2);
-        try (Directory dir = new MMapDirectory(createTempDir("testRace"), maxChunkSize)) {
+        try (Directory dir = new MMapDirectory(createTempDir("testRace"))) {
             String fileName = "testRace-" + dims;
             try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
                 writePackedVectorWithCorrection(out, packed1, correction1);


### PR DESCRIPTION
Make all HNSW native scorers using `IndexInputUtils.withSlice` fall back early to non-native scorers in case they cannot slice a single segment for the whole input, so that the copy-to-heap path is avoided. 

NOTE: if we get https://github.com/elastic/elasticsearch/pull/145779 in, this won't be needed and can be closed.
