### PR TITLE
Unmute testCleanShardFollowTaskAfterDeleteFollower

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -22,9 +22,6 @@ tests:
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
   issue: https://github.com/elastic/elasticsearch/issues/120127
-- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-  method: testCleanShardFollowTaskAfterDeleteFollower
-  issue: https://github.com/elastic/elasticsearch/issues/120339
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568

--- a/x-pack/plugin/ccr/src/javaRestTest/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/src/javaRestTest/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -312,7 +312,7 @@ public class FollowIndexSecurityIT extends AbstractCCRRestTestCase {
         final String cleanFollower = "clean-follower";
         if (targetCluster == TargetCluster.LEADER) {
             logger.info("running against leader cluster");
-            final Settings indexSettings = indexSettings(1, 0).put("index.soft_deletes.enabled", true).build();
+            final Settings indexSettings = indexSettings(1, 0).build();
             createIndex(adminClient(), cleanLeader, indexSettings);
         } else {
             logger.info("running against follower cluster");


### PR DESCRIPTION
Cleans up unnecessary override on `index.soft_deletes.enabled` and unmute `FollowIndexSecurityIT.testCleanShardFollowTaskAfterDeleteFollower`. See: https://github.com/elastic/elasticsearch/issues/120339#issuecomment-4208961823 for failure analysis and details.

Closes #120339

Ran `FollowIndexSecurityIT` locally 1000 times in batches of 200 via:
```
for i in $(seq 1 200); do 
    echo "=== run $i / 200 ===" 
    ./gradlew :x-pack:plugin:ccr:javaRestTest --tests 'org.elasticsearch.xpack.ccr.FollowIndexSecurityIT' \
      || break
  done
```
and no failures