### PR TITLE
[CI] DLMFrozenTransitionServiceTests testCheckForFrozenIndicesReturnsEarlyWhenCapacityExhausted failing [#145778]

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -329,9 +329,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
   method: testGettingValidIntegerWithCasting
   issue: https://github.com/elastic/elasticsearch/issues/145735
-- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionServiceTests
-  method: testCheckForFrozenIndicesReturnsEarlyWhenCapacityExhausted
-  issue: https://github.com/elastic/elasticsearch/issues/145778
 - class: org.elasticsearch.xpack.sql.qa.jdbc.multi_node.MultiNodeJdbcFetchSizeIT
   method: testPivotPagingWithLimit
   issue: https://github.com/elastic/elasticsearch/issues/145792

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionServiceTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionServiceTests.java
@@ -311,6 +311,9 @@ public class DLMFrozenTransitionServiceTests extends ESTestCase {
 
             // Wait until all maxJobs tasks have been accepted by the executor (capacity now exhausted)
             safeAwait(allSubmitted);
+            // The factory latch fires before executor.submit() adds the task to submittedTransitions,
+            // so we must also wait for the executor to reflect full capacity exhaustion.
+            assertBusy(() -> assertFalse(service.getTransitionExecutor().hasCapacity()));
             assertEquals(maxJobs, submittedIndices.size());
 
             // Add more marked indices to the cluster state


### PR DESCRIPTION
Add busy assert to the test to ensure execution happens and capacity is fully saturated before asserting

Fixes #145778