### PR TITLE
[DOCS] memory circuit breaker for synonym token filters

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md
@@ -163,3 +163,17 @@ The request breaker settings (`indices.breaker.request.limit`, `indices.breaker.
 `breaker.model_inference.type`
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The underlying type of the circuit breaker. There are two valid options: `noop` and `memory`. `noop` means the circuit breaker does nothing to prevent too much memory usage. `memory` means the circuit breaker tracks the memory used by trained models and can potentially break and prevent `OutOfMemory` errors. The default value is `memory`.
 
+
+## Synonym circuit breaker [circuit-breakers-page-synonym]
+
+```{applies_to}
+stack: ga 9.4
+serverless: ga
+```
+
+The [`synonym`](/reference/text-analysis/analysis-synonym-tokenfilter.md) and [`synonym_graph`](/reference/text-analysis/analysis-synonym-graph-tokenfilter.md) token filters check real heap memory usage when building the synonyms map, to prevent large synonym sets from causing out-of-memory errors. This check uses the [parent circuit breaker](#parent-circuit-breaker), which trips when memory usage exceeds the `indices.breaker.total.limit` threshold (defaults to 95% of JVM heap when `indices.breaker.total.use_real_memory` is `true`).
+
+The threshold is configurable using the [parent circuit breaker settings](#parent-circuit-breaker). {applies_to}`serverless: unavailable`
+
+For details on behavior when the circuit breaker trips, refer to the [synonym token filter](/reference/text-analysis/analysis-synonym-tokenfilter.md#synonym-tokenizer-circuit-breaker) and [synonym graph token filter](/reference/text-analysis/analysis-synonym-graph-tokenfilter.md#synonym-graph-tokenizer-circuit-breaker) documentation.
+

--- a/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
@@ -233,3 +233,19 @@ For example, a synonym rule like `foo, bar => baz` and a stop filter that remove
 
 If the stop filter removed `foo` instead, then searching for `foo` would get expanded to `baz`, which is not removed by the stop filter thus potentially providing matches for `baz`.
 
+
+## Memory circuit breaker [synonym-graph-tokenizer-circuit-breaker]
+
+```{applies_to}
+stack: ga 9.4
+serverless: ga
+```
+
+When building the synonyms map, {{es}} checks available heap memory using a circuit breaker to prevent synonym graph token filters from causing out-of-memory errors when processing large numbers of synonym rules. By default, the circuit breaker trips when more than 95% of heap memory is in use.
+
+The threshold is configurable using the [parent circuit breaker settings](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
+
+When the circuit breaker trips, the behavior is determined by the `lenient` parameter:
+
+* If `lenient` is `true`, an empty synonyms map is used and the event is logged in the {{es}} logs.
+* If `lenient` is `false`, the affected index enters a red state.

--- a/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter.md
@@ -243,7 +243,7 @@ serverless: ga
 
 When building the synonyms map, {{es}} checks available heap memory using a circuit breaker to prevent synonym graph token filters from causing out-of-memory errors when processing large numbers of synonym rules. By default, the circuit breaker trips when more than 95% of heap memory is in use.
 
-The threshold is configurable using the [parent circuit breaker settings](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
+The threshold is configurable using the [`indices.breaker.total.limit` parent circuit breaker setting](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
 
 When the circuit breaker trips, the behavior is determined by the `lenient` parameter:
 

--- a/docs/reference/text-analysis/analysis-synonym-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-tokenfilter.md
@@ -223,3 +223,19 @@ For example, a synonym rule like `foo, bar => baz` and a stop filter that remove
 
 If the stop filter removed `foo` instead, then searching for `foo` would get expanded to `baz`, which is not removed by the stop filter thus potentially providing matches for `baz`.
 
+
+## Memory circuit breaker [synonym-tokenizer-circuit-breaker]
+
+```{applies_to}
+stack: ga 9.4
+serverless: ga
+```
+
+When building the synonyms map, {{es}} checks available heap memory using a circuit breaker to prevent synonym token filters from causing out-of-memory errors when processing large numbers of synonym rules. By default, the circuit breaker trips when more than 95% of heap memory is in use.
+
+The threshold is configurable using the [parent circuit breaker settings](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
+
+When the circuit breaker trips, the behavior is determined by the `lenient` parameter:
+
+* If `lenient` is `true`, an empty synonyms map is used and the event is logged in the {{es}} logs.
+* If `lenient` is `false`, the affected index enters a red state.

--- a/docs/reference/text-analysis/analysis-synonym-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-synonym-tokenfilter.md
@@ -233,7 +233,7 @@ serverless: ga
 
 When building the synonyms map, {{es}} checks available heap memory using a circuit breaker to prevent synonym token filters from causing out-of-memory errors when processing large numbers of synonym rules. By default, the circuit breaker trips when more than 95% of heap memory is in use.
 
-The threshold is configurable using the [parent circuit breaker settings](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
+The threshold is configurable using the [`indices.breaker.total.limit` parent circuit breaker setting](/reference/elasticsearch/configuration-reference/circuit-breaker-settings.md#parent-circuit-breaker). {applies_to}`serverless: unavailable`
 
 When the circuit breaker trips, the behavior is determined by the `lenient` parameter:
 


### PR DESCRIPTION
## contributes to https://github.com/elastic/docs-content/issues/5522

## Summary

- Adds a **Memory circuit breaker** section to the `synonym` and `synonym_graph` token filter reference pages documenting the new (9.4+/serverless) behavior that checks real heap usage when building the synonyms map
- Adds a **Synonym circuit breaker** section to the circuit breaker settings reference page, explaining that the feature uses the parent circuit breaker and linking back to the filter docs
- Both sections use `{applies_to}` tagging (`stack: ga 9.4`, `serverless: ga`) with the configurable threshold note marked `serverless: unavailable`


## Test plan

- [x] Verify `{applies_to}` tags render correctly for stack 9.4 and serverless contexts
- [x] Verify `serverless: unavailable` tag on the configurable threshold note hides that line in serverless docs
- [x] Confirm cross-links between the three pages resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)