### PR TITLE
ES|QL: Unmute CommandLicenseTests and add more logging

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,9 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcFetchSizeIT
   method: testScrollWithDatetimeAndTimezoneParam
   issue: https://github.com/elastic/elasticsearch/issues/145592
-- class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
-  method: testLicenseCheck
-  issue: https://github.com/elastic/elasticsearch/issues/145600
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
   method: testTopNByKeyEncoderTooMuchMemory
   issue: https://github.com/elastic/elasticsearch/issues/145627

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/CommandLicenseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/CommandLicenseTests.java
@@ -49,6 +49,7 @@ public class CommandLicenseTests extends ESTestCase {
                 checkLicense(commandName, createInstance(commandClass, arg));
             } catch (Exception e) {
                 Throwable c = e.getCause();
+                log.error("Failed to create instance of command class: " + commandClass.getName() + " - " + e.getMessage() + " - " + c, e);
                 fail("Failed to create instance of command class: " + commandClass.getName() + " - " + e.getMessage() + " - " + c);
             }
         }


### PR DESCRIPTION
Unmute tests and add better logging.
The test failure doesn't reproduce locally, and the CI build contains many other errors, so it could very well be a transient problem.
Anyway, we need better logging to understand the root cause in case it fails again

Fixes: https://github.com/elastic/elasticsearch/issues/145600