### PR TITLE
[9.3] Fix parsing "request" parameter in clear cache API (#145726)

### DIFF
--- a/docs/changelog/145726.yaml
+++ b/docs/changelog/145726.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 145726
+summary: Fix bug parsing "request" parameter in clear cache API, it should clear the request cache only
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheParamsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheParamsIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.cache.clear;
+
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.IndicesQueryCache;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class ClearIndicesCacheParamsIT extends ESIntegTestCase {
+
+    private static final String INDEX = "test";
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(InternalSettingsPlugin.class, getTestTransportPlugin());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+            .build();
+    }
+
+    public void testNoParamsClearsAll() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should be cleared", getQueryCacheMemory(), equalTo(0L));
+        assertThat("request cache should be cleared", getRequestCacheMemory(), equalTo(0L));
+        assertThat("fielddata should be cleared", getFieldDataMemory(), equalTo(0L));
+    }
+
+    public void testClearOnlyQueryCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?query=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should be cleared", getQueryCacheMemory(), equalTo(0L));
+        assertThat("request cache should not be cleared", getRequestCacheMemory(), greaterThan(0L));
+        assertThat("fielddata should not be cleared", getFieldDataMemory(), greaterThan(0L));
+    }
+
+    public void testClearOnlyRequestCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?request=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should not be cleared", getQueryCacheMemory(), greaterThan(0L));
+        assertThat("request cache should be cleared", getRequestCacheMemory(), equalTo(0L));
+        assertThat("fielddata should not be cleared", getFieldDataMemory(), greaterThan(0L));
+    }
+
+    public void testClearOnlyFielddataCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?fielddata=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should not be cleared", getQueryCacheMemory(), greaterThan(0L));
+        assertThat("request cache should not be cleared", getRequestCacheMemory(), greaterThan(0L));
+        assertThat("fielddata should be cleared", getFieldDataMemory(), equalTo(0L));
+    }
+
+    public void testClearQueryAndRequestCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?query=true&request=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should be cleared", getQueryCacheMemory(), equalTo(0L));
+        assertThat("request cache should be cleared", getRequestCacheMemory(), equalTo(0L));
+        assertThat("fielddata should not be cleared", getFieldDataMemory(), greaterThan(0L));
+    }
+
+    public void testClearQueryAndFielddataCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?query=true&fielddata=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should be cleared", getQueryCacheMemory(), equalTo(0L));
+        assertThat("request cache should not be cleared", getRequestCacheMemory(), greaterThan(0L));
+        assertThat("fielddata should be cleared", getFieldDataMemory(), equalTo(0L));
+    }
+
+    public void testClearRequestAndFielddataCache() throws Exception {
+        createTestIndex();
+        populateAllCaches();
+
+        Request request = new Request("POST", "/" + INDEX + "/_cache/clear?request=true&fielddata=true");
+        Response response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        assertThat("query cache should not be cleared", getQueryCacheMemory(), greaterThan(0L));
+        assertThat("request cache should be cleared", getRequestCacheMemory(), equalTo(0L));
+        assertThat("fielddata should be cleared", getFieldDataMemory(), equalTo(0L));
+    }
+
+    private void createTestIndex() {
+        assertAcked(
+            indicesAdmin().prepareCreate(INDEX)
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), true)
+                        .put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true)
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                )
+                .setMapping("field", "type=text,fielddata=true")
+        );
+        ensureGreen(INDEX);
+
+        prepareIndex(INDEX).setId("1").setSource("field", "value").get();
+        indicesAdmin().prepareRefresh(INDEX).get();
+    }
+
+    private void populateAllCaches() {
+        // Populate query cache
+        prepareSearch(INDEX).setQuery(QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("field", "value"))).get().decRef();
+        assertThat(getQueryCacheMemory(), greaterThan(0L));
+
+        // Populate fielddata
+        prepareSearch(INDEX).addSort("field", SortOrder.ASC).get().decRef();
+        assertThat(getFieldDataMemory(), greaterThan(0L));
+
+        // Populate request cache
+        assertHitCount(prepareSearch(INDEX).setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).setRequestCache(true), 1);
+        assertThat(getRequestCacheMemory(), greaterThan(0L));
+    }
+
+    private long getQueryCacheMemory() {
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(INDEX).setQueryCache(true).get();
+        return stats.getTotal().getQueryCache().getMemorySizeInBytes();
+    }
+
+    private long getRequestCacheMemory() {
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(INDEX).setRequestCache(true).get();
+        return stats.getTotal().getRequestCache().getMemorySizeInBytes();
+    }
+
+    private long getFieldDataMemory() {
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(INDEX).setFieldData(true).get();
+        return stats.getTotal().getFieldData().getMemorySizeInBytes();
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -1370,7 +1370,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     /**
      * Clears the caches for the given shard id if the shard is still allocated on this node
      */
-    public boolean clearCaches(boolean queryCache, boolean fieldDataCache, String... fields) {
+    public boolean clearCaches(boolean queryCache, boolean fieldDataCache, boolean requestCache, String... fields) {
         boolean clearedAtLeastOne = false;
         if (queryCache) {
             clearedAtLeastOne = true;
@@ -1386,7 +1386,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 }
             }
         }
-        if (clearedAtLeastOne == false) {
+        if (clearedAtLeastOne == false && requestCache == false) {
             if (fields.length == 0) {
                 indexCache.clear("api");
                 indexFieldData.clear();

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1929,7 +1929,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final IndexService service = indexService(shardId.getIndex());
         if (service != null) {
             IndexShard shard = service.getShardOrNull(shardId.id());
-            final boolean clearedAtLeastOne = service.clearCaches(queryCache, fieldDataCache, fields);
+            final boolean clearedAtLeastOne = service.clearCaches(queryCache, fieldDataCache, requestCache, fields);
             if ((requestCache || (clearedAtLeastOne == false && fields.length == 0)) && shard != null) {
                 indicesRequestCache.clear(new IndexShardCacheEntity(shard));
             }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -620,7 +620,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         assertThat(ifd.loadGlobal(topLevelReader), not(sameInstance(globalOrdinals)));
 
-        indexService.clearCaches(false, true);
+        indexService.clearCaches(false, true, false);
         assertThat(indicesFieldDataCache.getCache().weight(), equalTo(0L));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
@@ -52,7 +52,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         final MapperBuilderContext builderContext = MapperBuilderContext.root(false, false);
 
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("high_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(0, random.nextBoolean() ? 100 : 0.5d, 0)
                 .build(builderContext)
@@ -67,7 +67,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             }
         }
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("high_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, 201, 100)
                 .build(builderContext)
@@ -82,7 +82,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         }
 
         {
-            indexService.clearCaches(false, true);// test # docs with value
+            indexService.clearCaches(false, true, false);// test # docs with value
             MappedFieldType ft = new TextFieldMapper.Builder("med_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)
@@ -98,7 +98,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         }
 
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("med_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix parsing "request" parameter in clear cache API (#145726)