### PR TITLE
Index a document when testing runtime fields shadowing dimensions & metrics

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
@@ -88,6 +88,14 @@ can't shadow dimensions:
                       deepest:
                         type: keyword
                         time_series_dimension: true
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:03.142Z", "routing_dim": "pod", "metric": 10}'
+  - is_false: errors
 
   - do:
       catch: /Field \[dim\] attempted to shadow a time_series_dimension/
@@ -154,6 +162,14 @@ can't shadow metrics:
                       deepest:
                         type: long
                         time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:03.142Z", "dim": "pod", "metric": 10}'
+  - is_false: errors
 
   - do:
       catch: /Field \[metric\] attempted to shadow a time_series_metric/


### PR DESCRIPTION
This PR is adding an indexing step to ensure that the search requests will reach the shard and trigger the error and it will not be optimised away.