### PR TITLE
PromQL: Add `days_in_month()` function

### DIFF
--- a/docs/reference/query-languages/promql/kibana/definition/functions/days_in_month.json
+++ b/docs/reference/query-languages/promql/kibana/definition/functions/days_in_month.json
@@ -1,0 +1,25 @@
+{
+  "comment" : "PromQL function definition for Kibana. See https://prometheus.io/docs/prometheus/latest/querying/functions/",
+  "type" : "time",
+  "name" : "days_in_month",
+  "description" : "returns the number of days in the month of each of those timestamps (in UTC)",
+  "signatures" : [
+    {
+      "params" : [
+        {
+          "name" : "v",
+          "type" : "instant_vector",
+          "optional" : true,
+          "description" : "Optional instant vector input. If omitted, evaluation timestamp is used."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "instant_vector"
+    }
+  ],
+  "examples" : [
+    "days_in_month()"
+  ],
+  "preview" : true,
+  "snapshot_only" : false
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -580,6 +580,64 @@ result:double | step:datetime
 0.0           | 2024-05-10T00:00:00.000Z
 ;
 
+days_in_month_may_31
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month());
+
+result:double | step:datetime
+31.0          | 2024-05-10T00:00:00.000Z
+;
+
+days_in_month_april_30
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month(vector(1712574000)));
+
+result:double | step:datetime
+30.0          | 2024-05-10T00:00:00.000Z
+;
+
+days_in_month_february_leap_year
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+// 1707955200 = 2024-02-15T00:00:00Z, leap year
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month(vector(1707955200)));
+
+result:double | step:datetime
+29.0          | 2024-05-10T00:00:00.000Z
+;
+
+days_in_month_february_non_leap_year
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+// 1676419200 = 2023-02-15T00:00:00Z, non-leap year
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month(vector(1676419200)));
+
+result:double | step:datetime
+28.0          | 2024-05-10T00:00:00.000Z
+;
+
+days_in_month_january_31
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+// 1704067200 = 2024-01-01T00:00:00Z
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month(vector(1704067200)));
+
+result:double | step:datetime
+31.0          | 2024-05-10T00:00:00.000Z
+;
+
+days_in_month_june_30
+required_capability: promql_command_v0
+required_capability: promql_days_in_month
+// 1717200000 = 2024-06-01T00:00:00Z
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(days_in_month(vector(1717200000)));
+
+result:double | step:datetime
+30.0          | 2024-05-10T00:00:00.000Z
+;
+
 time_in_arithmetic
 required_capability: promql_command_v0
 required_capability: promql_time

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2606,6 +2606,11 @@ public class EsqlCapabilities {
          */
         PROMQL_TIME_FUNCTIONS,
 
+        /**
+         * Support for PromQL days_in_month() function.
+         */
+        PROMQL_DAYS_IN_MONTH,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/FunctionType.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/FunctionType.java
@@ -92,7 +92,7 @@ public enum FunctionType {
      * <br>
      * Output: Instant vector (timestamp replaced with time component)
      * <p>
-     * Examples: day_of_month(), day_of_week(), hour(), minute(), month(), year(), timestamp()
+     * Examples: day_of_month(), day_of_week(), days_in_month(), hour(), minute(), month(), year(), timestamp()
      */
     TIME_EXTRACTION(PromqlDataType.INSTANT_VECTOR, PromqlDataType.INSTANT_VECTOR),
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlBuiltinFunctionDefinitions.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Scalar;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateExtract;
+import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateUnitCount;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mod;
 
@@ -85,6 +86,24 @@ class PromqlBuiltinFunctionDefinitions {
     static final PromqlFunctionDefinition MINUTE = dateExtraction(ChronoField.MINUTE_OF_HOUR).description(
         "returns the minute of the hour for each of those timestamps (in UTC). Returned values are from 0 to 59."
     ).example("minute()").name("minute");
+
+    static final PromqlFunctionDefinition DAYS_IN_MONTH = PromqlFunctionDefinition.def()
+        .dateTime(
+            (source, date, configuration) -> new ToDouble(
+                source,
+                new DateUnitCount(
+                    source,
+                    Literal.keyword(source, "day"),
+                    Literal.keyword(source, "month"),
+                    date,
+                    configuration.withZoneId(ZoneOffset.UTC)
+                )
+            )
+        )
+        .counterSupport(PromqlFunctionDefinition.CounterSupport.SUPPORTED)
+        .description("returns the number of days in the month of each of those timestamps (in UTC)")
+        .example("days_in_month()")
+        .name("days_in_month");
 
     static final PromqlFunctionDefinition TIME = PromqlFunctionDefinition.def()
         .scalarWithStep((source, step) -> new Div(source, new ToDouble(source, step), Literal.fromDouble(source, 1000.0)))

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -148,6 +148,7 @@ public class PromqlFunctionRegistry {
         PromqlBuiltinFunctionDefinitions.DAY_OF_MONTH,
         PromqlBuiltinFunctionDefinitions.DAY_OF_WEEK,
         PromqlBuiltinFunctionDefinitions.DAY_OF_YEAR,
+        PromqlBuiltinFunctionDefinitions.DAYS_IN_MONTH,
         PromqlBuiltinFunctionDefinitions.HOUR,
         PromqlBuiltinFunctionDefinitions.MINUTE,
         PromqlBuiltinFunctionDefinitions.TIME, };
@@ -190,7 +191,6 @@ public class PromqlFunctionRegistry {
         "sort_desc",
 
         // Time functions
-        "days_in_month",
         "timestamp",
 
         // Label manipulation functions

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -109,6 +109,22 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
         assertTimeExtraction(ctx, "day_of_week", 0.0);
     }
 
+    public void testDaysInMonth() {
+        assertTimeExtraction(ctxAt("2024-05-10T14:30:00Z"), "days_in_month", 31.0);
+        assertTimeExtraction(ctxAt("2024-02-15T00:00:00Z"), "days_in_month", 29.0);
+        assertTimeExtraction(ctxAt("2023-02-15T00:00:00Z"), "days_in_month", 28.0);
+        assertTimeExtraction(ctxAt("2024-04-01T00:00:00Z"), "days_in_month", 30.0);
+    }
+
+    private PromqlFunctionRegistry.PromqlContext ctxAt(String instant) {
+        return new PromqlFunctionRegistry.PromqlContext(
+            Literal.NULL,
+            Literal.NULL,
+            Literal.dateTime(Source.EMPTY, Instant.parse(instant)),
+            EsqlTestUtils.TEST_CFG
+        );
+    }
+
     private void assertTimeExtraction(PromqlFunctionRegistry.PromqlContext ctx, String function, double expected) {
         var expression = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(function, Source.EMPTY, null, ctx, List.of());
         assertThat(function, as(expression.fold(FoldContext.small()), Double.class), equalTo(expected));


### PR DESCRIPTION
Implements PromQL `days_in_month()` function by composing `DateUnitCount("day", "month", date)` from #146003 wrapped in `ToDouble`.

Depends on #146003.