### PR TITLE
Reindexing add index filter support

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -292,7 +292,7 @@ public class Reindexer {
         // Elasticsearch uses an index-filter when opening a PIT to perform shard-level pruning (removing unnecessary shards from the
         // point-in-time snapshot, improving performance and memory demands). Document filtering still runs for each subsequent pit
         // search. When the source query is null, the effective query is match_all, and we omit the index_filter parameter rather than
-        // explicitly setting it.
+        // explicitly setting it, saving the cost of the match_all search incurred during the shard-level pruning.
         if (searchRequest.source() != null && searchRequest.source().query() != null) {
             pitRequest.indexFilter(searchRequest.source().query());
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -283,12 +283,18 @@ public class Reindexer {
         assert searchRequest.allowPartialSearchResults() == null || searchRequest.allowPartialSearchResults() == false
             : "allow_partial_search_results must be false when opening a PIT to match scroll search behavior";
 
-        // TODO - Do we need to set the IndexFilter field here? https://github.com/elastic/elasticsearch-team/issues/2392
         OpenPointInTimeRequest pitRequest = new OpenPointInTimeRequest(indices).indicesOptions(searchRequest.indicesOptions())
             .keepAlive(pitKeepAlive(request))
             .allowPartialSearchResults(false);
         if (searchRequest.getProjectRouting() != null) {
             pitRequest.projectRouting(searchRequest.getProjectRouting());
+        }
+        // Elasticsearch uses an index-filter when opening a PIT to perform shard-level pruning (removing unnecessary shards from the
+        // point-in-time snapshot, improving performance and memory demands). Document filtering still runs for each subsequent pit
+        // search. When the source query is null, the effective query is match_all, and we omit the index_filter parameter rather than
+        // explicitly setting it.
+        if (searchRequest.source() != null && searchRequest.source().query() != null) {
+            pitRequest.indexFilter(searchRequest.source().query());
         }
 
         // NB this is a local request, so we call the TransportAction rather than issuing a REST call

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
@@ -86,13 +86,7 @@ public class RemoteReindexingUtils {
         assert request.preference() == null : "Preference is set in the search request, but is not being used when opening the PIT.";
         assert request.allowPartialSearchResults() == null || request.allowPartialSearchResults() == false
             : "allow_partial_search_results must be false when opening a PIT to match scroll search behavior";
-        execute(
-            RemoteRequestBuilders.openPit(indices, keepAlive, request.getProjectRouting()),
-            OPEN_PIT_PARSER,
-            listener,
-            threadPool,
-            client
-        );
+        execute(RemoteRequestBuilders.openPit(indices, keepAlive, request), OPEN_PIT_PARSER, listener, threadPool, client);
     }
 
     /**

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -185,17 +186,31 @@ final class RemoteRequestBuilders {
         return request;
     }
 
-    // TODO - Do we need to set the IndexFilter field here? https://github.com/elastic/elasticsearch-team/issues/2392
-    static Request openPit(String[] indices, TimeValue keepAlive, @Nullable String projectRouting) {
+    /**
+     * Builds POST /{index}/_pit. Optional JSON body may include {@code project_routing} and/or {@code index_filter}
+     * (from {@link SearchRequest#getProjectRouting()} and {@link org.elasticsearch.search.builder.SearchSourceBuilder#query()}).
+     */
+    static Request openPit(String[] indices, TimeValue keepAlive, SearchRequest searchRequest) {
         StringBuilder path = new StringBuilder("/");
         addIndices(path, indices);
         path.append("_pit");
         Request request = new Request("POST", path.toString());
         request.addParameter("keep_alive", keepAlive.getStringRep());
         request.addParameter("allow_partial_search_results", "false");
-        if (projectRouting != null) {
+
+        String projectRouting = searchRequest.getProjectRouting();
+        QueryBuilder indexFilter = searchRequest.source() != null ? searchRequest.source().query() : null;
+        if (projectRouting != null || indexFilter != null) {
             try (XContentBuilder entity = JsonXContent.contentBuilder()) {
-                entity.startObject().field("project_routing", projectRouting).endObject();
+                entity.startObject();
+                if (projectRouting != null) {
+                    entity.field("project_routing", projectRouting);
+                }
+                if (indexFilter != null) {
+                    entity.field("index_filter");
+                    indexFilter.toXContent(entity, ToXContent.EMPTY_PARAMS);
+                }
+                entity.endObject();
                 request.setJsonEntity(Strings.toString(entity));
             } catch (IOException e) {
                 throw new ElasticsearchException("unexpected error building open pit entity", e);

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
@@ -187,8 +187,7 @@ final class RemoteRequestBuilders {
     }
 
     /**
-     * Builds POST /{index}/_pit. Optional JSON body may include {@code project_routing} and/or {@code index_filter}
-     * (from {@link SearchRequest#getProjectRouting()} and {@link org.elasticsearch.search.builder.SearchSourceBuilder#query()}).
+     * Builds a {@code POST /{index}/_pit} request. Optional JSON body may include {@code project_routing} and/or {@code index_filter}
      */
     static Request openPit(String[] indices, TimeValue keepAlive, SearchRequest searchRequest) {
         StringBuilder path = new StringBuilder("/");

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.PaginatedSearchFailure;
@@ -1010,6 +1011,79 @@ public class ReindexerTests extends ESTestCase {
                 assertNull("routing should not be set", pitRequest.routing());
                 assertNull("preference should not be set", pitRequest.preference());
                 assertFalse("allowPartialSearchResults should be false", pitRequest.allowPartialSearchResults());
+            } finally {
+                terminate(threadPool);
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * This tests that when a source query is provided, the open pit request includes an index filter.
+     * The case when the source query is null is tested in {@link #testLocalOpenPitRequestHasExpectedProperties} above
+     */
+    public void testLocalOpenPitSetsIndexFilterFromSourceQuery() {
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+
+        final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
+        try {
+            final TestThreadPool threadPool = new TestThreadPool(getTestName()) {
+                @Override
+                public ExecutorService executor(String name) {
+                    return DIRECT_EXECUTOR_SERVICE;
+                }
+            };
+            try {
+                final ClusterService clusterService = mock(ClusterService.class);
+                final DiscoveryNode localNode = DiscoveryNodeUtils.builder("local-node").build();
+                when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
+                when(clusterService.localNode()).thenReturn(localNode);
+
+                final ProjectResolver projectResolver = mock(ProjectResolver.class);
+                when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
+
+                FeatureService featureService = mock(FeatureService.class);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+
+                final Reindexer reindexer = new Reindexer(
+                    clusterService,
+                    projectResolver,
+                    client,
+                    threadPool,
+                    mock(ScriptService.class),
+                    mock(ReindexSslConfig.class),
+                    null,
+                    mock(TransportService.class),
+                    mock(ReindexRelocationNodePicker.class),
+                    featureService
+                );
+
+                final var termQuery = QueryBuilders.termQuery("field", "value");
+                final ReindexRequest request = new ReindexRequest();
+                request.setSourceIndices("source");
+                request.setDestIndex("dest");
+                request.setSlices(1);
+                request.getSearchRequest().source().query(termQuery);
+
+                final BulkByScrollTask task = new BulkByScrollTask(
+                    randomTaskId(),
+                    "reindex",
+                    "reindex",
+                    "test",
+                    TaskId.EMPTY_TASK_ID,
+                    Collections.emptyMap(),
+                    false,
+                    randomOrigin()
+                );
+
+                final PlainActionFuture<BulkByScrollResponse> initFuture = new PlainActionFuture<>();
+                reindexer.initTask(task, request, initFuture.delegateFailure((l, v) -> reindexer.execute(task, request, client, l)));
+                initFuture.actionGet();
+
+                OpenPointInTimeRequest pitRequest = client.getCapturedPitRequest();
+                assertNotNull(pitRequest);
+                assertSame(termQuery, pitRequest.indexFilter());
             } finally {
                 terminate(threadPool);
             }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
@@ -482,8 +482,7 @@ public class RemoteReindexingUtilsTests extends ESTestCase {
     }
 
     /**
-     * Verifies that open PIT sends {@code index_filter} in the JSON body when the source {@link SearchRequest} has a query,
-     * matching {@link org.elasticsearch.reindex.remote.RemoteRequestBuilders#openPit}.
+     * Verifies that open PIT sends {@code index_filter} in the JSON body when the source {@link SearchRequest} has a query
      */
     public void testOpenPitSuccessWithIndexFilterInRequestBody() throws IOException {
         byte[] pitIdBytes = randomByteArrayOfLength(between(1, 64));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.ResponseListener;
@@ -30,19 +31,25 @@ import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.RejectAwareActionListener;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -472,6 +479,48 @@ public class RemoteReindexingUtilsTests extends ESTestCase {
         );
         assertTrue("listener should have received success", success.get());
         assertArrayEquals(pitIdBytes, BytesReference.toBytes(capturedPitId[0]));
+    }
+
+    /**
+     * Verifies that open PIT sends {@code index_filter} in the JSON body when the source {@link SearchRequest} has a query,
+     * matching {@link org.elasticsearch.reindex.remote.RemoteRequestBuilders#openPit}.
+     */
+    public void testOpenPitSuccessWithIndexFilterInRequestBody() throws IOException {
+        byte[] pitIdBytes = randomByteArrayOfLength(between(1, 64));
+        String base64Id = Base64.getUrlEncoder().encodeToString(pitIdBytes);
+        String json = "{\"id\":\"" + base64Id + "\"}";
+        Response response = mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity(json, ContentType.APPLICATION_JSON));
+        mockSuccess(response);
+
+        String index = randomAlphaOfLength(between(1, 10));
+        SearchRequest searchRequest = new SearchRequest().indices(index);
+        searchRequest.source(new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
+        AtomicBoolean success = new AtomicBoolean(false);
+        BytesReference[] capturedPitId = new BytesReference[1];
+        RemoteReindexingUtils.openPit(
+            searchRequest,
+            new String[] { index },
+            TimeValue.timeValueMillis(between(1, 60000)),
+            RejectAwareActionListener.wrap(pitId -> {
+                capturedPitId[0] = pitId;
+                success.set(true);
+            }, e -> fail("unexpected failure"), e -> fail("unexpected rejection")),
+            threadPool,
+            client
+        );
+        assertTrue("listener should have received success", success.get());
+        assertArrayEquals(pitIdBytes, BytesReference.toBytes(capturedPitId[0]));
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(client, times(1)).performRequestAsync(requestCaptor.capture(), any());
+        Request capturedRequest = requestCaptor.getValue();
+        assertNotNull(capturedRequest.getEntity());
+        String body = Streams.copyToString(new InputStreamReader(capturedRequest.getEntity().getContent(), StandardCharsets.UTF_8));
+        assertThat(body, containsString("\"index_filter\""));
+        assertThat(body, containsString("term"));
+        assertThat(body, containsString("\"field\""));
+        assertThat(body, containsString("\"value\""));
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
@@ -642,6 +642,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         String body = Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8));
         assertThat(body, containsString("\"project_routing\":\"" + projectRouting + "\""));
     }
+
     public void testOpenPitBodyIncludesIndexFilterWhenQuerySet() throws IOException {
         String index = randomAlphaOfLength(between(1, 20));
         TimeValue keepAlive = randomPositiveTimeValue();

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteRequestBuildersTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
@@ -347,7 +348,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
     public void testOpenPitSingleIndex() {
         String index = randomAlphaOfLength(between(1, 20));
         TimeValue keepAlive = randomPositiveTimeValue();
-        Request request = openPit(new String[] { index }, keepAlive, null);
+        Request request = openPit(new String[] { index }, keepAlive, emptySearchRequestForOpenPit());
         assertEquals("POST", request.getMethod());
         assertEquals("/" + index + "/_pit", request.getEndpoint());
         assertThat(request.getParameters(), hasEntry("keep_alive", keepAlive.getStringRep()));
@@ -370,7 +371,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         }
         expectedPath.append("/_pit");
         TimeValue keepAlive = randomPositiveTimeValue();
-        Request request = openPit(indices, keepAlive, null);
+        Request request = openPit(indices, keepAlive, emptySearchRequestForOpenPit());
         assertEquals("POST", request.getMethod());
         assertEquals(expectedPath.toString(), request.getEndpoint());
         assertThat(request.getParameters(), hasEntry("keep_alive", keepAlive.getStringRep()));
@@ -382,13 +383,13 @@ public class RemoteRequestBuildersTests extends ESTestCase {
      */
     public void testOpenPitNullOrEmptyIndices() {
         TimeValue keepAlive = randomPositiveTimeValue();
-        Request nullRequest = openPit(null, keepAlive, null);
+        Request nullRequest = openPit(null, keepAlive, emptySearchRequestForOpenPit());
         assertEquals("POST", nullRequest.getMethod());
         assertEquals("/_pit", nullRequest.getEndpoint());
         assertThat(nullRequest.getParameters(), hasEntry("keep_alive", keepAlive.getStringRep()));
         assertThat(nullRequest.getParameters(), hasEntry("allow_partial_search_results", "false"));
 
-        Request emptyRequest = openPit(new String[] {}, keepAlive, null);
+        Request emptyRequest = openPit(new String[] {}, keepAlive, emptySearchRequestForOpenPit());
         assertEquals("POST", emptyRequest.getMethod());
         assertEquals("/_pit", emptyRequest.getEndpoint());
         assertThat(emptyRequest.getParameters(), hasEntry("keep_alive", keepAlive.getStringRep()));
@@ -401,7 +402,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
     public void testOpenPitEncodesSpecialCharactersInIndices() {
         String prefix1 = randomAlphaOfLength(between(1, 5));
         String prefix2 = randomAlphaOfLength(between(1, 5));
-        Request request = openPit(new String[] { prefix1 + ",", prefix2 + "/" }, randomPositiveTimeValue(), null);
+        Request request = openPit(new String[] { prefix1 + ",", prefix2 + "/" }, randomPositiveTimeValue(), emptySearchRequestForOpenPit());
         assertEquals("POST", request.getMethod());
         assertEquals("/" + prefix1 + "%2C," + prefix2 + "%2F/_pit", request.getEndpoint());
         assertThat(request.getParameters(), hasEntry("allow_partial_search_results", "false"));
@@ -413,17 +414,17 @@ public class RemoteRequestBuildersTests extends ESTestCase {
     public void testOpenPitKeepAliveParameter() {
         String index = randomAlphaOfLength(between(1, 10));
         long millis = between(1, 100000);
-        var params = openPit(new String[] { index }, timeValueMillis(millis), null).getParameters();
+        var params = openPit(new String[] { index }, timeValueMillis(millis), emptySearchRequestForOpenPit()).getParameters();
         assertThat(params, hasEntry("allow_partial_search_results", "false"));
         assertThat(params, hasEntry("keep_alive", TimeValue.timeValueMillis(millis).getStringRep()));
         int minutes = between(1, 60);
         assertThat(
-            openPit(new String[] { index }, TimeValue.timeValueMinutes(minutes), null).getParameters(),
+            openPit(new String[] { index }, TimeValue.timeValueMinutes(minutes), emptySearchRequestForOpenPit()).getParameters(),
             hasEntry("keep_alive", TimeValue.timeValueMinutes(minutes).getStringRep())
         );
         int hours = between(1, 24);
         assertThat(
-            openPit(new String[] { index }, TimeValue.timeValueHours(hours), null).getParameters(),
+            openPit(new String[] { index }, TimeValue.timeValueHours(hours), emptySearchRequestForOpenPit()).getParameters(),
             hasEntry("keep_alive", TimeValue.timeValueHours(hours).getStringRep())
         );
     }
@@ -634,10 +635,38 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         String index = randomAlphaOfLength(between(1, 20));
         TimeValue keepAlive = randomPositiveTimeValue();
         String projectRouting = "_alias:linked";
-        Request request = openPit(new String[] { index }, keepAlive, projectRouting);
+        SearchRequest searchRequest = emptySearchRequestForOpenPit();
+        searchRequest.setProjectRouting(projectRouting);
+        Request request = openPit(new String[] { index }, keepAlive, searchRequest);
         assertNotNull(request.getEntity());
         String body = Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8));
         assertThat(body, containsString("\"project_routing\":\"" + projectRouting + "\""));
+    }
+    public void testOpenPitBodyIncludesIndexFilterWhenQuerySet() throws IOException {
+        String index = randomAlphaOfLength(between(1, 20));
+        TimeValue keepAlive = randomPositiveTimeValue();
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().query(QueryBuilders.termQuery("k", "v")));
+        Request request = openPit(new String[] { index }, keepAlive, searchRequest);
+        assertNotNull(request.getEntity());
+        String body = Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8));
+        assertThat(body, containsString("\"index_filter\""));
+        assertThat(body, containsString("term"));
+        assertThat(body, containsString("\"k\""));
+        assertThat(body, containsString("\"v\""));
+    }
+
+    public void testOpenPitBodyIncludesProjectRoutingAndIndexFilterWhenBothSet() throws IOException {
+        String index = randomAlphaOfLength(between(1, 20));
+        TimeValue keepAlive = randomPositiveTimeValue();
+        String projectRouting = "_alias:linked";
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
+        searchRequest.setProjectRouting(projectRouting);
+        Request request = openPit(new String[] { index }, keepAlive, searchRequest);
+        assertNotNull(request.getEntity());
+        String body = Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8));
+        assertThat(body, containsString("\"project_routing\":\"" + projectRouting + "\""));
+        assertThat(body, containsString("\"index_filter\""));
+        assertThat(body, containsString("match_all"));
     }
 
     /**
@@ -734,6 +763,10 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         String body = Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8));
         assertThat(body.trim(), startsWith("{"));
         assertThat(body.trim(), endsWith("}"));
+    }
+
+    private static SearchRequest emptySearchRequestForOpenPit() {
+        return new SearchRequest().source(new SearchSourceBuilder());
     }
 
     private Request pitSearchWithDefaults(SearchRequest searchRequest, @Nullable Object[] searchAfter) {


### PR DESCRIPTION
Extends the reindexing point-in-time request to use an index filter to perform shard-level pruning.

Closes: https://github.com/elastic/elasticsearch-team/issues/2392