### PR TITLE
Stabilize big-string lookup heap attack test on CI

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLookupJoinIT.java
@@ -139,9 +139,21 @@ public class HeapAttackLookupJoinIT extends HeapAttackTestCase {
     }
 
     public void testLookupExplosionBigStringManyMatches() throws IOException {
-        // 500, 1 is enough with a single node, but the serverless copy of this test uses many nodes.
-        // So something like 5000, 10 is much more of a sure thing there.
-        assertCircuitBreaks(attempt -> lookupExplosionBigString(attempt * 5000, 10));
+        /*
+         * 500, 1 is enough with a single node, but the serverless copy of this test uses many nodes,
+         * so 5000, 10 is a surer hit there.
+         *
+         * Lower the request breaker for this test only: on large heaps the streaming lookup path can
+         * otherwise finish successfully, which forces assertCircuitBreaks through several scaled attempts.
+         * Each attempt reindexes and force-merges a larger sensor_data index; on single-processor CI that
+         * can exceed the suite timeout (#145710).
+         */
+        setRequestBreakerLimit("40%");
+        try {
+            assertCircuitBreaks(attempt -> lookupExplosionBigString(attempt * 5000, 10));
+        } finally {
+            setRequestBreakerLimit(null);
+        }
     }
 
     private Map<String, Object> lookupExplosion(


### PR DESCRIPTION
## Summary

Lower the request circuit breaker to 40% for `HeapAttackLookupJoinIT#testLookupExplosionBigStringManyMatches` only (set before the assertion, restored in `finally`).

On large heaps the streaming lookup path can finish without a `circuit_breaking_exception`, which made `assertCircuitBreaks` retry with larger `sensor_data` each time. Each attempt reindexes and force-merges; on single-processor CI that could hit the suite timeout (see #145710).

## Notes

The triage issue named `HeapAttackIT`; the test actually lives in `HeapAttackLookupJoinIT`.

Fixes #145710

Made with [Cursor](https://cursor.com)