### PR TITLE
Add shared DirectAccessIndexInput test utility

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -16,15 +16,14 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.store.NIOFSDirectory;
-import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.common.lucene.store.DirectAccessIndexInput;
 import org.elasticsearch.core.DirectAccessInput;
+import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -58,7 +57,7 @@ public class IndexInputUtilsTests extends ESTestCase {
         try (Directory dir = new NIOFSDirectory(createTempDir())) {
             writeData(dir, data);
             try (IndexInput rawIn = dir.openInput(FILE_NAME, IOContext.DEFAULT)) {
-                IndexInput in = new DirectAccessWrapper("dai", rawIn, data);
+                IndexInput in = new DirectAccessIndexInput("dai", rawIn, data, NativeAccess.instance());
                 assertThat(in, instanceOf(DirectAccessInput.class));
                 verifyWithSlice(in, data);
             }
@@ -124,7 +123,7 @@ public class IndexInputUtilsTests extends ESTestCase {
         try (Directory dir = new NIOFSDirectory(createTempDir())) {
             writeData(dir, data);
             try (IndexInput rawIn = dir.openInput(FILE_NAME, IOContext.DEFAULT)) {
-                IndexInput in = new DirectAccessWrapper("dai", rawIn, data);
+                IndexInput in = new DirectAccessIndexInput("dai", rawIn, data, NativeAccess.instance());
                 new MemorySegmentES92Int7VectorsScorer(in, 64, 16);
             }
         }
@@ -159,7 +158,7 @@ public class IndexInputUtilsTests extends ESTestCase {
         try (Directory dir = new NIOFSDirectory(createTempDir())) {
             writeData(dir, data);
             try (IndexInput rawIn = dir.openInput(FILE_NAME, IOContext.DEFAULT)) {
-                IndexInput in = new DirectAccessWrapper("dai", rawIn, data);
+                IndexInput in = new DirectAccessIndexInput("dai", rawIn, data, NativeAccess.instance());
                 assertThat(in, instanceOf(DirectAccessInput.class));
                 verifyWithSlices(in, data, 64);
             }
@@ -218,7 +217,7 @@ public class IndexInputUtilsTests extends ESTestCase {
         try (Directory dir = new NIOFSDirectory(createTempDir())) {
             writeData(dir, data);
             try (IndexInput rawIn = dir.openInput(FILE_NAME, IOContext.DEFAULT)) {
-                IndexInput in = new DirectAccessWrapper("dai", rawIn, data);
+                IndexInput in = new DirectAccessIndexInput("dai", rawIn, data, NativeAccess.instance());
                 assertThat(in, instanceOf(DirectAccessInput.class));
                 verifyWithSliceAddresses(in, data, 64);
             }
@@ -303,51 +302,4 @@ public class IndexInputUtilsTests extends ESTestCase {
         }
     }
 
-    /**
-     * Wraps an existing IndexInput with DirectAccessInput support,
-     * serving byte-buffer slices from the provided data array.
-     */
-    static class DirectAccessWrapper extends FilterIndexInput implements DirectAccessInput {
-        private final byte[] data;
-
-        DirectAccessWrapper(String resourceDescription, IndexInput delegate, byte[] data) {
-            super(resourceDescription, delegate);
-            this.data = data;
-        }
-
-        @Override
-        public boolean withByteBufferSlice(long offset, long length, CheckedConsumer<ByteBuffer, IOException> action) throws IOException {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment segment = arena.allocate(length);
-                MemorySegment.copy(data, (int) offset, segment, ValueLayout.JAVA_BYTE, 0, (int) length);
-                action.accept(segment.asByteBuffer().asReadOnlyBuffer());
-                return true;
-            }
-        }
-
-        @Override
-        public boolean withByteBufferSlices(long[] offsets, int length, int count, CheckedConsumer<ByteBuffer[], IOException> action)
-            throws IOException {
-            try (Arena arena = Arena.ofConfined()) {
-                ByteBuffer[] buffers = new ByteBuffer[count];
-                for (int i = 0; i < count; i++) {
-                    MemorySegment segment = arena.allocate(length);
-                    MemorySegment.copy(data, (int) offsets[i], segment, ValueLayout.JAVA_BYTE, 0, length);
-                    buffers[i] = segment.asByteBuffer().asReadOnlyBuffer();
-                }
-                action.accept(buffers);
-                return true;
-            }
-        }
-
-        @Override
-        public IndexInput clone() {
-            return new DirectAccessWrapper("clone", in.clone(), data);
-        }
-
-        @Override
-        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
-            return new DirectAccessWrapper(sliceDescription, in.slice(sliceDescription, offset, length), data);
-        }
-    }
 }

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   api project(':modules:transport-netty4')
   api project(':libs:ssl-config')
   api project(":server")
+  api project(":libs:native")
   api project(":libs:cli")
   api project(":libs:entitlement:bridge")
   api ("com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}") {

--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/DirectAccessIndexInput.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/DirectAccessIndexInput.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.lucene.store;
+
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.DirectAccessInput;
+import org.elasticsearch.nativeaccess.CloseableByteBuffer;
+import org.elasticsearch.nativeaccess.NativeAccess;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A test utility that wraps an {@link IndexInput} and implements {@link DirectAccessInput},
+ * serving direct {@link ByteBuffer} slices backed by {@link CloseableByteBuffer} for
+ * deterministic native memory management. The buffers are allocated via {@link NativeAccess}
+ * and freed eagerly when the action completes.
+ */
+public class DirectAccessIndexInput extends FilterIndexInput implements DirectAccessInput {
+
+    private final byte[] data;
+    private final NativeAccess nativeAccess;
+
+    public DirectAccessIndexInput(String resourceDescription, IndexInput delegate, byte[] data, NativeAccess nativeAccess) {
+        super(resourceDescription, delegate);
+        this.data = data;
+        this.nativeAccess = nativeAccess;
+    }
+
+    @Override
+    public boolean withByteBufferSlice(long offset, long length, CheckedConsumer<ByteBuffer, IOException> action) throws IOException {
+        try (CloseableByteBuffer cbuf = nativeAccess.newConfinedBuffer((int) length)) {
+            cbuf.buffer().put(0, data, (int) offset, (int) length);
+            action.accept(cbuf.buffer().asReadOnlyBuffer());
+        }
+        return true;
+    }
+
+    @Override
+    public boolean withByteBufferSlices(long[] offsets, int length, int count, CheckedConsumer<ByteBuffer[], IOException> action)
+        throws IOException {
+        if (DirectAccessInput.checkSlicesArgs(offsets, count)) {
+            return true;
+        }
+        CloseableByteBuffer[] cbufs = new CloseableByteBuffer[count];
+        try {
+            ByteBuffer[] views = new ByteBuffer[count];
+            for (int i = 0; i < count; i++) {
+                cbufs[i] = nativeAccess.newConfinedBuffer(length);
+                cbufs[i].buffer().put(0, data, (int) offsets[i], length);
+                views[i] = cbufs[i].buffer().asReadOnlyBuffer();
+            }
+            action.accept(views);
+        } finally {
+            for (CloseableByteBuffer cbuf : cbufs) {
+                if (cbuf != null) {
+                    cbuf.close();
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public IndexInput clone() {
+        return new DirectAccessIndexInput("clone(" + toString() + ")", in.clone(), data, nativeAccess);
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        return new DirectAccessIndexInput(sliceDescription, in.slice(sliceDescription, offset, length), data, nativeAccess);
+    }
+}


### PR DESCRIPTION
This commit adds a reusable `DirectAccessIndexInput` to the test:framework, for testing code paths that interact with `DirectAccessInput`. It wraps an `IndexInput` and implements `DirectAccessInput` by serving direct `ByteBuffer` slices backed by `CloseableByteBuffer`, which gives deterministic native memory management through eager close rather than relying on GC. The `NativeAccess` instance is accepted as a constructor parameter so that callers can guard appropriately when native access is unavailable. 

We avoid direct use of preview `MemorySegment` APIs, relying instead on `NativeAccess.newConfinedBuffer()` which encapsulates the foreign memory allocation internally. 

`IndexInputUtilsTests` in `simdvec` is updated to use the shared class, replacing its private `DirectAccessWrapper` inner class that previously used `Arena` and `MemorySegment` directly.