### PR TITLE
Stabilise test: wait longer for reindex operation to finish

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexListRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexListRelocationIT.java
@@ -127,7 +127,7 @@ public class ReindexListRelocationIT extends ESIntegTestCase {
         final TaskId relocatedTaskId = getRelocatedTaskIdFromTasksIndex(originalTaskId);
         unthrottleReindex(relocatedTaskId);
 
-        assertBusy(() -> assertThat("there's no running reindexes", getRunningReindexes(), hasSize(0)));
+        assertBusy(() -> assertThat("there's no running reindexes", getRunningReindexes(), hasSize(0)), 30, TimeUnit.SECONDS);
     }
 
     private GetReindexResponse getReindexWithWaitForCompletion(final TaskId taskId, final boolean waitForCompletion) {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,9 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/145948
-- class: org.elasticsearch.reindex.management.ReindexListRelocationIT
-  method: testListReindexShowsOriginalIdentityAfterRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/145963
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
   method: testTopNByManySortColumns
   issue: https://github.com/elastic/elasticsearch/issues/145965


### PR DESCRIPTION
On a local machine under stress the `assertBusy` (which fails sporadically) takes up to 9 seconds (the `assertBusy` waits for 10 secs by default). I assume something similar happened on the remote machine and it caused a test to fail. 

I've increased the wait time for the failing assertions to see whether it solves a problem.

Closes: #145963
