### PR TITLE
ESQL: More efficient toStrings (#145320)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
@@ -142,8 +142,9 @@ public final class Alias extends NamedExpression {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return child.nodeString() + " AS " + name() + "#" + id();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        child.nodeString(sb, format);
+        sb.append(" AS ").append(name()).append("#").append(id());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
@@ -215,13 +215,15 @@ public abstract class Attribute extends NamedExpression {
     }
 
     @Override
-    public String toString() {
-        return qualifiedName() + "{" + label() + (synthetic() ? "$" : "") + "}" + "#" + id();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(qualifiedName()).append("{").append(label()).append(synthetic() ? "$" : "").append("}").append("#").append(id());
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public final String toString() {
+        StringBuilder sb = new StringBuilder();
+        nodeString(sb, NodeStringFormat.LIMITED);
+        return sb.toString();
     }
 
     protected abstract String label();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
@@ -229,7 +229,7 @@ public abstract class Expression extends Node<Expression> implements Resolvable 
     }
 
     @Override
-    public String propertiesToString(boolean skipIfChild, NodeStringFormat format) {
-        return super.propertiesToString(false, format);
+    public void propertiesToString(StringBuilder sb, boolean skipIfChild, NodeStringFormat format) {
+        super.propertiesToString(sb, false, format);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -20,7 +20,9 @@ import org.elasticsearch.xpack.esql.core.util.PlanStreamInput;
 import org.elasticsearch.xpack.esql.core.util.PlanStreamOutput;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Attribute for an ES field.
@@ -50,6 +52,22 @@ public class FieldAttribute extends TypedAttribute {
 
     // Only public for testing
     public static final TransportVersion ESQL_FIELD_ATTRIBUTE_DROP_TYPE = TransportVersion.fromName("esql_field_attribute_drop_type");
+
+    private static final EsField TIMESERIES_FIELD = new EsField(
+        MetadataAttribute.TIMESERIES,
+        DataType.KEYWORD,
+        Map.of(),
+        false,
+        EsField.TimeSeriesFieldType.DIMENSION
+    );
+
+    static EsField timeSeriesField() {
+        return TIMESERIES_FIELD;
+    }
+
+    public static TimeSeriesMetadataAttribute timeSeriesAttribute(Source source) {
+        return new TimeSeriesMetadataAttribute(source, Set.of());
+    }
 
     private final String parentName;
     private final EsField field;
@@ -258,5 +276,22 @@ public class FieldAttribute extends TypedAttribute {
 
     public EsField field() {
         return field;
+    }
+
+    @Override
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        switch (format) {
+            case FULL -> {
+                sb.append(qualifiedName()).append("{").append(label());
+                if (field.getNodeStringName().isEmpty() == false) {
+                    sb.append("(").append(field.getNodeStringName()).append(")");
+                }
+                if (synthetic()) {
+                    sb.append("$");
+                }
+                sb.append("}#").append(id());
+            }
+            case LIMITED -> super.nodeString(sb, format);
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Literal.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Literal.java
@@ -171,8 +171,8 @@ public class Literal extends LeafExpression implements Accountable {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString() + "[" + dataType + "]";
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(toString(format)).append("[").append(dataType).append("]");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NamedExpression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NamedExpression.java
@@ -117,7 +117,7 @@ public abstract class NamedExpression extends Expression implements NamedWriteab
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return name();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(name());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/TimeSeriesMetadataAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/TimeSeriesMetadataAttribute.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Field attribute for {@code _timeseries} field
+ */
+public final class TimeSeriesMetadataAttribute extends FieldAttribute {
+    private final Set<String> withoutFields;
+
+    public TimeSeriesMetadataAttribute(Source source, Set<String> withoutFields) {
+        this(source, null, null, MetadataAttribute.TIMESERIES, timeSeriesField(), Nullability.TRUE, null, false, withoutFields);
+    }
+
+    public TimeSeriesMetadataAttribute(
+        Source source,
+        @Nullable String parentName,
+        @Nullable String qualifier,
+        String name,
+        EsField field,
+        Nullability nullability,
+        @Nullable NameId id,
+        boolean synthetic,
+        Set<String> withoutFields
+    ) {
+        super(source, parentName, qualifier, name, field, nullability, id, synthetic);
+        this.withoutFields = asImmutableSet(withoutFields);
+    }
+
+    private static Set<String> asImmutableSet(Set<String> without) {
+        if (without.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(new LinkedHashSet<>(without));
+    }
+
+    /**
+     * Builds a {@code _timeseries} attribute from an existing attribute while preserving its identity.
+     */
+    public static TimeSeriesMetadataAttribute from(Attribute attribute, Set<String> withoutFields) {
+        if (attribute instanceof TimeSeriesMetadataAttribute timeSeriesAttribute
+            && timeSeriesAttribute.withoutFields.equals(withoutFields)) {
+            return timeSeriesAttribute;
+        }
+        String parentName = attribute instanceof FieldAttribute fieldAttribute ? fieldAttribute.parentName() : null;
+        return new TimeSeriesMetadataAttribute(
+            attribute.source(),
+            parentName,
+            attribute.qualifier(),
+            MetadataAttribute.TIMESERIES,
+            timeSeriesField(),
+            attribute.nullable(),
+            attribute.id(),
+            attribute.synthetic(),
+            withoutFields
+        );
+    }
+
+    public Set<String> withoutFields() {
+        return withoutFields;
+    }
+
+    @Override
+    protected NodeInfo<FieldAttribute> info() {
+        return NodeInfo.create(
+            this,
+            TimeSeriesMetadataAttribute::new,
+            parentName(),
+            qualifier(),
+            name(),
+            field(),
+            nullable(),
+            id(),
+            synthetic(),
+            withoutFields
+        );
+    }
+
+    @Override
+    protected Attribute clone(
+        Source source,
+        String qualifier,
+        String name,
+        DataType type,
+        Nullability nullability,
+        NameId id,
+        boolean synthetic
+    ) {
+        // Ignore `type`, this must be the same as the field's type.
+        return new TimeSeriesMetadataAttribute(source, parentName(), qualifier, name, field(), nullability, id, synthetic, withoutFields);
+    }
+
+    @Override
+    protected int innerHashCode(boolean ignoreIds) {
+        return Objects.hash(super.innerHashCode(ignoreIds), withoutFields);
+    }
+
+    @Override
+    protected boolean innerEquals(Object o, boolean ignoreIds) {
+        TimeSeriesMetadataAttribute other = (TimeSeriesMetadataAttribute) o;
+        return super.innerEquals(other, ignoreIds) && Objects.equals(withoutFields, other.withoutFields);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedAttribute.java
@@ -122,11 +122,6 @@ public class UnresolvedAttribute extends Attribute implements Unresolvable {
     }
 
     @Override
-    public String toString() {
-        return UNRESOLVED_PREFIX + qualifiedName();
-    }
-
-    @Override
     protected String label() {
         return UNRESOLVED_PREFIX;
     }
@@ -144,8 +139,8 @@ public class UnresolvedAttribute extends Attribute implements Unresolvable {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(UNRESOLVED_PREFIX).append(qualifiedName());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedStar.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/UnresolvedStar.java
@@ -77,8 +77,8 @@ public class UnresolvedStar extends UnresolvedNamedExpression {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(toString());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.StringJoiner;
 
 /**
  * Any ESQL function; generally this is translated into a computation to be evaluated on arguments, including scalar functions (e.g. in
@@ -59,11 +58,15 @@ public abstract class Function extends Expression {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        StringJoiner sj = new StringJoiner(",", functionName() + "(", ")");
-        for (Expression ex : arguments()) {
-            sj.add(ex.nodeString(format));
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(functionName()).append("(");
+        List<Expression> args = arguments();
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            args.get(i).nodeString(sb, format);
         }
-        return sj.toString();
+        sb.append(")");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
@@ -65,7 +65,9 @@ public abstract class BinaryPredicate<T, U, R, F extends PredicateBiFunction<T, 
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return left().nodeString() + " " + symbol() + " " + right().nodeString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        left().nodeString(sb, format);
+        sb.append(" ").append(symbol()).append(" ");
+        right().nodeString(sb, format);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.core.tree;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.util.Holder;
@@ -269,6 +271,50 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         return transformDown((t) -> (nodePredicate.test(t) ? rule.apply((E) t) : t));
     }
 
+    /**
+     * Asynchronous variant of {@link #transformDown(Function)} that allows the transformation rule to perform
+     * async I/O operations (e.g., transport actions) without blocking the caller thread.
+     * <p>
+     * Children are transformed sequentially, not concurrently, one after another in order.
+     * This method is intended for cases where async I/O is needed during transformation, not for parallel
+     * processing.
+     */
+    @SuppressWarnings("unchecked")
+    public void transformDown(BiConsumer<? super T, ActionListener<T>> rule, ActionListener<T> listener) {
+        rule.accept((T) this, listener.delegateFailureAndWrap((originalListener, root) -> {
+            Node<T> node = this.equals(root) ? this : root;
+            node.transformChildren((child, childListener) -> child.transformDown(rule, childListener), originalListener);
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void transformChildren(BiConsumer<T, ActionListener<T>> traversalOperation, ActionListener<T> listener) {
+        if (children.isEmpty()) {
+            listener.onResponse((T) this);
+            return;
+        }
+
+        final Holder<List<T>> updatedChildren = new Holder<>();
+        SubscribableListener<Void> chain = SubscribableListener.newForked(l -> l.onResponse(null));
+        for (int i = 0; i < children.size(); i++) {
+            int index = i;
+            T child = children.get(index);
+            chain = chain.andThen(originalListener -> {
+                traversalOperation.accept(child, originalListener.delegateFailureAndWrap((o, maybeTransformed) -> {
+                    if (maybeTransformed.equals(child) == false) {
+                        if (updatedChildren.get() == null) {
+                            updatedChildren.set(new ArrayList<>(children));
+                        }
+                        updatedChildren.get().set(index, maybeTransformed);
+                    }
+                    o.onResponse(null);
+                }));
+            });
+        }
+        chain.andThenApply(ignored -> updatedChildren.get() == null ? (T) this : replaceChildrenSameSize(updatedChildren.get()))
+            .addListener(listener);
+    }
+
     @SuppressWarnings("unchecked")
     public T transformUp(Function<? super T, ? extends T> rule) {
         T transformed = transformChildren(child -> child.transformUp(rule));
@@ -392,10 +438,13 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         return info().properties();
     }
 
+    /**
+     * Configuration for rendering the string representation.
+     */
     public enum NodeStringFormat {
         /** No list truncation, no line breaks due to string width. */
         FULL(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE),
-        /** List truncation and line breaks due to string width applied. */
+        /** List truncation, line breaks, and limited number of lines. */
         LIMITED(TO_STRING_MAX_PROP, TO_STRING_MAX_WIDTH, TO_STRING_MAX_LINES);
 
         final int maxProperties;
@@ -409,17 +458,28 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         }
     }
 
+    /**
+     * Render this {@link Node} to a {@link String} with the
+     * {@link NodeStringFormat#LIMITED limited} format. This does not include
+     * this node's {@link #children()}.
+     */
     public final String nodeString() {
-        return nodeString(NodeStringFormat.LIMITED);
+        StringBuilder sb = new StringBuilder();
+        nodeString(sb, NodeStringFormat.LIMITED);
+        return sb.toString();
     }
 
-    public String nodeString(NodeStringFormat format) {
-        StringBuilder sb = new StringBuilder();
+    /**
+     * Append this {@link Node}'s string representation to {@code sb}. This
+     * does not include this node's {@link #children()}.
+     * @param sb target for the string
+     * @param format configuration for rendering the string representation
+     */
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
         sb.append(nodeName());
         sb.append("[");
-        sb.append(propertiesToString(true, format));
+        propertiesToString(sb, true, format);
         sb.append("]");
-        return sb.toString();
     }
 
     @Override
@@ -431,8 +491,8 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
         return new NodeToString(format).treeString(this, 0).toString();
     }
 
-    protected String propertiesToString(boolean skipIfChild, NodeStringFormat format) {
-        return new NodePropertiesToString(format, this, skipIfChild).propertiesToString();
+    protected void propertiesToString(StringBuilder sb, boolean skipIfChild, NodeStringFormat format) {
+        new NodePropertiesToString(sb, format, this, skipIfChild).propertiesToString();
     }
 
     private <U> boolean containsNull(List<U> us) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodePropertiesToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodePropertiesToString.java
@@ -17,11 +17,12 @@ class NodePropertiesToString {
     private final Node.NodeStringFormat format;
     private final Node<?> node;
     private final boolean skipIfChild;
-    private final StringBuilder result = new StringBuilder();
+    private final StringBuilder sb;
     private int charactersRemainingInLine;
     private int linesUsed = 0;
 
-    NodePropertiesToString(Node.NodeStringFormat format, Node<?> node, boolean skipIfChild) {
+    NodePropertiesToString(StringBuilder sb, Node.NodeStringFormat format, Node<?> node, boolean skipIfChild) {
+        this.sb = sb;
         this.format = format;
         this.node = node;
         this.skipIfChild = skipIfChild;
@@ -33,7 +34,7 @@ class NodePropertiesToString {
      * one like {@code foo bar baz}. These go inside the
      * {@code [} and {@code ]} of the output of {@link NodeToString#treeString}.
      */
-    String propertiesToString() {
+    void propertiesToString() {
         List<Object> props = node.nodeProperties();
         int remainingProperties = format.maxProperties;
         boolean firstProperty = true;
@@ -43,7 +44,7 @@ class NodePropertiesToString {
                 continue;
             }
             if (remainingProperties-- < 0) {
-                result.append("...").append(props.size() - format.maxProperties).append("fields not shown");
+                sb.append("...").append(props.size() - format.maxProperties).append("fields not shown");
                 break;
             }
 
@@ -57,28 +58,26 @@ class NodePropertiesToString {
                 break;
             }
         }
-
-        return result.toString();
     }
 
     /**
-     * Append {@code stringValue} to {@link #result}, wrapping at line boundaries.
+     * Append {@code stringValue} to {@link #sb}, wrapping at line boundaries.
      * Returns {@code true} if rendering can continue, {@code false} if the line budget is exhausted.
      */
     private boolean appendString(String stringValue) {
         int start = 0;
         while (stringValue.length() - start > charactersRemainingInLine) {
-            result.append(stringValue, start, start + charactersRemainingInLine);
+            sb.append(stringValue, start, start + charactersRemainingInLine);
             if (linesUsed >= format.maxLines - 1) {
-                result.append("...");
+                sb.append("...");
                 return false;
             }
-            result.append("\n");
+            sb.append("\n");
             linesUsed++;
             start += charactersRemainingInLine;
             charactersRemainingInLine = format.maxWidth;
         }
-        result.append(stringValue, start, stringValue.length());
+        sb.append(stringValue, start, stringValue.length());
         charactersRemainingInLine -= stringValue.length() - start;
         return true;
     }
@@ -105,7 +104,16 @@ class NodePropertiesToString {
     private String propertyToString(Object obj) {
         return switch (obj) {
             case null -> "null";
-            case Node<?> n -> n.nodeString(format);
+            case Node<?> n -> {
+                /*
+                 * We still build a string here which we then cut up. But this is only
+                 * for things like the expression tree. Most other nodes are skipped
+                 * and rendered as proper children, properly sharing the StringBuilder.
+                 */
+                StringBuilder str = new StringBuilder();
+                n.nodeString(str, format);
+                yield str.toString();
+            }
             case NameId nameId -> "#" + obj;
             default -> String.valueOf(obj);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeToString.java
@@ -33,7 +33,7 @@ class NodeToString {
     StringBuilder treeString(Node<?> node, int depth) {
         indent(depth);
 
-        sb.append(node.nodeString(format));
+        node.nodeString(sb, format);
 
         List<? extends Node<?>> children = node.children();
         if (children.isEmpty() == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeUtils.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.core.tree;
 
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -58,29 +60,56 @@ public abstract class NodeUtils {
 
     private static final int TO_STRING_LIMIT = 52;
 
-    public static <E> String limitedToString(Collection<E> c) {
-        Iterator<E> it = c.iterator();
+    public static void toString(StringBuilder sb, Collection<? extends Attribute> c, Node.NodeStringFormat format) {
+        switch (format) {
+            case LIMITED -> limitedToString(sb, c);
+            case FULL -> unlimitedToString(sb, c);
+        }
+    }
+
+    private static void limitedToString(StringBuilder sb, Collection<?> c) {
+        Iterator<?> it = c.iterator();
         if (it.hasNext() == false) {
-            return "[]";
+            sb.append("[]");
+            return;
         }
 
-        // ..]
-        StringBuilder sb = new StringBuilder(TO_STRING_LIMIT + 4);
+        // track how many characters we've added since the opening '[' for the truncation limit
+        int start = sb.length();
         sb.append('[');
         for (;;) {
-            E e = it.next();
+            Object e = it.next();
             String next = e == c ? "(this Collection)" : String.valueOf(e);
-            if (next.length() + sb.length() > TO_STRING_LIMIT) {
-                sb.append(next.substring(0, Math.max(0, TO_STRING_LIMIT - sb.length())));
+            int used = sb.length() - start;
+            if (next.length() + used > TO_STRING_LIMIT) {
+                sb.append(next, 0, Math.max(0, TO_STRING_LIMIT - used));
                 sb.append('.').append('.').append(']');
-                return sb.toString();
+                return;
             } else {
                 sb.append(next);
             }
             if (it.hasNext() == false) {
-                return sb.append(']').toString();
+                sb.append(']');
+                return;
             }
             sb.append(',').append(' ');
         }
+    }
+
+    private static void unlimitedToString(StringBuilder sb, Collection<? extends Attribute> c) {
+        sb.append('[');
+        boolean first = true;
+        for (Attribute s : c) {
+            if (first == false) {
+                sb.append(", ");
+            }
+            if (s == null) {
+                sb.append("null");
+            } else {
+                s.nodeString(sb, Node.NodeStringFormat.FULL);
+            }
+            first = false;
+        }
+        sb.append(']');
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -206,6 +206,10 @@ public class EsField implements Writeable {
         return "EsField";
     }
 
+    public String getNodeStringName() {
+        return "";
+    }
+
     /**
      * Returns the simple name, but not the full field path. The latter requires knowing the path of the parent field.
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/MultiTypeEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/MultiTypeEsField.java
@@ -67,6 +67,11 @@ public class MultiTypeEsField extends EsField {
         return "MultiTypeEsField";
     }
 
+    @Override
+    public String getNodeStringName() {
+        return "MultiTypeEsField";
+    }
+
     public Map<String, Expression> getIndexToConversionExpressions() {
         return indexToConversionExpressions;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
@@ -29,4 +29,9 @@ public class PotentiallyUnmappedKeywordEsField extends KeywordEsField {
     public String getWriteableName(TransportVersion transportVersion) {
         return "PotentiallyUnmappedKeywordEsField";
     }
+
+    @Override
+    public String getNodeStringName() {
+        return "PotentiallyUnmappedKeywordEsField";
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/UnresolvedNamePattern.java
@@ -112,8 +112,8 @@ public class UnresolvedNamePattern extends UnresolvedNamedExpression {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(toString());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnresolvedFunction.java
@@ -164,8 +164,8 @@ public class UnresolvedFunction extends Function implements Unresolvable {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(toString());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
@@ -159,13 +159,8 @@ public final class UnsupportedAttribute extends FieldAttribute implements Unreso
     }
 
     @Override
-    public String toString() {
-        return "!" + qualifiedName();
-    }
-
-    @Override
-    public String nodeString(NodeStringFormat format) {
-        return toString();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append("!").append(qualifiedName());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -71,8 +71,10 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return name() + "(" + field().nodeString(format) + ", \"" + pattern().pattern() + "\", " + caseInsensitive() + ")";
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(name()).append("(");
+        field().nodeString(sb, format);
+        sb.append(", \"").append(pattern().pattern()).append("\", ").append(caseInsensitive()).append(")");
     }
 
     void serializeCaseInsensitivity(StreamOutput out) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -160,13 +160,12 @@ public class EsRelation extends LeafPlan {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return nodeName()
-            + "["
-            + indexPattern
-            + "]"
-            + (indexMode != IndexMode.STANDARD ? "[" + indexMode.name() + "]" : "")
-            + NodeUtils.limitedToString(attrs);
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName()).append("[").append(indexPattern).append("]");
+        if (indexMode != IndexMode.STANDARD) {
+            sb.append("[").append(indexMode.name()).append("]");
+        }
+        NodeUtils.toString(sb, attrs, format);
     }
 
     public EsRelation withAttributes(List<Attribute> newAttributes) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Subquery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Subquery.java
@@ -83,8 +83,8 @@ public class Subquery extends UnaryPlan implements TelemetryAware, SortAgnostic 
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return nodeName() + "[]";
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName()).append("[]");
     }
 
     public LogicalPlan plan() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -241,8 +241,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        StringBuilder sb = new StringBuilder();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
         sb.append(nodeName());
         sb.append(" start=[").append(start);
         sb.append("] end=[").append(end);
@@ -251,7 +250,6 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         sb.append("] promql=[<>\n");
         sb.append(promqlPlan.toString());
         sb.append("\n<>]]");
-        return sb.toString();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -347,24 +347,18 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return nodeName()
-            + "["
-            + indexPattern
-            + "], "
-            + "indexMode["
-            + indexMode
-            + "], "
-            + NodeUtils.limitedToString(attrs)
-            + ", limit["
-            + (limit != null ? limit.toString() : "")
-            + "], sort["
-            + (sorts != null ? sorts.toString() : "")
-            + "] estimatedRowSize["
-            + estimatedRowSize
-            + "] queryBuilderAndTags ["
-            + (queryBuilderAndTags != null ? queryBuilderAndTags.toString() : "")
-            + "]";
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName()).append("[").append(indexPattern).append("], ").append("indexMode[").append(indexMode).append("], ");
+        NodeUtils.toString(sb, attrs, format);
+        sb.append(", limit[")
+            .append(limit != null ? limit.toString(format) : "")
+            .append("], sort[")
+            .append(sorts != null ? sorts.toString() : "")
+            .append("] estimatedRowSize[")
+            .append(estimatedRowSize)
+            .append("] queryBuilderAndTags [")
+            .append(queryBuilderAndTags != null ? queryBuilderAndTags.toString() : "")
+            .append("]");
     }
 
     public enum Direction {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
@@ -126,7 +126,8 @@ public class EsSourceExec extends LeafExec {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return nodeName() + "[" + indexPattern + "]" + NodeUtils.limitedToString(attributes);
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName()).append("[").append(indexPattern).append("]");
+        NodeUtils.toString(sb, attributes, format);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
@@ -164,18 +164,16 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return nodeName()
-            + "["
-            + indexPattern
-            + "], stats"
-            + stat
-            + "], query["
-            + (query != null ? Strings.toString(query, false, true) : "")
-            + "]"
-            + NodeUtils.limitedToString(attrs)
-            + ", limit["
-            + (limit != null ? limit.toString() : "")
-            + "], ";
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName())
+            .append("[")
+            .append(indexPattern)
+            .append("], stats[")
+            .append(stat)
+            .append("], query[")
+            .append(query != null ? Strings.toString(query, false, true) : "")
+            .append("]");
+        NodeUtils.toString(sb, attrs, format);
+        sb.append(", limit[").append(limit != null ? limit.toString(format) : "").append("], ");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -206,13 +205,10 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        return Strings.format(
-            "%s<%s,%s>",
-            nodeName() + NodeUtils.limitedToString(attributesToExtract),
-            docValuesAttributes,
-            boundsAttributes
-        );
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
+        sb.append(nodeName());
+        NodeUtils.toString(sb, attributesToExtract, format);
+        sb.append("<").append(docValuesAttributes).append(",").append(boundsAttributes).append(">");
     }
 
     public MappedFieldType.FieldExtractPreference fieldExtractPreference(Attribute attr) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
@@ -128,8 +128,7 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
     }
 
     @Override
-    public String nodeString(NodeStringFormat format) {
-        StringBuilder sb = new StringBuilder();
+    public void nodeString(StringBuilder sb, NodeStringFormat format) {
         sb.append(nodeName());
         sb.append("[filter=");
         sb.append(esFilter);
@@ -139,6 +138,5 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
         sb.append("], fragment=[<>\n");
         sb.append(fragment.toString());
         sb.append("<>]]");
-        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/EmptyAttributeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/EmptyAttributeTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class EmptyAttributeTests extends ESTestCase {
+    public void testToString() {
+        EmptyAttribute attr = new EmptyAttribute(Source.EMPTY);
+        assertThat(attr.toString(), equalTo("{e}#" + attr.id()));
+    }
+
+    public void testEquals() {
+        EmptyAttribute a = new EmptyAttribute(Source.EMPTY);
+        EmptyAttribute b = new EmptyAttribute(Source.EMPTY);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    public void testDataType() {
+        assertEquals(DataType.NULL, new EmptyAttribute(Source.EMPTY).dataType());
+    }
+
+    public void testCloneReturnsSelf() {
+        EmptyAttribute attr = new EmptyAttribute(Source.EMPTY);
+        assertThat(attr.withId(new NameId()), sameInstance(attr));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/TimeSeriesMetadataAttributeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/TimeSeriesMetadataAttributeTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSeriesMetadataAttributeTests extends ESTestCase {
+    public void testToString() {
+        TimeSeriesMetadataAttribute attr = new TimeSeriesMetadataAttribute(Source.EMPTY, Set.of());
+        assertThat(attr.toString(), equalTo("_timeseries{f}#" + attr.id()));
+    }
+
+    public void testWithoutFields() {
+        Set<String> without = Set.of("foo", "bar");
+        TimeSeriesMetadataAttribute attr = new TimeSeriesMetadataAttribute(Source.EMPTY, without);
+        assertEquals(without, attr.withoutFields());
+    }
+
+    public void testEqualsSameId() {
+        TimeSeriesMetadataAttribute a = new TimeSeriesMetadataAttribute(Source.EMPTY, Set.of("x"));
+        TimeSeriesMetadataAttribute b = (TimeSeriesMetadataAttribute) a.withId(a.id());
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    public void testNotEqualWithDifferentWithoutFields() {
+        TimeSeriesMetadataAttribute a = new TimeSeriesMetadataAttribute(Source.EMPTY, Set.of("x"));
+        TimeSeriesMetadataAttribute b = TimeSeriesMetadataAttribute.from(a, Set.of("y"));
+        assertNotEquals(a, b);
+    }
+
+    public void testFrom() {
+        TimeSeriesMetadataAttribute original = new TimeSeriesMetadataAttribute(Source.EMPTY, Set.of("x"));
+        Set<String> newWithout = Set.of("y");
+        TimeSeriesMetadataAttribute derived = TimeSeriesMetadataAttribute.from(original, newWithout);
+        assertEquals(newWithout, derived.withoutFields());
+        assertEquals(original.id(), derived.id());
+    }
+
+    public void testFromReturnsSameInstanceWhenUnchanged() {
+        Set<String> without = Set.of("x");
+        TimeSeriesMetadataAttribute original = new TimeSeriesMetadataAttribute(Source.EMPTY, without);
+        assertSame(original, TimeSeriesMetadataAttribute.from(original, without));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/tree/NodeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/tree/NodeTests.java
@@ -6,6 +6,9 @@
  */
 package org.elasticsearch.xpack.esql.core.tree;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
@@ -14,11 +17,16 @@ import org.hamcrest.Matcher;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.StringJoiner;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -222,6 +230,62 @@ public class NodeTests extends ESTestCase {
         assertEquals(node.children().size(), 0);
     }
 
+    public void testTransformDownAsyncNoChildren() throws InterruptedException {
+        NoChildren node = new NoChildren(randomSource(), "original");
+
+        assertAsyncTransform(node, (n, listener) -> {
+            NoChildren transformed = new NoChildren(n.source(), "transformed");
+            listener.onResponse(transformed);
+        }, result -> {
+            assertEquals(NoChildren.class, result.getClass());
+            assertEquals("transformed", result.thing());
+        });
+    }
+
+    public void testTransformDownAsyncWithChildren() throws InterruptedException {
+        NoChildren child1 = new NoChildren(randomSource(), "child1");
+        NoChildren child2 = new NoChildren(randomSource(), "child2");
+        ChildrenAreAProperty parent = new ChildrenAreAProperty(randomSource(), Arrays.asList(child1, child2), "parent");
+
+        assertAsyncTransform(parent, (n, listener) -> {
+            if (n instanceof NoChildren) {
+                NoChildren nc = (NoChildren) n;
+                if ("child1".equals(nc.thing())) {
+                    listener.onResponse(new NoChildren(nc.source(), "transformed1"));
+                } else {
+                    listener.onResponse(n);
+                }
+            } else {
+                listener.onResponse(n);
+            }
+        }, result -> {
+            assertEquals(ChildrenAreAProperty.class, result.getClass());
+            ChildrenAreAProperty transformed = (ChildrenAreAProperty) result;
+            assertEquals(2, transformed.children().size());
+            assertEquals("transformed1", transformed.children().get(0).thing());
+            assertEquals("child2", transformed.children().get(1).thing());
+        });
+    }
+
+    public void testTransformDownAsyncNoChange() throws InterruptedException {
+        NoChildren node = new NoChildren(randomSource(), "unchanged");
+        assertAsyncTransform(node, (n, listener) -> listener.onResponse(n), result -> assertSame(node, result));
+    }
+
+    private void assertAsyncTransform(Dummy node, BiConsumer<? super Dummy, ActionListener<Dummy>> rule, Consumer<Dummy> assertions)
+        throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+
+        LatchedActionListener<Dummy> listener = new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(result -> {
+            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
+            assertions.accept(result);
+        }), latch);
+
+        node.transformDown(rule, listener);
+        assertTrue("timed out after 5s", latch.await(5, TimeUnit.SECONDS));
+    }
+
     public abstract static class Dummy extends Node<Dummy> {
         private final String thing;
 
@@ -294,12 +358,16 @@ public class NodeTests extends ESTestCase {
         }
 
         @Override
-        public String nodeString(NodeStringFormat format) {
-            StringJoiner sj = new StringJoiner(",", nodeName() + "(", ")");
-            for (Dummy child : children()) {
-                sj.add(child.nodeString(format));
+        public void nodeString(StringBuilder sb, NodeStringFormat format) {
+            sb.append(nodeName()).append("(");
+            List<Dummy> kids = children();
+            for (int i = 0; i < kids.size(); i++) {
+                if (i > 0) {
+                    sb.append(",");
+                }
+                kids.get(i).nodeString(sb, format);
             }
-            return sj.toString();
+            sb.append(")");
         }
     }
 


### PR DESCRIPTION
Allocates fewer Strings when building the plan's toString. It's pretty complex and can get large, especially in tests.
