### PR TITLE
Remove feature flag for disabling sequence numbers

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -135,7 +135,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
             templateSettings.put("index.routing_path", "metricset");
         }
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         var mapping = new CompressedXContent(randomBoolean() ? MAPPING_TEMPLATE : MAPPING_TEMPLATE.replace("date", "date_nanos"));
@@ -342,7 +342,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
             settingsBuilder.put("index.routing_path", "metricset");
         }
         settingsBuilder.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             settingsBuilder.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         request.indexTemplate(
@@ -394,7 +394,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         {
             var templateSettings = Settings.builder().put("index.mode", "time_series").put("index.routing_path", "metricset");
             templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-            if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+            if (randomBoolean()) {
                 templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
             }
             var request = new TransportPutComposableIndexTemplateAction.Request("id1");
@@ -600,7 +600,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         String reindexedDataStreamName = "my-reindexed-ds";
         var templateSettings = Settings.builder().put("index.mode", "time_series");
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
@@ -660,7 +660,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
             .put("index.mode", "time_series")
             .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabled)
             .put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         putTemplateRequest.indexTemplate(
@@ -745,7 +745,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         String dataStreamName = "my-ds";
         var templateSettings = Settings.builder().put("index.mode", "time_series");
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
@@ -812,7 +812,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         String dataStreamName = "my-ds";
         var templateSettings = Settings.builder().put("index.mode", "time_series");
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -466,11 +466,9 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
             .put("index.soft_deletes.retention_lease.sync_interval", "100ms")
             // This test checks that _id's are pruned, that only applies
             // when regular _id's are used.
-            .put(IndexSettings.SYNTHETIC_ID.getKey(), false);
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            // This test relies on sequence numbers to verify ids.
-            indexSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false);
-        }
+            .put(IndexSettings.SYNTHETIC_ID.getKey(), false)
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false);
+
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName + "*"))

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBPassthroughIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBPassthroughIndexingIT.java
@@ -150,7 +150,7 @@ public class TSDBPassthroughIndexingIT extends ESSingleNodeTestCase {
     public void testIndexingGettingAndSearching() throws Exception {
         var templateSettings = indexSettings(randomIntBetween(2, 10), 0).put("index.mode", "time_series");
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
 
@@ -234,7 +234,7 @@ public class TSDBPassthroughIndexingIT extends ESSingleNodeTestCase {
         String dataStreamName = "k8s";
         var templateSettings = indexSettings(8, 0).put("index.mode", "time_series");
         templateSettings.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean()) {
+        if (randomBoolean()) {
             templateSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
         }
 

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
@@ -1772,10 +1772,9 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
     ) throws IOException {
         final var settings = indexSettings(primaries, replicas).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)
-            .put(IndexSettings.SYNTHETIC_ID.getKey(), true);
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            settings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false); // Sequence numbers are needed for id validation.
-        }
+            .put(IndexSettings.SYNTHETIC_ID.getKey(), true)
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false); // Sequence numbers are needed for id validation.
+
         if (randomBoolean()) {
             settings.put(EngineConfig.INDEX_CODEC_SETTING.getKey(), randomValidCodec());
         }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -119,9 +119,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                     assert start.isBefore(end) : "data stream backing index's start time is not before end time";
                     additionalSettings.put(IndexSettings.TIME_SERIES_START_TIME.getKey(), FORMATTER.format(start));
                     additionalSettings.put(IndexSettings.TIME_SERIES_END_TIME.getKey(), FORMATTER.format(end));
-                    if ((IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
-                        && indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS)
-                        || indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT))
+                    if (indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT)
                         && indexTemplateAndCreateRequestSettings.hasValue(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey()) == false) {
                         additionalSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
                     }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -66,9 +66,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         } else {
             indexVersion = IndexVersionUtils.randomPreviousCompatibleVersion(IndexVersions.TSID_CREATED_DURING_ROUTING);
         }
-        expectedDisabledSequenceNumbers = (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
-            && indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS))
-            || indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT);
+        expectedDisabledSequenceNumbers = indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT);
         indexDimensionsTsidStrategyEnabledSetting = usually();
         expectedIndexDimensionsTsidOptimizationEnabled = indexDimensionsTsidStrategyEnabledSetting
             && indexVersion.onOrAfter(IndexVersions.TSID_CREATED_DURING_ROUTING);

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollSeqNoSettingIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollSeqNoSettingIT.java
@@ -124,8 +124,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testUpdateByQueryOnRegularIndex() {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         boolean disableSequenceNumbers = randomBoolean();
         createIndex("test-index", disableSeqNoSettings(disableSequenceNumbers));
         indexDoc("test-index", "1", "field", "value");
@@ -147,8 +145,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testDeleteByQueryOnRegularIndex() {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         boolean disableSequenceNumbers = randomBoolean();
         createIndex("test-index", disableSeqNoSettings(disableSequenceNumbers));
         indexDoc("test-index", "1", "field", "value");
@@ -171,8 +167,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testPatternMatchingMultipleIndicesWithMixedSettings() {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         createIndex("test-index-1", disableSeqNoSettings(randomBoolean()));
         createIndex("test-index-2", disableSeqNoSettings(randomBoolean()));
         indexDoc("test-index-1", "1", "field", "value");
@@ -195,8 +189,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testDataStreamWithSeqNoDisabledOnAllBackingIndices() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         String dsName = "my-data-stream";
         createDataStreamWithTemplate(dsName, disableSeqNoTemplateSettings(true));
 
@@ -218,8 +210,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testDataStreamWithMixedBackingIndices() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         String dsName = "my-data-stream";
         createDataStreamWithTemplate(dsName, disableSeqNoSettings(randomBoolean()));
         int numDocs = between(1, 5);
@@ -249,8 +239,6 @@ public class BulkByScrollSeqNoSettingIT extends ReindexTestCase {
     }
 
     public void testMixedDataStreamAndRegularIndex() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         String dsName = "test-ds";
         createDataStreamWithTemplate(dsName, disableSeqNoSettings(randomBoolean()));
         int numDocs = between(1, 5);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -152,8 +152,6 @@ public class BulkIntegrationIT extends ESIntegTestCase {
      * and that the responses contain unassigned seqNo and primaryTerm sentinel values in XContent output.
      */
     public void testBulkReplicationWithSequenceNumbersDisabled() throws IOException {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         int numReplicas = Math.min(between(1, 2), cluster().numDataNodes() - 1);
         assumeTrue("Need at least 2 data nodes for replication", numReplicas > 0);
         indicesAdmin().prepareCreate("test-repl")

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/OperationsOnSeqNoDisabledIndicesIT.java
@@ -52,8 +52,6 @@ public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
     }
 
     public void testBulkWithMixedOperationsAcrossSeqNoDisabledAndEnabledIndices() {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         final var numSeqNoDisabled = randomIntBetween(1, 3);
         final var numSeqNoEnabled = randomIntBetween(1, 3);
         final var seqNoDisabledIndices = new HashSet<String>(numSeqNoDisabled);
@@ -232,8 +230,6 @@ public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
     }
 
     public void testBulkIndexToDataStreamBackingIndexBypassesCreateRestriction() throws Exception {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         String dataStreamName = "test-ds-overwrite";
         createDataStreamWithTemplate(dataStreamName, disableSeqNoTemplateSettings(true));
 
@@ -283,7 +279,6 @@ public class OperationsOnSeqNoDisabledIndicesIT extends ESIntegTestCase {
     }
 
     public void testSingleUpdateOnSeqNoDisabledIndexIsRejected() {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         createIndex(
             "test",
             indexSettings(1, 0).put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
@@ -1103,7 +1103,6 @@ public class GetActionIT extends ESIntegTestCase {
     }
 
     public void testGetWithSequenceNumbersDisabled() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         String index = "test-seq-no-disabled";
         assertAcked(
             prepareCreate(index).setSettings(

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/SeqNoPruningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/SeqNoPruningIT.java
@@ -57,8 +57,6 @@ public class SeqNoPruningIT extends ESIntegTestCase {
     }
 
     public void testSeqNoPrunedAfterMerge() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNodes(2);
         ensureStableCluster(3);
@@ -140,8 +138,6 @@ public class SeqNoPruningIT extends ESIntegTestCase {
     }
 
     public void testSeqNoPartiallyPrunedWithRetentionLease() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNodes(2);
         ensureStableCluster(3);
@@ -302,8 +298,6 @@ public class SeqNoPruningIT extends ESIntegTestCase {
      * that still need to be replayed to the replica.
      */
     public void testSeqNoRetainedDuringInProgressRecovery() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNodes(2);
         ensureStableCluster(3);
@@ -424,8 +418,6 @@ public class SeqNoPruningIT extends ESIntegTestCase {
     }
 
     public void testSeqNoPrunedAfterMergeWithTsdbCodec() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
@@ -492,8 +484,6 @@ public class SeqNoPruningIT extends ESIntegTestCase {
      * by a force merge.
      */
     public void testWritesSucceedOnReplicaAfterSeqNoPruning() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNodes(2);
         ensureStableCluster(3);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/NestedSeqNoPruningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/NestedSeqNoPruningIT.java
@@ -47,8 +47,6 @@ public class NestedSeqNoPruningIT extends ESIntegTestCase {
     }
 
     public void testNestedQueriesAfterSeqNoPruningMerge() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
@@ -143,8 +141,6 @@ public class NestedSeqNoPruningIT extends ESIntegTestCase {
     }
 
     public void testMultiLevelNestedAfterSeqNoPruningMerge() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -423,8 +423,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 if (task != null) {
                     bulkShardRequest.setParentTask(nodeId, task.getId());
                 }
-                boolean redactSeqNo = IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
-                    && IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(indexMetadata.getSettings());
+                boolean redactSeqNo = IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(indexMetadata.getSettings());
                 executeBulkShardRequest(bulkShardRequest, project.id(), bulkItemRequestCompleteRefCount.acquire(), redactSeqNo);
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -554,7 +554,7 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
 
         // When sequence numbers are disabled, OCC (if_seq_no/if_primary_term) cannot be used,
         // so we allow writes with an explicit document ID directly to backing indices.
-        if (writeRequest.id() != null && IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
+        if (writeRequest.id() != null) {
             IndexMetadata targetMetadata = indexMetadataProvider.apply(indexAbstraction.getWriteIndex());
             if (targetMetadata != null && targetMetadata.sequenceNumbersDisabled()) {
                 return;

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -48,7 +48,6 @@ import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.SystemIndices;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2576,9 +2576,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
             boolean useTimeSeriesSyntheticId = shouldUseTimeSeriesSyntheticId(isTsdb, indexCreatedVersion, settings);
-            final boolean sequenceNumbersDisabled = IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
-                && indexCreatedVersion.onOrAfter(IndexVersions.DISABLE_SEQUENCE_NUMBERS)
-                && settings.getAsBoolean(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false);
+            final boolean sequenceNumbersDisabled = indexCreatedVersion.onOrAfter(
+                IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT
+            ) && settings.getAsBoolean(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false);
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -261,9 +261,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             )
         );
 
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            settings.add(IndexSettings.DISABLE_SEQUENCE_NUMBERS);
-        }
+        settings.add(IndexSettings.DISABLE_SEQUENCE_NUMBERS);
         settings.add(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_LARGE_BINARY_BLOCK_SIZE);
         if (IndexSettings.TIME_SERIES_TEMPORALITY_FEATURE_FLAG.isEnabled()) {
             settings.add(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -991,15 +991,11 @@ public final class IndexSettings {
         );
     }
 
-    public static final boolean DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG = new FeatureFlag("disable_sequence_numbers").isEnabled();
-
     public static final Setting<SeqNoFieldMapper.SeqNoIndexOptions> SEQ_NO_INDEX_OPTIONS_SETTING = Setting.enumSetting(
         SeqNoFieldMapper.SeqNoIndexOptions.class,
         settings -> {
             IndexVersion indexVersionCreated = SETTING_INDEX_VERSION_CREATED.get(settings);
-            if ((DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG
-                || indexVersionCreated.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT))
-                && settings.getAsBoolean("index.disable_sequence_numbers", false)) {
+            if (settings.getAsBoolean("index.disable_sequence_numbers", false)) {
                 return SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY.toString();
             }
             final IndexMode indexMode = IndexSettings.MODE.get(settings);
@@ -1437,8 +1433,7 @@ public final class IndexSettings {
                 );
             }
         }
-        disableSequenceNumbers = DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && DISABLE_SEQUENCE_NUMBERS.get(settings);
-
+        disableSequenceNumbers = DISABLE_SEQUENCE_NUMBERS.get(settings);
         scopedSettings.addSettingsUpdateConsumer(
             MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING,
             mergePolicyConfig::setCompoundFormatThreshold

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
-import org.elasticsearch.index.IndexSettings;
-
 import java.util.HashSet;
 import java.util.Set;
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -46,12 +46,10 @@ public class CreateIndexCapabilities {
                 LOOKUP_INDEX_MODE_CAPABILITY,
                 NESTED_DENSE_VECTOR_SYNTHETIC_TEST,
                 POORLY_FORMATTED_BAD_REQUEST,
-                HUNSPELL_DICT_400
+                HUNSPELL_DICT_400,
+                DISABLE_SEQUENCE_NUMBERS_CAPABILITY
             )
         );
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            caps.add(DISABLE_SEQUENCE_NUMBERS_CAPABILITY);
-        }
         CAPABILITIES = Set.copyOf(caps);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -326,8 +326,6 @@ public class TransportBulkActionTests extends ESTestCase {
     }
 
     public void testProhibitAppendWritesInBackingIndicesSkippedForSeqNoDisabled() throws Exception {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         String dataStreamName = "logs-foobar";
         Index seqNoDisabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 1), IndexMetadata.INDEX_UUID_NA_VALUE);
         Index seqNoEnabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 2), IndexMetadata.INDEX_UUID_NA_VALUE);

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -330,7 +330,7 @@ public class TransportBulkActionTests extends ESTestCase {
         Index seqNoDisabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 1), IndexMetadata.INDEX_UUID_NA_VALUE);
         Index seqNoEnabledIdx = new Index(DataStream.getDefaultBackingIndexName(dataStreamName, 2), IndexMetadata.INDEX_UUID_NA_VALUE);
         final var seqNoDisabledMetadata = indexMetadata(seqNoDisabledIdx.getName()).settings(
-            settings(IndexVersions.DISABLE_SEQUENCE_NUMBERS).put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+            settings(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT).put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
                 .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY)
         ).numberOfShards(1).numberOfReplicas(1).build();
         final var seqNoEnabledMetadata = indexMetadata(seqNoEnabledIdx.getName()).build();

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -1297,7 +1297,6 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
     }
 
     public void testBulkIndexWithSeqNoDisabledPreservesRealSeqNo() throws Exception {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         Settings settings = Settings.builder()
             .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
             .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY)

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -935,7 +935,6 @@ public class IndexMetadataTests extends ESTestCase {
     }
 
     public void testSequenceNumbersDisabled() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
         var disabled = randomBoolean();
         IndexMetadata metadata = IndexMetadata.builder("test")

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -1121,7 +1121,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersSetting() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
 
         var disabled = randomBoolean();
@@ -1135,7 +1134,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersImpliesDocValuesOnly() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         final var indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
 
         var builder = Settings.builder().put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
@@ -1148,7 +1146,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersRequiresDocValuesOnly() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         final var indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
 
         var builder = Settings.builder().put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
@@ -1171,7 +1168,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersRequiresDocValuesOnlyForNonStandardModes() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
 
         IndexMode mode = randomFrom(IndexMode.TIME_SERIES, IndexMode.LOGSDB);
@@ -1200,7 +1196,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersValidationWithInvalidVersion() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         IndexVersion badVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DISABLE_SEQUENCE_NUMBERS);
 
         Settings settings = Settings.builder().put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true).build();

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -8069,7 +8069,6 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testGetWithSequenceNumbersDisabled() throws IOException {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         Settings settings = Settings.builder()
             .put(defaultSettings.getSettings())
             .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)

--- a/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
@@ -372,10 +372,6 @@ public class PruningMergePolicyTests extends ESTestCase {
         final boolean pruneSequenceNumber,
         final boolean useSyntheticRecoverySource
     ) throws IOException {
-        assumeTrue(
-            "Sequence number pruning requires a feature flag",
-            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || pruneSequenceNumber == false
-        );
         try (var dir = newDirectory()) {
             dir.setCheckIndexOnClose(false);
 
@@ -578,10 +574,6 @@ public class PruningMergePolicyTests extends ESTestCase {
         boolean syntheticRecoverySource = randomBoolean();
         boolean pruneIdField = randomBoolean();
         boolean pruneSequenceNumber = randomBoolean();
-        assumeTrue(
-            "Sequence number pruning requires a feature flag",
-            IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG || (pruneSequenceNumber == false && pruneIdField == false)
-        );
         String pruneStoredFieldName = syntheticRecoverySource ? null : SourceFieldMapper.RECOVERY_SOURCE_NAME;
         String pruneNumericDVFieldName = syntheticRecoverySource
             ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME

--- a/server/src/test/java/org/elasticsearch/index/mapper/SeqNoFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SeqNoFieldTypeTests.java
@@ -12,7 +12,6 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.IndexSettings;
 
 import static org.hamcrest.Matchers.containsString;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/SeqNoFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SeqNoFieldTypeTests.java
@@ -33,14 +33,12 @@ public class SeqNoFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testRangeQueryDisabled() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         MappedFieldType ft = SeqNoFieldMapper.UNSEARCHABLE.fieldType();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> seqNoRangeQuery(ft, 0, 10));
         assertThat(e.getMessage(), containsString("_seq_no cannot be queried when [index.disable_sequence_numbers] is [true]"));
     }
 
     public void testTermQueryDisabled() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         MappedFieldType ft = SeqNoFieldMapper.UNSEARCHABLE.fieldType();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ft.termQuery(1, MOCK_CONTEXT));
         assertThat(e.getMessage(), containsString("_seq_no cannot be queried when [index.disable_sequence_numbers] is [true]"));

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilderTests.java
@@ -29,9 +29,6 @@ public class RandomScoreFunctionBuilderTests extends AbstractBuilderTestCase {
 
     @Override
     protected Settings createTestIndexSettings() {
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG == false) {
-            return super.createTestIndexSettings();
-        }
         return Settings.builder()
             .put("index.version.created", IndexVersion.current())
             .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
@@ -40,7 +37,6 @@ public class RandomScoreFunctionBuilderTests extends AbstractBuilderTestCase {
     }
 
     public void testRandomScoreWithoutFieldRequiresFieldWhenSeqNoDisabled() throws Exception {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         builder.seed(42);
         SearchExecutionContext context = createSearchExecutionContext();
@@ -51,7 +47,6 @@ public class RandomScoreFunctionBuilderTests extends AbstractBuilderTestCase {
     }
 
     public void testRandomScoreWithExplicitFieldWhenSeqNoDisabled() throws Exception {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         builder.seed(42);
         builder.setField(KEYWORD_FIELD_NAME);
@@ -63,7 +58,6 @@ public class RandomScoreFunctionBuilderTests extends AbstractBuilderTestCase {
     }
 
     public void testRandomScoreWithoutSeedFallsBackToDocIdWhenSeqNoDisabled() throws Exception {
-        assumeTrue("Test requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         SearchExecutionContext context = createSearchExecutionContext();
         assertTrue(context.getIndexSettings().sequenceNumbersDisabled());

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
@@ -3010,7 +3010,6 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
     }
 
     public void testSeqNoAndPrimaryTermReturnsSentinelsWhenSequenceNumbersDisabled() {
-        assumeTrue("Test should only run with feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
         final Settings settings = Settings.builder()
             .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
             .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), "doc_values_only")

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrSeqNoPruningIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrSeqNoPruningIT.java
@@ -60,8 +60,6 @@ public class CcrSeqNoPruningIT extends CcrIntegTestCase {
     }
 
     public void testSeqNoPrunedOnLeaderAfterFollowerCatchesUp() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         final var leaderIndex = randomIdentifier();
         final var followerIndex = "follower-" + leaderIndex;
         final int numberOfShards = 1;
@@ -134,8 +132,6 @@ public class CcrSeqNoPruningIT extends CcrIntegTestCase {
     }
 
     public void testSeqNoPartiallyRetainedByCcrLease() throws Exception {
-        assumeTrue("requires disable_sequence_numbers feature flag", IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG);
-
         final var leaderIndex = randomIdentifier();
         final var followerIndex = "follower-" + leaderIndex;
         final int numberOfShards = 1;

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrTimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrTimeSeriesDataStreamsIT.java
@@ -82,7 +82,7 @@ public class CcrTimeSeriesDataStreamsIT extends CcrIntegTestCase {
         final var dataStreamName = randomIdentifier();
         final int nbPrimaries = randomIntBetween(1, 5);
         final int nbReplicas = between(0, 1);
-        final boolean disableSeqNo = IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG && randomBoolean();
+        final boolean disableSeqNo = randomBoolean();
         final long expectedPrimaryTerm = disableSeqNo ? SequenceNumbers.UNASSIGNED_PRIMARY_TERM : 1L;
         putDataStreamTemplate(leaderClient(), dataStreamName, nbPrimaries, nbReplicas, useSyntheticId, disableSeqNo);
 
@@ -287,10 +287,8 @@ public class CcrTimeSeriesDataStreamsIT extends CcrIntegTestCase {
         var settingsBuilder = indexSettings(primaries, replicas).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)
             .put(IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey(), randomBoolean())
-            .put(IndexSettings.SYNTHETIC_ID.getKey(), useSyntheticId);
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            settingsBuilder.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), disableSeqNo);
-        }
+            .put(IndexSettings.SYNTHETIC_ID.getKey(), useSyntheticId)
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), disableSeqNo);
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request(getTestClass().getName().toLowerCase(Locale.ROOT))
             .indexTemplate(
                 ComposableIndexTemplate.builder()


### PR DESCRIPTION
This is a follow-up on #145737. Some code paths were still guarded by the feature flag, removing it. 

Introduced in: #145737
