### PR TITLE
Extends ReindexCancelIT

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
@@ -82,16 +82,16 @@ public class ReindexCancelIT extends ESIntegTestCase {
      * Test <code>POST _reindex/{taskId}/_cancel</code> endpoint, and its intended side effects, end-to-end, by doing the following:
      * 1. Create throttled reindex task that takes a while to complete
      * 2. Ensure task has expected number of sub-tasks
-     * 3. Ensure there's an expected number of search scroll contexts open for the reindexing
+     * 3. Ensure the source index has open search contexts for the shared point-in-time
      * 4. Cancel reindex
-     * 5. Ensure there's no failures, and all scroll contexts and sub-tasks are closed/cancelled
+     * 5. Ensure there's no failures, and all search contexts and sub-tasks are closed/cancelled
      * 6. Ensure reindex task and sub-tasks have correct cancelled reason
      * 7. Subsequent calls to cancel already-cancelled reindex task fail
      * <p>
      * We test synchronous (<code>?wait_for_completion=true</code>) invocation of the _cancel endpoint in this test.
      */
     public void testCancelEndpointEndToEndSynchronously() throws Exception {
-        assumeFalse("scroll-based reindex uses a different code path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
 
         final TaskId parentTaskId = startAsyncThrottledReindex();
 
@@ -100,9 +100,17 @@ public class ReindexCancelIT extends ESIntegTestCase {
         assertThat(running.cancellable(), is(true));
         assertThat(running.cancelled(), is(false));
 
+        assertBusy(() -> {
+            final TaskGroup group = findTaskGroup(parentTaskId).orElse(null);
+            assertNotNull("parent group should exist", group);
+            assertThat(
+                "slice workers register after the leader opens PIT; wait for all " + NUM_OF_SLICES,
+                group.childTasks().size(),
+                equalTo(NUM_OF_SLICES)
+            );
+        });
         final TaskGroup parent = findTaskGroup(parentTaskId).orElse(null);
         assertNotNull("parent group should exist", parent);
-        assertThat(parent.childTasks().size(), equalTo(2));
 
         final TaskId firstSubTask = parent.childTasks().getFirst().task().taskId();
         final var cancelSubTaskException = expectThrows(ResourceNotFoundException.class, () -> cancelReindexSynchronously(firstSubTask));
@@ -113,9 +121,13 @@ public class ReindexCancelIT extends ESIntegTestCase {
 
         final int sourceIndexNumOfPrimaryShards = primaryShards(SOURCE_INDEX);
         assertBusy(() -> {
-            final long currentScrollContexts = currentNumberOfScrollContexts();
-            final long expectedScrollContexts = (long) sourceIndexNumOfPrimaryShards * NUM_OF_SLICES;
-            assertThat("expected number of scroll contexts are open", currentScrollContexts, equalTo(expectedScrollContexts));
+            assertThat("PIT reindex does not use scroll", currentNumberOfScrollContexts(), equalTo(0L));
+            final long openContexts = currentOpenSearchContextsOnSourceIndex();
+            assertThat(
+                "shared PIT holds one reader context per primary shard (replicas do not); not multiplied by slice count",
+                openContexts,
+                equalTo((long) sourceIndexNumOfPrimaryShards)
+            );
         });
 
         final CancelReindexResponse cancelResponse = cancelReindexSynchronously(parentTaskId);
@@ -133,6 +145,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
         assertThat("parent group should be absent", findTaskGroup(parentTaskId).isEmpty(), is(true));
 
         assertThat("there are no open scroll contexts", currentNumberOfScrollContexts(), equalTo(0L));
+        assertThat("PIT and search contexts are released on cancel", currentOpenSearchContextsOnSourceIndex(), equalTo(0L));
 
         final RawTaskStatus parentTaskStatus = (RawTaskStatus) getCompletedTaskResult(parentTaskId).getTask().status();
         final String cancelledReason = (String) parentTaskStatus.toMap().get("canceled");
@@ -141,7 +154,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
 
     /** Same test as above but calling _cancel asynchronously and wrapping assertions after cancellation in assertBusy. */
     public void testCancelEndpointEndToEndAsynchronously() throws Exception {
-        assumeFalse("scroll-based reindex uses a different code path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
 
         final TaskId parentTaskId = startAsyncThrottledReindex();
 
@@ -150,9 +163,17 @@ public class ReindexCancelIT extends ESIntegTestCase {
         assertThat(running.cancellable(), is(true));
         assertThat(running.cancelled(), is(false));
 
+        assertBusy(() -> {
+            final TaskGroup group = findTaskGroup(parentTaskId).orElse(null);
+            assertNotNull("parent group should exist", group);
+            assertThat(
+                "slice workers register after the leader opens PIT; wait for all " + NUM_OF_SLICES,
+                group.childTasks().size(),
+                equalTo(NUM_OF_SLICES)
+            );
+        });
         final TaskGroup parent = findTaskGroup(parentTaskId).orElse(null);
         assertNotNull("parent group should exist", parent);
-        assertThat(parent.childTasks().size(), equalTo(2));
 
         final TaskId firstSubTask = parent.childTasks().getFirst().task().taskId();
         final var cancellingSubTaskException = expectThrows(
@@ -166,9 +187,13 @@ public class ReindexCancelIT extends ESIntegTestCase {
 
         final int sourceIndexNumOfPrimaryShards = primaryShards(SOURCE_INDEX);
         assertBusy(() -> {
-            final long currentScrollContexts = currentNumberOfScrollContexts();
-            final long expectedScrollContexts = (long) sourceIndexNumOfPrimaryShards * NUM_OF_SLICES;
-            assertThat("expected number of scroll contexts are open", currentScrollContexts, equalTo(expectedScrollContexts));
+            assertThat("PIT reindex does not use scroll", currentNumberOfScrollContexts(), equalTo(0L));
+            final long openContexts = currentOpenSearchContextsOnSourceIndex();
+            assertThat(
+                "shared PIT holds one reader context per primary shard (replicas do not); not multiplied by slice count",
+                openContexts,
+                equalTo((long) sourceIndexNumOfPrimaryShards)
+            );
         });
 
         final CancelReindexResponse cancelResponse = cancelReindexAsynchronously(parentTaskId);
@@ -178,6 +203,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
         assertThat("reindex is cancelled and contains acknowledged response", responseBody, equalTo(Map.of("acknowledged", true)));
 
         assertBusy(() -> assertThat("there are no open scroll contexts", currentNumberOfScrollContexts(), equalTo(0L)));
+        assertBusy(() -> assertThat("PIT and search contexts are released on cancel", currentOpenSearchContextsOnSourceIndex(), equalTo(0L)));
         assertBusy(() -> assertThat("parent group should be absent", findTaskGroup(parentTaskId).isEmpty(), is(true)));
         assertBusy(() -> {
             final RawTaskStatus parentTaskStatus = (RawTaskStatus) getCompletedTaskResult(parentTaskId).getTask().status();
@@ -278,5 +304,10 @@ public class ReindexCancelIT extends ESIntegTestCase {
         final TimeValue timeout = TimeValue.THIRTY_SECONDS;
         final var response = client().admin().indices().prepareGetIndex(timeout).addIndices(index).get();
         return Integer.parseInt(response.getSetting(index, IndexMetadata.SETTING_NUMBER_OF_SHARDS));
+    }
+
+    /** Open search contexts on the source index (includes point-in-time reader contexts). */
+    private long currentOpenSearchContextsOnSourceIndex() {
+        return indicesAdmin().prepareStats(SOURCE_INDEX).setSearch(true).get().getTotal().getSearch().getOpenContexts();
     }
 }

--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
@@ -203,7 +203,9 @@ public class ReindexCancelIT extends ESIntegTestCase {
         assertThat("reindex is cancelled and contains acknowledged response", responseBody, equalTo(Map.of("acknowledged", true)));
 
         assertBusy(() -> assertThat("there are no open scroll contexts", currentNumberOfScrollContexts(), equalTo(0L)));
-        assertBusy(() -> assertThat("PIT and search contexts are released on cancel", currentOpenSearchContextsOnSourceIndex(), equalTo(0L)));
+        assertBusy(
+            () -> assertThat("PIT and search contexts are released on cancel", currentOpenSearchContextsOnSourceIndex(), equalTo(0L))
+        );
         assertBusy(() -> assertThat("parent group should be absent", findTaskGroup(parentTaskId).isEmpty(), is(true)));
         assertBusy(() -> {
             final RawTaskStatus parentTaskStatus = (RawTaskStatus) getCompletedTaskResult(parentTaskId).getTask().status();


### PR DESCRIPTION
Extends `testCancelEndpointEndToEndSynchronously` and `testCancelEndpointEndToEndAsynchronously` to work for point-in-time search

Relates: https://github.com/elastic/elasticsearch-team/issues/2088
