### PR TITLE
Fix failing test after Lucene 10.5 SegmentInfo#toString() change

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -1679,10 +1679,10 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 );
                 mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
-                        "should see segment message including timestamp",
+                        "should see segment message including Lucene SegmentCommitInfo",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.DEBUG,
-                        "loading cluster state from segment: *timestamp=*"
+                        "loading cluster state from segment: *"
                     )
                 );
 


### PR DESCRIPTION
Lucene's `SegmentCommitInfo#toString()` changed in commit `03fc503a` (see https://github.com/apache/lucene/pull/15885) to a less verbose message that no longer includes "timestamp". This causes this test to fail on `lucene_snapshot` branch. The `main` branch doesn't need this yet because it's still on Lucene `10.4` where the aforementioned `toString()` still emits the usual and verbose segment diagnostic that includes the timestamp.