### PR TITLE
Always register disable_sequence_numbers index setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -261,9 +261,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             )
         );
 
-        if (IndexSettings.DISABLE_SEQUENCE_NUMBERS_FEATURE_FLAG) {
-            settings.add(IndexSettings.DISABLE_SEQUENCE_NUMBERS);
-        }
+        settings.add(IndexSettings.DISABLE_SEQUENCE_NUMBERS);
+
         settings.add(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_LARGE_BINARY_BLOCK_SIZE);
         if (IndexSettings.TIME_SERIES_TEMPORALITY_FEATURE_FLAG.isEnabled()) {
             settings.add(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD);


### PR DESCRIPTION
We’ve graduated the feature, but the index setting is still behind a feature flag. This setting should now always be registered.