### PR TITLE
Add test for ignored malformed scaled_float values in SourceMatcher

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
@@ -229,4 +229,25 @@ public class SourceMatcherTests extends ESTestCase {
         var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
         assertTrue(sut.match().isMatch());
     }
+
+    public void testIgnoredMalformedScaledFloatMatchesMalformedValue() throws IOException {
+        List<Map<String, Object>> expected = List.of(Map.of("field", "not-a-number"));
+        List<Map<String, Object>> actual = List.of(Map.of("field", "not-a-number"));
+
+        var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
+        mapping.startObject();
+        mapping.startObject("_doc");
+        {
+            mapping.startObject("field")
+                .field("type", "scaled_float")
+                .field("scaling_factor", 10)
+                .field("ignore_malformed", true)
+                .endObject();
+        }
+        mapping.endObject();
+        mapping.endObject();
+
+        var sut = new SourceMatcher(Map.of(), mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
+        assertTrue(sut.match().isMatch());
+    }
 }


### PR DESCRIPTION
Add a follow-up test for https://github.com/elastic/elasticsearch/pull/145757