### PR TITLE
Unmute testGetReindexFollowsRelocation

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -172,9 +172,6 @@ tests:
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteBlobWithRetries
   issue: https://github.com/elastic/elasticsearch/issues/144025
-- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
-  method: testGetReindexFollowsRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/144364
 - class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
   method: testOpenAiEmbeddings {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/144440


### PR DESCRIPTION
This should be fixed by https://github.com/elastic/elasticsearch/pull/144677. The test was muted again by https://github.com/elastic/elasticsearch/pull/144928, which seems unrelated and probably accidental.