### PR TITLE
Added support for restricting fields to be single valued when multi_value = no

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -1020,10 +1020,10 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 @Override
                 public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
                     // match_only_text fields with doc_values may have all values stored in fallback fields if every value exceeds
-                    // MAX_TERM_LENGTH. In that case, there will be no SortedSetDocValues, but the "main" field might still be indexed.
+                    // MAX_TERM_LENGTH. In that case, there will be no doc values at all, but the "main" field might still be indexed.
                     // As a result, we can't use SortedSetDocValuesSyntheticFieldLoaderLayer since it uses DocValues.getSortedSet(),
-                    // which will throw.
-                    if (reader.getSortedSetDocValues(fieldName()) == null) {
+                    // which will throw. Check for both SORTED_SET (multi-valued) and SORTED (multi_value=no) doc values types.
+                    if (reader.getSortedSetDocValues(fieldName()) == null && reader.getSortedDocValues(fieldName()) == null) {
                         return null;
                     }
                     return super.docValuesLoader(reader, docIdsInLeaf);

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -75,6 +75,7 @@ import org.elasticsearch.index.mapper.TextParams;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
@@ -209,7 +210,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 usesBinaryDocValuesForFallbackFields,
                 indexCreatedVersion(),
                 docValuesParameters.getValue().enabled(),
-                usesBinaryDocValues()
+                usesBinaryDocValues(),
+                docValuesParameters.getValue()
             );
         }
 
@@ -244,6 +246,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final boolean usesBinaryDocValuesForFallbackFields;
         private final IndexVersion indexVersion;
         private final boolean usesBinaryDocValues;
+        private final FieldMapper.DocValuesParameter.Values docValuesParams;
 
         public MatchOnlyTextFieldType(
             String name,
@@ -257,7 +260,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             boolean usesBinaryDocValuesForFallbackFields,
             IndexVersion indexVersion,
             boolean hasDocValues,
-            boolean usesBinaryDocValues
+            boolean usesBinaryDocValues,
+            FieldMapper.DocValuesParameter.Values docValuesParams
         ) {
             super(name, IndexType.terms(true, hasDocValues), false, tsi, meta, isSyntheticSource, withinMultiField);
             this.indexAnalyzer = Objects.requireNonNull(indexAnalyzer);
@@ -266,6 +270,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
             this.indexVersion = indexVersion;
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.docValuesParams = docValuesParams;
         }
 
         public MatchOnlyTextFieldType(String name) {
@@ -281,12 +286,18 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 false,
                 IndexVersion.current(),
                 false,
-                false
+                false,
+                null
             );
         }
 
         public boolean usesBinaryDocValues() {
             return usesBinaryDocValues;
+        }
+
+        @Override
+        public FieldMapper.DocValuesParameter.Values docValuesParameters() {
+            return docValuesParams;
         }
 
         /**
@@ -466,7 +477,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
         private IOFunction<LeafReaderContext, CheckedIntFunction<List<Object>, IOException>> binaryDocValuesFieldFetcher(String fieldName) {
             return context -> {
-                SortedBinaryDocValues binaryDocValues = MultiValuedSortedBinaryDocValues.from(context.reader(), fieldName);
+                SortedBinaryDocValues binaryDocValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
+                    ? MultiValuedSortedBinaryDocValues.from(context.reader(), fieldName)
+                    : MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), fieldName);
                 return docId -> getValuesFromDocValues(binaryDocValues, docId);
             };
         }
@@ -724,6 +737,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             // Check if we can load from doc values
             if (hasDocValues()) {
                 if (usesBinaryDocValues) {
+                    if (docValuesParams != null && docValuesParams.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO) {
+                        return new BytesRefsFromBinaryBlockLoader(name());
+                    }
                     return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
@@ -810,7 +826,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     return (cache, breaker) -> new BytesBinaryIndexFieldData(
                         syntheticSourceFallbackFieldName(),
                         CoreValuesSourceType.KEYWORD,
-                        TextDocValuesField::new
+                        TextDocValuesField::new,
+                        indexVersion
                     );
                 }
                 // For older indexes, fallback data is stored in stored fields
@@ -841,7 +858,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new, indexVersion);
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -900,6 +917,11 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final var value = context.parser().optimizedTextOrNull();
 
@@ -919,7 +941,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     context.doc(),
                     fieldType().name(),
                     binaryValue,
-                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                    docValuesParameters.multiValue(),
+                    indexCreatedVersion
                 );
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
@@ -969,6 +993,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             fallbackFieldName,
             bytesRef,
             MultiValuedBinaryDocValuesField.ValueOrdering.SORTED,
+            docValuesParameters.multiValue(),
             indexCreatedVersion
         );
     }
@@ -994,7 +1019,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override
@@ -1021,7 +1046,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             });
 
             // also load from fallback field for values that exceeded MAX_TERM_LENGTH
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName(), indexCreatedVersion));
         }
         return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
     }
@@ -1032,7 +1057,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         // layer for loading from a fallback field created during indexing by this text field mapper
         final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
         if (usesBinaryDocValuesForFallbackFields) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName, indexCreatedVersion));
         } else {
             // for bwc - fallback fields were originally stored in StoredFields
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fallbackFieldName) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -57,6 +57,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
@@ -877,6 +878,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private final boolean storedFieldInBinaryFormat;
     private final boolean usesBinaryDocValuesForFallbackFields;
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
 
     private MatchOnlyTextFieldMapper(
         String simpleName,
@@ -897,6 +899,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         this.storedFieldInBinaryFormat = builder.storedFieldInBinaryFormat;
         this.usesBinaryDocValuesForFallbackFields = builder.usesBinaryDocValuesForFallbackFields;
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, indexCreatedVersion);
     }
 
     @Override
@@ -932,20 +935,18 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         if (docValuesParameters.enabled()) {
             BytesRef binaryValue = new BytesRef(utfBytes.bytes(), utfBytes.offset(), utfBytes.length());
             if (fieldType().usesBinaryDocValues()) {
-                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                dvFactory.addBinaryField(
                     context.doc(),
                     fieldType().name(),
                     binaryValue,
-                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
-                    docValuesParameters.multiValue(),
-                    indexCreatedVersion
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
                 );
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
                 // in such cases, store the value in binary doc values instead, which don't have these length limitations
                 storeValueInFallbackField(fieldType().syntheticSourceFallbackFieldName(), binaryValue, context);
             } else {
-                context.doc().add(new SortedSetDocValuesField(fieldType().name(), binaryValue));
+                dvFactory.addSortedField(context.doc(), fieldType().name(), binaryValue);
             }
         } else {
             // only add to field names when doc_values are disabled (doc_values track field existence implicitly)
@@ -983,14 +984,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     private void storeValueInFallbackField(String fallbackFieldName, BytesRef bytesRef, DocumentParserContext context) {
-        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
-            context.doc(),
-            fallbackFieldName,
-            bytesRef,
-            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED,
-            docValuesParameters.multiValue(),
-            indexCreatedVersion
-        );
+        dvFactory.addBinaryField(context.doc(), fallbackFieldName, bytesRef, MultiValuedBinaryDocValuesField.ValueOrdering.SORTED);
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -917,11 +917,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final var value = context.parser().optimizedTextOrNull();
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -658,11 +658,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         Object value;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -593,6 +594,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     private final Explicit<Boolean> coerce;
     private final boolean indexed;
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final Double nullValue;
     private final double scalingFactor;
@@ -614,6 +616,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         this.isSourceSynthetic = isSourceSynthetic;
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, builder.indexSettings.getIndexVersionCreated());
         this.stored = builder.stored.getValue();
         this.scalingFactor = builder.scalingFactor.getValue();
         this.nullValue = builder.nullValue.getValue();
@@ -722,7 +725,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             fieldType().name(),
             scaledValue,
             IndexType.points(indexed, docValuesParameters.enabled()),
-            stored
+            stored,
+            dvFactory
         );
 
         if (shouldStoreOffsets) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -658,6 +658,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         Object value;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -164,6 +164,11 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -164,11 +164,6 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -12,8 +12,10 @@ package org.elasticsearch.index.mapper.extras;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.DocValueFetcher;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
@@ -148,6 +150,7 @@ public class TokenCountFieldMapper extends FieldMapper {
 
     private final boolean index;
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean store;
     private final NamedAnalyzer analyzer;
     private final boolean enablePositionIncrements;
@@ -160,6 +163,7 @@ public class TokenCountFieldMapper extends FieldMapper {
         this.nullValue = builder.nullValue.getValue();
         this.index = builder.index.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, IndexVersion.current());
         this.store = builder.store.getValue();
     }
 
@@ -183,7 +187,8 @@ public class TokenCountFieldMapper extends FieldMapper {
             fieldType().name(),
             tokenCount,
             IndexType.points(index, docValuesParameters.enabled()),
-            store
+            store,
+            dvFactory
         );
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -248,7 +248,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -272,7 +273,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -303,7 +305,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -352,7 +355,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -404,7 +408,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -441,7 +446,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         var mockedSearchLookup = mock(SearchLookup.class);
@@ -491,7 +497,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -516,7 +523,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -541,7 +549,8 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES),
             false,
-            false
+            false,
+            null
         );
 
         // when

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -512,7 +512,8 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
     public void testIgnoreMalformedWithObject() {} // TODO: either implement this, remove it, or update ScaledFloatFieldMapper's behaviour
 
     @Override
-    public void testAllowMultipleValuesField() {} // TODO: either implement this, remove it, or update ScaledFloatFieldMapper's behaviour
+    public void testRejectMultipleValuesWhenMultiValueIsDisabled() {} // TODO: either implement this, remove it, or update
+                                                                      // ScaledFloatFieldMapper's behaviour
 
     @Override
     public void testScriptableTypes() {} // TODO: either implement this, remove it, or update ScaledFloatFieldMapper's behaviour

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -107,7 +107,8 @@ public class QueryBuilderStoreTests extends ESTestCase {
             BytesBinaryIndexFieldData fieldData = new BytesBinaryIndexFieldData(
                 fieldMapper.fullPath(),
                 CoreValuesSourceType.KEYWORD,
-                BinaryDocValuesField::new
+                BinaryDocValuesField::new,
+                indexVersion
             );
             BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup = (mft, fdc) -> fieldData;
             Settings indexSettingsSettings = indexSettings(indexVersion, 1, 1).build();
@@ -224,7 +225,8 @@ public class QueryBuilderStoreTests extends ESTestCase {
             BytesBinaryIndexFieldData fieldData = new BytesBinaryIndexFieldData(
                 fieldMapper.fullPath(),
                 CoreValuesSourceType.KEYWORD,
-                BinaryDocValuesField::new
+                BinaryDocValuesField::new,
+                indexVersion
             );
             BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup = (mft, fdc) -> fieldData;
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -1,0 +1,167 @@
+---
+"multi_value=no rejects multiple values for keyword":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_keyword
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      index:
+        index: test_keyword
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: "single_value"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_keyword
+        body:
+          query:
+            term:
+              kw: "single_value"
+  - match: { hits.total.value: 1 }
+
+  - do:
+      catch: /configured with multi_value=no but more than one value was detected/
+      index:
+        index: test_keyword
+        id: "2"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: ["value1", "value2"]
+
+---
+"multi_value=no is enforced per document not per segment":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_per_document
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      index:
+        index: test_per_document
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: "value_a"
+
+  - do:
+      index:
+        index: test_per_document
+        id: "2"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: "value_b"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_per_document
+        body:
+          query:
+            match_all: {}
+  - match: { hits.total.value: 2 }
+
+---
+"multi_value=no mapping serialization roundtrip":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_roundtrip
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      indices.get_mapping:
+        index: test_roundtrip
+
+  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "no" }
+
+---
+"multi_value=no rejects multiple values for text":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_text
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              message:
+                type: text
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      index:
+        index: test_text
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          message: "hello world"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_text
+        body:
+          query:
+            match:
+              message: "hello world"
+  - match: { hits.total.value: 1 }
+
+  - do:
+      catch: /configured with multi_value=no but more than one value was detected/
+      index:
+        index: test_text
+        id: "2"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          message: ["hello", "world"]
+

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
@@ -34,32 +34,65 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
         this.values = values;
     }
 
-    public static MultiValuedSortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
+    /**
+     * Reads binary doc values written in the current format ({@link SeparateCounts} or {@link PlainBinary}).
+     * <ul>
+     *   <li>{@code .counts} present &rarr; {@link SeparateCounts} (multi-valued)</li>
+     *   <li>{@code .counts} absent &rarr; {@link PlainBinary} (single-valued)</li>
+     * </ul>
+     * For indices created before {@code DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES}, use {@link #fromLegacy(LeafReader, String)}
+     * instead.
+     */
+    public static SortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
         BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
-
-        // Obtain counts directly from leafReader so that null is returned rather than an empty doc values.
-        // Whether counts is null allows us to determine which multivalued format was used.
-        return from(leafReader, valuesFieldName, values);
+        String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
+        NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);
+        if (counts != null) {
+            return buildSeparateCounts(leafReader, countsFieldName, values, counts);
+        }
+        return new PlainBinary(values);
     }
 
-    public static MultiValuedSortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
+    /**
+     * Legacy reader for callers that read inherently multi-valued internal fields (ex. {@code _ignored_source}) that may contain data in
+     * the deprecated {@link IntegratedCounts} format. Falls back to {@link IntegratedCounts} when no {@code .counts} companion field is
+     * present. New callers should use {@link #from(LeafReader, String)}.
+     */
+    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName) throws IOException {
+        BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
+        return fromLegacy(leafReader, valuesFieldName, values);
+    }
+
+    /**
+     * Legacy reader variant that accepts pre-loaded {@link BinaryDocValues}.
+     */
+    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
         throws IOException {
         String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
         NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);
         if (counts == null) {
             return new IntegratedCounts(values);
         } else {
-            Sparsity sparsity = Sparsity.UNKNOWN;
-            ValueMode valueMode = ValueMode.UNKNOWN;
-
-            DocValuesSkipper countsSkipper = leafReader.getDocValuesSkipper(countsFieldName);
-            if (countsSkipper != null) {
-                sparsity = countsSkipper.docCount() == leafReader.maxDoc() ? Sparsity.DENSE : Sparsity.SPARSE;
-                valueMode = countsSkipper.maxValue() == 1 ? ValueMode.SINGLE_VALUED : ValueMode.MULTI_VALUED;
-            }
-
-            return new SeparateCounts(values, counts, sparsity, valueMode);
+            return buildSeparateCounts(leafReader, countsFieldName, values, counts);
         }
+    }
+
+    private static SeparateCounts buildSeparateCounts(
+        LeafReader leafReader,
+        String countsFieldName,
+        BinaryDocValues values,
+        NumericDocValues counts
+    ) throws IOException {
+        Sparsity sparsity = Sparsity.UNKNOWN;
+        ValueMode valueMode = ValueMode.UNKNOWN;
+
+        DocValuesSkipper countsSkipper = leafReader.getDocValuesSkipper(countsFieldName);
+        if (countsSkipper != null) {
+            sparsity = countsSkipper.docCount() == leafReader.maxDoc() ? Sparsity.DENSE : Sparsity.SPARSE;
+            valueMode = countsSkipper.maxValue() == 1 ? ValueMode.SINGLE_VALUED : ValueMode.MULTI_VALUED;
+        }
+
+        return new SeparateCounts(values, counts, sparsity, valueMode);
     }
 
     @Override
@@ -166,6 +199,37 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
         @Override
         public ValueMode getValueMode() {
             return valueMode;
+        }
+    }
+
+    /**
+     * Single-valued binary doc values written as a plain {@link org.apache.lucene.document.BinaryDocValuesField}.
+     * No companion {@code .counts} field exists; each document has at most one value.
+     */
+    private static class PlainBinary extends MultiValuedSortedBinaryDocValues {
+        PlainBinary(BinaryDocValues values) {
+            super(values);
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+            if (values.advanceExact(doc)) {
+                count = 1;
+                return true;
+            } else {
+                count = 0;
+                return false;
+            }
+        }
+
+        @Override
+        public BytesRef nextValue() throws IOException {
+            return values.binaryValue();
+        }
+
+        @Override
+        public ValueMode getValueMode() {
+            return ValueMode.SINGLE_VALUED;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -31,15 +32,18 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    protected final IndexVersion indexVersion;
 
     public BytesBinaryIndexFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -75,7 +79,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion);
     }
 
     @Override
@@ -87,17 +91,24 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
         private final String name;
         private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
         private final ValuesSourceType valuesSourceType;
+        private final IndexVersion indexVersion;
 
-        public Builder(String name, ValuesSourceType valuesSourceType, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+        public Builder(
+            String name,
+            ValuesSourceType valuesSourceType,
+            ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+            IndexVersion indexVersion
+        ) {
             this.name = name;
             this.valuesSourceType = valuesSourceType;
             this.toScriptFieldFactory = toScriptFieldFactory;
+            this.indexVersion = indexVersion;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             // Ignore breaker
-            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory);
+            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory, indexVersion);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -19,21 +21,24 @@ import org.elasticsearch.script.field.ToScriptFieldFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public final class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
+public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
 
     private final String fieldName;
     private final LeafReader leafReader;
     private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    private final IndexVersion indexVersion;
 
-    MultiValuedBinaryDVLeafFieldData(
+    protected MultiValuedBinaryDVLeafFieldData(
         String fieldName,
         LeafReader leafReader,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         super();
         this.fieldName = fieldName;
         this.leafReader = leafReader;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -46,7 +51,10 @@ public final class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         try {
             // Need to return a new instance each time this gets invoked,
             // otherwise a positioned or exhausted instance can be returned:
-            return MultiValuedSortedBinaryDocValues.from(leafReader, fieldName);
+            if (indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
+                return MultiValuedSortedBinaryDocValues.from(leafReader, fieldName);
+            }
+            return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -28,15 +29,18 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    protected final IndexVersion indexVersion;
 
     public StringBinaryIndexFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -57,7 +61,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
@@ -11,6 +11,8 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -20,11 +22,13 @@ import java.io.IOException;
 public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
 
     private final String name;
+    private final IndexVersion indexVersion;
     private SortedBinaryDocValues bytesValues;
     private boolean hasValue;
 
-    public BinaryDocValuesSyntheticFieldLoaderLayer(String name) {
+    public BinaryDocValuesSyntheticFieldLoaderLayer(String name, IndexVersion indexVersion) {
         this.name = name;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -41,7 +45,9 @@ public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSynthe
             return null;
         }
 
-        bytesValues = MultiValuedSortedBinaryDocValues.from(leafReader, name, docValues);
+        bytesValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
+            ? MultiValuedSortedBinaryDocValues.from(leafReader, name)
+            : MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, name, docValues);
 
         return docId -> {
             hasValue = bytesValues.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
@@ -18,17 +20,23 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.MultiValuedBinaryDVLeafFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.field.BinaryDocValuesField;
+import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,7 +141,7 @@ public class BinaryFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
             failIfNoDocValues();
-            return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, BinaryDocValuesField::new);
+            return (cache, breakerService) -> new CustomBinaryIndexFieldData(name(), BinaryDocValuesField::new);
         }
 
         @Override
@@ -231,6 +239,45 @@ public class BinaryFieldMapper extends FieldMapper {
         }
 
         return super.syntheticSourceSupport();
+    }
+
+    /**
+     * This class is necessary because BinaryFieldMapper uses its own binary encoding format, matching that of
+     * {@link MultiValuedBinaryDocValuesField.IntegratedCount}.
+     */
+    private static final class CustomBinaryDVLeafFieldData extends MultiValuedBinaryDVLeafFieldData {
+        private final LeafReader leafReader;
+        private final String fieldName;
+
+        CustomBinaryDVLeafFieldData(
+            String fieldName,
+            LeafReader leafReader,
+            ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ) {
+            super(fieldName, leafReader, toScriptFieldFactory, IndexVersion.current());
+            this.leafReader = leafReader;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public SortedBinaryDocValues getBytesValues() {
+            try {
+                return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private static final class CustomBinaryIndexFieldData extends BytesBinaryIndexFieldData {
+        CustomBinaryIndexFieldData(String fieldName, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+            super(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory, IndexVersion.current());
+        }
+
+        @Override
+        public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
+            return new CustomBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        }
     }
 
     public static final class CustomBinaryDocValuesField extends CustomDocValuesField {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -516,6 +516,7 @@ public class BooleanFieldMapper extends FieldMapper {
     private final Boolean nullValue;
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final Script script;
     private final FieldValues<Boolean> scriptValues;
@@ -539,6 +540,11 @@ public class BooleanFieldMapper extends FieldMapper {
         this.stored = builder.stored.getValue();
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType().indexType.hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.script = builder.script.get();
         this.scriptValues = builder.scriptValues();
         this.scriptCompiler = builder.scriptCompiler;
@@ -620,11 +626,7 @@ public class BooleanFieldMapper extends FieldMapper {
             context.doc().add(new StoredField(fieldType().name(), value ? "T" : "F"));
         }
         if (docValuesParameters.enabled()) {
-            if (fieldType().indexType.hasDocValuesSkipper()) {
-                context.doc().add(SortedNumericDocValuesField.indexedField(fieldType().name(), value ? 1 : 0));
-            } else {
-                context.doc().add(new SortedNumericDocValuesField(fieldType().name(), value ? 1 : 0));
-            }
+            dvFactory.addNumericField(context.doc(), fieldType().name(), value ? 1 : 0);
         } else {
             context.addToFieldNames(fieldType().name());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -568,6 +568,11 @@ public class BooleanFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         if (indexed == false && stored == false && docValuesParameters.enabled() == false) {
             return;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -568,11 +568,6 @@ public class BooleanFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         if (indexed == false && stored == false && docValuesParameters.enabled() == false) {
             return;

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
@@ -180,7 +180,7 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
      */
     public static Layer malformedValuesLayer(String fieldName, IndexVersion indexVersion) {
         if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new MalformedValuesBinaryDocValuesLayer(fieldName);
+            return new MalformedValuesBinaryDocValuesLayer(fieldName, indexVersion);
         } else {
             return new MalformedValuesStoredFieldLayer(fieldName);
         }
@@ -209,8 +209,8 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
      * Layer that loads malformed values from binary doc values for synthetic source.
      */
     private static class MalformedValuesBinaryDocValuesLayer extends BinaryDocValuesSyntheticFieldLoaderLayer {
-        MalformedValuesBinaryDocValuesLayer(String fieldName) {
-            super(IgnoreMalformedStoredValues.name(fieldName));
+        MalformedValuesBinaryDocValuesLayer(String fieldName, IndexVersion indexVersion) {
+            super(IgnoreMalformedStoredValues.name(fieldName), indexVersion);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -11,11 +11,9 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -1075,6 +1073,7 @@ public final class DateFieldMapper extends FieldMapper {
     private final boolean store;
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final Locale locale;
     private final String format;
     private final boolean ignoreMalformed;
@@ -1103,6 +1102,11 @@ public final class DateFieldMapper extends FieldMapper {
         this.store = builder.store.getValue();
         this.indexed = builder.index.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType().hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.locale = builder.locale.getValue();
         this.format = builder.format.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
@@ -1232,18 +1236,7 @@ public final class DateFieldMapper extends FieldMapper {
             DataStreamTimestampFieldMapper.storeTimestampValueForReuse(context.doc(), timestamp);
         }
 
-        if (fieldType().hasDocValuesSkipper()) {
-            context.doc().add(SortedNumericDocValuesField.indexedField(fieldType().name(), timestamp));
-        } else if (indexed && docValuesParameters.enabled()) {
-            context.doc().add(new LongField(fieldType().name(), timestamp, Field.Store.NO));
-        } else if (docValuesParameters.enabled()) {
-            context.doc().add(new SortedNumericDocValuesField(fieldType().name(), timestamp));
-        } else if (indexed) {
-            context.doc().add(new LongPoint(fieldType().name(), timestamp));
-        }
-        if (store) {
-            context.doc().add(new StoredField(fieldType().name(), timestamp));
-        }
+        NumberFieldMapper.NumberType.LONG.addFields(context.doc(), fieldType().name(), timestamp, fieldType().indexType, store, dvFactory);
         if (docValuesParameters.enabled() == false && (indexed || store)) {
             // When the field doesn't have doc values so that we can run exists queries, we also need to index the field name separately.
             context.addToFieldNames(fieldType().name());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1159,11 +1159,6 @@ public final class DateFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
 
         long timestamp;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1159,6 +1159,11 @@ public final class DateFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
 
         long timestamp;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.FieldMapper.DocValuesParameter.Values.MultiValue;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ValueOrdering;
+
+/**
+ * Centralizes doc values field creation, branching between single-valued (multi_value=no) and multi-valued Lucene types.
+ * <p>
+ * For {@link MultiValue#NO}, uses single-valued Lucene types ({@link NumericDocValuesField}, {@link SortedDocValuesField},
+ * {@link BinaryDocValuesField}) which enforce single-valuedness natively and enable storage optimizations.
+ * For other multi-value modes, uses multi-valued types ({@link SortedNumericDocValuesField}, {@link SortedSetDocValuesField},
+ * {@link MultiValuedBinaryDocValuesField}).
+ */
+public class DocValuesFieldFactory {
+
+    private final MultiValue multiValue;
+    private final boolean hasSkipper;
+    private final IndexVersion indexVersion;
+
+    public DocValuesFieldFactory(MultiValue multiValue, boolean hasSkipper, IndexVersion indexVersion) {
+        this.multiValue = multiValue;
+        this.hasSkipper = hasSkipper;
+        this.indexVersion = indexVersion;
+    }
+
+    public boolean isSingleValued() {
+        return multiValue == MultiValue.NO;
+    }
+
+    /**
+     * Adds a numeric doc values field. For {@code multi_value=no}, creates a {@link NumericDocValuesField} (single-valued).
+     * Otherwise, creates a {@link SortedNumericDocValuesField} (multi-valued).
+     */
+    public void addNumericField(LuceneDocument doc, String name, long value) {
+        if (multiValue == MultiValue.NO) {
+            doc.add(hasSkipper ? NumericDocValuesField.indexedField(name, value) : new NumericDocValuesField(name, value));
+        } else {
+            doc.add(hasSkipper ? SortedNumericDocValuesField.indexedField(name, value) : new SortedNumericDocValuesField(name, value));
+        }
+    }
+
+    /**
+     * Adds a sorted (bytes) doc values field. For {@code multi_value=no}, creates a {@link SortedDocValuesField} (single-valued).
+     * Otherwise, creates a {@link SortedSetDocValuesField} (multi-valued).
+     */
+    public void addSortedField(LuceneDocument doc, String name, BytesRef value) {
+        if (multiValue == MultiValue.NO) {
+            doc.add(hasSkipper ? SortedDocValuesField.indexedField(name, value) : new SortedDocValuesField(name, value));
+        } else {
+            doc.add(hasSkipper ? SortedSetDocValuesField.indexedField(name, value) : new SortedSetDocValuesField(name, value));
+        }
+    }
+
+    /**
+     * Adds a binary doc values field. For {@code multi_value=no}, creates a plain {@link BinaryDocValuesField} (single-valued,
+     * no companion {@code .counts} field). Otherwise, delegates to {@link MultiValuedBinaryDocValuesField#addToBinaryFieldInDoc}
+     * which handles the multi-valued encoding.
+     */
+    public void addBinaryField(LuceneDocument doc, String name, BytesRef value, ValueOrdering ordering) {
+        if (multiValue == MultiValue.NO) {
+            doc.add(new BinaryDocValuesField(name, value));
+        } else {
+            MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(doc, name, value, ordering, indexVersion);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -164,7 +164,6 @@ public abstract class DocumentParserContext {
     private final SourceToParse sourceToParse;
 
     private final Set<String> ignoredFields;
-    private final Set<String> singleValueFields;
     private final List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues;
     private Scope currentScope;
 
@@ -202,7 +201,6 @@ public abstract class DocumentParserContext {
         MappingParserContext mappingParserContext,
         SourceToParse sourceToParse,
         Set<String> ignoreFields,
-        Set<String> singleValueFields,
         List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues,
         Scope currentScope,
         Map<String, List<Mapper.Builder>> dynamicMappers,
@@ -225,7 +223,6 @@ public abstract class DocumentParserContext {
         this.mappingParserContext = mappingParserContext;
         this.sourceToParse = sourceToParse;
         this.ignoredFields = ignoreFields;
-        this.singleValueFields = singleValueFields;
         this.ignoredFieldValues = ignoredFieldValues;
         this.currentScope = currentScope;
         this.dynamicMappers = dynamicMappers;
@@ -253,7 +250,6 @@ public abstract class DocumentParserContext {
             in.mappingParserContext,
             in.sourceToParse,
             in.ignoredFields,
-            in.singleValueFields,
             in.ignoredFieldValues,
             in.currentScope,
             in.dynamicMappers,
@@ -285,7 +281,6 @@ public abstract class DocumentParserContext {
             mappingLookup,
             mappingParserContext,
             source,
-            new HashSet<>(),
             new HashSet<>(),
             new ArrayList<>(),
             Scope.SINGLETON,
@@ -440,18 +435,6 @@ public abstract class DocumentParserContext {
     public final void addToFieldNames(String field) {
         if (fieldNamesFieldMapper != null) {
             fieldNamesFieldMapper.addFieldNames(this, field);
-        }
-    }
-
-    /**
-     * Enforces that a field configured with {@code multi_value=no} stores at most one value per document.
-     * Throws {@link IllegalStateException} on the second call for the same field name.
-     */
-    public final void enforceSingleValue(String fieldName) {
-        if (singleValueFields.add(fieldName) == false) {
-            throw new IllegalStateException(
-                "Field [" + fieldName + "] is configured with multi_value=no but more than one value was detected"
-            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -164,6 +164,7 @@ public abstract class DocumentParserContext {
     private final SourceToParse sourceToParse;
 
     private final Set<String> ignoredFields;
+    private final Set<String> singleValueFields;
     private final List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues;
     private Scope currentScope;
 
@@ -201,6 +202,7 @@ public abstract class DocumentParserContext {
         MappingParserContext mappingParserContext,
         SourceToParse sourceToParse,
         Set<String> ignoreFields,
+        Set<String> singleValueFields,
         List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues,
         Scope currentScope,
         Map<String, List<Mapper.Builder>> dynamicMappers,
@@ -223,6 +225,7 @@ public abstract class DocumentParserContext {
         this.mappingParserContext = mappingParserContext;
         this.sourceToParse = sourceToParse;
         this.ignoredFields = ignoreFields;
+        this.singleValueFields = singleValueFields;
         this.ignoredFieldValues = ignoredFieldValues;
         this.currentScope = currentScope;
         this.dynamicMappers = dynamicMappers;
@@ -250,6 +253,7 @@ public abstract class DocumentParserContext {
             in.mappingParserContext,
             in.sourceToParse,
             in.ignoredFields,
+            in.singleValueFields,
             in.ignoredFieldValues,
             in.currentScope,
             in.dynamicMappers,
@@ -281,6 +285,7 @@ public abstract class DocumentParserContext {
             mappingLookup,
             mappingParserContext,
             source,
+            new HashSet<>(),
             new HashSet<>(),
             new ArrayList<>(),
             Scope.SINGLETON,
@@ -435,6 +440,18 @@ public abstract class DocumentParserContext {
     public final void addToFieldNames(String field) {
         if (fieldNamesFieldMapper != null) {
             fieldNamesFieldMapper.addFieldNames(this, field);
+        }
+    }
+
+    /**
+     * Enforces that a field configured with {@code multi_value=no} stores at most one value per document.
+     * Throws {@link IllegalStateException} on the second call for the same field name.
+     */
+    public final void enforceSingleValue(String fieldName) {
+        if (singleValueFields.add(fieldName) == false) {
+            throw new IllegalStateException(
+                "Field [" + fieldName + "] is configured with multi_value=no but more than one value was detected"
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -136,7 +136,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
             this.ignoredSourceFormat = ignoredSourceFormat;
             if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                 this.ignoredSourceDocValues = Objects.requireNonNull(
-                    MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                    MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
                 );
             } else {
                 this.ignoredSourceDocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -191,22 +191,10 @@ public abstract class FieldMapper extends Mapper {
     /**
      * Parse the field value using the provided {@link DocumentParserContext}.
      */
-    /**
-     * Returns {@code true} if this field is configured with {@code multi_value=no} and should reject multiple values per document.
-     * Subclasses that support the {@code multi_value} parameter should override this method.
-     */
-    protected boolean isSingleValueEnforced() {
-        return false;
-    }
-
     public void parse(DocumentParserContext context) throws IOException {
         try {
             if (builderParams.hasScript) {
                 throwIndexingWithScriptParam();
-            }
-
-            if (isSingleValueEnforced()) {
-                context.enforceSingleValue(fieldType().name());
             }
 
             parseCreateField(context);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -191,10 +191,22 @@ public abstract class FieldMapper extends Mapper {
     /**
      * Parse the field value using the provided {@link DocumentParserContext}.
      */
+    /**
+     * Returns {@code true} if this field is configured with {@code multi_value=no} and should reject multiple values per document.
+     * Subclasses that support the {@code multi_value} parameter should override this method.
+     */
+    protected boolean isSingleValueEnforced() {
+        return false;
+    }
+
     public void parse(DocumentParserContext context) throws IOException {
         try {
             if (builderParams.hasScript) {
                 throwIndexingWithScriptParam();
+            }
+
+            if (isSingleValueEnforced()) {
+                context.enforceSingleValue(fieldType().name());
             }
 
             parseCreateField(context);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -143,7 +143,7 @@ public abstract class IgnoreMalformedStoredValues {
      */
     public static IgnoreMalformedStoredValues forSyntheticSource(String fieldName, IndexVersion indexVersion) {
         if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new DocValues(fieldName);
+            return new DocValues(fieldName, indexVersion);
         } else {
             return new Stored(fieldName);
         }
@@ -239,8 +239,8 @@ public abstract class IgnoreMalformedStoredValues {
 
         private final BinaryDocValuesSyntheticFieldLoaderLayer delegate;
 
-        DocValues(String fieldName) {
-            this.delegate = new BinaryDocValuesSyntheticFieldLoaderLayer(name(fieldName)) {
+        DocValues(String fieldName, IndexVersion indexVersion) {
+            this.delegate = new BinaryDocValuesSyntheticFieldLoaderLayer(name(fieldName), indexVersion) {
                 @Override
                 protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
                     XContentDataHelper.decodeAndWrite(b, value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -174,7 +174,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         @Override
         public void setNextReader(LeafReaderContext context) {
             try {
-                docValues = MultiValuedSortedBinaryDocValues.from(context.reader(), NAME);
+                docValues = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), NAME);
             } catch (IOException e) {
                 throw new ElasticsearchException("Failed to load doc values for " + NAME, e);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -599,6 +599,7 @@ public class IpFieldMapper extends FieldMapper {
 
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final boolean ignoreMalformed;
     private final boolean storeIgnored;
@@ -625,6 +626,11 @@ public class IpFieldMapper extends FieldMapper {
         super(simpleName, mappedFieldType, builderParams);
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType().indexType.hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.stored = builder.stored.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.nullValue = builder.parseNullValue();
@@ -699,11 +705,7 @@ public class IpFieldMapper extends FieldMapper {
             doc.add(address);
         }
         if (fieldType().indexType.hasDocValues()) {
-            if (fieldType().indexType.hasDocValuesSkipper()) {
-                doc.add(SortedSetDocValuesField.indexedField(fieldType().name(), address.binaryValue()));
-            } else {
-                doc.add(new SortedSetDocValuesField(fieldType().name(), address.binaryValue()));
-            }
+            dvFactory.addSortedField(doc, fieldType().name(), address.binaryValue());
         } else if (stored || indexed) {
             context.addToFieldNames(fieldType().name());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -658,6 +658,11 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         ESInetAddressPoint address;
         XContentString value = context.parser().optimizedTextOrNull();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -658,11 +658,6 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         ESInetAddressPoint address;
         XContentString value = context.parser().optimizedTextOrNull();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -16,6 +16,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InvertableType;
+import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesSkipIndexType;
@@ -508,7 +509,10 @@ public final class KeywordFieldMapper extends FieldMapper {
 
             DocValuesParameter.Values docValuesParameters = this.docValuesParameters.get();
             if (docValuesParameters.enabled() && docValuesParameters.cardinality() == DocValuesParameter.Values.Cardinality.LOW) {
-                fieldtype.setDocValuesType(DocValuesType.SORTED_SET);
+                DocValuesType dvType = docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO
+                    ? DocValuesType.SORTED
+                    : DocValuesType.SORTED_SET;
+                fieldtype.setDocValuesType(dvType);
             } else {
                 fieldtype.setDocValuesType(DocValuesType.NONE);
                 fieldtype.setDocValuesSkipIndexType(DocValuesSkipIndexType.NONE);
@@ -689,6 +693,10 @@ public final class KeywordFieldMapper extends FieldMapper {
             return docValuesParams;
         }
 
+        private boolean usesSingleValuedDocValues() {
+            return docValuesParams != null && docValuesParams.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+        }
+
         @Override
         public boolean isSearchable() {
             return indexType.hasTerms() || hasDocValues();
@@ -701,6 +709,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                 return super.termQuery(value, context);
             } else if (usesBinaryDocValues) {
                 return new SlowCustomBinaryDocValuesTermQuery(name(), indexedValueForSearch(value));
+            } else if (usesSingleValuedDocValues()) {
+                return SortedDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
             } else {
                 return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
@@ -714,6 +724,9 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return new SlowCustomBinaryDocValuesTermInSetQuery(name(), bytesRefs);
+            } else if (usesSingleValuedDocValues()) {
+                Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
+                return SortedDocValuesField.newSlowSetQuery(name(), bytesRefs);
             } else {
                 Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
@@ -738,6 +751,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm).utf8ToString(),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm).utf8ToString(),
+                    includeLower,
+                    includeUpper
+                );
+            } else if (usesSingleValuedDocValues()) {
+                return SortedDocValuesField.newSlowRangeQuery(
+                    name(),
+                    lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
+                    upperTerm == null ? null : indexedValueForSearch(upperTerm),
                     includeLower,
                     includeUpper
                 );
@@ -1285,6 +1306,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final String indexOptions;
     private final FieldType fieldType;
     private final String normalizerName;
@@ -1314,6 +1336,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType().indexType.hasDocValuesSkipper(),
+            builder.indexCreatedVersion
+        );
         this.indexOptions = builder.indexOptions.getValue();
         this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.normalizerName = builder.normalizer.getValue();
@@ -1409,15 +1436,13 @@ public final class KeywordFieldMapper extends FieldMapper {
                 final String fieldName = fieldType().syntheticSourceFallbackFieldName();
 
                 if (storeIgnoredFieldsInBinaryDocValues) {
-                    MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    dvFactory.addBinaryField(
                         context.doc(),
                         fieldName,
                         bytesRef,
                         keepDuplicatesInBinaryDocValues()
                             ? MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
-                            : MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
-                        docValuesParameters.multiValue(),
-                        indexCreatedVersion
+                            : MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
                     );
                 } else {
                     // otherwise for bwc, store the value in a stored fields like we used to
@@ -1461,13 +1486,11 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         if (fieldType().usesBinaryDocValues()) {
             assert fieldType.docValuesType() == DocValuesType.NONE;
-            MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            dvFactory.addBinaryField(
                 context.doc(),
                 fieldType().name(),
                 binaryValue,
-                MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
-                docValuesParameters.multiValue(),
-                indexCreatedVersion
+                MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -62,6 +62,7 @@ import org.elasticsearch.index.fielddata.StoredFieldSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.ByteLengthFromBytesRefDocValuesBlockLoader;
@@ -567,6 +568,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final boolean isDimension;
         private final boolean usesBinaryDocValues;
         private final boolean usesBinaryDocValuesForIgnoredFields;
+        private final DocValuesParameter.Values docValuesParams;
+        private final IndexVersion indexVersion;
 
         public KeywordFieldType(
             String name,
@@ -597,6 +600,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = builder.dimension.getValue();
             this.usesBinaryDocValues = builder.usesBinaryDocValues();
             this.usesBinaryDocValuesForIgnoredFields = builder.storeIgnoredFieldsInBinaryDocValues;
+            this.docValuesParams = builder.docValuesParameters();
+            this.indexVersion = builder.indexSettings.getIndexVersionCreated();
         }
 
         public KeywordFieldType(String name) {
@@ -623,6 +628,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.docValuesParams = null;
+            this.indexVersion = IndexVersion.current();
         }
 
         public KeywordFieldType(String name, FieldType fieldType, boolean isSyntheticSource) {
@@ -643,6 +650,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = false;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.docValuesParams = null;
+            this.indexVersion = IndexVersion.current();
         }
 
         public KeywordFieldType(String name, NamedAnalyzer analyzer) {
@@ -663,6 +672,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = false;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.docValuesParams = null;
+            this.indexVersion = IndexVersion.current();
         }
 
         public boolean usesBinaryDocValues() {
@@ -671,6 +682,11 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         public boolean usesBinaryDocValuesForIgnoredFields() {
             return usesBinaryDocValuesForIgnoredFields;
+        }
+
+        @Override
+        public DocValuesParameter.Values docValuesParameters() {
+            return docValuesParams;
         }
 
         @Override
@@ -718,7 +734,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldRangeQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm).utf8ToString(),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm).utf8ToString(),
@@ -752,7 +768,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return StringScriptFieldFuzzyQuery.build(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     fuzziness.asDistance(BytesRefs.toString(value)),
@@ -784,7 +800,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldPrefixQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     caseInsensitive
@@ -812,7 +828,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldTermQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     true
@@ -883,7 +899,11 @@ public final class KeywordFieldMapper extends FieldMapper {
                 BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
                 if (cfg == null) {
                     if (usesBinaryDocValues) {
-                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                        if (docValuesParams != null && docValuesParams.multiValue() == DocValuesParameter.Values.MultiValue.NO) {
+                            return new BytesRefsFromBinaryBlockLoader(name());
+                        } else {
+                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
+                        }
                     } else {
                         return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                     }
@@ -1032,7 +1052,12 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, KeywordDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(
+                    name(),
+                    CoreValuesSourceType.KEYWORD,
+                    KeywordDocValuesField::new,
+                    indexVersion
+                );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -1154,7 +1179,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (usesBinaryDocValues) {
                     return new StringScriptFieldWildcardQuery(
                         new Script(""),
-                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                         name(),
                         value,
                         false
@@ -1190,7 +1215,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (usesBinaryDocValues) {
                     return new StringScriptFieldRegexpQuery(
                         new Script(""),
-                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                         name(),
                         value,
                         syntaxFlags,
@@ -1323,6 +1348,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         return docValuesParameters;
     }
 
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+    }
+
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         var value = context.parser().optimizedTextOrNull();
 
@@ -1391,6 +1421,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                         keepDuplicatesInBinaryDocValues()
                             ? MultiValuedBinaryDocValuesField.ValueOrdering.SORTED
                             : MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                        docValuesParameters.multiValue(),
                         indexCreatedVersion
                     );
                 } else {
@@ -1439,7 +1470,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                 context.doc(),
                 fieldType().name(),
                 binaryValue,
-                MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                docValuesParameters.multiValue(),
+                indexCreatedVersion
             );
         }
 
@@ -1587,7 +1620,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
             } else {
                 assert offsetsFieldName == null;
-                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().name()));
+                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().name(), fieldType().indexVersion));
             }
         }
 
@@ -1597,7 +1630,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             final String fieldName = fieldType().syntheticSourceFallbackFieldName();
 
             if (storeIgnoredFieldsInBinaryDocValues) {
-                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldName));
+                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldName, fieldType().indexVersion));
             } else {
                 // old indices, stored ignored values in stored fields
                 layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fieldName) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1348,11 +1348,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         return docValuesParameters;
     }
 
-    @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
-    }
-
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         var value = context.parser().optimizedTextOrNull();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -126,6 +126,14 @@ public abstract class MappedFieldType {
     }
 
     /**
+     * Returns the extended doc values parameters for this field type, or {@code null} if the field type does not support them.
+     */
+    @Nullable
+    public FieldMapper.DocValuesParameter.Values docValuesParameters() {
+        return null;
+    }
+
+    /**
      * Returns the collapse type of the field
      * CollapseType.NONE means the field can'be used for collapsing.
      * @return collapse type of the field

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -110,6 +111,22 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
             SeparateCount.addToDoc(doc, fieldName, value, ordering);
         } else {
             IntegratedCount.addToDoc(doc, fieldName, value, ordering);
+        }
+    }
+
+    public static void addToBinaryFieldInDoc(
+        LuceneDocument doc,
+        String fieldName,
+        BytesRef value,
+        ValueOrdering ordering,
+        FieldMapper.DocValuesParameter.Values.MultiValue multiValue,
+        IndexVersion indexVersion
+    ) {
+        if (multiValue == FieldMapper.DocValuesParameter.Values.MultiValue.NO) {
+            // If single values are enforced, use a basic Lucene binary doc values field instead
+            doc.add(new BinaryDocValuesField(fieldName, value));
+        } else {
+            addToBinaryFieldInDoc(doc, fieldName, value, ordering, indexVersion);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -111,22 +110,6 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
             SeparateCount.addToDoc(doc, fieldName, value, ordering);
         } else {
             IntegratedCount.addToDoc(doc, fieldName, value, ordering);
-        }
-    }
-
-    public static void addToBinaryFieldInDoc(
-        LuceneDocument doc,
-        String fieldName,
-        BytesRef value,
-        ValueOrdering ordering,
-        FieldMapper.DocValuesParameter.Values.MultiValue multiValue,
-        IndexVersion indexVersion
-    ) {
-        if (multiValue == FieldMapper.DocValuesParameter.Values.MultiValue.NO) {
-            // If single values are enforced, use a basic Lucene binary doc values field instead
-            doc.add(new BinaryDocValuesField(fieldName, value));
-        } else {
-            addToBinaryFieldInDoc(doc, fieldName, value, ordering, indexVersion);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2460,12 +2460,6 @@ public class NumberFieldMapper extends FieldMapper {
      * fields that want to share the behavior of numeric fields.
      */
     public void indexValue(DocumentParserContext context, Number numericValue) {
-        // Single-value enforcement is handled here instead of in parse() because this method is called directly by composite mappers
-        // such as AggregateMetricDoubleFieldMapper, bypassing parse() entirely. Placing the check here covers both the normal
-        // document-parser path parse() → parseCreateField() → indexValue() and the direct-call path.
-        if (docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO) {
-            context.enforceSingleValue(fieldType.name());
-        }
         final String name = fieldType.name();
         final LuceneDocument doc = context.doc();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -469,6 +469,27 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                final float f = value.floatValue();
+                if (indexType.hasPoints()) {
+                    document.add(new HalfFloatPoint(name, f));
+                }
+                if (indexType.hasDocValues()) {
+                    dvFactory.addNumericField(document, name, HalfFloatPoint.halfFloatToSortableShort(f));
+                }
+                if (stored) {
+                    document.add(new StoredField(name, f));
+                }
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return HalfFloatPoint.halfFloatToSortableShort(value.floatValue());
             }
@@ -678,6 +699,32 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                final float f = value.floatValue();
+                if (indexType.hasPoints() && indexType.hasDocValues()) {
+                    if (dvFactory.isSingleValued()) {
+                        document.add(new SingleValuedFloatField(name, f));
+                    } else {
+                        document.add(new FloatField(name, f, Field.Store.NO));
+                    }
+                } else if (indexType.hasDocValues()) {
+                    dvFactory.addNumericField(document, name, toSortableLong(value));
+                } else if (indexType.hasPoints()) {
+                    document.add(new FloatPoint(name, f));
+                }
+                if (stored) {
+                    document.add(new StoredField(name, f));
+                }
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return NumericUtils.floatToSortableInt(value.floatValue());
             }
@@ -853,6 +900,32 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                final double d = value.doubleValue();
+                if (indexType.hasPoints() && indexType.hasDocValues()) {
+                    if (dvFactory.isSingleValued()) {
+                        document.add(new SingleValuedDoubleField(name, d));
+                    } else {
+                        document.add(new DoubleField(name, d, Field.Store.NO));
+                    }
+                } else if (indexType.hasDocValues()) {
+                    dvFactory.addNumericField(document, name, toSortableLong(value));
+                } else if (indexType.hasPoints()) {
+                    document.add(new DoublePoint(name, d));
+                }
+                if (stored) {
+                    document.add(new StoredField(name, d));
+                }
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return NumericUtils.doubleToSortableLong(value.doubleValue());
             }
@@ -992,6 +1065,18 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                INTEGER.addFields(document, name, value, indexType, stored, dvFactory);
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return INTEGER.toSortableLong(value);
             }
@@ -1127,6 +1212,18 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
                 INTEGER.addFields(document, name, value, indexType, stored);
+            }
+
+            @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                INTEGER.addFields(document, name, value, indexType, stored, dvFactory);
             }
 
             @Override
@@ -1352,6 +1449,32 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                final int i = value.intValue();
+                if (indexType.hasPoints() && indexType.hasDocValues()) {
+                    if (dvFactory.isSingleValued()) {
+                        document.add(new SingleValuedIntField(name, i));
+                    } else {
+                        document.add(new IntField(name, i, Field.Store.NO));
+                    }
+                } else if (indexType.hasDocValues()) {
+                    dvFactory.addNumericField(document, name, i);
+                } else if (indexType.hasPoints()) {
+                    document.add(new IntPoint(name, i));
+                }
+                if (stored) {
+                    document.add(new StoredField(name, i));
+                }
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return value.intValue();
             }
@@ -1530,6 +1653,32 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                final long l = value.longValue();
+                if (indexType.hasPoints() && indexType.hasDocValues()) {
+                    if (dvFactory.isSingleValued()) {
+                        document.add(new SingleValuedLongField(name, l));
+                    } else {
+                        document.add(new LongField(name, l, Field.Store.NO));
+                    }
+                } else if (indexType.hasDocValues()) {
+                    dvFactory.addNumericField(document, name, l);
+                } else if (indexType.hasPoints()) {
+                    document.add(new LongPoint(name, l));
+                }
+                if (stored) {
+                    document.add(new StoredField(name, l));
+                }
+            }
+
+            @Override
             public long toSortableLong(Number value) {
                 return value.longValue();
             }
@@ -1682,6 +1831,20 @@ public class NumberFieldMapper extends FieldMapper {
          * @param stored whether or not the field is stored
          */
         public abstract void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored);
+
+        /**
+         * Variant of {@link #addFields} that uses the given factory for doc values creation. Each type overrides this to use its
+         * single-valued counterpart (e.g. {@link SingleValuedFloatField}) when the factory is single-valued, or the standard Lucene
+         * convenience class (e.g. {@link FloatField}) when multi-valued.
+         */
+        public abstract void addFields(
+            LuceneDocument document,
+            String name,
+            Number value,
+            IndexType indexType,
+            boolean stored,
+            DocValuesFieldFactory dvFactory
+        );
 
         /**
          * For a given {@code Number}, returns the sortable long representation that will be stored in the doc values.
@@ -2306,6 +2469,7 @@ public class NumberFieldMapper extends FieldMapper {
     private final NumberType type;
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final Explicit<Boolean> ignoreMalformed;
     private final Explicit<Boolean> coerce;
@@ -2335,6 +2499,11 @@ public class NumberFieldMapper extends FieldMapper {
         this.type = builder.type;
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            ((NumberFieldType) mappedFieldType).indexType().hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.stored = builder.stored.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.coerce = builder.coerce.getValue();
@@ -2471,7 +2640,7 @@ public class NumberFieldMapper extends FieldMapper {
         switch (type) {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue());
             case LONG -> addLongFields(doc, name, numericValue.longValue());
-            default -> type.addFields(doc, name, numericValue, fieldType.indexType, stored);
+            case HALF_FLOAT, FLOAT, DOUBLE -> type.addFields(doc, name, numericValue, fieldType.indexType, stored, dvFactory);
         }
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {
@@ -2482,13 +2651,13 @@ public class NumberFieldMapper extends FieldMapper {
     private void addIntFields(LuceneDocument document, String name, int i) {
         final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
-            document.add(new IntField(name, i, Field.Store.NO));
-        } else if (indexType.hasDocValues()) {
-            if (indexType.hasDocValuesSkipper()) {
-                document.add(SortedNumericDocValuesField.indexedField(name, i));
+            if (dvFactory.isSingleValued()) {
+                document.add(new SingleValuedIntField(name, i));
             } else {
-                document.add(new SortedNumericDocValuesField(name, i));
+                document.add(new IntField(name, i, Field.Store.NO));
             }
+        } else if (indexType.hasDocValues()) {
+            dvFactory.addNumericField(document, name, i);
         } else if (indexType.hasPoints()) {
             document.add(new IntPoint(name, i));
         }
@@ -2500,13 +2669,13 @@ public class NumberFieldMapper extends FieldMapper {
     private void addLongFields(LuceneDocument document, String name, long l) {
         final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
-            document.add(new LongField(name, l, Field.Store.NO));
-        } else if (indexType.hasDocValues()) {
-            if (indexType.hasDocValuesSkipper()) {
-                document.add(SortedNumericDocValuesField.indexedField(name, l));
+            if (dvFactory.isSingleValued()) {
+                document.add(new SingleValuedLongField(name, l));
             } else {
-                document.add(new SortedNumericDocValuesField(name, l));
+                document.add(new LongField(name, l, Field.Store.NO));
             }
+        } else if (indexType.hasDocValues()) {
+            dvFactory.addNumericField(document, name, l);
         } else if (indexType.hasPoints()) {
             document.add(new LongPoint(name, l));
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -20,7 +20,6 @@ import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
@@ -151,7 +150,6 @@ public class NumberFieldMapper extends FieldMapper {
             return type;
         }
 
-        private boolean allowMultipleValues = true;
         private final IndexSettings indexSettings;
 
         public static Builder docValuesOnly(String name, NumberType type, IndexSettings indexSettings) {
@@ -276,8 +274,9 @@ public class NumberFieldMapper extends FieldMapper {
             return metric;
         }
 
-        public Builder allowMultipleValues(boolean allowMultipleValues) {
-            this.allowMultipleValues = allowMultipleValues;
+        public Builder multiValue(DocValuesParameter.Values.MultiValue multiValue) {
+            var current = this.docValuesParameters.getValue();
+            this.docValuesParameters.setValue(new DocValuesParameter.Values(current.enabled(), current.cardinality(), multiValue));
             return this;
         }
 
@@ -2316,7 +2315,6 @@ public class NumberFieldMapper extends FieldMapper {
     private final ScriptCompiler scriptCompiler;
     private final Script script;
     private final MetricType metricType;
-    private boolean allowMultipleValues;
     private final boolean isSyntheticSource;
     private final String offsetsFieldName;
 
@@ -2346,7 +2344,6 @@ public class NumberFieldMapper extends FieldMapper {
         this.scriptCompiler = builder.scriptCompiler;
         this.script = builder.script.getValue();
         this.metricType = builder.metric.getValue();
-        this.allowMultipleValues = builder.allowMultipleValues;
         this.isSyntheticSource = isSyntheticSource;
         this.offsetsFieldName = offsetsFieldName;
         this.indexSettings = builder.indexSettings;
@@ -2463,6 +2460,12 @@ public class NumberFieldMapper extends FieldMapper {
      * fields that want to share the behavior of numeric fields.
      */
     public void indexValue(DocumentParserContext context, Number numericValue) {
+        // Single-value enforcement is handled here instead of in parse() because this method is called directly by composite mappers
+        // such as AggregateMetricDoubleFieldMapper, bypassing parse() entirely. Placing the check here covers both the normal
+        // document-parser path parse() → parseCreateField() → indexValue() and the direct-call path.
+        if (docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO) {
+            context.enforceSingleValue(fieldType.name());
+        }
         final String name = fieldType.name();
         final LuceneDocument doc = context.doc();
 
@@ -2475,14 +2478,6 @@ public class NumberFieldMapper extends FieldMapper {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue());
             case LONG -> addLongFields(doc, name, numericValue.longValue());
             default -> type.addFields(doc, name, numericValue, fieldType.indexType, stored);
-        }
-
-        if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
-            // the last field is the current field, Add to the key map, so that we can validate if it has been added
-            List<IndexableField> fields = doc.getFields();
-            final IndexableField last = fields.getLast();
-            assert last.name().equals(name) : "last field name [" + last.name() + "] mis match field name [" + name + "]";
-            doc.onlyAddKey(name, last);
         }
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {
@@ -2538,10 +2533,7 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(leafName(), type, scriptCompiler, indexSettings).dimension(dimension)
-            .metric(metricType)
-            .allowMultipleValues(allowMultipleValues)
-            .init(this);
+        return new Builder(leafName(), type, scriptCompiler, indexSettings).dimension(dimension).metric(metricType).init(this);
     }
 
     @Override
@@ -2586,8 +2578,4 @@ public class NumberFieldMapper extends FieldMapper {
         return super.syntheticSourceSupport();
     }
 
-    // For testing only:
-    void setAllowMultipleValues(boolean allowMultipleValues) {
-        this.allowMultipleValues = allowMultipleValues;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedDoubleField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedDoubleField.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued variant of Lucene's {@link org.apache.lucene.document.DoubleField}. Uses {@link DocValuesType#NUMERIC} instead of
+ * {@link DocValuesType#SORTED_NUMERIC}, enforcing single-valuedness natively and enabling storage optimizations.
+ */
+final class SingleValuedDoubleField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Double.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    SingleValuedDoubleField(String name, double value) {
+        super(name, FIELD_TYPE);
+        fieldsData = NumericUtils.doubleToSortableLong(value);
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] bytes = new byte[Double.BYTES];
+        DoublePoint.encodeDimension(NumericUtils.sortableLongToDouble((Long) fieldsData), bytes, 0);
+        return new BytesRef(bytes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedFloatField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedFloatField.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued variant of Lucene's {@link org.apache.lucene.document.FloatField}. Uses {@link DocValuesType#NUMERIC} instead of
+ * {@link DocValuesType#SORTED_NUMERIC}, enforcing single-valuedness natively and enabling storage optimizations.
+ */
+final class SingleValuedFloatField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Float.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    SingleValuedFloatField(String name, float value) {
+        super(name, FIELD_TYPE);
+        fieldsData = (long) NumericUtils.floatToSortableInt(value);
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] bytes = new byte[Float.BYTES];
+        FloatPoint.encodeDimension(NumericUtils.sortableIntToFloat(numericValue().intValue()), bytes, 0);
+        return new BytesRef(bytes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedIntField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedIntField.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued variant of Lucene's {@link org.apache.lucene.document.IntField}. Uses {@link DocValuesType#NUMERIC} instead of
+ * {@link DocValuesType#SORTED_NUMERIC}, enforcing single-valuedness natively and enabling storage optimizations.
+ */
+final class SingleValuedIntField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Integer.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    SingleValuedIntField(String name, int value) {
+        super(name, FIELD_TYPE);
+        fieldsData = value;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] bytes = new byte[Integer.BYTES];
+        NumericUtils.intToSortableBytes((Integer) fieldsData, bytes, 0);
+        return new BytesRef(bytes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedLongField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedLongField.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued variant of Lucene's {@link org.apache.lucene.document.LongField}. Uses {@link DocValuesType#NUMERIC} instead of
+ * {@link DocValuesType#SORTED_NUMERIC}, enforcing single-valuedness natively and enabling storage optimizations.
+ */
+final class SingleValuedLongField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Long.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    SingleValuedLongField(String name, long value) {
+        super(name, FIELD_TYPE);
+        fieldsData = value;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] bytes = new byte[Long.BYTES];
+        NumericUtils.longToSortableBytes((Long) fieldsData, bytes, 0);
+        return new BytesRef(bytes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesTerms.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesTerms.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiTerms;
@@ -37,8 +38,8 @@ class SortedSetDocValuesTerms extends Terms {
     public static Terms getTerms(IndexReader r, String field) throws IOException {
         final List<LeafReaderContext> leaves = r.leaves();
         if (leaves.size() == 1) {
-            SortedSetDocValues sortedSetDocValues = leaves.get(0).reader().getSortedSetDocValues(field);
-            if (sortedSetDocValues == null) {
+            SortedSetDocValues sortedSetDocValues = DocValues.getSortedSet(leaves.get(0).reader(), field);
+            if (sortedSetDocValues.getValueCount() == 0) {
                 return null;
             } else {
                 return new org.elasticsearch.index.mapper.SortedSetDocValuesTerms(sortedSetDocValues);
@@ -50,8 +51,8 @@ class SortedSetDocValuesTerms extends Terms {
 
         for (int leafIdx = 0; leafIdx < leaves.size(); leafIdx++) {
             LeafReaderContext ctx = leaves.get(leafIdx);
-            SortedSetDocValues sortedSetDocValues = ctx.reader().getSortedSetDocValues(field);
-            if (sortedSetDocValues != null) {
+            SortedSetDocValues sortedSetDocValues = DocValues.getSortedSet(ctx.reader(), field);
+            if (sortedSetDocValues.getValueCount() > 0) {
                 termsPerLeaf.add(new org.elasticsearch.index.mapper.SortedSetDocValuesTerms(sortedSetDocValues));
                 slicePerLeaf.add(new ReaderSlice(ctx.docBase, r.maxDoc(), leafIdx));
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -213,7 +213,7 @@ public interface SourceLoader {
                 this.ignoredSourceFormat = ignoredSourceFormat;
                 if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                     this.ignoredSourcedocValues = Objects.requireNonNull(
-                        MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                        MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
                     );
                 } else {
                     this.ignoredSourcedocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -2032,9 +2032,10 @@ public final class TextFieldMapper extends FieldMapper {
                 @Override
                 public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) throws IOException {
                     // text fields with doc_values may have all values stored in fallback fields; if every value exceeds MAX_TERM_LENGTH.
-                    // In that case, there will be no SortedSetDocValues, but the "main" field is still going to be indexed. As a result, we
-                    // can't use SortedSetDocValuesSyntheticFieldLoaderLayer since it uses DocValues.getSortedSet(), which will throw
-                    if (reader.getSortedSetDocValues(fieldName()) == null) {
+                    // In that case, there will be no doc values at all, but the "main" field is still going to be indexed. As a result,
+                    // we can't use SortedSetDocValuesSyntheticFieldLoaderLayer since it uses DocValues.getSortedSet(), which will throw.
+                    // Check for both SORTED_SET (multi-valued) and SORTED (multi_value=no) doc values types.
+                    if (reader.getSortedSetDocValues(fieldName()) == null && reader.getSortedDocValues(fieldName()) == null) {
                         return null;
                     }
                     return super.docValuesLoader(reader, docIdsInLeaf);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -76,6 +76,7 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
@@ -500,7 +501,8 @@ public final class TextFieldMapper extends FieldMapper {
                     indexPhrases.getValue(),
                     indexCreatedVersion,
                     usesBinaryDocValuesForFallbackFields,
-                    usesBinaryDocValues()
+                    usesBinaryDocValues(),
+                    docValuesParameters.getValue()
                 );
                 if (fieldData.getValue()) {
                     ft.setFielddata(true, freqFilter.getValue());
@@ -785,6 +787,7 @@ public final class TextFieldMapper extends FieldMapper {
         private final IndexVersion indexCreatedVersion;
         private final boolean usesBinaryDocValuesForFallbackFields;
         private final boolean usesBinaryDocValues;
+        private final DocValuesParameter.Values docValuesParams;
 
         /**
          * In some configurations text fields use a sub-keyword field to provide
@@ -807,7 +810,8 @@ public final class TextFieldMapper extends FieldMapper {
             boolean indexPhrases,
             IndexVersion indexCreatedVersion,
             boolean usesBinaryDocValuesForFallbackFields,
-            boolean usesBinaryDocValues
+            boolean usesBinaryDocValues,
+            DocValuesParameter.Values docValuesParams
         ) {
             super(name, IndexType.terms(indexed, hasDocValues), stored, tsi, meta, isSyntheticSource, isWithinMultiField);
             this.fielddata = false;
@@ -818,6 +822,7 @@ public final class TextFieldMapper extends FieldMapper {
             this.indexCreatedVersion = indexCreatedVersion;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.docValuesParams = docValuesParams;
         }
 
         public TextFieldType(
@@ -846,7 +851,8 @@ public final class TextFieldMapper extends FieldMapper {
                 indexPhrases,
                 IndexVersion.current(),
                 false,
-                false
+                false,
+                null
             );
         }
 
@@ -867,6 +873,7 @@ public final class TextFieldMapper extends FieldMapper {
             this.indexCreatedVersion = IndexVersion.current();
             this.usesBinaryDocValuesForFallbackFields = false;
             this.usesBinaryDocValues = false;
+            this.docValuesParams = null;
         }
 
         public TextFieldType(String name, boolean isSyntheticSource, boolean isWithinMultiField) {
@@ -910,6 +917,11 @@ public final class TextFieldMapper extends FieldMapper {
 
         public boolean usesBinaryDocValues() {
             return usesBinaryDocValues;
+        }
+
+        @Override
+        public DocValuesParameter.Values docValuesParameters() {
+            return docValuesParams;
         }
 
         @Override
@@ -1282,6 +1294,9 @@ public final class TextFieldMapper extends FieldMapper {
             // Check if we can load from doc values
             if (hasDocValues()) {
                 if (usesBinaryDocValues()) {
+                    if (docValuesParams != null && docValuesParams.multiValue() == DocValuesParameter.Values.MultiValue.NO) {
+                        return new BytesRefsFromBinaryBlockLoader(name());
+                    }
                     return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name());
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
@@ -1486,7 +1501,12 @@ public final class TextFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues()) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(
+                    name(),
+                    CoreValuesSourceType.KEYWORD,
+                    TextDocValuesField::new,
+                    indexCreatedVersion
+                );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -1504,7 +1524,7 @@ public final class TextFieldMapper extends FieldMapper {
     public static class ConstantScoreTextFieldType extends TextFieldType {
 
         public ConstantScoreTextFieldType(String name, boolean indexed, boolean stored, TextSearchInfo tsi, Map<String, String> meta) {
-            super(name, indexed, stored, false, tsi, false, false, null, meta, false, false, IndexVersion.current(), false, false);
+            super(name, indexed, stored, false, tsi, false, false, null, meta, false, false, IndexVersion.current(), false, false, null);
         }
 
         public ConstantScoreTextFieldType(String name) {
@@ -1695,6 +1715,11 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
 
@@ -1709,7 +1734,9 @@ public final class TextFieldMapper extends FieldMapper {
                     context.doc(),
                     fieldType().name(),
                     binaryValue,
-                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                    docValuesParameters.multiValue(),
+                    indexCreatedVersion
                 );
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
@@ -1723,7 +1750,7 @@ public final class TextFieldMapper extends FieldMapper {
         if (isIndexed() || fieldType.stored()) {
             Field field = new Field(fieldType().name(), value, fieldType);
             context.doc().add(field);
-            if (fieldType.omitNorms()) {
+            if (fieldType.omitNorms() && fieldType().hasDocValues() == false) {
                 context.addToFieldNames(fieldType().name());
             }
             if (prefixFieldInfo != null) {
@@ -1759,6 +1786,7 @@ public final class TextFieldMapper extends FieldMapper {
             fallbackFieldName,
             bytesRef,
             MultiValuedBinaryDocValuesField.ValueOrdering.SORTED,
+            docValuesParameters.multiValue(),
             indexCreatedVersion
         );
     }
@@ -1979,7 +2007,7 @@ public final class TextFieldMapper extends FieldMapper {
         // layer for loading from a fallback field created during indexing by this text field mapper
         final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
         if (usesBinaryDocValuesForFallbackFields) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName, indexCreatedVersion));
         } else {
             // for bwc - fallback fields were originally stored in StoredFields
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fallbackFieldName) {
@@ -2003,7 +2031,7 @@ public final class TextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override
@@ -2029,7 +2057,7 @@ public final class TextFieldMapper extends FieldMapper {
             });
 
             // also load from fallback field for values that exceeded MAX_TERM_LENGTH
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName(), indexCreatedVersion));
         }
         return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1628,6 +1628,7 @@ public final class TextFieldMapper extends FieldMapper {
     private final boolean index;
     private final boolean store;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final String indexOptions;
     private final boolean norms;
     private final String termVectors;
@@ -1672,6 +1673,7 @@ public final class TextFieldMapper extends FieldMapper {
         this.index = builder.index.getValue();
         this.store = builder.store.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, indexCreatedVersion);
         this.similarity = builder.similarity.getValue();
         this.indexOptions = builder.indexOptions.getValue();
         this.norms = builder.norms.getValue();
@@ -1725,20 +1727,18 @@ public final class TextFieldMapper extends FieldMapper {
         if (docValuesParameters.enabled()) {
             BytesRef binaryValue = new BytesRef(value);
             if (fieldType().usesBinaryDocValues()) {
-                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                dvFactory.addBinaryField(
                     context.doc(),
                     fieldType().name(),
                     binaryValue,
-                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
-                    docValuesParameters.multiValue(),
-                    indexCreatedVersion
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
                 );
             } else if (binaryValue.length > IndexWriter.MAX_TERM_LENGTH) {
                 // if the binary value's length exceeds Lucene's max term length, then we cannot store it in SortedSetDocValuesField
                 // in such cases, store the value in binary doc values instead, which don't have these length limitations
                 storeValueInFallbackField(fieldType().syntheticSourceFallbackFieldName(), binaryValue, context);
             } else {
-                context.doc().add(new SortedSetDocValuesField(fieldType().name(), binaryValue));
+                dvFactory.addSortedField(context.doc(), fieldType().name(), binaryValue);
             }
         }
 
@@ -1776,14 +1776,7 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     private void storeValueInFallbackField(String fallbackFieldName, BytesRef bytesRef, DocumentParserContext context) {
-        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
-            context.doc(),
-            fallbackFieldName,
-            bytesRef,
-            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED,
-            docValuesParameters.multiValue(),
-            indexCreatedVersion
-        );
+        dvFactory.addBinaryField(context.doc(), fallbackFieldName, bytesRef, MultiValuedBinaryDocValuesField.ValueOrdering.SORTED);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1715,11 +1715,6 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
@@ -110,7 +110,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (usesBinaryDocValues) {
             var binaryDv = reader.getBinaryDocValues(keyedFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, keyedFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedFieldFullPath, binaryDv);
                 docValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(docValues);
             } else {
@@ -129,7 +129,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         {
             var binaryDv = reader.getBinaryDocValues(offsetsFieldName);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, offsetsFieldName, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, offsetsFieldName);
                 offsetsDocValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(offsetsDocValues);
             } else {
@@ -148,7 +148,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (storeIgnoredFieldsInBinaryDocValues && keyedIgnoredValuesFieldFullPath != null) {
             var binaryDv = reader.getBinaryDocValues(keyedIgnoredValuesFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, keyedIgnoredValuesFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedIgnoredValuesFieldFullPath, binaryDv);
                 ignoredDocValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(ignoredDocValues);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldData;
@@ -427,7 +428,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 context.isSourceSynthetic(),
                 mappedSubFields,
                 storeIgnoredFieldsInBinaryDocValues,
-                preserveLeafArrays.get()
+                preserveLeafArrays.get(),
+                indexSettings.getIndexVersionCreated()
             );
             return new FlattenedFieldMapper(leafName(), ft, builderParams(this, context), this, mappedSubFields);
         }
@@ -541,6 +543,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         protected final boolean usesBinaryDocValues;
         protected final boolean hasRootDocValues;
         protected final String nullValue;
+        protected final IndexVersion indexVersion;
 
         BaseFlattenedFieldType(
             String name,
@@ -551,13 +554,15 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             IgnoreAbove ignoreAbove,
             boolean usesBinaryDocValues,
             boolean hasRootDocValues,
-            String nullValue
+            String nullValue,
+            IndexVersion indexVersion
         ) {
             super(name, indexType, isStored, textSearchInfo, meta);
             this.ignoreAbove = ignoreAbove;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.hasRootDocValues = hasRootDocValues;
             this.nullValue = nullValue;
+            this.indexVersion = indexVersion;
         }
 
         protected Mapper.IgnoreAbove ignoreAbove() {
@@ -611,7 +616,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             IgnoreAbove ignoreAbove,
             boolean usesBinaryDocValues,
             boolean hasRootDocValues,
-            String nullValue
+            String nullValue,
+            IndexVersion indexVersion
         ) {
             super(
                 rootName + KEYED_FIELD_SUFFIX,
@@ -622,7 +628,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 hasRootDocValues,
-                nullValue
+                nullValue,
+                indexVersion
             );
             this.key = key;
             this.rootName = rootName;
@@ -647,7 +654,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 ref.hasRootDocValues,
-                nullValue
+                nullValue,
+                ref.indexVersion
             );
         }
 
@@ -780,7 +788,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             failIfNoDocValues();
 
             if (usesBinaryDocValues) {
-                return new BinaryKeyedFlattenedFieldData.Builder(name(), key, FlattenedDocValuesField::new);
+                return new BinaryKeyedFlattenedFieldData.Builder(name(), key, FlattenedDocValuesField::new, indexVersion);
             } else {
                 return new KeyedFlattenedFieldData.Builder(name(), key, (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n));
             }
@@ -1108,16 +1116,23 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             private final String fieldName;
             private final String key;
             private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+            private final IndexVersion indexVersion;
 
-            Builder(String fieldName, String key, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+            Builder(
+                String fieldName,
+                String key,
+                ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+                IndexVersion indexVersion
+            ) {
                 this.fieldName = fieldName;
                 this.key = key;
                 this.toScriptFieldFactory = toScriptFieldFactory;
+                this.indexVersion = indexVersion;
             }
 
             @Override
             public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-                var delegate = new BytesBinaryIndexFieldData(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory);
+                var delegate = new BytesBinaryIndexFieldData(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory, indexVersion);
                 return new BinaryKeyedFlattenedFieldData(key, delegate, toScriptFieldFactory);
             }
         }
@@ -1164,7 +1179,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 isSyntheticSourceEnabled,
                 Collections.emptyMap(),
                 false,
-                preserveLeafArrays
+                preserveLeafArrays,
+                IndexVersion.current()
             );
         }
 
@@ -1182,7 +1198,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             boolean isSyntheticSourceEnabled,
             Map<String, FieldMapper> mappedSubFields,
             boolean storeIgnoredFieldsInBinaryDocValues,
-            PreserveLeafArrays preserveLeafArrays
+            PreserveLeafArrays preserveLeafArrays,
+            IndexVersion indexVersion
         ) {
             super(
                 name,
@@ -1193,7 +1210,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 hasRootDocValues,
-                nullValue
+                nullValue,
+                indexVersion
             );
             this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
@@ -1278,7 +1296,12 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
 
             if (hasRootDocValues) {
                 if (usesBinaryDocValues) {
-                    return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, FlattenedDocValuesField::new);
+                    return new BytesBinaryIndexFieldData.Builder(
+                        name(),
+                        CoreValuesSourceType.KEYWORD,
+                        FlattenedDocValuesField::new,
+                        indexVersion
+                    );
                 } else {
                     return new SortedSetOrdinalsIndexFieldData.Builder(
                         name(),
@@ -1287,7 +1310,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                     );
                 }
             }
-            return new RootFlattenedFromKeyedFieldData.Builder(name(), name() + KEYED_FIELD_SUFFIX, usesBinaryDocValues);
+            return new RootFlattenedFromKeyedFieldData.Builder(name(), name() + KEYED_FIELD_SUFFIX, usesBinaryDocValues, indexVersion);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1514,7 +1514,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         if (preserveLeafArrays == PreserveLeafArrays.LOSSY) {
             arrayContext = null;
         } else {
-            arrayContext = new FlattenedFieldArrayContext(mappedFieldType.name(), builder.indexSettings.getIndexVersionCreated());
+            arrayContext = new FlattenedFieldArrayContext(mappedFieldType.name());
         }
 
         try {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1514,7 +1514,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         if (preserveLeafArrays == PreserveLeafArrays.LOSSY) {
             arrayContext = null;
         } else {
-            arrayContext = new FlattenedFieldArrayContext(mappedFieldType.name());
+            arrayContext = new FlattenedFieldArrayContext(mappedFieldType.name(), builder.indexSettings.getIndexVersionCreated());
         }
 
         try {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
@@ -35,7 +35,7 @@ public class KeyedFlattenedDocValuesBlockLoader extends BlockDocValuesReader.Doc
     @Override
     public ColumnAtATimeReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
         if (usesBinaryDocValues) {
-            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(context.reader(), keyedFieldName);
+            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), keyedFieldName);
             SortedBinaryDocValues filtered = BinaryKeyedFlattenedLeafFieldData.getKeyFilteredSortedBinaryDocValues(dv, key);
             return new BinaryKeyedBlockDocValuesReader(breaker, filtered);
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldData.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.LeafFieldData;
@@ -177,18 +178,25 @@ public final class RootFlattenedFromKeyedFieldData implements IndexFieldData<Lea
         private final String rootFieldName;
         private final String keyedFieldName;
         private final boolean usesBinaryDocValues;
+        private final IndexVersion indexVersion;
 
-        public Builder(String rootFieldName, String keyedFieldName, boolean usesBinaryDocValues) {
+        public Builder(String rootFieldName, String keyedFieldName, boolean usesBinaryDocValues, IndexVersion indexVersion) {
             this.rootFieldName = rootFieldName;
             this.keyedFieldName = keyedFieldName;
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.indexVersion = indexVersion;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             IndexFieldData<?> keyedDelegate;
             if (usesBinaryDocValues) {
-                keyedDelegate = new BytesBinaryIndexFieldData(keyedFieldName, CoreValuesSourceType.KEYWORD, FlattenedDocValuesField::new);
+                keyedDelegate = new BytesBinaryIndexFieldData(
+                    keyedFieldName,
+                    CoreValuesSourceType.KEYWORD,
+                    FlattenedDocValuesField::new,
+                    indexVersion
+                );
             } else {
                 keyedDelegate = new SortedSetOrdinalsIndexFieldData(
                     cache,

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -50,13 +50,19 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
                 final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
-                final NumericDocValues counts = context.reader().getNumericDocValues(fieldName + COUNT_FIELD_SUFFIX);
 
                 if (values == null) {
                     return null;
                 }
 
-                final var iterator = multiValuedIterator(values, counts, matcher, matchCost());
+                final NumericDocValues counts = context.reader().getNumericDocValues(fieldName + COUNT_FIELD_SUFFIX);
+                final DocIdSetIterator iterator;
+                if (counts == null) {
+                    // Single-valued binary doc values (multi_value=no): no .counts companion field
+                    iterator = singleValuedIterator(values, matcher, matchCost());
+                } else {
+                    iterator = multiValuedIterator(values, counts, matcher, matchCost());
+                }
                 return new DefaultScorerSupplier(new ConstantScoreScorer(score(), scoreMode, iterator));
             }
 
@@ -74,6 +80,20 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
         if (visitor.acceptField(fieldName)) {
             visitor.visitLeaf(this);
         }
+    }
+
+    static DocIdSetIterator singleValuedIterator(BinaryDocValues values, Predicate<BytesRef> predicate, float cost) {
+        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+            @Override
+            public boolean matches() throws IOException {
+                return predicate.test(values.binaryValue());
+            }
+
+            @Override
+            public float matchCost() {
+                return cost;
+            }
+        });
     }
 
     static DocIdSetIterator multiValuedIterator(

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -57,11 +57,26 @@ final class BinaryDocValuesLengthQuery extends Query {
 
                 String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                 final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
-                DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
-                assert countsSkipper != null : "no skipper for counts field [" + countsFieldName + "]";
+
+                // When counts is null (multi_value=no) or all documents in the segment have exactly one value the binary blob stores raw
+                // bytes with no length prefix. Both cases are equivalent for length queries.
+                final boolean singleValued;
+                if (counts == null) {
+                    singleValued = true;
+                } else {
+                    DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
+                    assert countsSkipper != null : "no skipper for counts field [" + countsFieldName + "]";
+                    singleValued = countsSkipper.maxValue() == 1;
+                }
+
                 final DocIdSetIterator iterator;
-                if (countsSkipper.maxValue() == 1 && values instanceof BlockLoader.OptionalLengthReader direct) {
+                if (singleValued && values instanceof BlockLoader.OptionalLengthReader direct) {
+                    // TSDB codec: check lengths directly from compressed encoding without decoding BytesRefs
                     iterator = direct.tryLengthIterator(length);
+                } else if (singleValued) {
+                    // Non-TSDB codec: OptionalLengthReader not available, fall back to iterating and checking
+                    Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
+                    iterator = AbstractBinaryDocValuesQuery.singleValuedIterator(values, lengthPredicate, matchCost());
                 } else {
                     Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
                     iterator = AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost());

--- a/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
@@ -11,6 +11,8 @@ package org.elasticsearch.script;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.OnScriptError;
@@ -23,10 +25,17 @@ public class SortedBinaryDocValuesStringFieldScript extends StringFieldScript {
     private final SortedBinaryDocValues sortedBinaryDocValues;
     boolean hasValue = false;
 
-    public SortedBinaryDocValuesStringFieldScript(String fieldName, SearchLookup searchLookup, LeafReaderContext ctx) {
+    public SortedBinaryDocValuesStringFieldScript(
+        String fieldName,
+        SearchLookup searchLookup,
+        LeafReaderContext ctx,
+        IndexVersion indexVersion
+    ) {
         super(fieldName, Map.of(), searchLookup, OnScriptError.FAIL, ctx);
         try {
-            sortedBinaryDocValues = MultiValuedSortedBinaryDocValues.from(ctx.reader(), fieldName);
+            sortedBinaryDocValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
+                ? MultiValuedSortedBinaryDocValues.from(ctx.reader(), fieldName)
+                : MultiValuedSortedBinaryDocValues.fromLegacy(ctx.reader(), fieldName);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -332,7 +332,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
                                 isMultiValue = true;
                             }
                         } else if (fieldContext.fieldType().hasDocValues()) {
-                            if (DocValues.unwrapSingleton(leaf.reader().getSortedNumericDocValues(fieldContext.field())) == null) {
+                            if (DocValues.unwrapSingleton(DocValues.getSortedNumeric(leaf.reader(), fieldContext.field())) == null) {
                                 isMultiValue = true;
                             }
                         }

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.MapperTestUtils;
 import org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat;
 import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -292,6 +293,44 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     public void testSeqnoField() throws IOException {
         PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(IndexMode.LOGSDB, MAPPING_3);
         assertThat((perFieldMapperCodec.useTSDBDocValuesFormat(SeqNoFieldMapper.NAME)), is(true));
+    }
+
+    /**
+     * Verifies that the TSDB codec is enabled for fields configured with {@code multi_value=no} in LOGSDB mode.
+     * <p>
+     * This is important because the TSDB doc values format provides single-value storage optimizations:
+     * it detects single-valued {@code SortedNumericDocValuesField} documents and uses a more compact ordinal encoding,
+     * and automatically promotes single-valued {@code SortedSetDocValuesField} to {@code SortedDocValuesField}.
+     * Without the TSDB codec, {@code multi_value=no} would only enforce at indexing time but would not
+     * benefit from these storage savings.
+     */
+    public void testLogsDbUsesTSDBCodecForMultiValueNoFields() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        // @timestamp cannot have doc_values attributes; use other field types to cover SortedNumericDocValues (integer)
+        // and SortedSetDocValues (keyword) storage formats that benefit from TSDB single-value optimizations.
+        String mapping = """
+            {
+                "_data_stream_timestamp": {
+                    "enabled": true
+                },
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "doc_values": { "multi_value": "no" }
+                    },
+                    "hostname": {
+                        "type": "keyword",
+                        "doc_values": { "multi_value": "no" }
+                    }
+                }
+            }
+            """;
+        PerFieldFormatSupplier perFieldFormatSupplier = createFormatSupplier(IndexMode.LOGSDB, mapping);
+        assertThat(perFieldFormatSupplier.useTSDBDocValuesFormat("status"), is(true));
+        assertThat(perFieldFormatSupplier.useTSDBDocValuesFormat("hostname"), is(true));
     }
 
     private PerFieldFormatSupplier createFormatSupplier(IndexMode mode, String mapping) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.index.MapperTestUtils;
 import org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat;
 import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -293,44 +292,6 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     public void testSeqnoField() throws IOException {
         PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(IndexMode.LOGSDB, MAPPING_3);
         assertThat((perFieldMapperCodec.useTSDBDocValuesFormat(SeqNoFieldMapper.NAME)), is(true));
-    }
-
-    /**
-     * Verifies that the TSDB codec is enabled for fields configured with {@code multi_value=no} in LOGSDB mode.
-     * <p>
-     * This is important because the TSDB doc values format provides single-value storage optimizations:
-     * it detects single-valued {@code SortedNumericDocValuesField} documents and uses a more compact ordinal encoding,
-     * and automatically promotes single-valued {@code SortedSetDocValuesField} to {@code SortedDocValuesField}.
-     * Without the TSDB codec, {@code multi_value=no} would only enforce at indexing time but would not
-     * benefit from these storage savings.
-     */
-    public void testLogsDbUsesTSDBCodecForMultiValueNoFields() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        // @timestamp cannot have doc_values attributes; use other field types to cover SortedNumericDocValues (integer)
-        // and SortedSetDocValues (keyword) storage formats that benefit from TSDB single-value optimizations.
-        String mapping = """
-            {
-                "_data_stream_timestamp": {
-                    "enabled": true
-                },
-                "properties": {
-                    "@timestamp": {
-                        "type": "date"
-                    },
-                    "status": {
-                        "type": "integer",
-                        "doc_values": { "multi_value": "no" }
-                    },
-                    "hostname": {
-                        "type": "keyword",
-                        "doc_values": { "multi_value": "no" }
-                    }
-                }
-            }
-            """;
-        PerFieldFormatSupplier perFieldFormatSupplier = createFormatSupplier(IndexMode.LOGSDB, mapping);
-        assertThat(perFieldFormatSupplier.useTSDBDocValuesFormat("status"), is(true));
-        assertThat(perFieldFormatSupplier.useTSDBDocValuesFormat("hostname"), is(true));
     }
 
     private PerFieldFormatSupplier createFormatSupplier(IndexMode mode, String mapping) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.store.Directory;
@@ -47,7 +48,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -90,7 +91,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -122,7 +123,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -159,9 +160,72 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+            }
+        }
+    }
+
+    /**
+     * Verifies that the PlainBinary reader correctly reads single-valued binary doc values
+     * written as a plain {@link BinaryDocValuesField} via auto-detection.
+     */
+    public void testReadSingleValuedBinaryDocValues() throws IOException {
+        // given
+        BytesRef expected = new BytesRef("potato");
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                doc.addWithKey("field", new BinaryDocValuesField("field", expected));
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertNotNull(values);
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+                assertEquals(SortedBinaryDocValues.ValueMode.SINGLE_VALUED, values.getValueMode());
+            }
+        }
+    }
+
+    /**
+     * Verifies that fromLegacy() falls back to IntegratedCounts when .counts is absent.
+     */
+    public void testFromLegacyFallsBackToIntegratedCounts() throws IOException {
+        IndexVersion oldVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES);
+
+        // Write an IntegratedCount value using the old index version
+        BytesRef expected = new BytesRef("potato");
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    doc,
+                    "field",
+                    expected,
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                    oldVersion
+                );
+                iw.addDocument(doc);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+
+                // IntegratedCounts reader should decode correctly
                 assertTrue(values.advanceExact(0));
                 assertEquals(1, values.docValueCount());
                 assertEquals(expected, values.nextValue());

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -100,4 +100,29 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
     }
+
+    // -----------------------------------------------------------------------
+    // multi_value=no enforcement tests
+    // -----------------------------------------------------------------------
+
+    public void testMultiValueNoKeywordRejectsDuplicates() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+
+        // when — single value succeeds
+        mapperService.documentMapper().parse(source(b -> b.field("field", "one")));
+
+        // when — multiple values fails
+        Exception e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapperService.documentMapper().parse(source(b -> b.array("field", "one", "two")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("Field [field] is configured with multi_value=no but more than one value was detected")
+        );
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -9,10 +9,13 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.mapper.FieldMapper.DocValuesParameter.Values.MultiValue;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.IntegratedCount;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.SeparateCount;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ValueOrdering;
@@ -269,6 +272,56 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         // then
         var field = (SeparateCount) doc.getByKey("field");
         assertEquals(2, field.count());
+    }
+
+    // =====================================================================================================================================
+    // multi_value=no tests
+    // =====================================================================================================================================
+
+    public void testMultiValueNoUsesBinaryDocValuesFieldWithRawBytes() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+        BytesRef value = new BytesRef("potato");
+
+        // when
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            doc,
+            "field",
+            value,
+            ValueOrdering.SORTED_UNIQUE,
+            MultiValue.NO,
+            IndexVersion.current()
+        );
+
+        // then — field is stored as a plain BinaryDocValuesField with the raw value
+        IndexableField storedField = doc.getField("field");
+        assertNotNull(storedField);
+        assertTrue(storedField instanceof BinaryDocValuesField);
+        assertEquals(value, storedField.binaryValue());
+    }
+
+    public void testMultiValueNoDoesNotStoreInKeyedFields() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+
+        // when
+        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+            doc,
+            "field",
+            new BytesRef("potato"),
+            ValueOrdering.SORTED_UNIQUE,
+            MultiValue.NO,
+            IndexVersion.current()
+        );
+
+        // then — field is NOT registered in keyedFields; only in the Lucene fields list.
+        // This avoids double storage: the field name would otherwise appear in both the keyedFields
+        // map and the fields list, with the keyedFields entry serving no purpose since single-value
+        // enforcement is already guaranteed by DocumentParserContext.enforceSingleValue() before
+        // addToBinaryFieldInDoc is ever reached.
+        assertNull(doc.getByKey("field"));
+        assertNull(doc.getByKey("field.counts"));
+        assertNull(doc.getField("field.counts"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -315,10 +315,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         );
 
         // then — field is NOT registered in keyedFields; only in the Lucene fields list.
-        // This avoids double storage: the field name would otherwise appear in both the keyedFields
-        // map and the fields list, with the keyedFields entry serving no purpose since single-value
-        // enforcement is already guaranteed by DocumentParserContext.enforceSingleValue() before
-        // addToBinaryFieldInDoc is ever reached.
+        // Single-value enforcement is handled by Lucene: BinaryDocValuesField rejects a second add for the same field.
         assertNull(doc.getByKey("field"));
         assertNull(doc.getByKey("field.counts"));
         assertNull(doc.getField("field.counts"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -283,15 +283,9 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         LuceneDocument doc = new LuceneDocument();
         BytesRef value = new BytesRef("potato");
 
-        // when
-        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
-            doc,
-            "field",
-            value,
-            ValueOrdering.SORTED_UNIQUE,
-            MultiValue.NO,
-            IndexVersion.current()
-        );
+        // when — use DocValuesFieldFactory which handles multi_value=no branching
+        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.NO, false, IndexVersion.current());
+        factory.addBinaryField(doc, "field", value, ValueOrdering.SORTED_UNIQUE);
 
         // then — field is stored as a plain BinaryDocValuesField with the raw value
         IndexableField storedField = doc.getField("field");
@@ -304,15 +298,9 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         // given
         LuceneDocument doc = new LuceneDocument();
 
-        // when
-        MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
-            doc,
-            "field",
-            new BytesRef("potato"),
-            ValueOrdering.SORTED_UNIQUE,
-            MultiValue.NO,
-            IndexVersion.current()
-        );
+        // when — use DocValuesFieldFactory which handles multi_value=no branching
+        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.NO, false, IndexVersion.current());
+        factory.addBinaryField(doc, "field", new BytesRef("potato"), ValueOrdering.SORTED_UNIQUE);
 
         // then — field is NOT registered in keyedFields; only in the Lucene fields list.
         // Single-value enforcement is handled by Lucene: BinaryDocValuesField rejects a second add for the same field.

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -552,7 +552,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
             true,
-            false
+            false,
+            null
         );
 
         // when
@@ -592,7 +593,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             false,
             legacyVersion,
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -631,7 +633,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             false,
             legacyVersion,
             true,
-            false
+            false,
+            null
         );
 
         // when
@@ -660,7 +663,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            false
+            false,
+            null
         );
 
         // when
@@ -688,7 +692,8 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
             false,
             IndexVersion.current(),
             false,
-            true
+            true,
+            null
         );
 
         // when

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -57,7 +58,8 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             IGNORE_ABOVE,
             true,
             false,
-            null
+            null,
+            IndexVersion.current()
         );
     }
 
@@ -93,7 +95,8 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             IGNORE_ABOVE,
             true,
             false,
-            null
+            null,
+            IndexVersion.current()
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("field", null));
         assertEquals("Cannot search on field [" + ft.name() + "] since it is not indexed.", e.getMessage());

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -242,7 +243,7 @@ public class RootFlattenedFromKeyedFieldDataTests extends ESTestCase {
     }
 
     private static SortedBinaryDocValues loadRootValues(IndexReader reader, boolean binary) {
-        var builder = new RootFlattenedFromKeyedFieldData.Builder(ROOT_FIELD, KEYED_FIELD, binary);
+        var builder = new RootFlattenedFromKeyedFieldData.Builder(ROOT_FIELD, KEYED_FIELD, binary, IndexVersion.current());
         IndexFieldData<?> fieldData = builder.build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
         return fieldData.load(reader.leaves().get(0)).getBytesValues();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -356,21 +356,21 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         }
     }
 
-    public void testAllowMultipleValuesField() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> minimalMapping(b)));
-
-        Mapper mapper = mapperService.mappingLookup().getMapper("field");
-        if (mapper instanceof NumberFieldMapper numberFieldMapper) {
-            numberFieldMapper.setAllowMultipleValues(false);
-        } else {
-            fail("mapper [" + mapper.getClass() + "] error, not number field");
-        }
+    public void testRejectMultipleValuesWhenMultiValueIsDisabled() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
 
         Exception e = expectThrows(
             DocumentParsingException.class,
             () -> mapperService.documentMapper().parse(source(b -> b.array("field", randomNumber(), randomNumber(), randomNumber())))
         );
-        assertThat(e.getCause().getMessage(), containsString("Only one field can be stored per key"));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("Field [field] is configured with multi_value=no but more than one value was detected")
+        );
     }
 
     protected abstract Number randomNumber();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -372,7 +372,7 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
             this.ignoredSourceFormat = ignoredSourceFormat;
             this.filter = filter;
             // convert incoming binary doc values to reuse the code provided by MultiValuedSortedBinaryDocValues
-            this.multiValues = MultiValuedSortedBinaryDocValues.from(reader, IgnoredSourceFieldMapper.NAME, dv);
+            this.multiValues = MultiValuedSortedBinaryDocValues.fromLegacy(reader, IgnoredSourceFieldMapper.NAME, dv);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.lucene.query;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -135,7 +136,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
                 }
                 if (scorer.isDone() == false) {
                     // could not apply shortcut, trigger the search
-                    final LongValues values = numberType.multiValueMode(reader.getSortedNumericDocValues(fieldName));
+                    final LongValues values = numberType.multiValueMode(DocValues.getSortedNumeric(reader, fieldName));
                     final LeafCollector leafCollector = new LeafCollector() {
                         @Override
                         public void setScorer(Scorable scorer) {}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
@@ -225,7 +225,7 @@ public final class SingleValueMatchQuery extends Query {
             final int maxDoc = reader.maxDoc();
             final LeafFieldData lfd = fieldData.load(context);
             if (lfd instanceof LeafNumericFieldData) {
-                NumericDocValues singleton = DocValues.unwrapSingleton(reader.getSortedNumericDocValues(fieldData.getFieldName()));
+                NumericDocValues singleton = DocValues.unwrapSingleton(DocValues.getSortedNumeric(reader, fieldData.getFieldName()));
                 if (singleton != null) {
                     singleton.nextDoc();
                     if (singleton.docIDRunEnd() == maxDoc) {
@@ -239,7 +239,7 @@ public final class SingleValueMatchQuery extends Query {
                 }
                 return super.rewrite(indexSearcher);
             } else if (lfd instanceof LeafOrdinalsFieldData) {
-                SortedDocValues singleton = DocValues.unwrapSingleton(reader.getSortedSetDocValues(fieldData.getFieldName()));
+                SortedDocValues singleton = DocValues.unwrapSingleton(DocValues.getSortedSet(reader, fieldData.getFieldName()));
                 if (singleton != null) {
                     singleton.nextDoc();
                     if (singleton.docIDRunEnd() == maxDoc) {

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -229,7 +229,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                         NumberFieldMapper.NumberType.INTEGER,
                         ScriptCompiler.NONE,
                         indexSettings
-                    ).allowMultipleValues(false).ignoreMalformed(false).coerce(false);
+                    ).multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.NO).ignoreMalformed(false).coerce(false);
                     if (indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.AGG_METRIC_DOUBLE_REMOVE_POINTS)) {
                         builder.index(false);
                     }
@@ -239,7 +239,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                         NumberFieldMapper.NumberType.DOUBLE,
                         ScriptCompiler.NONE,
                         indexSettings
-                    ).allowMultipleValues(false).ignoreMalformed(false).coerce(true);
+                    ).multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.NO).ignoreMalformed(false).coerce(true);
                     if (indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.AGG_METRIC_DOUBLE_REMOVE_POINTS)) {
                         builder.index(false);
                     }
@@ -754,7 +754,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
             // Check that there aren't any duplicates already parsed
             for (Metric m : metricsParsed.keySet()) {
                 NumberFieldMapper delegateFieldMapper = metricFieldMappers.get(m);
-                if (context.doc().getByKey(delegateFieldMapper.fieldType().name()) != null) {
+                if (context.doc().getFields(delegateFieldMapper.fieldType().name()).isEmpty() == false) {
                     throw new IllegalArgumentException(
                         "Field ["
                             + fullPath()

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -747,11 +747,6 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected boolean isSingleValueEnforced() {
-        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         Long numericValue;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -747,6 +747,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO;
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         Long numericValue;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -686,6 +687,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     private final boolean isSourceSynthetic;
     private final boolean indexed;
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final Explicit<Boolean> ignoreMalformed;
     private final String nullValue;
@@ -707,6 +709,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         this.isSourceSynthetic = isSourceSynthetic;
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType().indexType().hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.stored = builder.stored.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.nullValue = builder.nullValue.getValue();
@@ -788,7 +795,14 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
         if (numericValue != null) {
             List<Field> fields = new ArrayList<>();
-            if (indexed && docValuesParameters.enabled()) {
+            if (docValuesParameters.multiValue() == FieldMapper.DocValuesParameter.Values.MultiValue.NO) {
+                if (indexed) {
+                    fields.add(new LongPoint(fieldType().name(), numericValue));
+                }
+                if (docValuesParameters.enabled()) {
+                    dvFactory.addNumericField(context.doc(), fieldType().name(), numericValue);
+                }
+            } else if (indexed && docValuesParameters.enabled()) {
                 fields.add(new LongField(fieldType().name(), numericValue, Field.Store.NO));
             } else if (docValuesParameters.enabled()) {
                 if (fieldType().indexType().hasDocValuesSkipper()) {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -409,7 +409,7 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
     public void testIgnoreMalformedWithObject() {} // unimplemented
 
     @Override
-    public void testAllowMultipleValuesField() {} // unimplemented
+    public void testRejectMultipleValuesWhenMultiValueIsDisabled() {} // unimplemented
 
     @Override
     public void testScriptableTypes() {} // unimplemented

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -150,7 +150,7 @@ abstract class BinaryDvConfirmedQuery extends Query {
                     // No matches to be had
                     return null;
                 }
-                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(context.reader(), field);
+                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), field);
                 return new ScorerSupplier() {
                     @Override
                     public Scorer get(long leadCost) throws IOException {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -991,7 +991,8 @@ public class WildcardFieldMapper extends FieldMapper {
             return (cache, breakerService) -> new StringBinaryIndexFieldData(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                WildcardDocValuesField::new
+                WildcardDocValuesField::new,
+                indexVersion
             );
         }
 
@@ -1139,10 +1140,10 @@ public class WildcardFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         return new SyntheticSourceSupport.Native(() -> {
             var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexVersionCreated));
             if (ignoreAbove.valuesPotentiallyIgnored()) {
                 if (storeIgnoredFieldsInBinaryDocValues) {
-                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(originalName()));
+                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(originalName(), indexVersionCreated));
                 } else {
                     layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(originalName()) {
                         @Override


### PR DESCRIPTION
This PR adds enforcement and support around `multi_value = no`. 

Enforcement is achieved via `isSingleValueEnforced()`, which is defined in `FieldMapper`. Field mappers that support `multi_value` can override this method. No other action is necessary - `FieldMapper` will call this method during parsing and store fields in a HashSet for tracking.

Support itself doesn't require many changes as the TSDC codec already optimizes single-valued fields. That said, binary doc values are not optimized, and the support for them is achieved using a basic `BinaryDocValuesField`.

Notes:
- flattented fields are not covered by this PR due to their complexity - I will do a follow up for them.
- In `NumberFieldMapper`, previous single value enforcement via `allowMultipleValues` has been removed in favor of `multi_value = no`

Addresses https://github.com/elastic/logs-program/issues/44