### PR TITLE
[9.3] ES|QL: Fix handling of values on the time bucket boundaries for rate increase (#145794)

### DIFF
--- a/docs/changelog/145794.yaml
+++ b/docs/changelog/145794.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 145794
+summary: Fix handling of values on the time bucket boundaries for ES|QL increase
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -721,20 +721,22 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
 
         if (lastTsSec == firstTsSec) {
-            // Check for the case where there is only one sample in state, right at the boundary towards a non-empty adjacent state.
+            // Check for the case where there is only one sample in state, right at the lower boundary
+            // of the time bucket towards a non-empty adjacent state.
+            // In this case we want to have a result value as the time bucket is not empty,
+            // but we already included the increase in the previous time bucket.
+            // Therefore, we return the last seen rate of the previous time bucket for rate and zero for increase
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
                     assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
-                    final double delta = deltaBetweenStates(previousState, state, dateFactor);
-                    return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
-                }
-                if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
-                    final double delta = deltaBetweenStates(state, nextState, dateFactor);
-                    return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
+                    if (isRateOverTime) {
+                        final double startTs = previousState.intervals[0].t1 / dateFactor;
+                        final double delta = deltaBetweenStates(previousState, state, dateFactor);
+                        return delta / (firstTsSec - startTs);
+                    } else {
+                        return 0.0;
+                    }
                 }
             }
             return Double.NaN;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -721,20 +721,22 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
 
         if (lastTsSec == firstTsSec) {
-            // Check for the case where there is only one sample in state, right at the boundary towards a non-empty adjacent state.
+            // Check for the case where there is only one sample in state, right at the lower boundary
+            // of the time bucket towards a non-empty adjacent state.
+            // In this case we want to have a result value as the time bucket is not empty,
+            // but we already included the increase in the previous time bucket.
+            // Therefore, we return the last seen rate of the previous time bucket for rate and zero for increase
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
                     assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
-                    final double delta = deltaBetweenStates(previousState, state, dateFactor);
-                    return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
-                }
-                if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
-                    final double delta = deltaBetweenStates(state, nextState, dateFactor);
-                    return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
+                    if (isRateOverTime) {
+                        final double startTs = previousState.intervals[0].t1 / dateFactor;
+                        final double delta = deltaBetweenStates(previousState, state, dateFactor);
+                        return delta / (firstTsSec - startTs);
+                    } else {
+                        return 0.0;
+                    }
                 }
             }
             return Double.NaN;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -721,20 +721,22 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
 
         if (lastTsSec == firstTsSec) {
-            // Check for the case where there is only one sample in state, right at the boundary towards a non-empty adjacent state.
+            // Check for the case where there is only one sample in state, right at the lower boundary
+            // of the time bucket towards a non-empty adjacent state.
+            // In this case we want to have a result value as the time bucket is not empty,
+            // but we already included the increase in the previous time bucket.
+            // Therefore, we return the last seen rate of the previous time bucket for rate and zero for increase
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
                     assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
-                    final double delta = deltaBetweenStates(previousState, state, dateFactor);
-                    return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
-                }
-                if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
-                    final double delta = deltaBetweenStates(state, nextState, dateFactor);
-                    return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
+                    if (isRateOverTime) {
+                        final double startTs = previousState.intervals[0].t1 / dateFactor;
+                        final double delta = deltaBetweenStates(previousState, state, dateFactor);
+                        return delta / (firstTsSec - startTs);
+                    } else {
+                        return 0.0;
+                    }
                 }
             }
             return Double.NaN;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -721,20 +721,22 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
 
         if (lastTsSec == firstTsSec) {
-            // Check for the case where there is only one sample in state, right at the boundary towards a non-empty adjacent state.
+            // Check for the case where there is only one sample in state, right at the lower boundary
+            // of the time bucket towards a non-empty adjacent state.
+            // In this case we want to have a result value as the time bucket is not empty,
+            // but we already included the increase in the previous time bucket.
+            // Therefore, we return the last seen rate of the previous time bucket for rate and zero for increase
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
                     assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
-                    final double delta = deltaBetweenStates(previousState, state, dateFactor);
-                    return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
-                }
-                if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
-                    final double delta = deltaBetweenStates(state, nextState, dateFactor);
-                    return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
+                    if (isRateOverTime) {
+                        final double startTs = previousState.intervals[0].t1 / dateFactor;
+                        final double delta = deltaBetweenStates(previousState, state, dateFactor);
+                        return delta / (firstTsSec - startTs);
+                    } else {
+                        return 0.0;
+                    }
                 }
             }
             return Double.NaN;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
@@ -1,6 +1,6 @@
 increase_of_long_no_grouping
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -14,15 +14,15 @@ increase_bytes_in:double | time_bucket:datetime
 961.1440972222222        | 2024-05-10T00:01:00.000Z
 930.90625                | 2024-05-10T00:00:00.000Z
 914.237233611577         | 2024-05-10T00:18:00.000Z
-839.854243117019         | 2024-05-10T00:20:00.000Z
 838.6380935298255        | 2024-05-10T00:09:00.000Z
 795.8137508015253        | 2024-05-10T00:04:00.000Z
 764.6877930046035        | 2024-05-10T00:11:00.000Z
+737.7229103434985        | 2024-05-10T00:06:00.000Z
 ;
 
 increase_of_long_grouping
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -117,7 +117,7 @@ increase_bytes_in:double | cluster:keyword | time_bucket:datetime
 
 eval_on_increase
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -132,7 +132,7 @@ increase_bytes:double | cluster:keyword | time_bucket:datetime     | increase_kb
 6082.001022561896     | prod            | 2024-05-10T00:10:00.000Z | 5.939454123595602
 6974.883531451061     | qa              | 2024-05-10T00:10:00.000Z | 6.811409698682676
 3855.6246268438786    | staging         | 2024-05-10T00:10:00.000Z | 3.765258424652225
-1557.7298894639323    | prod            | 2024-05-10T00:20:00.000Z | 1.5212205951796214
+1299.7298894639323    | prod            | 2024-05-10T00:20:00.000Z | 1.2692674701796214
 987.1325706421782     | qa              | 2024-05-10T00:20:00.000Z | 0.9639966510177521
 789.2720220707564     | staging         | 2024-05-10T00:20:00.000Z | 0.770773459053473
 
@@ -154,7 +154,7 @@ sum_bytes:double   | max_bytes:double | min_bytes:double   | avg_bytes:double   
 
 increase_of_expression
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -168,16 +168,16 @@ increase_bytes_in:double | time_bucket:datetime
 971.1440972222222        | 2024-05-10T00:01:00.000Z
 940.90625                | 2024-05-10T00:00:00.000Z
 924.237233611577         | 2024-05-10T00:18:00.000Z
-849.854243117019         | 2024-05-10T00:20:00.000Z
 848.6380935298255        | 2024-05-10T00:09:00.000Z
 805.8137508015253        | 2024-05-10T00:04:00.000Z
 774.6877930046035        | 2024-05-10T00:11:00.000Z
+747.7229103434985        | 2024-05-10T00:06:00.000Z
 
 ;
 
 increase_combined_avg
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -192,14 +192,14 @@ avg_increase_bytes:double | avg_increase_cost:double | cluster:keyword | time_bu
 6082.001022561896         | 60.814444388750196       | prod            | 2024-05-10T00:10:00.000Z | 100.00915216265594
 6974.883531451061         | 84.55437658033073        | qa              | 2024-05-10T00:10:00.000Z | 82.4899172998406
 3855.6246268438786        | 46.208665245625674       | staging         | 2024-05-10T00:10:00.000Z | 83.43942865150969
-1557.7298894639323        | 12.277326528656317       | prod            | 2024-05-10T00:20:00.000Z | 126.87859085836473
+1299.7298894639323        | 12.277326528656317       | prod            | 2024-05-10T00:20:00.000Z | 105.86424385066675
 987.1325706421782         | 14.973618104590294       | qa              | 2024-05-10T00:20:00.000Z | 65.9247860969263
 789.2720220707564         | 15.735844017094015       | staging         | 2024-05-10T00:20:00.000Z | 50.15759060736506
 ;
 
 increase_combined_sum
 required_capability: increase
-required_capability: rate_with_interpolation_v2
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
@@ -214,7 +214,7 @@ sum_increase_bytes:double | sum_increase_cost:double | cluster:keyword | time_bu
 18246.003067685688        | 182.4433331662506        | prod            | 2024-05-10T00:10:00.000Z | 100.00915216265594
 20924.65059435318         | 253.6631297409922        | qa              | 2024-05-10T00:10:00.000Z | 82.4899172998406
 11566.873880531635        | 138.62599573687703       | staging         | 2024-05-10T00:10:00.000Z | 83.43942865150967
-4673.189668391797         | 36.83197958596895        | prod            | 2024-05-10T00:20:00.000Z | 126.87859085836473
+3899.1896683917967        | 36.83197958596895        | prod            | 2024-05-10T00:20:00.000Z | 105.86424385066674
 2961.3977119265346        | 44.92085431377088        | qa              | 2024-05-10T00:20:00.000Z | 65.9247860969263
 2367.816066212269         | 47.207532051282044       | staging         | 2024-05-10T00:20:00.000Z | 50.15759060736506
 
@@ -223,12 +223,14 @@ sum_increase_bytes:double | sum_increase_cost:double | cluster:keyword | time_bu
 
 increase_of_ratio
 required_capability: increase
-required_capability: rate_with_interpolation
+required_capability: rate_with_interpolation_v3
 required_capability: ts_command_v0
 
 TS k8s
 | STATS increase_of_ratio = sum(increase(network.total_cost) / increase(network.total_bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute)
 | SORT time_bucket, cluster | LIMIT 10;
+warning:Line 2:33: evaluation of [increase(network.total_cost) / increase(network.total_bytes_in)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:33: java.lang.ArithmeticException: / by zero
 
 increase_of_ratio:double | cluster:keyword | time_bucket:datetime
 0.05584479370760387      | prod            | 2024-05-10T00:00:00.000Z

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -556,3 +556,22 @@ TS k8s
 row_count:long
 9
 ;
+
+// ---------------------------------------
+// This is a regression test ensuring we handle values falling exactly on bucket boundaries correctly
+
+rateWithSamplesOnBucketBoundaries
+required_capability: ts_command_v0
+required_capability: rate_with_interpolation_v3
+
+TS k8s-downsampled
+| WHERE cluster == "prod" AND pod == "one"
+| STATS increase_bytes_in=sum(increase(network.total_bytes_in)), rate_bytes_in=sum(rate(network.total_bytes_in)) BY time_bucket = TBUCKET(10m)
+| SORT time_bucket ASC
+;
+
+increase_bytes_in:double | rate_bytes_in:double | time_bucket:datetime
+24.0                     | 0.04                 | 2024-05-09T23:30:00.000Z
+27.0                     | 0.045                | 2024-05-09T23:40:00.000Z
+0.0                      | 0.045                | 2024-05-09T23:50:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1603,6 +1603,10 @@ public class EsqlCapabilities {
          */
         RATE_WITH_INTERPOLATION,
         RATE_WITH_INTERPOLATION_V2,
+        /**
+         * V3 fixes a bug on how we handle single-value time buckets for INCREASE with the sole value falling onto the bucket boundary.
+         */
+        RATE_WITH_INTERPOLATION_V3,
 
         /**
          * INLINE STATS fix incorrect prunning of null filtering


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ES|QL: Fix handling of values on the time bucket boundaries for rate increase (#145794)](https://github.com/elastic/elasticsearch/pull/145794)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)