### PR TITLE
Allow hasPendingAsyncFetch to be used in immutable routing allocations

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,9 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/145948
-- class: org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainIT
-  method: testUnassignedReplicaWithPriorCopy
-  issue: https://github.com/elastic/elasticsearch/issues/145952
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ImmutableRoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ImmutableRoutingAllocation.java
@@ -81,16 +81,6 @@ final class ImmutableRoutingAllocation extends RoutingAllocation {
     }
 
     @Override
-    public boolean hasPendingAsyncFetch() {
-        return false;
-    }
-
-    @Override
-    public void setHasPendingAsyncFetch() {
-        assert false : "This should never be called on an immutable routing allocation";
-    }
-
-    @Override
     public boolean isSimulating() {
         return false;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocation.java
@@ -33,7 +33,6 @@ final class MutableRoutingAllocation extends RoutingAllocation {
     private final RoutingNodes routingNodes;
     private final boolean isSimulating;
     private boolean isReconciling;
-    private boolean hasPendingAsyncFetch;
     private boolean ignoreDisable;
 
     /**
@@ -155,16 +154,6 @@ final class MutableRoutingAllocation extends RoutingAllocation {
     @Override
     public boolean routingNodesChanged() {
         return nodesChangedObserver.isChanged();
-    }
-
-    @Override
-    public boolean hasPendingAsyncFetch() {
-        return hasPendingAsyncFetch;
-    }
-
-    @Override
-    public void setHasPendingAsyncFetch() {
-        this.hasPendingAsyncFetch = true;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -58,6 +58,8 @@ public abstract sealed class RoutingAllocation permits ImmutableRoutingAllocatio
 
     private DebugMode debugDecision = DebugMode.OFF;
 
+    private boolean hasPendingAsyncFetch = false;
+
     protected final long currentNanoTime;
 
     private final Map<String, SingleNodeShutdownMetadata> nodeReplacementTargets;
@@ -312,13 +314,17 @@ public abstract sealed class RoutingAllocation permits ImmutableRoutingAllocatio
      * Returns <code>true</code> iff the current allocation run has not processed all of the in-flight or available
      * shard or store fetches. Otherwise <code>true</code>
      */
-    public abstract boolean hasPendingAsyncFetch();
+    public boolean hasPendingAsyncFetch() {
+        return hasPendingAsyncFetch;
+    }
 
     /**
      * Sets a flag that signals that current allocation run has not processed all of the in-flight or available shard or store fetches.
      * This state is anti-viral and can be reset in on allocation run.
      */
-    public abstract void setHasPendingAsyncFetch();
+    public void setHasPendingAsyncFetch() {
+        this.hasPendingAsyncFetch = true;
+    }
 
     /**
      * Returns an approximation of the size (in bytes) of the unaccounted searchable snapshots before the allocation


### PR DESCRIPTION
I tightened up the use of the `RoutingAllocation` a bit too severely, it turns out allocation explain does use this field.

Fixes #145952