### PR TITLE
Fix WriteLoadConstraintDeciderIT.testAverageWriteLoadMetricIsPublished

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -246,9 +246,6 @@ tests:
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageServiceTests
   method: testApplicationDefaultCredentialsFallbackToComputeEngine
   issue: https://github.com/elastic/elasticsearch/issues/145689
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testAverageWriteLoadMetricIsPublished
-  issue: https://github.com/elastic/elasticsearch/issues/145855
 - class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
   method: testSeqNoPrunedOnLeaderAfterFollowerCatchesUp
   issue: https://github.com/elastic/elasticsearch/issues/145877

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -659,6 +659,7 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             .put(onlyRoles(Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.INDEX_ROLE)))
             .build();
         final var dataNodes = internalCluster().startNodes(3, settings);
+        ensureStableCluster(3);
 
         // Refresh cluster info (should trigger polling)
         refreshClusterInfo();


### PR DESCRIPTION
A simple fix for this one, we need to wait for the new nodes to come up before we refresh cluster info

Fixes #145855 