### PR TITLE
Document GA of FORK and changes after rm implicit LIMIT

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -22,7 +22,7 @@ Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) com
 
 ::::{applies-switch}
 
-:::{applies-item} { serverless:ga , stack: ga 9.4+ }
+:::{applies-item} { serverless: ga, stack: ga 9.4+ }
 `FORK` branches do not have an implicit `LIMIT 1000`.
 :::
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -1,6 +1,6 @@
 ```yaml {applies_to}
 serverless: ga
-stack: preview 9.1 - 9.3, ga 9.4+
+stack: preview 9.1-9.3, ga 9.4+
 ```
 
 The `FORK` processing command creates multiple execution branches to operate
@@ -22,7 +22,7 @@ Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) com
 
 ::::{applies-switch}
 
-:::{applies-item} { serverless: , stack: preview 9.4+ }
+:::{applies-item} { serverless:ga , stack: ga 9.4+ }
 `FORK` branches do not have an implicit `LIMIT 1000`.
 :::
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -1,6 +1,6 @@
 ```yaml {applies_to}
-serverless: preview
-stack: preview 9.1.0
+serverless: ga
+stack: preview 9.1 - 9.3, ga 9.4+
 ```
 
 The `FORK` processing command creates multiple execution branches to operate
@@ -20,14 +20,15 @@ on the same input data and combines the results in a single output table. A disc
 Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) command, `FORK` enables hybrid search to combine and score results from multiple queries. To learn more about using {{esql}} for search, refer to [ES|QL for search](docs-content://solutions/search/esql-for-search.md).
 
 
-% Use applies-switch tabs once we remove the implicit limit.
+::::{applies-switch}
 
-::::{note}
+:::{applies-item} { serverless: , stack: preview 9.4+ }
+`FORK` branches do not have an implicit `LIMIT 1000`.
+:::
 
-`FORK` branches default to `LIMIT 1000` if no `LIMIT` is provided.
-In a future release, no implicit `LIMIT` will be added to `FORK` branches.
-To maintain the current behavior of the queries using `FORK`, it is recommended
-to include a `LIMIT` in each `FORK` branch.
+:::{applies-item} stack: preview 9.1-9.3
+An implicit `LIMIT 1000` is added to each `FORK` branch.
+:::
 
 ::::
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fuse.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fuse.md
@@ -19,6 +19,23 @@ and the values from the `<group_column>` and `<score_column>`
 Learn more about [how search works in ES|QL](docs-content://solutions/search/esql-for-search.md#how-search-works-in-esql).
 :::::
 
+A `LIMIT` is required before `FUSE`, since `FUSE` can only with a finite set of rows.
+
+::::{applies-switch}
+
+:::{applies-item} { serverless: , stack: preview 9.4+ }
+`FORK` branches do not have an implicit `LIMIT 1000`.
+When using `FUSE` after `FORK`, a `LIMIT` must be added to each `FORK` branch.
+:::
+
+:::{applies-item} stack: preview 9.1-9.3
+An implicit `LIMIT 1000` is added to each `FORK` branch.
+When using `FUSE` after `FORK`, `FUSE` does not require an explicit `LIMIT` in each `FORK` branch.
+However, as a best practice and to avoid issues when upgrading to newer versions, it is advised to still add an explicit `LIMIT` before `FUSE`.
+:::
+
+::::
+
 ## Syntax
 
 Use default parameters:
@@ -84,9 +101,10 @@ Run a lexical and a semantic query in parallel with `FORK`, then merge with `FUS
 
 ```esql
 FROM books METADATA _id, _index, _score  # Include document ID, index name, and relevance score
-| FORK (WHERE title:"Shakespeare" | SORT _score DESC)  # Fork 1: Lexical search on title field, sorted by relevance score
-       (WHERE semantic_title:"Shakespeare" | SORT _score DESC)  # Fork 2: Semantic search on semantic_title field, sorted by relevance score
+| FORK (WHERE title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 1: Lexical search on title field, sorted by relevance score
+       (WHERE semantic_title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 2: Semantic search on semantic_title field, sorted by relevance score
 | FUSE  # Merge results using RRF algorithm by default
+| SORT _score DESC # sort results by the new scores, since `FUSE` does not do any sorting.
 ```
 
 ### Use linear combination
@@ -94,10 +112,11 @@ FROM books METADATA _id, _index, _score  # Include document ID, index name, and 
 `FUSE` can also use linear score combination:
 
 ```esql
-FROM books METADATA _id, _index, _score 
-| FORK (WHERE title:"Shakespeare" | SORT _score DESC)  # Fork 1: Lexical search on title
-       (WHERE semantic_title:"Shakespeare" | SORT _score DESC)  # Fork 2: Semantic search on semantic_title
+FROM books METADATA _id, _index, _score
+| FORK (WHERE title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 1: Lexical search on title
+       (WHERE semantic_title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 2: Semantic search on semantic_title
 | FUSE LINEAR  # Merge results using linear combination of scores (equal weights by default)
+| SORT _score DESC # sort results by the new scores, since `FUSE` does not do any sorting.
 ```
 
 ### Normalize scores
@@ -109,9 +128,10 @@ This means the scores normalize and assign values between 0 and 1, before combin
 
 ```esql
 FROM books METADATA _id, _index, _score
-| FORK (WHERE title:"Shakespeare" | SORT _score DESC)  # Fork 1: Lexical search
-       (WHERE semantic_title:"Shakespeare" | SORT _score DESC)  # Fork 2: Semantic search
+| FORK (WHERE title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 1: Lexical search
+       (WHERE semantic_title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 2: Semantic search
 | FUSE LINEAR WITH { "normalizer": "minmax" }  # Linear combination with min-max normalization (scales scores to 0-1 range)
+| SORT _score DESC # sort results by the new scores, since `FUSE` does not do any sorting.
 ```
 
 ### Set custom weights
@@ -120,9 +140,10 @@ FROM books METADATA _id, _index, _score
 
 ```esql
 FROM books METADATA _id, _index, _score
-| FORK (WHERE title:"Shakespeare" | SORT _score DESC)  # Fork 1: Lexical search
-       (WHERE semantic_title:"Shakespeare" | SORT _score DESC)  # Fork 2: Semantic search
+| FORK (WHERE title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 1: Lexical search
+       (WHERE semantic_title:"Shakespeare" | SORT _score DESC | LIMIT 100)  # Fork 2: Semantic search
 | FUSE LINEAR WITH { "weights": { "fork1": 0.7, "fork2": 0.3 }, "normalizer": "minmax" }  # Weighted linear combination: 70% lexical, 30% semantic, with min-max normalization
+| SORT _score DESC # sort results by the new scores, since `FUSE` does not do any sorting.
 ```
 
 ## Limitations

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fuse.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fuse.md
@@ -19,11 +19,11 @@ and the values from the `<group_column>` and `<score_column>`
 Learn more about [how search works in ES|QL](docs-content://solutions/search/esql-for-search.md#how-search-works-in-esql).
 :::::
 
-A `LIMIT` is required before `FUSE`, since `FUSE` can only with a finite set of rows.
+A `LIMIT` is required before `FUSE`, because `FUSE` can only work with a finite set of rows.
 
 ::::{applies-switch}
 
-:::{applies-item} { serverless: , stack: preview 9.4+ }
+:::{applies-item} { serverless: ga , stack: ga 9.4+ }
 `FORK` branches do not have an implicit `LIMIT 1000`.
 When using `FUSE` after `FORK`, a `LIMIT` must be added to each `FORK` branch.
 :::


### PR DESCRIPTION
related: https://github.com/elastic/elasticsearch/pull/145429

does what it says.
we needed to do some explicit changes to the FUSE docs, since FUSE requires a LIMIT to be present before.
now that we don't have an implicit LIMIT for FORK, an explicit one needs to be added to each branch when FUSE follows FORK.

