### PR TITLE
PromQL: Add year() scalar function

### DIFF
--- a/docs/reference/query-languages/promql/kibana/definition/functions/year.json
+++ b/docs/reference/query-languages/promql/kibana/definition/functions/year.json
@@ -1,0 +1,25 @@
+{
+  "comment" : "PromQL function definition for Kibana. See https://prometheus.io/docs/prometheus/latest/querying/functions/",
+  "type" : "scalar",
+  "name" : "year",
+  "description" : "returns the year of each of those timestamps (in UTC)",
+  "signatures" : [
+    {
+      "params" : [
+        {
+          "name" : "v",
+          "type" : "instant_vector",
+          "optional" : true,
+          "description" : "Optional instant vector input. If omitted, evaluation timestamp is used."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "scalar"
+    }
+  ],
+  "examples" : [
+    "year()"
+  ],
+  "preview" : true,
+  "snapshot_only" : false
+}

--- a/docs/reference/query-languages/promql/kibana/definition/functions/year.json
+++ b/docs/reference/query-languages/promql/kibana/definition/functions/year.json
@@ -1,6 +1,6 @@
 {
   "comment" : "PromQL function definition for Kibana. See https://prometheus.io/docs/prometheus/latest/querying/functions/",
-  "type" : "scalar",
+  "type" : "time",
   "name" : "year",
   "description" : "returns the year of each of those timestamps (in UTC)",
   "signatures" : [
@@ -14,7 +14,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "scalar"
+      "returnType" : "instant_vector"
     }
   ],
   "examples" : [

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -499,6 +499,24 @@ result:double    | step:datetime
 1.7152992E9      | 2024-05-10T00:00:00.000Z
 ;
 
+year_scalar
+required_capability: promql_command_v0
+required_capability: promql_year
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(year());
+
+result:double | step:datetime
+2024.0        | 2024-05-10T00:00:00.000Z
+;
+
+year_with_arg
+required_capability: promql_command_v0
+required_capability: promql_year
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(year(vector(1712574000)));
+
+result:double | step:datetime
+2024.0        | 2024-05-10T00:00:00.000Z
+;
+
 time_in_arithmetic
 required_capability: promql_command_v0
 required_capability: promql_time
@@ -837,4 +855,3 @@ PROMQL index=k8s step=1h result=(scalar(sum(network.cost)) + 1);
 result:double | step:datetime
 62.0          | 2024-05-10T00:00:00.000Z
 ;
-

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2554,6 +2554,11 @@ public class EsqlCapabilities {
          */
         APPROXIMATION_INLINE_STATS(Build.current().isSnapshot()),
 
+        /**
+         * Support for PromQL year() function.
+         */
+        PROMQL_YEAR,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateExtract;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
 
 /**
  * PromQL built-in function definitions that do not correspond to a dedicated ES|QL function class.
@@ -40,7 +41,7 @@ class PromqlBuiltinFunctionDefinitions {
         .dateTime(
             (source, date, configuration) -> new ToDouble(
                 source,
-                new DateExtract(source, Literal.keyword(source, "year"), date, configuration.withZoneId(ZoneOffset.UTC))
+                new DateExtract(source, Literal.keyword(source, ChronoField.YEAR.name()), date, configuration.withZoneId(ZoneOffset.UTC))
             )
         )
         .counterSupport(PromqlFunctionDefinition.CounterSupport.SUPPORTED)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
@@ -10,7 +10,10 @@ package org.elasticsearch.xpack.esql.expression.promql.function;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Scalar;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
+import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateExtract;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
+
+import java.time.ZoneOffset;
 
 /**
  * PromQL built-in function definitions that do not correspond to a dedicated ES|QL function class.
@@ -32,6 +35,18 @@ class PromqlBuiltinFunctionDefinitions {
             If the input vector does not have exactly one element, scalar returns NaN.""")
         .example("scalar(sum(http_requests_total))")
         .name("scalar");
+
+    static final PromqlFunctionDefinition YEAR = PromqlFunctionDefinition.def()
+        .dateTime(
+            (source, date, configuration) -> new ToDouble(
+                source,
+                new DateExtract(source, Literal.keyword(source, "year"), date, configuration.withZoneId(ZoneOffset.UTC))
+            )
+        )
+        .counterSupport(PromqlFunctionDefinition.CounterSupport.SUPPORTED)
+        .description("returns the year of each of those timestamps (in UTC)")
+        .example("year()")
+        .name("year");
 
     static final PromqlFunctionDefinition TIME = PromqlFunctionDefinition.def()
         .scalarWithStep((source, step) -> new Div(source, new ToDouble(source, step), Literal.fromDouble(source, 1000.0)))

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
@@ -206,7 +206,7 @@ public final class PromqlFunctionDefinition {
         "Optional instant vector input. If omitted, evaluation timestamp is used."
     );
     public static final PromqlParamInfo SCALAR = PromqlParamInfo.child("s", PromqlDataType.SCALAR, "Scalar value.");
-    public static final PromqlParamInfo QUANTILE = PromqlParamInfo.of("\u03c6", PromqlDataType.SCALAR, "Quantile value (0 \u2264 \u03c6 \u2264 1).");
+    public static final PromqlParamInfo QUANTILE = PromqlParamInfo.of("φ", PromqlDataType.SCALAR, "Quantile value (0 ≤ φ ≤ 1).");
     public static final PromqlParamInfo TO_NEAREST = PromqlParamInfo.optional(
         "to_nearest",
         PromqlDataType.SCALAR,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
@@ -64,6 +64,9 @@ public final class PromqlFunctionDefinition {
         UNSUPPORTED
     }
 
+    /**
+     * Builds an ES|QL expression for a PromQL date/time extraction function (e.g. year, month, day_of_month).
+     */
     @FunctionalInterface
     public interface DateTimeFunctionBuilder {
         Expression build(Source source, Expression date, Configuration configuration);
@@ -82,6 +85,9 @@ public final class PromqlFunctionDefinition {
             return new PromqlParamInfo(name, type, description, true, false);
         }
 
+        /**
+         * Creates a parameter that is both optional and acts as the primary child expression for the function.
+         */
         public static PromqlParamInfo optionalChild(String name, PromqlDataType type, String description) {
             return new PromqlParamInfo(name, type, description, true, true);
         }
@@ -375,7 +381,7 @@ public final class PromqlFunctionDefinition {
          * When the argument is a numeric value (seconds since epoch), it is converted to a datetime first.
          */
         public PromqlFunctionDefinition.Builder dateTime(DateTimeFunctionBuilder ctorRef) {
-            this.functionType = FunctionType.SCALAR;
+            this.functionType = FunctionType.TIME_EXTRACTION;
             this.arity = PromqlFunctionArity.optional(1);
             this.builder = (source, target, ctx, extraParams) -> {
                 var step = ctx.step();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionDefinition.java
@@ -11,14 +11,23 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDatetime;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlDataType;
+import org.elasticsearch.xpack.esql.session.Configuration;
 
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.isDateNanos;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isDateTime;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isNull;
 
 /**
  * Function definition record for registration and metadata.
@@ -55,6 +64,11 @@ public final class PromqlFunctionDefinition {
         UNSUPPORTED
     }
 
+    @FunctionalInterface
+    public interface DateTimeFunctionBuilder {
+        Expression build(Source source, Expression date, Configuration configuration);
+    }
+
     public record PromqlParamInfo(String name, PromqlDataType type, String description, boolean optional, boolean child) {
         public static PromqlParamInfo child(String name, PromqlDataType type, String description) {
             return new PromqlParamInfo(name, type, description, false, true);
@@ -66,6 +80,10 @@ public final class PromqlFunctionDefinition {
 
         public static PromqlParamInfo optional(String name, PromqlDataType type, String description) {
             return new PromqlParamInfo(name, type, description, true, false);
+        }
+
+        public static PromqlParamInfo optionalChild(String name, PromqlDataType type, String description) {
+            return new PromqlParamInfo(name, type, description, true, true);
         }
     }
 
@@ -99,6 +117,10 @@ public final class PromqlFunctionDefinition {
 
         private static PromqlFunctionDefinition.PromqlFunctionArity range(int min, int max) {
             return min == max ? fixed(min) : new PromqlFunctionDefinition.PromqlFunctionArity(min, max);
+        }
+
+        private static PromqlFunctionDefinition.PromqlFunctionArity optional(int max) {
+            return new PromqlFunctionDefinition.PromqlFunctionArity(0, max);
         }
     }
 
@@ -178,8 +200,13 @@ public final class PromqlFunctionDefinition {
 
     public static final PromqlParamInfo RANGE_VECTOR = PromqlParamInfo.child("v", PromqlDataType.RANGE_VECTOR, "Range vector input.");
     public static final PromqlParamInfo INSTANT_VECTOR = PromqlParamInfo.child("v", PromqlDataType.INSTANT_VECTOR, "Instant vector input.");
+    public static final PromqlParamInfo INSTANT_VECTOR_OPTIONAL = PromqlParamInfo.optionalChild(
+        "v",
+        PromqlDataType.INSTANT_VECTOR,
+        "Optional instant vector input. If omitted, evaluation timestamp is used."
+    );
     public static final PromqlParamInfo SCALAR = PromqlParamInfo.child("s", PromqlDataType.SCALAR, "Scalar value.");
-    public static final PromqlParamInfo QUANTILE = PromqlParamInfo.of("φ", PromqlDataType.SCALAR, "Quantile value (0 ≤ φ ≤ 1).");
+    public static final PromqlParamInfo QUANTILE = PromqlParamInfo.of("\u03c6", PromqlDataType.SCALAR, "Quantile value (0 \u2264 \u03c6 \u2264 1).");
     public static final PromqlParamInfo TO_NEAREST = PromqlParamInfo.optional(
         "to_nearest",
         PromqlDataType.SCALAR,
@@ -339,6 +366,37 @@ public final class PromqlFunctionDefinition {
             this.arity = PromqlFunctionArity.NONE;
             this.builder = (source, target, ctx, extraParams) -> ctorRef.apply(source, ctx.step());
             this.params = List.of();
+            return this;
+        }
+
+        /**
+         * Builds a date/time extraction function that accepts an optional instant vector argument.
+         * When no argument is provided, the evaluation step timestamp (or fallback timestamp) is used.
+         * When the argument is a numeric value (seconds since epoch), it is converted to a datetime first.
+         */
+        public PromqlFunctionDefinition.Builder dateTime(DateTimeFunctionBuilder ctorRef) {
+            this.functionType = FunctionType.SCALAR;
+            this.arity = PromqlFunctionArity.optional(1);
+            this.builder = (source, target, ctx, extraParams) -> {
+                var step = ctx.step();
+                var defaultTimestamp = (step == null || isNull(step.dataType())) ? ctx.timestamp() : step;
+                var date = target == null ? defaultTimestamp : target;
+
+                if (isDateTime(date.dataType()) || isDateNanos(date.dataType())) {
+                    return ctorRef.build(source, date, ctx.configuration());
+                } else {
+                    return ctorRef.build(
+                        source,
+                        new ToDatetime(
+                            source,
+                            new Mul(source, new ToDouble(source, date), Literal.fromDouble(source, 1000.0)),
+                            ctx.configuration().withZoneId(ZoneOffset.UTC)
+                        ),
+                        ctx.configuration()
+                    );
+                }
+            };
+            this.params = List.of(INSTANT_VECTOR_OPTIONAL);
             return this;
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -157,6 +157,9 @@ public class PromqlFunctionRegistry {
         }
     }
 
+    /**
+     * Carries the PromQL evaluation context needed by function builders to construct ES|QL expressions.
+     */
     public record PromqlContext(Expression timestamp, Expression window, Expression step, Configuration configuration) {}
 
     // PromQL function names not yet implemented

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.math.Sqrt;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Tan;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Tanh;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -142,6 +143,7 @@ public class PromqlFunctionRegistry {
         PromqlBuiltinFunctionDefinitions.VECTOR,
         PromqlBuiltinFunctionDefinitions.SCALAR,
         Pi.PROMQL_DEFINITION,
+        PromqlBuiltinFunctionDefinitions.YEAR,
         PromqlBuiltinFunctionDefinitions.TIME, };
 
     public static final PromqlFunctionRegistry INSTANCE = new PromqlFunctionRegistry();
@@ -155,7 +157,7 @@ public class PromqlFunctionRegistry {
         }
     }
 
-    public record PromqlContext(Expression timestamp, Expression window, Expression step) {}
+    public record PromqlContext(Expression timestamp, Expression window, Expression step, Configuration configuration) {}
 
     // PromQL function names not yet implemented
     // https://github.com/elastic/metrics-program/issues/39
@@ -182,12 +184,10 @@ public class PromqlFunctionRegistry {
         "day_of_month",
         "day_of_week",
         "day_of_year",
-        "days_in_month",
         "hour",
         "minute",
         "month",
         "timestamp",
-        "year",
 
         // Label manipulation functions
         "label_join",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -184,6 +184,7 @@ public class PromqlFunctionRegistry {
         "day_of_month",
         "day_of_week",
         "day_of_year",
+        "days_in_month",
         "hour",
         "minute",
         "month",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -408,7 +408,8 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
             ctx.promqlCommand().timestamp(),
             window,
-            ctx.stepAttr()
+            ctx.stepAttr(),
+            ctx.optimizerContext().configuration()
         );
 
         Expression function = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
@@ -468,7 +469,8 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
             ctx.promqlCommand().timestamp(),
             null,
-            ctx.stepAttr()
+            ctx.stepAttr(),
+            ctx.optimizerContext().configuration()
         );
         Expression function = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
             scalarFunction.functionName(),
@@ -627,7 +629,8 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
             ctx.promqlCommand().timestamp(),
             AggregateFunction.NO_WINDOW,
-            ctx.stepAttr()
+            ctx.stepAttr(),
+            ctx.optimizerContext().configuration()
         );
         return PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(agg.functionName(), agg.source(), inputValue, promqlCtx, agg.parameters());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
@@ -507,7 +507,7 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
                 case VALUE_TRANSFORMATION -> new ValueTransformationFunction(source, child, name, extraParams);
                 case VECTOR_CONVERSION -> new VectorConversionFunction(source, child, name, extraParams);
                 case SCALAR_CONVERSION -> new ScalarConversionFunction(source, child, name, extraParams);
-                case SCALAR -> child == null
+                case SCALAR, TIME_EXTRACTION -> child == null
                     ? new ScalarFunction(source, name)
                     : new ValueTransformationFunction(source, child, name, extraParams);
                 default -> throw new ParsingException(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
@@ -507,7 +507,9 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
                 case VALUE_TRANSFORMATION -> new ValueTransformationFunction(source, child, name, extraParams);
                 case VECTOR_CONVERSION -> new VectorConversionFunction(source, child, name, extraParams);
                 case SCALAR_CONVERSION -> new ScalarConversionFunction(source, child, name, extraParams);
-                case SCALAR -> new ScalarFunction(source, name);
+                case SCALAR -> child == null
+                    ? new ScalarFunction(source, name)
+                    : new ValueTransformationFunction(source, child, name, extraParams);
                 default -> throw new ParsingException(
                     source,
                     "Unsupported function type [{}] for function [{}]",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
@@ -435,6 +435,33 @@ public class Configuration implements Writeable {
         );
     }
 
+    /**
+     * Returns a copy of this configuration with the supplied timezone.
+     */
+    public Configuration withZoneId(ZoneId zoneId) {
+        return new Configuration(
+            zoneId,
+            now,
+            locale,
+            username,
+            clusterName,
+            pragmas,
+            resultTruncationMaxSizeRegular,
+            resultTruncationDefaultSizeRegular,
+            query,
+            profile,
+            tables,
+            queryStartTimeNanos,
+            allowPartialResults,
+            resultTruncationMaxSizeTimeseries,
+            resultTruncationDefaultSizeTimeseries,
+            projectRouting,
+            approximationSettings,
+            viewQueries,
+            explainOnly
+        );
+    }
+
     private static void writeQuery(StreamOutput out, String query) throws IOException {
         if (query.length() > QUERY_COMPRESS_THRESHOLD_CHARS) { // compare on chars to avoid UTF-8 encoding unless actually required
             out.writeBoolean(true);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -7,21 +7,29 @@
 
 package org.elasticsearch.xpack.esql.optimizer.promql;
 
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.junit.Before;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
@@ -31,6 +39,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTests {
+
+    @Before
+    public void assumePromqlYearCapability() {
+        assumeTrue("Requires PROMQL year capability", EsqlCapabilities.Cap.PROMQL_YEAR.isEnabled());
+    }
 
     public void testConstantResults() {
         assertConstantResult("ceil(vector(3.14159))", equalTo(4.0));
@@ -46,6 +59,36 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
         assertConstantResult("round(vector(pi()), 0.001)", equalTo(3.142)); // round up 3 decimal places
         assertConstantResult("round(vector(pi()), 0.15)", equalTo(3.15)); // rounds up to nearest
         assertConstantResult("round(vector(pi()), 0.5)", equalTo(3.0)); // rounds down to nearest
+    }
+
+    public void testYearUsesStepTimestampWhenNoArgument() {
+        var ctx = new PromqlFunctionRegistry.PromqlContext(
+            Literal.NULL,
+            Literal.NULL,
+            Literal.dateTime(Source.EMPTY, Instant.parse("2023-12-31T23:30:00Z")),
+            EsqlTestUtils.TEST_CFG.withZoneId(ZoneId.of("Europe/Paris"))
+        );
+
+        var expression = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction("year", Source.EMPTY, null, ctx, List.of());
+        assertThat(as(expression.fold(FoldContext.small()), Double.class), equalTo(2023.0));
+    }
+
+    public void testYearWithArgumentUsesSuppliedTimestampSeconds() {
+        var ctx = new PromqlFunctionRegistry.PromqlContext(
+            Literal.NULL,
+            Literal.NULL,
+            Literal.dateTime(Source.EMPTY, Instant.parse("2025-05-10T00:00:00Z")),
+            EsqlTestUtils.TEST_CFG
+        );
+
+        var expression = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
+            "year",
+            Source.EMPTY,
+            Literal.fromDouble(Source.EMPTY, 1712574000.0),
+            ctx,
+            List.of()
+        );
+        assertThat(as(expression.fold(FoldContext.small()), Double.class), equalTo(2024.0));
     }
 
     public void testClamp() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer.promql;
 
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -25,7 +24,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
-import org.junit.Before;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -39,11 +37,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTests {
-
-    @Before
-    public void assumePromqlYearCapability() {
-        assumeTrue("Requires PROMQL_YEAR capability", EsqlCapabilities.Cap.PROMQL_YEAR.isEnabled());
-    }
 
     public void testConstantResults() {
         assertConstantResult("ceil(vector(3.14159))", equalTo(4.0));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -42,7 +42,7 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
 
     @Before
     public void assumePromqlYearCapability() {
-        assumeTrue("Requires PROMQL year capability", EsqlCapabilities.Cap.PROMQL_YEAR.isEnabled());
+        assumeTrue("Requires PROMQL_YEAR capability", EsqlCapabilities.Cap.PROMQL_YEAR.isEnabled());
     }
 
     public void testConstantResults() {


### PR DESCRIPTION
 Add PromQL [`year()`](https://prometheus.io/docs/prometheus/latest/querying/functions/#year) scalar function that extracts the year from a timestamp in UTC.