### PR TITLE
Fix FirstDocIdGroupingAggregatorFunctionTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,9 +279,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
   issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.FirstDocIdGroupingAggregatorFunctionTests
-  method: testSimple
-  issue: https://github.com/elastic/elasticsearch/issues/145923
 - class: org.elasticsearch.xpack.esql.action.EsqlDisruptionIT
   method: testFromStatsProjectAgg
   issue: https://github.com/elastic/elasticsearch/issues/145927

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstDocIdGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstDocIdGroupingAggregatorFunctionTests.java
@@ -62,7 +62,7 @@ public class FirstDocIdGroupingAggregatorFunctionTests extends ComputeTestCase {
                     expectedFirstDocs.putIfAbsent(group, doc);
                 }
                 DocVector docVector = docs.shardRefCounters(new FirstDocIdGroupingAggregatorFunction.MappedShardRefs<>(shardRefs))
-                    .build(DocVector.config());
+                    .build(DocVector.config().mayContainDuplicates());
                 pages.add(new Page(docVector.asBlock(), groups.build().asBlock()));
             }
         }


### PR DESCRIPTION
The doc block is randomly generated, so it may contain duplicates; its configuration should account for this.

Closes #145923