### PR TITLE
[DOCS] Finalize release notes for 8.19

### DIFF
--- a/docs/reference/release-notes/8.19.11.asciidoc
+++ b/docs/reference/release-notes/8.19.11.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.19.11]]
 == {es} version 8.19.11
 
-coming[8.19.11]
-
 Also see <<breaking-changes-8.19,Breaking changes in 8.19>>.
 
 [[bug-8.19.11]]

--- a/docs/reference/release-notes/8.19.12.asciidoc
+++ b/docs/reference/release-notes/8.19.12.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.19.12]]
 == {es} version 8.19.12
 
-coming[8.19.12]
-
 Also see <<breaking-changes-8.19,Breaking changes in 8.19>>.
 
 [[bug-8.19.12]]

--- a/docs/reference/release-notes/8.19.13.asciidoc
+++ b/docs/reference/release-notes/8.19.13.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.19.13]]
 == {es} version 8.19.13
 
-coming[8.19.13]
-
 Also see <<breaking-changes-8.19,Breaking changes in 8.19>>.
 
 [[bug-8.19.13]]

--- a/docs/reference/release-notes/8.19.14.asciidoc
+++ b/docs/reference/release-notes/8.19.14.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.19.14]]
 == {es} version 8.19.14
 
-coming[8.19.14]
-
 Also see <<breaking-changes-8.19,Breaking changes in 8.19>>.
 
 [[bug-8.19.14]]


### PR DESCRIPTION
This PR finalizes the release notes for the 8.19 branch by removing the `coming` tag from the release note pages for already released versions. 