### PR TITLE
ESQL: Unmute CsvIT sumWithOverflowRow

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -265,9 +265,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidLongWithCasting
   issue: https://github.com/elastic/elasticsearch/issues/145435
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats.sumWithOverflowRow}
-  issue: https://github.com/elastic/elasticsearch/issues/145437
 - class: org.elasticsearch.compute.aggregation.SumLongGroupingAggregatorFunctionTests
   method: testOverflowInGroupingProducesNullAndWarning
   issue: https://github.com/elastic/elasticsearch/issues/145438


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/145437

Just unmute it. Issue was already fixed in https://github.com/elastic/elasticsearch/pull/145434