### PR TITLE
Allow deleting multiple views in one request

### DIFF
--- a/docs/changelog/145816.yaml
+++ b/docs/changelog/145816.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 145816
+summary: Allow deleting multiple views in one request
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1715,7 +1715,9 @@ public class IndexNameExpressionResolver {
                 : "selectors are enabled in this context, but a selector was not provided";
             List<ResolvedExpression> concreteIndices = resolveEmptyOrTrivialWildcard(context, selector);
 
-            if (context.includeDataStreams() == false && context.getOptions().ignoreAliases()) {
+            if (context.includeDataStreams() == false
+                && context.getOptions().ignoreAliases()
+                && context.getOptions().indexAbstractionOptions().resolveViews() == false) {
                 return concreteIndices;
             }
 
@@ -1724,9 +1726,10 @@ public class IndexNameExpressionResolver {
                 .getIndicesLookup()
                 .values()
                 .stream()
-                .filter(ia -> ia.getType() != Type.VIEW)
                 .filter(ia -> context.getOptions().expandWildcardsHidden() || ia.isHidden() == false)
-                .filter(ia -> shouldIncludeIfDataStream(ia, context) || shouldIncludeIfAlias(ia, context))
+                .filter(
+                    ia -> shouldIncludeIfDataStream(ia, context) || shouldIncludeIfAlias(ia, context) || shouldIncludeIfView(ia, context)
+                )
                 .filter(ia -> ia.isSystem() == false || context.systemIndexAccessPredicate.test(ia.getName()))
                 .forEach(ia -> resolved.addAll(expandToOpenClosed(context, ia, selector)));
 
@@ -1740,6 +1743,10 @@ public class IndexNameExpressionResolver {
 
         private static boolean shouldIncludeIfAlias(IndexAbstraction ia, IndexNameExpressionResolver.Context context) {
             return context.getOptions().ignoreAliases() == false && ia.getType() == Type.ALIAS;
+        }
+
+        private static boolean shouldIncludeIfView(IndexAbstraction ia, IndexNameExpressionResolver.Context context) {
+            return context.getOptions().indexAbstractionOptions().resolveViews() && ia.getType() == Type.VIEW;
         }
 
         private static IndexMetadata.State excludeState(IndicesOptions options) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -322,6 +322,27 @@ public class IndexNameExpressionResolver {
         }).toList();
     }
 
+    public List<String> views(ProjectMetadata projectMetadata, IndicesOptions options, IndicesRequest request) {
+        Context context = new Context(
+            projectMetadata,
+            options,
+            System.currentTimeMillis(),
+            false,
+            false,
+            false,
+            false,
+            false,
+            getSystemIndexAccessLevel(),
+            getSystemIndexAccessPredicate(),
+            getNetNewSystemIndexPredicate()
+        );
+        final Collection<ResolvedExpression> expressions = resolveExpressionsToResources(context, request.indices());
+        return expressions.stream().map(ResolvedExpression::resource).filter(view -> {
+            IndexAbstraction ia = projectMetadata.getIndicesLookup().get(view);
+            return ia != null && Type.VIEW == ia.getType();
+        }).toList();
+    }
+
     /**
      * Returns {@link IndexAbstraction} instance for the provided write request. This instance isn't fully resolved,
      * meaning that {@link IndexAbstraction#getWriteIndex()} should be invoked in order to get concrete write index.

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -3350,6 +3350,63 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(names, containsInAnyOrder(dataStream1, dataStream2));
     }
 
+    public void testViewNames() {
+        final String view1Name = "my-view-1";
+        final String view2Name = "other-view-2";
+        View view1 = new View(view1Name, "FROM logs");
+        View view2 = new View(view2Name, "FROM metrics");
+
+        final IndicesOptions defaultViewOptions = IndicesOptions.builder()
+            .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
+            .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveViews(true).build())
+            .build();
+
+        IndexMetadata justAnIndex = IndexMetadata.builder("my-view-index")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+
+        ProjectMetadata project = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
+            .put(justAnIndex, false)
+            .views(Map.of(view1Name, view1, view2Name, view2))
+            .build();
+
+        // Concrete view name resolves to a single view
+        List<String> views = indexNameExpressionResolver.views(project, defaultViewOptions, viewRequest(defaultViewOptions, view1Name));
+        assertThat(views, contains(view1Name));
+
+        // Both concrete view names
+        views = indexNameExpressionResolver.views(project, defaultViewOptions, viewRequest(defaultViewOptions, view1Name, view2Name));
+        assertThat(views, containsInAnyOrder(view1Name, view2Name));
+
+        // Wildcard matching all views
+        views = indexNameExpressionResolver.views(project, defaultViewOptions, viewRequest(defaultViewOptions, "*view*"));
+        assertThat(views, containsInAnyOrder(view1Name, view2Name));
+
+        // Wildcard matching one view
+        views = indexNameExpressionResolver.views(project, defaultViewOptions, viewRequest(defaultViewOptions, "my-*"));
+        assertThat(views, contains(view1Name));
+
+        // Index name does not appear in views()
+        views = indexNameExpressionResolver.views(project, defaultViewOptions, viewRequest(defaultViewOptions, "my-view-index"));
+        assertThat(views, empty());
+    }
+
+    private static IndicesRequest viewRequest(IndicesOptions options, String... indices) {
+        return new IndicesRequest() {
+            @Override
+            public String[] indices() {
+                return indices;
+            }
+
+            @Override
+            public IndicesOptions indicesOptions() {
+                return options;
+            }
+        };
+    }
+
     public void testDateMathMixedArray() {
         long now = System.currentTimeMillis();
         String dataMathIndex1 = ".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(now));

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -506,7 +506,10 @@ public class CsvIT extends ESTestCase {
             logger.info("Unloading view [{}]", name);
             assertAcked(
                 cluster.client()
-                    .execute(DeleteViewAction.INSTANCE, new DeleteViewAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, name))
+                    .execute(
+                        DeleteViewAction.INSTANCE,
+                        new DeleteViewAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, new String[] { name })
+                    )
             );
         }
     };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/DeleteViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/DeleteViewAction.java
@@ -12,13 +12,14 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.esql.EsqlViewActionNames;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -30,6 +31,7 @@ public class DeleteViewAction extends ActionType<AcknowledgedResponse> {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.builder()
         .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
+        .wildcardOptions(IndicesOptions.WildcardOptions.builder().matchOpen(true).matchClosed(true).allowEmptyExpressions(true).build())
         .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveViews(true).build())
         .build();
 
@@ -37,35 +39,34 @@ public class DeleteViewAction extends ActionType<AcknowledgedResponse> {
         super(NAME);
     }
 
-    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest {
-        private final String name;
+    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest.Replaceable {
+        private String[] views;
 
-        // TODO: Should this match delete index request and allow for several views and `_all`?
-        public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout, String name) {
+        public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout, String[] views) {
             super(masterNodeTimeout, ackTimeout);
-            this.name = Objects.requireNonNull(name, "name cannot be null");
+            this.views = Objects.requireNonNull(views, "views cannot be null");
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            name = in.readString();
+            views = in.readStringArray();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(name);
+            out.writeStringArray(views);
         }
 
-        public String name() {
-            return name;
+        public String[] views() {
+            return views;
         }
 
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException validationException = null;
-            if (Strings.hasText(name) == false) {
-                validationException = addValidationError("name cannot be null or missing", validationException);
+            if (CollectionUtils.isEmpty(views)) {
+                validationException = addValidationError("views cannot be null or missing", validationException);
             }
             return validationException;
         }
@@ -75,17 +76,23 @@ public class DeleteViewAction extends ActionType<AcknowledgedResponse> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return name.equals(request.name);
+            return Arrays.equals(views, request.views);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(name);
+            return Arrays.hashCode(views);
         }
 
         @Override
         public String[] indices() {
-            return new String[] { name };
+            return views;
+        }
+
+        @Override
+        public IndicesRequest indices(String... indices) {
+            this.views = indices;
+            return this;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/DeleteViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/DeleteViewAction.java
@@ -31,7 +31,6 @@ public class DeleteViewAction extends ActionType<AcknowledgedResponse> {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.builder()
         .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
-        .wildcardOptions(IndicesOptions.WildcardOptions.builder().matchOpen(true).matchClosed(true).allowEmptyExpressions(true).build())
         .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveViews(true).build())
         .build();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/RestDeleteViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/RestDeleteViewAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.view;
 
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestUtils;
@@ -33,7 +34,7 @@ public class RestDeleteViewAction extends BaseRestHandler {
         DeleteViewAction.Request req = new DeleteViewAction.Request(
             RestUtils.getMasterNodeTimeout(request),
             RestUtils.getAckTimeout(request),
-            request.param("name")
+            Strings.splitStringByCommaToArray(request.param("name"))
         );
         return channel -> client.execute(DeleteViewAction.INSTANCE, req, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportDeleteViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportDeleteViewAction.java
@@ -6,22 +6,31 @@
  */
 package org.elasticsearch.xpack.esql.view;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeProjectAction;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.List;
+
 public class TransportDeleteViewAction extends AcknowledgedTransportMasterNodeProjectAction<DeleteViewAction.Request> {
+
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final DestructiveOperations destructiveOperations;
     private final ViewService viewService;
 
     @Inject
@@ -31,7 +40,9 @@ public class TransportDeleteViewAction extends AcknowledgedTransportMasterNodePr
         ThreadPool threadPool,
         ActionFilters actionFilters,
         ProjectResolver projectResolver,
-        ViewService viewService
+        ViewService viewService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        DestructiveOperations destructiveOperations
     ) {
         super(
             DeleteViewAction.NAME,
@@ -44,6 +55,14 @@ public class TransportDeleteViewAction extends AcknowledgedTransportMasterNodePr
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.viewService = viewService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.destructiveOperations = destructiveOperations;
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteViewAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        destructiveOperations.failDestructive(request.views());
+        super.doExecute(task, request, listener);
     }
 
     @Override
@@ -53,7 +72,18 @@ public class TransportDeleteViewAction extends AcknowledgedTransportMasterNodePr
         ProjectState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        viewService.deleteView(state.projectId(), request, listener);
+        List<String> viewNames;
+        try {
+            viewNames = indexNameExpressionResolver.views(state.metadata(), request.indicesOptions(), request);
+        } catch (IndexNotFoundException e) {
+            listener.onFailure(new ResourceNotFoundException("view [{}] not found", e.getIndex().getName()));
+            return;
+        }
+        if (viewNames.isEmpty()) {
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return;
+        }
+        viewService.deleteViews(state.projectId(), request.masterNodeTimeout(), request.ackTimeout(), viewNames, listener);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
@@ -25,11 +25,14 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class ViewService {
@@ -126,36 +129,41 @@ public class ViewService {
     }
 
     /**
-     * Removes a view from the cluster state.
+     * Removes views from the cluster state.
      */
-    public void deleteView(ProjectId projectId, DeleteViewAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        // TODO this should support wildcard deletion if action.destructive_requires_name = false
-        final String name = request.name();
+    public void deleteViews(
+        ProjectId projectId,
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        Collection<String> viewNames,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
         final ProjectMetadata metadata = clusterService.state().metadata().getProject(projectId);
         final ViewMetadata viewMetadata = metadata.custom(ViewMetadata.TYPE, ViewMetadata.EMPTY);
-        if (viewMetadata.getView(name) == null) {
-            listener.onFailure(new ResourceNotFoundException("view [{}] not found", name));
+        Optional<String> notFoundView = viewNames.stream().filter(v -> viewMetadata.getView(v) == null).findAny();
+        // at least one of the explicitly requested views was not found, so we can fail fast without submitting a cluster state update task
+        if (notFoundView.isPresent()) {
+            listener.onFailure(new ResourceNotFoundException("view [{}] not found", notFoundView.get()));
             return;
         }
 
-        final AckedClusterStateUpdateTask task = new AckedClusterStateUpdateTask(request, listener) {
+        final AckedClusterStateUpdateTask task = new AckedClusterStateUpdateTask(masterNodeTimeout, ackTimeout, listener) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final ProjectMetadata project = currentState.metadata().getProject(projectId);
                 final ViewMetadata viewMetadata = getMetadata(project);
-                final View currentView = viewMetadata.getView(name);
-                if (currentView == null) {
-                    // The update is a no-op, because we're trying to remove the view, but it doesn't exist, so no change is necessary
+                if (viewNames.stream().allMatch(v -> viewMetadata.getView(v) == null)) {
+                    // The update is a no-op, because none of the views that we're trying to remove exist.
+                    // Perhaps the views were deleted in the meantime by another job, so no change is necessary
                     return currentState;
                 }
                 final Map<String, View> updatedViews = new HashMap<>(viewMetadata.views());
-                final View existingView = updatedViews.remove(name);
-                assert existingView != null : "we should have short-circuited if removing a view that already didn't exist";
+                viewNames.forEach(updatedViews::remove);
                 var metadata = ProjectMetadata.builder(project).views(updatedViews);
                 return ClusterState.builder(currentState).putProjectMetadata(metadata).build();
             }
         };
-        taskQueue.submitTask("delete-esql-view-metadata-[" + name + "]", task, task.timeout());
+        taskQueue.submitTask("delete-esql-view-metadata-" + viewNames, task, task.timeout());
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/DeleteViewActionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/DeleteViewActionTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.view;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DeleteViewActionTests extends ESTestCase {
+
+    public void testValidateWithMultipleViews() {
+        DeleteViewAction.Request request = new DeleteViewAction.Request(
+            TimeValue.ONE_MINUTE,
+            TimeValue.ONE_MINUTE,
+            new String[] { "view1", "view2", "view3" }
+        );
+        assertThat(request.validate(), nullValue());
+    }
+
+    public void testValidateEmptyArray() {
+        DeleteViewAction.Request request = new DeleteViewAction.Request(TimeValue.ONE_MINUTE, TimeValue.ONE_MINUTE, new String[0]);
+        ActionRequestValidationException validation = request.validate();
+        assertThat(validation, notNullValue());
+        assertThat(validation.getMessage(), containsString("views cannot be null or missing"));
+    }
+
+    public void testIndicesReturnsSameAsViews() {
+        String[] views = new String[] { "a", "b", "c" };
+        DeleteViewAction.Request request = new DeleteViewAction.Request(TimeValue.ONE_MINUTE, TimeValue.ONE_MINUTE, views);
+        assertArrayEquals(views, request.indices());
+        assertSame(request.views(), request.indices());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.view;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -20,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -28,10 +30,12 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -129,10 +133,21 @@ public class InMemoryViewService extends ViewService implements Closeable {
     }
 
     @Override
-    public void deleteView(ProjectId projectId, DeleteViewAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+    public void deleteViews(
+        ProjectId projectId,
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        Collection<String> viewNames,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
         try {
+            Optional<String> notFoundView = viewNames.stream().filter(v -> viewMetadata.getView(v) == null).findAny();
+            if (notFoundView.isPresent()) {
+                throw new ResourceNotFoundException("view [{}] not found", notFoundView.get());
+            }
+
             Map<String, View> existingViews = new HashMap<>(viewMetadata.views());
-            existingViews.remove(request.name());
+            viewNames.forEach(existingViews::remove);
             viewMetadata = new ViewMetadata(existingViews);
             listener.onResponse(AcknowledgedResponse.TRUE);
         } catch (Exception e) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.view;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.View;
 import org.elasticsearch.common.settings.Settings;
@@ -1813,6 +1814,31 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
             generateCombinations(matchers, size, i + 1, current, result);
             current.removeLast();
         }
+    }
+
+    public void testDeleteMultipleViews() {
+        addView("view1", "FROM emp");
+        addView("view2", "FROM emp");
+        addView("view3", "FROM emp");
+        assertThat(viewService.list(projectId).size(), equalTo(3));
+
+        deleteViews("view1", "view3");
+        assertThat(viewService.list(projectId).size(), equalTo(1));
+        assertNull(viewService.get(projectId, "view1"));
+        assertNotNull(viewService.get(projectId, "view2"));
+        assertNull(viewService.get(projectId, "view3"));
+    }
+
+    public void testDeleteEmptyListIsNoOp() {
+        addView("view1", "FROM emp");
+        deleteViews();
+        assertNotNull(viewService.get(projectId, "view1"));
+    }
+
+    private void deleteViews(String... views) {
+        PlainActionFuture<AcknowledgedResponse> future = new PlainActionFuture<>();
+        viewService.deleteViews(projectId, TimeValue.ONE_MINUTE, TimeValue.ONE_MINUTE, List.of(views), future);
+        assertTrue(future.actionGet().isAcknowledged());
     }
 
     protected LogicalPlan query(String e) {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_view.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_view.yml
@@ -87,6 +87,105 @@ setup:
   - length: { views: 0 }
 
 ---
+"delete-multiple-views":
+  - do:
+      esql.put_view:
+        name: dogs
+        body:
+          query: 'FROM test | WHERE animal == "dog"'
+
+  - do:
+      esql.put_view:
+        name: cats
+        body:
+          query: 'FROM test | WHERE animal == "cat"'
+
+  - do:
+      esql.put_view:
+        name: foxes
+        body:
+          query: 'FROM test | WHERE animal == "fox"'
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 3 }
+
+  - do:
+      esql.delete_view:
+        name: dogs,cats
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 1 }
+  - match: { views.0.name: "foxes" }
+
+  - do:
+      esql.delete_view:
+        name: foxes
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 0 }
+
+---
+"delete-multiple-views-with-wildcard":
+  - do:
+      esql.put_view:
+        name: animals-1
+        body:
+          query: 'FROM test | WHERE animal == "dog"'
+
+  - do:
+      esql.put_view:
+        name: animals-2
+        body:
+          query: 'FROM test | WHERE animal == "cat"'
+
+  - do:
+      esql.put_view:
+        name: faxes
+        body:
+          query: 'FROM test | WHERE animal == "office_appliance"'
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 3 }
+
+  - do:
+      esql.delete_view:
+        name: animals-*
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 1 }
+  - match: { views.0.name: "faxes" }
+
+---
+"delete-multiple-views-one-missing":
+  - do:
+      esql.put_view:
+        name: dogs
+        body:
+          query: 'FROM test | WHERE animal == "dog"'
+
+  - do:
+      catch: /view \[nonexistent\] not found/
+      esql.delete_view:
+        name: dogs,nonexistent
+
+  # The view should still exist since the request failed
+  - do:
+      esql.get_view:
+        name: dogs
+
+  - match: { views.0.name: "dogs" }
+
+---
 "invalid-views":
   - do:
       catch: /invalid view name/

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_view.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_view.yml
@@ -166,6 +166,34 @@ setup:
   - match: { views.0.name: "faxes" }
 
 ---
+"delete-all-views":
+  - do:
+      esql.put_view:
+        name: dogs
+        body:
+          query: 'FROM test | WHERE animal == "dog"'
+
+  - do:
+      esql.put_view:
+        name: cats
+        body:
+          query: 'FROM test | WHERE animal == "cat"'
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 2 }
+
+  - do:
+      esql.delete_view:
+        name: _all
+
+  - do:
+      esql.get_view: { }
+
+  - length: { views: 0 }
+
+---
 "delete-multiple-views-one-missing":
   - do:
       esql.put_view:


### PR DESCRIPTION
When handling delete view request, allow users to specify multiple comma-separated view names, and use wildcards.
