### PR TITLE
ESQL: don't use a Literal for constant_keyword fields when used inside full-text functions (#145632)

### DIFF
--- a/docs/changelog/145632.yaml
+++ b/docs/changelog/145632.yaml
@@ -1,0 +1,7 @@
+area: ES|QL
+issues:
+ - 145570
+pr: 145632
+summary: Don't use a Literal for `constant_keyword` fields when used inside full-text
+  functions
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -908,3 +908,33 @@ book_no:keyword | author:text
 2883            | William Faulkner
 3293            | Danny Faulkner
 ;
+;
+matchOnConstantKeywordField
+required_capability: match_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match(`constant_keyword-foo`, "foo")
+| keep `constant_keyword-foo`, keyword
+| sort keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+foo                          | key1
+foo                          | key2
+foo                          | key3
+foo                          | key4
+foo                          | key5
+;
+
+matchOnConstantKeywordFieldNoMatch
+required_capability: match_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match(`constant_keyword-foo`, "bar")
+| keep `constant_keyword-foo`, keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -802,3 +802,32 @@ from books
 c:long
 22
 ;
+matchOperatorOnConstantKeywordField
+required_capability: match_operator_colon
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where `constant_keyword-foo` : "foo"
+| keep `constant_keyword-foo`, keyword
+| sort keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+foo                          | key1
+foo                          | key2
+foo                          | key3
+foo                          | key4
+foo                          | key5
+;
+
+matchOperatorOnConstantKeywordFieldNoMatch
+required_capability: match_operator_colon
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where `constant_keyword-foo` : "bar"
+| keep `constant_keyword-foo`, keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
@@ -453,3 +453,77 @@ from books
 
 book_no:keyword
 ;
+matchPhraseOnConstantKeywordField
+required_capability: match_phrase_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match_phrase(`constant_keyword-foo`, "foo")
+| keep `constant_keyword-foo`, keyword
+| sort keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+foo                          | key1
+foo                          | key2
+foo                          | key3
+foo                          | key4
+foo                          | key5
+;
+
+matchPhraseOnConstantKeywordFieldNoMatch
+required_capability: match_phrase_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match_phrase(`constant_keyword-foo`, "bar")
+| keep `constant_keyword-foo`, keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+;
+
+matchPhraseOnConstantKeywordFieldWithOtherConditions
+required_capability: match_phrase_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match_phrase(`constant_keyword-foo`, "foo") and integer > 3
+| keep `constant_keyword-foo`, integer
+| sort integer
+;
+
+constant_keyword-foo:keyword | integer:integer
+foo                          | 4
+foo                          | 5
+;
+
+matchPhraseOnRegularFieldWithConstantKeywordEquality
+required_capability: match_phrase_function
+required_capability: fix_full_text_functions_on_constant_keyword
+
+from all_types
+| where match_phrase(text, "text3") and `constant_keyword-foo` == "foo"
+| keep text, `constant_keyword-foo`
+;
+
+text:text | constant_keyword-foo:keyword
+text3     | foo
+;
+
+matchPhraseOnConstantKeywordFieldInsideFork
+required_capability: match_phrase_function
+required_capability: fix_full_text_functions_on_constant_keyword
+required_capability: fork_v9
+
+from all_types
+| FORK (where integer > 3)
+       (where match_phrase(`constant_keyword-foo`, "foo") and keyword == "key2")
+| WHERE _fork == "fork2"
+| DROP _fork
+| keep `constant_keyword-foo`, keyword
+;
+
+constant_keyword-foo:keyword | keyword:keyword
+foo                          | key2
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1727,6 +1727,13 @@ public class EsqlCapabilities {
 
         KEYWORDS_MV_COUNT_AS_SINGLE_VALUE_FIX,
 
+        /**
+         * Fix for full-text functions (MATCH, MATCH_PHRASE, :) on constant_keyword fields.
+         * The optimizer no longer replaces their field arguments with literal constants.
+         * See https://github.com/elastic/elasticsearch/issues/145570
+         */
+        FIX_FULL_TEXT_FUNCTIONS_ON_CONSTANT_KEYWORD,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceFieldWithConstantOrNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceFieldWithConstantOrNull.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.RuleUtils;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -110,9 +111,18 @@ public class ReplaceFieldWithConstantOrNull extends ParameterizedRule<LogicalPla
             || plan instanceof OrderBy
             || plan instanceof RegexExtract
             || plan instanceof TopN) {
-            return plan.transformExpressionsOnlyUp(FieldAttribute.class, f -> {
+
+            // full-text functions need actual index fields to construct Lucene queries
+            // Note: AttributeSet uses semanticEquals for lookups, so any FieldAttribute that refers to the same underlying field as
+            // one used inside a FullTextFunction is protected here, even if it also appears outside the function (e.g. in a plain equality
+            // check). This slight loss of constant-folding opportunity is intentional to keep the logic simple.
+            var fullTextFieldArgsBuilder = AttributeSet.builder();
+            plan.forEachExpression(FullTextFunction.class, ftf -> ftf.forEachDown(FieldAttribute.class, fullTextFieldArgsBuilder::add));
+            AttributeSet fullTextFieldArgs = fullTextFieldArgsBuilder.build();
+
+            LogicalPlan transformed = plan.transformExpressionsOnlyUp(FieldAttribute.class, f -> {
                 if (attrToConstant.containsKey(f)) {// handle constant values field and use the value itself instead
-                    return attrToConstant.get(f);
+                    return fullTextFieldArgs.contains(f) ? f : attrToConstant.get(f);
                 } else {// handle missing fields and replace them with null
                     return shouldBeRetained.test(f) ? f : Literal.of(f, null);
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -108,6 +108,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -1144,6 +1145,136 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var filter = as(limit.child(), Filter.class);
         var fullTextFunction = as(filter.condition(), SingleFieldFullTextFunction.class);
         assertThat(Expressions.name(fullTextFunction.field()), equalTo("text"));
+    }
+
+    public void testFullTextFunctionOnConstantField() {
+        String functionName = randomFrom("match", "match_phrase");
+        var plan = plan(String.format(Locale.ROOT, """
+            from test
+            | where %s(first_name, "John")
+            """, functionName));
+
+        var searchStats = new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public String constantValue(FieldAttribute.FieldName name) {
+                if (name.string().equals("first_name")) {
+                    return "John";
+                }
+                return null;
+            }
+        };
+        var localPlan = localPlan(plan, searchStats);
+
+        var limit = as(localPlan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var fullTextFunction = as(filter.condition(), SingleFieldFullTextFunction.class);
+        // The field must remain a FieldAttribute — not replaced with a constant Literal
+        assertThat(fullTextFunction.field(), instanceOf(FieldAttribute.class));
+        assertThat(Expressions.name(fullTextFunction.field()), equalTo("first_name"));
+    }
+
+    public void testConstantFieldReplacedOutsideFullTextFunction() {
+        var plan = plan("""
+            from test
+            | where match_phrase(first_name, "John") and last_name == "Doe"
+            """);
+
+        var searchStats = new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public String constantValue(FieldAttribute.FieldName name) {
+                if (name.string().equals("last_name")) {
+                    return "Doe";
+                }
+                return null;
+            }
+        };
+        var localPlan = localPlan(plan, searchStats);
+
+        var limit = as(localPlan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        // last_name is a constant field with value "Doe", so last_name == "Doe" folds to true
+        // and is eliminated from the AND, leaving only the full-text function in the condition.
+        // If constant substitution had NOT happened, the condition would still be an And.
+        var matchPhrase = as(filter.condition(), SingleFieldFullTextFunction.class);
+        assertThat(matchPhrase.field(), instanceOf(FieldAttribute.class));
+        assertThat(Expressions.name(matchPhrase.field()), equalTo("first_name"));
+    }
+
+    public void testMatchOperatorOnConstantField() {
+        var plan = plan("""
+            from test
+            | where first_name : "John"
+            """);
+
+        var searchStats = new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public String constantValue(FieldAttribute.FieldName name) {
+                if (name.string().equals("first_name")) {
+                    return "John";
+                }
+                return null;
+            }
+        };
+        var localPlan = localPlan(plan, searchStats);
+
+        var limit = as(localPlan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var matchOp = as(filter.condition(), SingleFieldFullTextFunction.class);
+        assertThat(matchOp.field(), instanceOf(FieldAttribute.class));
+        assertThat(Expressions.name(matchOp.field()), equalTo("first_name"));
+    }
+
+    public void testSameConstantFieldProtectedInFullTextAndOutside() {
+        var plan = plan("""
+            from test
+            | where match(first_name, "John") and first_name == "John"
+            """);
+
+        var searchStats = new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public String constantValue(FieldAttribute.FieldName name) {
+                if (name.string().equals("first_name")) {
+                    return "John";
+                }
+                return null;
+            }
+        };
+        var localPlan = localPlan(plan, searchStats);
+
+        var limit = as(localPlan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        // first_name is protected everywhere because it appears in a full-text function;
+        // semantic equality in AttributeSet means all references to the same field are kept.
+        filter.condition().forEachDown(FieldAttribute.class, fa -> assertThat(Expressions.name(fa), equalTo("first_name")));
+        filter.condition().forEachDown(SingleFieldFullTextFunction.class, ftf -> assertThat(ftf.field(), instanceOf(FieldAttribute.class)));
+    }
+
+    public void testMultipleFullTextFunctionsOnConstantFields() {
+        var plan = plan("""
+            from test
+            | where match(first_name, "John") and match_phrase(last_name, "Doe")
+            """);
+
+        var searchStats = new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public String constantValue(FieldAttribute.FieldName name) {
+                if (name.string().equals("first_name") || name.string().equals("last_name")) {
+                    return "constant";
+                }
+                return null;
+            }
+        };
+        var localPlan = localPlan(plan, searchStats);
+
+        var limit = as(localPlan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var and = as(filter.condition(), And.class);
+        var match = as(and.left(), SingleFieldFullTextFunction.class);
+        assertThat(match.field(), instanceOf(FieldAttribute.class));
+        assertThat(Expressions.name(match.field()), equalTo("first_name"));
+        var matchPhrase = as(and.right(), SingleFieldFullTextFunction.class);
+        assertThat(matchPhrase.field(), instanceOf(FieldAttribute.class));
+        assertThat(Expressions.name(matchPhrase.field()), equalTo("last_name"));
     }
 
     private IsNotNull isNotNull(Expression field) {


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/145632
(cherry picked from commit 5e46b506682a40bd59f7d443ed04ee4b6391afeb)