### PR TITLE
[9.2] EQL: Fix propagation of filters on join keys for missing events (#145813)

### DIFF
--- a/docs/changelog/145813.yaml
+++ b/docs/changelog/145813.yaml
@@ -1,0 +1,6 @@
+area: EQL
+issues:
+ - 145402
+pr: 145813
+summary: Fix propagation of filters on join keys for missing events
+type: bug

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_missing_events.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_missing_events.toml
@@ -302,6 +302,30 @@ join_keys = ["foo", "foo",
              "baz", "baz"]
 
 
+# Regression test for https://github.com/elastic/elasticsearch/issues/145402:
+# a key constraint in a negated rule must NOT be propagated to positive rules.
+# The condition k2 == "foo" in the negated rule is a key constraint (k2 is the per-rule key).
+# Before the fix it was propagated to positive rules, causing events with k2 == "baz" to be
+# silently excluded and the last sequence ([9, 10, -1, 12] / baz) to disappear.
+[[queries]]
+name = "withByKeyNegatedRuleKeyConstraintNotPropagated"
+query = '''
+  sequence by k1 with maxspan=1s
+    [ test5 where tag == "normal" ] by k2
+    [ test5 where tag == "normal" ] by k2
+   ![ test5 where tag == "missing" and k2 == "foo" ] by k2
+    [ test5 where tag == "normal" ] by k2
+'''
+expected_event_ids = [2, 4, -1, 5,
+                      4, 5, -1, 6,
+                      5, 6, -1, 8,
+                      9, 10, -1, 12]
+join_keys = ["foo", "foo",
+             "foo", "foo",
+             "foo", "foo",
+             "baz", "baz"]
+
+
 [[queries]]
 name = "withByKey_tail"
 query = '''

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -395,11 +395,19 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         protected LogicalPlan rule(AbstractJoin join) {
             List<Constraint> constraints = new ArrayList<>();
 
-            // collect constraints for each filter
-            join.queries().forEach(k -> k.forEachDown(Filter.class, f -> constraints.addAll(detectKeyConstraints(f.condition(), k))));
+            // collect constraints for each non-negated filter only; negated (missing event) filters use different semantics
+            for (KeyedFilter k : join.queries()) {
+                if (k.isMissingEventFilter() == false) {
+                    k.forEachDown(Filter.class, f -> constraints.addAll(detectKeyConstraints(f.condition(), k)));
+                }
+            }
 
             if (constraints.isEmpty() == false) {
-                List<KeyedFilter> queries = join.queries().stream().map(k -> addConstraint(k, constraints)).collect(toList());
+                // propagate constraints only to non-negated filters; applying key constraints to missing event filters is incorrect
+                List<KeyedFilter> queries = new ArrayList<>(join.queries().size());
+                for (KeyedFilter k : join.queries()) {
+                    queries.add(k.isMissingEventFilter() ? k : addConstraint(k, constraints));
+                }
 
                 if (join instanceof Join j) {
                     join = j.with(queries, j.until(), j.direction());
@@ -564,7 +572,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         protected LogicalPlan rule(AbstractJoin plan) {
             // check for empty filters
             for (KeyedFilter filter : plan.queries()) {
-                if (filter.anyMatch(LocalRelation.class::isInstance)) {
+                if (filter.isMissingEventFilter() == false && filter.anyMatch(LocalRelation.class::isInstance)) {
                     return new LocalRelation(plan.source(), plan.output(), plan instanceof Sample ? Type.SAMPLE : Type.SEQUENCE);
                 }
             }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/KeyedFilter.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/KeyedFilter.java
@@ -113,6 +113,6 @@ public class KeyedFilter extends UnaryPlan {
             && Objects.equals(timestamp, other.timestamp)
             && Objects.equals(tiebreaker, other.tiebreaker)
             && Objects.equals(child(), other.child())
-            && isMissingEventFilter == isMissingEventFilter;
+            && isMissingEventFilter == other.isMissingEventFilter;
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
@@ -292,6 +292,61 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(LocalRelation.class, optimized.getClass());
     }
 
+    /**
+     * A LocalRelation inside a missing event filter means no event can ever satisfy the negated condition,
+     * so the absence is always guaranteed — the sequence must NOT be skipped.
+     * <p>
+     * sequence
+     * ![ LocalRelation ]   -- always absent, absence always satisfied
+     * [ filter X ]
+     * ==
+     * sequence (unchanged, not replaced with LocalRelation)
+     */
+    public void testSkipEmptyJoinDoesNotSkipWhenMissingEventFilterIsEmpty() {
+        KeyedFilter negatedRule = missingEventKeyedFilter(new LocalRelation(EMPTY, emptyList()));
+        KeyedFilter positiveRule = keyedFilter(basicFilter(new IsNull(EMPTY, TRUE)));
+        KeyedFilter until = keyedFilter(basicFilter(Literal.FALSE));
+        Sequence s = new Sequence(
+            EMPTY,
+            asList(negatedRule, positiveRule),
+            until,
+            TimeValue.MINUS_ONE,
+            timestamp(),
+            tiebreaker(),
+            OrderDirection.ASC
+        );
+
+        LogicalPlan result = new Optimizer.SkipEmptyJoin().rule(s);
+        assertEquals(Sequence.class, result.getClass());
+    }
+
+    /**
+     * A LocalRelation inside a positive rule still causes the whole sequence to be skipped.
+     * <p>
+     * sequence
+     * [ LocalRelation ]    -- no events can ever match
+     * ![ filter X ]
+     * ==
+     * LocalRelation
+     */
+    public void testSkipEmptyJoinSkipsWhenPositiveRuleIsEmpty() {
+        KeyedFilter positiveRule = keyedFilter(new LocalRelation(EMPTY, emptyList()));
+        KeyedFilter negatedRule = missingEventKeyedFilter(basicFilter(new IsNull(EMPTY, TRUE)));
+        KeyedFilter until = keyedFilter(basicFilter(Literal.FALSE));
+        Sequence s = new Sequence(
+            EMPTY,
+            asList(positiveRule, negatedRule),
+            until,
+            TimeValue.MINUS_ONE,
+            timestamp(),
+            tiebreaker(),
+            OrderDirection.ASC
+        );
+
+        LogicalPlan result = new Optimizer.SkipEmptyJoin().rule(s);
+        assertEquals(LocalRelation.class, result.getClass());
+    }
+
     public void testSortByLimit() {
         Filter f = new Filter(EMPTY, rel(), TRUE);
         OrderBy o = new OrderBy(EMPTY, f, singletonList(new Order(EMPTY, tiebreaker(), OrderDirection.ASC, NullsPosition.FIRST)));
@@ -627,6 +682,92 @@ public class OptimizerTests extends ESTestCase {
     }
 
     /**
+     * Key conditions in a negated (missing event) rule must NOT be propagated to positive rules.
+     * <p>
+     * sequence by a
+     * ![ filter a gt 1 by a ]
+     * [ filter X by a ]
+     * ==
+     * same (no propagation)
+     */
+    public void testKeyConstraintNotPropagatedFromMissingEventFilter() {
+        Attribute a = key("a");
+
+        Expression keyCondition = gtExpression(a);
+        Expression filter = equalsExpression();
+
+        KeyedFilter negatedRule = missingEventKeyedFilter(basicFilter(keyCondition), a);
+        KeyedFilter positiveRule = keyedFilter(basicFilter(filter), a);
+
+        Sequence seq = sequence(negatedRule, positiveRule);
+        LogicalPlan result = new Optimizer.PropagateJoinKeyConstraints().apply(seq);
+        Sequence resultSeq = (Sequence) result;
+
+        List<KeyedFilter> queries = resultSeq.queries();
+        assertEquals(negatedRule, queries.get(0));
+        assertEquals(positiveRule, queries.get(1));
+    }
+
+    /**
+     * Key conditions in a positive rule must NOT be propagated into a negated (missing event) rule.
+     * <p>
+     * sequence by a
+     * [ filter a gt 1 by a ]
+     * ![ filter X by a ]
+     * ==
+     * same (missing event filter unchanged)
+     */
+    public void testKeyConstraintNotPropagatedToMissingEventFilter() {
+        Attribute a = key("a");
+
+        Expression keyCondition = gtExpression(a);
+        Expression filter = equalsExpression();
+
+        KeyedFilter positiveRule = keyedFilter(basicFilter(keyCondition), a);
+        KeyedFilter negatedRule = missingEventKeyedFilter(basicFilter(filter), a);
+
+        Sequence seq = sequence(positiveRule, negatedRule);
+        LogicalPlan result = new Optimizer.PropagateJoinKeyConstraints().apply(seq);
+        Sequence resultSeq = (Sequence) result;
+
+        List<KeyedFilter> queries = resultSeq.queries();
+        // positive rule is unchanged (no other positive rules to propagate to)
+        assertEquals(positiveRule, queries.get(0));
+        // negated rule must not receive the key constraint
+        assertEquals(negatedRule, queries.get(1));
+    }
+
+    /**
+     * Key conditions in the negated (middle) rule must NOT appear on the second positive rule.
+     * <p>
+     * sequence by a
+     * [ filter X by a ]
+     * ![ filter a gt 1 by a ]
+     * [ filter X by a ]
+     * ==
+     * same (key condition from negated rule not propagated to positive2)
+     */
+    public void testKeyConstraintNotPropagatedAcrossMissingEventFilter() {
+        Attribute a = key("a");
+
+        Expression keyCondition = gtExpression(a);
+        Expression filter = equalsExpression();
+
+        KeyedFilter positive1 = keyedFilter(basicFilter(filter), a);
+        KeyedFilter negatedRule = missingEventKeyedFilter(basicFilter(keyCondition), a);
+        KeyedFilter positive2 = keyedFilter(basicFilter(filter), a);
+
+        Sequence seq = sequence(positive1, negatedRule, positive2);
+        LogicalPlan result = new Optimizer.PropagateJoinKeyConstraints().apply(seq);
+        Sequence resultSeq = (Sequence) result;
+
+        List<KeyedFilter> queries = resultSeq.queries();
+        assertEquals(positive1, queries.get(0));
+        assertEquals(negatedRule, queries.get(1));
+        assertEquals(positive2, queries.get(2));
+    }
+
+    /**
      * sequence
      * 1. filter startsWith(a, b) and c > 10 by a, c
      * 2. filter X by a, c
@@ -870,6 +1011,10 @@ public class OptimizerTests extends ESTestCase {
 
     private static KeyedFilter keyedFilter(LogicalPlan child, NamedExpression... keys) {
         return new KeyedFilter(EMPTY, child, asList(keys), timestamp(), tiebreaker(), false);
+    }
+
+    private static KeyedFilter missingEventKeyedFilter(LogicalPlan child, NamedExpression... keys) {
+        return new KeyedFilter(EMPTY, child, asList(keys), timestamp(), tiebreaker(), true);
     }
 
     private static Attribute key(String name) {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - EQL: Fix propagation of filters on join keys for missing events (#145813)