### PR TITLE
Optimize NumberFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2434,7 +2434,21 @@ public class NumberFieldMapper extends FieldMapper {
         if (currentToken == Token.START_OBJECT) {
             throw new IllegalArgumentException("Cannot parse object as number");
         }
-        return type.parse(parser, coerce());
+        // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
+        boolean coerce = coerce();
+        return switch (type) {
+            case BYTE -> {
+                int value = parser.intValue(coerce);
+                if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value [" + value + "] is out of range for a byte");
+                }
+                yield (byte) value;
+            }
+            case SHORT -> parser.shortValue(coerce);
+            case INTEGER -> parser.intValue(coerce);
+            case LONG -> parser.longValue(coerce);
+            default -> type.parse(parser, coerce);
+        };
     }
 
     /**
@@ -2446,7 +2460,16 @@ public class NumberFieldMapper extends FieldMapper {
         if (dimension && numericValue != null) {
             context.getRoutingFields().addLong(fieldType().name(), numericValue.longValue());
         }
-        fieldType().type.addFields(context.doc(), fieldType().name(), numericValue, fieldType().indexType, stored);
+        // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
+        final NumberFieldType ft = fieldType();
+        final LuceneDocument doc = context.doc();
+        final String name = ft.name();
+        final IndexType indexType = ft.indexType;
+        switch (type) {
+            case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue(), indexType);
+            case LONG -> addLongFields(doc, name, numericValue.longValue(), indexType);
+            default -> type.addFields(doc, name, numericValue, indexType, stored);
+        }
 
         if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
             // the last field is the current field, Add to the key map, so that we can validate if it has been added
@@ -2459,6 +2482,40 @@ public class NumberFieldMapper extends FieldMapper {
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {
             context.addToFieldNames(fieldType().name());
+        }
+    }
+
+    private void addIntFields(LuceneDocument document, String name, int i, IndexType indexType) {
+        if (indexType.hasPoints() && indexType.hasDocValues()) {
+            document.add(new IntField(name, i, Field.Store.NO));
+        } else if (indexType.hasDocValues()) {
+            if (indexType.hasDocValuesSkipper()) {
+                document.add(SortedNumericDocValuesField.indexedField(name, i));
+            } else {
+                document.add(new SortedNumericDocValuesField(name, i));
+            }
+        } else if (indexType.hasPoints()) {
+            document.add(new IntPoint(name, i));
+        }
+        if (stored) {
+            document.add(new StoredField(name, i));
+        }
+    }
+
+    private void addLongFields(LuceneDocument document, String name, long l, IndexType indexType) {
+        if (indexType.hasPoints() && indexType.hasDocValues()) {
+            document.add(new LongField(name, l, Field.Store.NO));
+        } else if (indexType.hasDocValues()) {
+            if (indexType.hasDocValuesSkipper()) {
+                document.add(SortedNumericDocValuesField.indexedField(name, l));
+            } else {
+                document.add(new SortedNumericDocValuesField(name, l));
+            }
+        } else if (indexType.hasPoints()) {
+            document.add(new LongPoint(name, l));
+        }
+        if (stored) {
+            document.add(new StoredField(name, l));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2464,7 +2464,7 @@ public class NumberFieldMapper extends FieldMapper {
      */
     public void indexValue(DocumentParserContext context, Number numericValue) {
         final String name = fieldType.name();
-        if (dimension && numericValue != null) {
+        if (dimension) {
             context.getRoutingFields().addLong(name, numericValue.longValue());
         }
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2428,14 +2428,14 @@ public class NumberFieldMapper extends FieldMapper {
         if (currentToken == Token.VALUE_NULL) {
             return nullValue;
         }
-        if (coerce() && currentToken == Token.VALUE_STRING && parser.textLength() == 0) {
+        final boolean coerce = coerce();
+        if (coerce && currentToken == Token.VALUE_STRING && parser.textLength() == 0) {
             return nullValue;
         }
         if (currentToken == Token.START_OBJECT) {
             throw new IllegalArgumentException("Cannot parse object as number");
         }
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
-        boolean coerce = coerce();
         return switch (type) {
             case BYTE -> {
                 int value = parser.intValue(coerce);

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2463,13 +2463,13 @@ public class NumberFieldMapper extends FieldMapper {
      * fields that want to share the behavior of numeric fields.
      */
     public void indexValue(DocumentParserContext context, Number numericValue) {
+        final String name = fieldType.name();
         if (dimension && numericValue != null) {
-            context.getRoutingFields().addLong(fieldType().name(), numericValue.longValue());
+            context.getRoutingFields().addLong(name, numericValue.longValue());
         }
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
         final NumberFieldType ft = fieldType();
         final LuceneDocument doc = context.doc();
-        final String name = ft.name();
         final IndexType indexType = ft.indexType;
         switch (type) {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue(), indexType);
@@ -2481,13 +2481,12 @@ public class NumberFieldMapper extends FieldMapper {
             // the last field is the current field, Add to the key map, so that we can validate if it has been added
             List<IndexableField> fields = context.doc().getFields();
             final IndexableField last = fields.getLast();
-            assert last.name().equals(fieldType().name())
-                : "last field name [" + last.name() + "] mis match field name [" + fieldType().name() + "]";
-            context.doc().onlyAddKey(fieldType().name(), last);
+            assert last.name().equals(name) : "last field name [" + last.name() + "] mis match field name [" + name + "]";
+            context.doc().onlyAddKey(name, last);
         }
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {
-            context.addToFieldNames(fieldType().name());
+            context.addToFieldNames(name);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2469,11 +2469,10 @@ public class NumberFieldMapper extends FieldMapper {
         }
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
         final LuceneDocument doc = context.doc();
-        final IndexType indexType = fieldType.indexType;
         switch (type) {
-            case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue(), indexType);
-            case LONG -> addLongFields(doc, name, numericValue.longValue(), indexType);
-            default -> type.addFields(doc, name, numericValue, indexType, stored);
+            case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue());
+            case LONG -> addLongFields(doc, name, numericValue.longValue());
+            default -> type.addFields(doc, name, numericValue, fieldType.indexType, stored);
         }
 
         if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
@@ -2489,7 +2488,8 @@ public class NumberFieldMapper extends FieldMapper {
         }
     }
 
-    private void addIntFields(LuceneDocument document, String name, int i, IndexType indexType) {
+    private void addIntFields(LuceneDocument document, String name, int i) {
+        final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
             document.add(new IntField(name, i, Field.Store.NO));
         } else if (indexType.hasDocValues()) {
@@ -2506,7 +2506,8 @@ public class NumberFieldMapper extends FieldMapper {
         }
     }
 
-    private void addLongFields(LuceneDocument document, String name, long l, IndexType indexType) {
+    private void addLongFields(LuceneDocument document, String name, long l) {
+        final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
             document.add(new LongField(name, l, Field.Store.NO));
         } else if (indexType.hasDocValues()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2322,6 +2322,9 @@ public class NumberFieldMapper extends FieldMapper {
 
     private final IndexSettings indexSettings;
 
+    // cached to avoid lookup overhead
+    private final NumberFieldType fieldType;
+
     private NumberFieldMapper(
         String simpleName,
         MappedFieldType mappedFieldType,
@@ -2347,6 +2350,9 @@ public class NumberFieldMapper extends FieldMapper {
         this.isSyntheticSource = isSyntheticSource;
         this.offsetsFieldName = offsetsFieldName;
         this.indexSettings = builder.indexSettings;
+
+        // this is basically just an inlined version of `(NumberFieldType) super.fieldType()`
+        this.fieldType = (NumberFieldType) mappedFieldType;
     }
 
     boolean coerce() {
@@ -2364,7 +2370,7 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     public NumberFieldType fieldType() {
-        return (NumberFieldType) super.fieldType();
+        return fieldType;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2464,11 +2464,13 @@ public class NumberFieldMapper extends FieldMapper {
      */
     public void indexValue(DocumentParserContext context, Number numericValue) {
         final String name = fieldType.name();
+        final LuceneDocument doc = context.doc();
+
         if (dimension) {
             context.getRoutingFields().addLong(name, numericValue.longValue());
         }
+
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
-        final LuceneDocument doc = context.doc();
         switch (type) {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue());
             case LONG -> addLongFields(doc, name, numericValue.longValue());
@@ -2477,10 +2479,10 @@ public class NumberFieldMapper extends FieldMapper {
 
         if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
             // the last field is the current field, Add to the key map, so that we can validate if it has been added
-            List<IndexableField> fields = context.doc().getFields();
+            List<IndexableField> fields = doc.getFields();
             final IndexableField last = fields.getLast();
             assert last.name().equals(name) : "last field name [" + last.name() + "] mis match field name [" + name + "]";
-            context.doc().onlyAddKey(name, last);
+            doc.onlyAddKey(name, last);
         }
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2480,10 +2480,10 @@ public class NumberFieldMapper extends FieldMapper {
         if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
             // the last field is the current field, Add to the key map, so that we can validate if it has been added
             List<IndexableField> fields = context.doc().getFields();
-            IndexableField last = fields.get(fields.size() - 1);
+            final IndexableField last = fields.getLast();
             assert last.name().equals(fieldType().name())
                 : "last field name [" + last.name() + "] mis match field name [" + fieldType().name() + "]";
-            context.doc().onlyAddKey(fieldType().name(), fields.get(fields.size() - 1));
+            context.doc().onlyAddKey(fieldType().name(), last);
         }
 
         if (docValuesParameters.enabled() == false && (stored || indexed)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2384,7 +2384,7 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     protected String contentType() {
-        return fieldType().type.typeName();
+        return fieldType.type.typeName();
     }
 
     @Override
@@ -2407,7 +2407,7 @@ public class NumberFieldMapper extends FieldMapper {
         if (value != null) {
             indexValue(context, value);
         } else {
-            value = fieldType().nullValue;
+            value = fieldType.nullValue;
         }
         if (offsetsFieldName != null && context.isImmediateParentAnArray() && context.canAddIgnoredField()) {
             if (value != null) {
@@ -2468,9 +2468,8 @@ public class NumberFieldMapper extends FieldMapper {
             context.getRoutingFields().addLong(name, numericValue.longValue());
         }
         // Switch avoids megamorphic virtual dispatch on the NumberType enum (visible in flamegraphs for bulk indexing).
-        final NumberFieldType ft = fieldType();
         final LuceneDocument doc = context.doc();
-        final IndexType indexType = ft.indexType;
+        final IndexType indexType = fieldType.indexType;
         switch (type) {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue(), indexType);
             case LONG -> addLongFields(doc, name, numericValue.longValue(), indexType);


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/144853

This cuts out the `vtable` blocks in `indexValue` and `value` (you can see that the red blocks drop out in the flamegraph below), also things generally inline better here, which you can see by there being more light blue (inlined) and less green (compiled). 

The two primary bits are the addition of switch statements in `indexValue` and `value` which gives the JVM more room to optimize, as well as caching the fieldType (post cast) as a field in the NumberFieldMapper itself. The rest is small potatoes, but every little bit helps. 😉

For the benchmark I'm focusing on right now, these changes appear to result in an overall improvement of approximately 2% for the `index` operation (not bad!).

Flamegraphs:

<img width="1521" height="414" alt="Screenshot 2026-04-08 at 12 13 45 PM" src="https://github.com/user-attachments/assets/581e15bb-b9a3-4fb3-b68c-0e664bfda654" />
<img width="1520" height="360" alt="Screenshot 2026-04-08 at 12 18 26 PM" src="https://github.com/user-attachments/assets/3992bd2b-6095-4496-ae60-b2bd0752c6e8" />

-----

Note: take an especially close look at 81bf68471794e34cb8cf8baac80218a261ff38a7 -- it seems to me that the `numericValue` can't ever be null, but I'm curious if you think otherwise. By my read, a `null` `numericValue` would always have NPE'ed in the previous code, and it still will in this code, so I'm not sure that the null check that I removed was doing anything of value.