### PR TITLE
[Inference API] Use 504 for timeout REST status code response

### DIFF
--- a/docs/changelog/145838.yaml
+++ b/docs/changelog/145838.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 145838
+summary: "[Inference API] Use 504 for timeout REST status code response"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -133,7 +133,7 @@ public class RetryingHttpSender implements RequestSender {
             if (hasRequestCompletedFunction.get()) {
                 // TimedListener will drop this, just being safe to avoid a hanging listener
                 listener.onFailure(
-                    new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.REQUEST_TIMEOUT)
+                    new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
                 );
                 return;
             }
@@ -163,7 +163,7 @@ public class RetryingHttpSender implements RequestSender {
                     if (hasRequestCompletedFunction.get()) {
                         // TimedListener will drop this, just being safe to avoid a hanging listener
                         inferenceServiceResultsActionListener.onFailure(
-                            new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.REQUEST_TIMEOUT)
+                            new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
                         );
                         return;
                     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListener.java
@@ -59,7 +59,7 @@ public class TimedListener<Response> {
             threadPool.executor(UTILITY_THREAD_POOL_NAME),
             notificationListener,
             (ignored) -> notificationListener.onFailure(
-                new ElasticsearchStatusException(Strings.format("Request timed out after [%s]", timeout), RestStatus.REQUEST_TIMEOUT)
+                new ElasticsearchStatusException(Strings.format("Request timed out after [%s]", timeout), RestStatus.GATEWAY_TIMEOUT)
             )
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
@@ -323,7 +323,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         executeTasks(() -> retrier.send(mock(Logger.class), mockRequest(inferenceEntityId), () -> true, handler, listener), 0);
 
         var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-        assertThat(thrownException.status(), is(RestStatus.REQUEST_TIMEOUT));
+        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
         assertThat(thrownException.getMessage(), is(Strings.format("Inference endpoint [%s]: request timed out", inferenceEntityId)));
         verifyNoInteractions(httpClient);
     }
@@ -344,7 +344,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-        assertThat(thrownException.status(), is(RestStatus.REQUEST_TIMEOUT));
+        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
         assertThat(thrownException.getMessage(), is(Strings.format("Inference endpoint [%s]: request timed out", inferenceEntityId)));
         verifyNoInteractions(httpClient);
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
@@ -373,7 +374,7 @@ public class HttpRequestSenderTests extends ESTestCase {
             var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
 
             assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status().getStatus(), is(408));
+            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
         }
     }
 
@@ -400,7 +401,7 @@ public class HttpRequestSenderTests extends ESTestCase {
             var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
 
             assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status().getStatus(), is(408));
+            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
         }
     }
 
@@ -428,7 +429,7 @@ public class HttpRequestSenderTests extends ESTestCase {
             var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
 
             assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status().getStatus(), is(408));
+            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -267,7 +268,7 @@ public class RequestExecutorServiceTests extends ESTestCase {
         var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
 
         assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-        assertThat(thrownException.status().getStatus(), is(408));
+        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
     }
 
     public void testExecute_PreservesThreadContext() throws InterruptedException, ExecutionException, TimeoutException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -91,7 +92,7 @@ public class RequestTaskTests extends ESTestCase {
         assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
         assertTrue(requestTask.hasCompleted());
         assertTrue(requestTask.getRequestCompletedFunction().get());
-        assertThat(thrownException.status().getStatus(), is(408));
+        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
     }
 
     public void testRequest_DoesNotCallOnFailureTwiceWhenTimingOut() throws Exception {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListenerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListenerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -73,7 +74,7 @@ public class TimedListenerTests extends ESTestCase {
         var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
         assertTrue(timedListener.hasCompleted());
-        assertThat(thrownException.status().getStatus(), is(408));
+        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
     }
 
     public void testRequest_DoesNotCallOnFailureTwiceWhenTimingOut() throws Exception {


### PR DESCRIPTION
This Inference API acts as a gateway. When a request times out we should return a 504 instead of a 408.