### PR TITLE
Switch GPU SQ format to ES94 (OSQ-based) 

### DIFF
--- a/docs/changelog/146006.yaml
+++ b/docs/changelog/146006.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 146006
+summary: Switch GPU SQ format to ES94 (OSQ-based)
+type: enhancement

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormat.java
@@ -17,7 +17,8 @@ import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.gpu.CuVSGPUSupport;
-import org.elasticsearch.index.codec.vectors.ES814ScalarQuantizedVectorsFormat;
+import org.elasticsearch.index.codec.vectors.es94.ES94ScalarQuantizedVectorsFormat;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -43,26 +44,11 @@ public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
     private final long totalDeviceMemory;
 
     public ES92GpuHnswSQVectorsFormat() {
-        this(
-            CuVSResourceManager::pooling,
-            CuVSGPUSupport.instance().getTotalGpuMemory(),
-            DEFAULT_MAX_CONN,
-            DEFAULT_BEAM_WIDTH,
-            null,
-            7,
-            false
-        );
+        this(CuVSResourceManager::pooling, CuVSGPUSupport.instance().getTotalGpuMemory(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, 7, false);
     }
 
-    public ES92GpuHnswSQVectorsFormat(
-        long totalDeviceMemory,
-        int maxConn,
-        int beamWidth,
-        Float confidenceInterval,
-        int bits,
-        boolean compress
-    ) {
-        this(CuVSResourceManager::pooling, totalDeviceMemory, maxConn, beamWidth, confidenceInterval, bits, compress);
+    public ES92GpuHnswSQVectorsFormat(long totalDeviceMemory, int maxConn, int beamWidth, int bits, boolean useDirectIO) {
+        this(CuVSResourceManager::pooling, totalDeviceMemory, maxConn, beamWidth, bits, useDirectIO);
     }
 
     ES92GpuHnswSQVectorsFormat(
@@ -70,9 +56,8 @@ public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
         long totalDeviceMemory,
         int maxConn,
         int beamWidth,
-        Float confidenceInterval,
         int bits,
-        boolean compress
+        boolean useDirectIO
     ) {
         super(NAME);
         this.totalDeviceMemory = totalDeviceMemory;
@@ -89,7 +74,7 @@ public class ES92GpuHnswSQVectorsFormat extends KnnVectorsFormat {
         }
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
-        this.flatVectorsFormat = new ES814ScalarQuantizedVectorsFormat(confidenceInterval, bits, compress);
+        this.flatVectorsFormat = new ES94ScalarQuantizedVectorsFormat(DenseVectorFieldMapper.ElementType.FLOAT, bits, useDirectIO);
     }
 
     @Override

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -29,7 +29,9 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
@@ -45,6 +47,9 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -524,9 +529,8 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 // we just build a mock graph where every node is connected to every other node
                 generateMockGraphAndWriteMeta(fieldInfo, numVectors);
             } else {
-                // getFlatRandomVectorScorerInnerSupplier returns null for ES94's scorer supplier
-                // (Lucene104's QuantizedCloseableRandomVectorScorerSupplier is not recognized),
-                // causing mergeFloatVectorField to fall through to MergedVectorValues.mergeFloatVectorValues.
+                // For Lucene99-backed formats, this unwraps the raw float scorer for mmap access.
+                // For ES94 (Lucene104), returns null and mergeFloatVectorField writes a temp file instead.
                 var randomScorerSupplier = VectorsFormatReflectionUtils.getFlatRandomVectorScorerInnerSupplier(scorerSupplier);
                 mergeFloatVectorField(fieldInfo, mergeState, randomScorerSupplier, numVectors);
             }
@@ -605,26 +609,88 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 }
             }
         } else {
-            logger.warn("Cannot get merged raw vectors from scorer.");
+            // ES94 path: scorer supplier is quantized (Lucene104), so raw float vectors
+            // are not accessible through the scorer. Write merged vectors to a temp file
+            // and mmap it for efficient GPU transfer.
+            mergeFloatVectorFieldViaTempFile(fieldInfo, mergeState, cagraIndexParams, numVectors);
+        }
+    }
+
+    /**
+     * Writes merged float vectors to a temp file and mmaps it for zero-copy GPU transfer.
+     * Falls back to per-vector host builder when the directory is not FS-backed (e.g. in tests).
+     */
+    private void mergeFloatVectorFieldViaTempFile(
+        FieldInfo fieldInfo,
+        MergeState mergeState,
+        CagraIndexParams cagraIndexParams,
+        int numVectors
+    ) throws IOException, InterruptedException {
+        int dims = fieldInfo.getVectorDimension();
+        long dataSize = (long) numVectors * dims * Float.BYTES;
+
+        FSDirectory fsDir;
+        try {
+            fsDir = MemorySegmentUtils.unwrapFSDirectory(segmentWriteState.directory);
+        } catch (IllegalArgumentException e) {
+            fsDir = null;
+        }
+
+        if (fsDir != null) {
             FloatVectorValues floatVectorValues = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
-
+            Path tempFile = writeVectorsToTempFile(floatVectorValues, dims, fsDir);
+            logger.info(
+                "Wrote [{}] merged vectors to temp file [{}] ([{}] bytes) for mmap GPU transfer",
+                numVectors,
+                tempFile.getFileName(),
+                dataSize
+            );
+            try (
+                var memorySegmentHolder = MemorySegmentUtils.createFileBackedMemorySegment(tempFile, dataSize);
+                var dataset = DatasetUtils.getInstance()
+                    .fromInput(memorySegmentHolder.memorySegment(), numVectors, dims, CuVSMatrix.DataType.FLOAT);
+                var resourcesHolder = new ResourcesHolder(
+                    cuVSResourceManager,
+                    cuVSResourceManager.acquire(numVectors, dims, CuVSMatrix.DataType.FLOAT, cagraIndexParams)
+                )
+            ) {
+                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
+            }
+        } else {
+            logger.info("Cannot mmap directory for GPU merge; falling back to host builder");
+            FloatVectorValues floatVectorValues = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
             // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem
-            var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT);
-
+            var builder = CuVSMatrix.hostBuilder(numVectors, dims, CuVSMatrix.DataType.FLOAT);
             final KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
             for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
-                float[] vector = floatVectorValues.vectorValue(iterator.index());
-                builder.addVector(vector);
+                builder.addVector(floatVectorValues.vectorValue(iterator.index()));
             }
             try (
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
+                    cuVSResourceManager.acquire(numVectors, dims, CuVSMatrix.DataType.FLOAT, cagraIndexParams)
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
             }
+        }
+    }
+
+    /**
+     * Writes float vectors to a temporary file as contiguous little-endian floats.
+     * The temp file is suitable for mmap-based GPU transfer.
+     */
+    private static Path writeVectorsToTempFile(FloatVectorValues floatVectorValues, int dims, FSDirectory fsDir) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(dims * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        try (IndexOutput tempOutput = fsDir.createTempOutput("gpu-merge", "vec_", IOContext.DEFAULT)) {
+            final KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
+            for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
+                float[] vector = floatVectorValues.vectorValue(iterator.index());
+                buffer.asFloatBuffer().put(vector);
+                tempOutput.writeBytes(buffer.array(), buffer.limit());
+            }
+            return fsDir.getDirectory().resolve(tempOutput.getName());
         }
     }
 

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -16,10 +16,9 @@ import com.nvidia.cuvs.CuVSMatrix;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsWriter.MergedVectorValues;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
-import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsWriter;
-import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
@@ -39,10 +38,8 @@ import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
-import org.apache.lucene.util.quantization.ScalarQuantizer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.gpu.GPUSupport;
-import org.elasticsearch.index.codec.vectors.ES814ScalarQuantizedVectorsFormat;
 import org.elasticsearch.index.codec.vectors.reflect.VectorsFormatReflectionUtils;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -62,8 +59,6 @@ import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.LUCENE99_HNSW
 import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.LUCENE99_VERSION_CURRENT;
 import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.MIN_NUM_VECTORS_FOR_GPU_BUILD;
 import static org.elasticsearch.gpu.codec.MemorySegmentUtils.getContiguousMemorySegment;
-import static org.elasticsearch.gpu.codec.MemorySegmentUtils.getContiguousPackedMemorySegment;
-import static org.elasticsearch.index.codec.vectors.Lucene99ScalarQuantizedVectorsWriter.mergeAndRecalculateQuantiles;
 
 /**
  * Writer that builds an Nvidia Carga Graph on GPU and then writes it into the Lucene99 HNSW format,
@@ -88,7 +83,6 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
 
     private final List<FieldWriter> fields = new ArrayList<>();
     private boolean finished;
-    private final CuVSMatrix.DataType dataType;
 
     ES92GpuHnswVectorsWriter(
         CuVSResourceManager cuVSResourceManager,
@@ -104,12 +98,6 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         this.M = M;
         this.beamWidth = beamWidth;
         this.flatVectorWriter = flatVectorWriter;
-        if (flatVectorWriter instanceof ES814ScalarQuantizedVectorsFormat.ES814ScalarQuantizedVectorsWriter) {
-            dataType = CuVSMatrix.DataType.BYTE;
-        } else {
-            assert flatVectorWriter instanceof Lucene99FlatVectorsWriter;
-            dataType = CuVSMatrix.DataType.FLOAT;
-        }
         this.segmentWriteState = state;
         String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, LUCENE99_HNSW_META_EXTENSION);
         String indexDataFileName = IndexFileNames.segmentFileName(
@@ -160,12 +148,9 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
     /**
      * Flushes vector data and associated data to disk.
      * <p>
-     * This method and the private helpers it calls only need to support FLOAT32.
-     * For FlatFieldVectorWriter we only need to support float[] during flush: during indexing users provide floats[], and pass floats to
-     * FlatFieldVectorWriter, even when we have a BYTE dataType (i.e. an "int8_hnsw" type).
-     * During merging, we use quantized data, so we need to support byte[] too (see {@link ES92GpuHnswVectorsWriter#mergeOneField}),
-     * but not here.
-     * That's how our other current formats work: use floats during indexing, and quantized data to build graph during merging.
+     * This method and the private helpers it calls only support FLOAT32.
+     * During indexing users provide float[] which are passed directly to FlatFieldVectorWriter.
+     * During merging, raw float vectors are read from source segments (see {@link ES92GpuHnswVectorsWriter#mergeOneField}).
      * </p>
      */
     @Override
@@ -337,7 +322,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     fieldInfo.getVectorSimilarityFunction(),
                     M,
                     beamWidth,
-                    dataType
+                    CuVSMatrix.DataType.FLOAT
                 );
             } else {
                 // IVF_PQ algorithm
@@ -352,7 +337,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     ivfPqIndexParams.getPqDim(),
                     ivfPqIndexParams.getPqBits(),
                     ivfPqIndexParams.getnLists(),
-                    dataType
+                    CuVSMatrix.DataType.FLOAT
                 );
             }
         }
@@ -371,16 +356,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         CagraIndexParams.CuvsDistanceType distanceType = switch (similarityFunction) {
             case COSINE -> CagraIndexParams.CuvsDistanceType.CosineExpanded;
             case EUCLIDEAN -> CagraIndexParams.CuvsDistanceType.L2Expanded;
-            case DOT_PRODUCT -> {
-                if (dataType == CuVSMatrix.DataType.BYTE) {
-                    yield CagraIndexParams.CuvsDistanceType.CosineExpanded;
-                }
-                yield CagraIndexParams.CuvsDistanceType.InnerProduct;
-            }
-            case MAXIMUM_INNER_PRODUCT -> {
-                assert dataType != CuVSMatrix.DataType.BYTE;
-                yield CagraIndexParams.CuvsDistanceType.InnerProduct;
-            }
+            case DOT_PRODUCT, MAXIMUM_INNER_PRODUCT -> CagraIndexParams.CuvsDistanceType.InnerProduct;
         };
 
         int numCPUThreads = 1; // TODO: how many CPU threads we can use?
@@ -392,7 +368,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         } else {
             // Check if we should use IVF_PQ due to insufficient GPU memory for NN_DESCENT
             if (totalDeviceMemory > 0) {
-                long requiredMemoryForNnDescent = CuVSResourceManager.estimateNNDescentMemory(numVectors, dims, dataType);
+                long requiredMemoryForNnDescent = CuVSResourceManager.estimateNNDescentMemory(numVectors, dims, CuVSMatrix.DataType.FLOAT);
                 if (requiredMemoryForNnDescent > totalDeviceMemory) {
                     useIvfPQ = true;
                     logger.debug(
@@ -548,127 +524,16 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 // we just build a mock graph where every node is connected to every other node
                 generateMockGraphAndWriteMeta(fieldInfo, numVectors);
             } else {
-                if (dataType == CuVSMatrix.DataType.FLOAT) {
-                    var randomScorerSupplier = VectorsFormatReflectionUtils.getFlatRandomVectorScorerInnerSupplier(scorerSupplier);
-                    mergeFloatVectorField(fieldInfo, mergeState, randomScorerSupplier, numVectors);
-                } else {
-                    // During merging, we use quantized data, so we need to support byte[] too.
-                    // That's how our current formats work: use floats during indexing, and quantized data to build a graph
-                    // during merging.
-                    assert dataType == CuVSMatrix.DataType.BYTE;
-                    var randomScorerSupplier = VectorsFormatReflectionUtils.getScalarQuantizedRandomVectorScorerInnerSupplier(
-                        scorerSupplier
-                    );
-                    mergeByteVectorField(fieldInfo, mergeState, randomScorerSupplier, numVectors);
-                }
+                // getFlatRandomVectorScorerInnerSupplier returns null for ES94's scorer supplier
+                // (Lucene104's QuantizedCloseableRandomVectorScorerSupplier is not recognized),
+                // causing mergeFloatVectorField to fall through to MergedVectorValues.mergeFloatVectorValues.
+                var randomScorerSupplier = VectorsFormatReflectionUtils.getFlatRandomVectorScorerInnerSupplier(scorerSupplier);
+                mergeFloatVectorField(fieldInfo, mergeState, randomScorerSupplier, numVectors);
             }
             var elapsed = System.nanoTime() - started;
             logger.debug("Merged [{}] vectors in [{}ms]", numVectors, elapsed / 1_000_000.0);
         } catch (Throwable t) {
             throw new IOException("Failed to merge GPU index: ", t);
-        }
-    }
-
-    private void mergeByteVectorField(
-        FieldInfo fieldInfo,
-        MergeState mergeState,
-        RandomVectorScorerSupplier randomScorerSupplier,
-        int numVectors
-    ) throws IOException, InterruptedException {
-        var vectorValues = randomScorerSupplier == null
-            ? null
-            : VectorsFormatReflectionUtils.getByteScoringSupplierVectorOrNull(randomScorerSupplier);
-
-        CagraIndexParams cagraIndexParams = createCagraIndexParams(
-            fieldInfo.getVectorSimilarityFunction(),
-            numVectors,
-            fieldInfo.getVectorDimension()
-        );
-
-        if (vectorValues != null) {
-            IndexInput slice = vectorValues.getSlice();
-            var input = FilterIndexInput.unwrap(slice);
-            if (input instanceof MemorySegmentAccessInput memorySegmentAccessInput) {
-                // Direct access to mmapped file
-                // for int8_hnsw, the raw vector data has extra 4-byte at the end of each vector to encode a correction constant
-                int sourceRowPitch = fieldInfo.getVectorDimension() + 4;
-
-                // The current (25.10) CuVS implementation of CAGRA index build has problems with strides;
-                // the explicit copy removes them.
-                // TODO: revert to directly pass data mapped with DatasetUtils.getInstance() to generateGpuGraphAndWriteMeta
-                // when cuvs has fixed this problem
-                int packedRowSize = fieldInfo.getVectorDimension();
-                try (
-                    var packedSegmentHolder = getContiguousPackedMemorySegment(
-                        memorySegmentAccessInput,
-                        mergeState.segmentInfo.dir,
-                        mergeState.segmentInfo.name,
-                        numVectors,
-                        sourceRowPitch,
-                        packedRowSize
-                    );
-                    var dataset = DatasetUtilsImpl.fromMemorySegment(
-                        packedSegmentHolder.memorySegment(),
-                        numVectors,
-                        packedRowSize,
-                        dataType
-                    );
-                    var resourcesHolder = new ResourcesHolder(
-                        cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
-                    )
-                ) {
-                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
-                }
-            } else {
-                logger.info(
-                    () -> "Cannot mmap merged raw vectors temporary file. IndexInput type [" + input.getClass().getSimpleName() + "]"
-                );
-
-                // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem
-                var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), dataType);
-
-                try (IndexInput clonedSlice = slice.clone()) {
-                    clonedSlice.seek(0);
-                    int dims = fieldInfo.getVectorDimension();
-                    byte[] vector = new byte[dims];
-                    for (int i = 0; i < numVectors; ++i) {
-                        clonedSlice.readBytes(vector, 0, dims);
-                        clonedSlice.skipBytes(4); // skip scalar quantization correction constant
-                        builder.addVector(vector);
-                    }
-                }
-
-                try (
-                    var dataset = builder.build();
-                    var resourcesHolder = new ResourcesHolder(
-                        cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
-                    )
-                ) {
-                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
-                }
-            }
-        } else {
-            logger.warn("Cannot get merged raw vectors from scorer. Performances will be degraded.");
-            var byteVectorValues = getMergedByteVectorValues(fieldInfo, mergeState);
-
-            // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem
-            final var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), dataType);
-            final KnnVectorValues.DocIndexIterator iterator = byteVectorValues.iterator();
-            for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
-                builder.addVector(byteVectorValues.vectorValue(iterator.index()));
-            }
-
-            try (
-                var dataset = builder.build();
-                var resourcesHolder = new ResourcesHolder(
-                    cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
-                )
-            ) {
-                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
-            }
         }
     }
 
@@ -699,10 +564,15 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         mergeState.segmentInfo.name
                     );
                     var dataset = DatasetUtils.getInstance()
-                        .fromInput(memorySegmentHolder.memorySegment(), numVectors, fieldInfo.getVectorDimension(), dataType);
+                        .fromInput(
+                            memorySegmentHolder.memorySegment(),
+                            numVectors,
+                            fieldInfo.getVectorDimension(),
+                            CuVSMatrix.DataType.FLOAT
+                        );
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
@@ -713,7 +583,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 );
 
                 // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem
-                var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), dataType);
+                var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT);
 
                 try (IndexInput clonedSlice = slice.clone()) {
                     clonedSlice.seek(0);
@@ -728,7 +598,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
@@ -739,7 +609,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
             FloatVectorValues floatVectorValues = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
 
             // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem
-            var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), dataType);
+            var builder = CuVSMatrix.hostBuilder(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT);
 
             final KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
             for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
@@ -750,20 +620,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
+                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
             }
         }
-    }
-
-    private ByteVectorValues getMergedByteVectorValues(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-        // TODO: expose confidence interval from the format
-        final byte bits = 7;
-        final Float confidenceInterval = null;
-        ScalarQuantizer quantizer = mergeAndRecalculateQuantiles(mergeState, fieldInfo, confidenceInterval, bits);
-        return MergedQuantizedVectorValues.mergeQuantizedByteVectorValues(fieldInfo, mergeState, quantizer);
     }
 
     private void writeMeta(

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormatTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormatTests.java
@@ -40,7 +40,7 @@ public class ES92GpuHnswSQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
         var gpuSupport = CuVSGPUSupport.instance();
         assumeTrue("cuvs not supported", gpuSupport.isSupported());
         codec = TestUtil.alwaysKnnVectorsFormat(
-            new ES92GpuHnswSQVectorsFormat(gpuSupport.getTotalGpuMemory(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null, 7, false)
+            new ES92GpuHnswSQVectorsFormat(gpuSupport.getTotalGpuMemory(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, 7, false)
         );
     }
 

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -519,7 +519,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.index.codec.vectors.diskbbq.es94 to org.elasticsearch.test.knn, org.elasticsearch.xpack.diskbbq;
     exports org.elasticsearch.index.codec.vectors.cluster to org.elasticsearch.test.knn;
     exports org.elasticsearch.index.codec.vectors.es93 to org.elasticsearch.test.knn;
-    exports org.elasticsearch.index.codec.vectors.es94 to org.elasticsearch.test.knn, org.elasticsearch.gpu;
+    exports org.elasticsearch.index.codec.vectors.es94; // to org.elasticsearch.test.knn, org.elasticsearch.gpu;
     exports org.elasticsearch.search.crossproject;
     exports org.elasticsearch.index.mapper.blockloader;
     exports org.elasticsearch.index.mapper.blockloader.docvalues;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -519,7 +519,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.index.codec.vectors.diskbbq.es94 to org.elasticsearch.test.knn, org.elasticsearch.xpack.diskbbq;
     exports org.elasticsearch.index.codec.vectors.cluster to org.elasticsearch.test.knn;
     exports org.elasticsearch.index.codec.vectors.es93 to org.elasticsearch.test.knn;
-    exports org.elasticsearch.index.codec.vectors.es94 to org.elasticsearch.test.knn;
+    exports org.elasticsearch.index.codec.vectors.es94 to org.elasticsearch.test.knn, org.elasticsearch.gpu;
     exports org.elasticsearch.search.crossproject;
     exports org.elasticsearch.index.mapper.blockloader;
     exports org.elasticsearch.index.mapper.blockloader.docvalues;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/reflect/VectorsFormatReflectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/reflect/VectorsFormatReflectionUtils.java
@@ -13,20 +13,16 @@ import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
-import org.elasticsearch.index.codec.vectors.Lucene99ScalarQuantizedVectorsWriter;
-import org.elasticsearch.simdvec.QuantizedByteVectorValuesAccess;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
 public class VectorsFormatReflectionUtils {
     private static final VarHandle FLOAT_SUPPLIER_HANDLE;
-    private static final VarHandle BYTE_SUPPLIER_HANDLE;
     private static final VarHandle L99_FLOAT_VECTORS_HANDLE;
     private static final VarHandle DEFAULT_FLOAT_VECTORS_HANDLE;
 
     private static final Class<?> FLAT_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS;
-    private static final Class<?> SCALAR_QUANTIZED_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS;
     private static final Class<?> L99_FLOAT_SCORING_SUPPLIER_CLASS;
     private static final Class<?> DEFAULT_FLOAT_SCORING_SUPPLIER_CLASS;
 
@@ -54,16 +50,6 @@ public class VectorsFormatReflectionUtils {
             lookup = MethodHandles.privateLookupIn(DEFAULT_FLOAT_SCORING_SUPPLIER_CLASS, MethodHandles.lookup());
             DEFAULT_FLOAT_VECTORS_HANDLE = lookup.findVarHandle(DEFAULT_FLOAT_SCORING_SUPPLIER_CLASS, "vectors", FloatVectorValues.class);
 
-            SCALAR_QUANTIZED_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS = Class.forName(
-                Lucene99ScalarQuantizedVectorsWriter.class.getCanonicalName() + "$ScalarQuantizedCloseableRandomVectorScorerSupplier"
-            );
-            lookup = MethodHandles.privateLookupIn(SCALAR_QUANTIZED_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS, MethodHandles.lookup());
-            BYTE_SUPPLIER_HANDLE = lookup.findVarHandle(
-                SCALAR_QUANTIZED_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS,
-                "supplier",
-                RandomVectorScorerSupplier.class
-            );
-
         } catch (IllegalAccessException e) {
             throw new AssertionError("should not happen, check opens", e);
         } catch (ReflectiveOperationException e) {
@@ -74,15 +60,6 @@ public class VectorsFormatReflectionUtils {
     public static RandomVectorScorerSupplier getFlatRandomVectorScorerInnerSupplier(CloseableRandomVectorScorerSupplier scorerSupplier) {
         if (scorerSupplier.getClass().equals(FLAT_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS)) {
             return (RandomVectorScorerSupplier) FLOAT_SUPPLIER_HANDLE.get(scorerSupplier);
-        }
-        return null;
-    }
-
-    public static RandomVectorScorerSupplier getScalarQuantizedRandomVectorScorerInnerSupplier(
-        CloseableRandomVectorScorerSupplier scorerSupplier
-    ) {
-        if (scorerSupplier.getClass().equals(SCALAR_QUANTIZED_CLOSEABLE_RANDOM_VECTOR_SCORER_SUPPLIER_CLASS)) {
-            return (RandomVectorScorerSupplier) BYTE_SUPPLIER_HANDLE.get(scorerSupplier);
         }
         return null;
     }
@@ -98,13 +75,6 @@ public class VectorsFormatReflectionUtils {
             if (vectorValues instanceof HasIndexSlice indexSlice) {
                 return indexSlice;
             }
-        }
-        return null;
-    }
-
-    public static HasIndexSlice getByteScoringSupplierVectorOrNull(RandomVectorScorerSupplier scorerSupplier) {
-        if (scorerSupplier instanceof QuantizedByteVectorValuesAccess quantizedByteVectorValuesAccess) {
-            return quantizedByteVectorValuesAccess.get();
         }
         return null;
     }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
@@ -209,14 +209,7 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
             int m = int8HnswIndexOptions.m();
             int gpuM = 2 + m * 2 / 3;
             int gpuEfConstruction = m + m * efConstruction / 256;
-            return new ES92GpuHnswSQVectorsFormat(
-                gpuSupport.getTotalGpuMemory(),
-                gpuM,
-                gpuEfConstruction,
-                int8HnswIndexOptions.confidenceInterval(),
-                7,
-                false
-            );
+            return new ES92GpuHnswSQVectorsFormat(gpuSupport.getTotalGpuMemory(), gpuM, gpuEfConstruction, 7, false);
         } else {
             throw new IllegalArgumentException(
                 "GPU vector indexing is not supported on this vector type: [" + indexOptions.getType() + "]"


### PR DESCRIPTION
Migrate ES92GpuHnswSQVectorsFormat from ES814ScalarQuantized
VectorsFormat (Lucene99/global quantization) to ES94Scalar
QuantizedVectorsFormat (Lucene104/OSQ with per-vector intervals).

With ES94 (Lucene104 OSQ), the scorer supplier returned by                                                                                                                                                          
mergeOneFieldToIndex wraps quantized byte vectors rather than                                                                                                                                                       
raw floats, so the GPU writer cannot extract a raw float vector                                                                                                                                                     
slice from it via reflection. Instead, we merge the raw float                                                                                                                                                       
vector values from the source segments using                                                                                                                                                                        
MergedVectorValues.mergeFloatVectorValues and write them to a
temporary file as contiguous little-endian floats. This temp                                                                                                                                                        
file is then memory-mapped and passed directly to the GPU for
zero-copy index building.
