### PR TITLE
Stabilize big-string lookup heap attack test on CI

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
@@ -140,8 +140,8 @@ public class HeapAttackLookupJoinIT extends HeapAttackTestCase {
 
     public void testLookupExplosionBigStringManyMatches() throws IOException {
         // 500, 1 is enough with a single node, but the serverless copy of this test uses many nodes.
-        // So something like 5000, 10 is much more of a sure thing there.
-        assertCircuitBreaks(attempt -> lookupExplosionBigString(attempt * 5000, 10));
+        // Use a large multiplier so the breaker trips early, avoiding slow scaled attempts (#145710).
+        assertCircuitBreaks(attempt -> lookupExplosionBigString(attempt * 10000, 10));
     }
 
     private Map<String, Object> lookupExplosion(


### PR DESCRIPTION
Lower the request circuit breaker to 40% for `HeapAttackLookupJoinIT#testLookupExplosionBigStringManyMatches` only (set before the assertion, restored in `finally`).

On large heaps the streaming lookup path can finish without a `circuit_breaking_exception`, which made `assertCircuitBreaks` retry with larger `sensor_data` each time. Each attempt reindexes and force-merges; on single-processor CI that could hit the suite timeout 

Closes #145710