### PR TITLE
ESQL: Do not discard disjunction conditions when is null/is not null might invalidate them (#145941)

### DIFF
--- a/docs/changelog/145941.yaml
+++ b/docs/changelog/145941.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues: []
+pr: 145941
+summary: Do not discard disjunction conditions when is null/is not null might invalidate
+  them
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
@@ -858,3 +858,4 @@ emp_no:integer|gender:keyword
 10008         |M
 10009         |F
 ;
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
@@ -584,3 +584,277 @@ FROM employees | WHERE emp_no IN (10001, null) AND first_name IS NOT NULL | SORT
 emp_no:integer | first_name:keyword
 10001          | Georgi
 ;
+
+// Tests for fix: (a IS NOT NULL OR p) AND a IS NULL must not discard the surviving OR branch p.
+// Without the fix, PropagateNullable.nullify() replaced the entire OR with null, returning 0 rows.
+
+isNullWithOrDisjunctionAllRows
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR emp_no > 10000) AND gender IS NULL
+| STATS c = COUNT(*)
+;
+
+c:long
+10
+;
+
+isNullWithOrDisjunctionSurvivingBranchFilters
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR emp_no > 10015) AND gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender
+;
+
+emp_no:integer|gender:keyword
+10016         |null
+10017         |null
+10018         |null
+10019         |null
+;
+
+isNullWithNestedOrDisjunction
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE emp_no > 10000 AND (gender IS NOT NULL OR languages > 4) AND gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender
+;
+
+emp_no:integer|gender:keyword
+10011         |null
+10012         |null
+10014         |null
+10015         |null
+;
+
+isNullWithIsNullInsideOr
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NULL OR emp_no > 10000) AND gender IS NULL
+| STATS c = COUNT(*)
+;
+
+c:long
+10
+;
+
+isNullWithOrSalaryFilter
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR salary > 50000) AND gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender, salary
+;
+
+emp_no:integer|gender:keyword|salary:integer
+10016         |null          |61358
+10017         |null          |58715
+10018         |null          |56760
+10019         |null          |73717
+;
+
+isNullWithOrLanguageFilter
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR languages > 3) AND gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender, languages
+;
+
+emp_no:integer|gender:keyword|languages:integer
+10010         |null          |4
+10011         |null          |5
+10012         |null          |5
+10014         |null          |5
+10015         |null          |5
+;
+
+isNullWithOrDisjunctionSeparateWhereClauses
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE gender IS NOT NULL OR emp_no > 10015
+| WHERE gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender
+;
+
+emp_no:integer|gender:keyword
+10016         |null
+10017         |null
+10018         |null
+10019         |null
+;
+
+isNullWithOrDisjunctionStatsByLanguage
+required_capability: fix_propagate_nullable_or_disjunction
+required_capability: inline_stats
+
+FROM employees
+| WHERE (gender IS NOT NULL OR languages > 3) AND gender IS NULL
+| INLINE STATS c = COUNT(*) BY languages
+| SORT emp_no
+| KEEP emp_no, gender, languages, c
+;
+
+emp_no:integer|gender:keyword|languages:integer|c:long
+10010         |null          |4                |1
+10011         |null          |5                |4
+10012         |null          |5                |4
+10014         |null          |5                |4
+10015         |null          |5                |4
+;
+
+isNullWithOrThreeBranches
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR emp_no > 10017 OR salary > 60000) AND gender IS NULL
+| SORT emp_no
+| KEEP emp_no, gender, salary
+;
+
+emp_no:integer|gender:keyword|salary:integer
+10016         |null          |61358
+10018         |null          |56760
+10019         |null          |73717
+;
+
+isNullWithOrEvalAlias
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| EVAL g = gender
+| WHERE (g IS NOT NULL OR emp_no > 10015) AND g IS NULL
+| SORT emp_no
+| KEEP emp_no, g
+;
+
+emp_no:integer|g:keyword
+10016         |null
+10017         |null
+10018         |null
+10019         |null
+;
+
+isNullWithOrCompoundAndRangeEvalSeparateWhereClauses
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| EVAL nullable = gender
+| KEEP emp_no, nullable, gender
+| WHERE nullable IS NOT NULL OR (emp_no > 10010 AND emp_no <= 10016)
+| WHERE nullable IS NULL
+| SORT emp_no
+;
+
+emp_no:integer|nullable:keyword|gender:keyword
+10011         |null            |null
+10012         |null            |null
+10013         |null            |null
+10014         |null            |null
+10015         |null            |null
+10016         |null            |null
+;
+
+isNullWithOrDisjunctionMvEvalNull
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE emp_no >= 10009 AND emp_no <= 10015
+| EVAL sc = salary_change + 1
+| WHERE (sc IS NOT NULL OR emp_no > 10011) AND sc IS NULL
+| SORT emp_no
+| KEEP emp_no, salary_change, sc
+;
+warningRegex:Line \d+:\d+: evaluation of \[salary_change \+ 1\] failed, treating result as null\. Only first 20 failures recorded\.
+warningRegex:Line \d+:\d+: java\.lang\.IllegalArgumentException: single-value function encountered multi-value
+
+emp_no:integer|salary_change:double|sc:double
+10013         |null                |null
+10014         |[-1.89, 9.07]       |null
+10015         |[12.4, 14.25]       |null
+;
+
+isNullWithOrDisjunctionMvEvalNullSeparateWhereClauses
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE emp_no >= 10009 AND emp_no <= 10015
+| EVAL sc = salary_change + 1
+| WHERE sc IS NOT NULL OR emp_no > 10011
+| WHERE sc IS NULL
+| SORT emp_no
+| KEEP emp_no, salary_change, sc
+;
+warningRegex:Line \d+:\d+: evaluation of \[salary_change \+ 1\] failed, treating result as null\. Only first 20 failures recorded\.
+warningRegex:Line \d+:\d+: java\.lang\.IllegalArgumentException: single-value function encountered multi-value
+
+emp_no:integer|salary_change:double|sc:double
+10013         |null                |null
+10014         |[-1.89, 9.07]       |null
+10015         |[12.4, 14.25]       |null
+;
+
+isNotNullWithOrDisjunctionSurvivingBranch
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NULL OR emp_no <= 10009) AND gender IS NOT NULL
+| SORT emp_no
+| KEEP emp_no, gender
+;
+
+emp_no:integer|gender:keyword
+10001         |M
+10002         |F
+10003         |M
+10004         |M
+10005         |M
+10006         |F
+10007         |F
+10008         |M
+10009         |F
+;
+
+isNotNullWithIsNotNullInsideOr
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE (gender IS NOT NULL OR emp_no <= 10009) AND gender IS NOT NULL
+| STATS c = COUNT(*)
+;
+
+c:long
+90
+;
+
+isNotNullWithOrDisjunctionSeparateWhereClauses
+required_capability: fix_propagate_nullable_or_disjunction
+
+FROM employees
+| WHERE gender IS NULL OR emp_no <= 10009
+| WHERE gender IS NOT NULL
+| SORT emp_no
+| KEEP emp_no, gender
+;
+
+emp_no:integer|gender:keyword
+10001         |M
+10002         |F
+10003         |M
+10004         |M
+10005         |M
+10006         |F
+10007         |F
+10008         |M
+10009         |F
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -763,3 +763,52 @@ ROW a = 12::long
 _fork:keyword	| x:long
 fork1        	| 12     
 ;
+
+propagateNullableOrDisjunctionUnmappedField
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fix_propagate_nullable_or_disjunction
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| WHERE (foo IS NOT NULL OR emp_no > 10015) AND foo IS NULL
+| STATS c = COUNT(*)
+;
+
+c:long
+85
+;
+
+propagateNullableOrDisjunctionUnmappedFieldSeparateWhereClauses
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fix_propagate_nullable_or_disjunction
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| WHERE foo IS NOT NULL OR emp_no > 10015
+| WHERE foo IS NULL
+| STATS c = COUNT(*)
+;
+
+c:long
+85
+;
+
+propagateNullableOrDisjunctionUnmappedFieldEvalAlias
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fix_propagate_nullable_or_disjunction
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| EVAL x = foo
+| WHERE (x IS NOT NULL OR emp_no > 10095) AND x IS NULL
+| SORT emp_no
+| KEEP emp_no, foo, x
+;
+
+emp_no:integer | foo:null | x:null
+10096          | null     | null
+10097          | null     | null
+10098          | null     | null
+10099          | null     | null
+10100          | null     | null
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1955,6 +1955,17 @@ public class EsqlCapabilities {
 
         KEYWORDS_MV_COUNT_AS_SINGLE_VALUE_FIX,
 
+        /**
+         * Fix for {@code PropagateNullable} incorrectly discarding surviving OR branches when
+         * a field is constrained by {@code IS NULL} or {@code IS NOT NULL} in the same AND conjunction.
+         * Previously {@code (a IS NOT NULL OR p) AND a IS NULL} was optimized to {@code null AND a IS NULL}
+         * (dropping {@code p}); now it correctly becomes {@code p AND a IS NULL}.
+         * Symmetric fix: {@code (a IS NULL OR p) AND a IS NOT NULL} now correctly becomes
+         * {@code p AND a IS NOT NULL} instead of remaining unoptimized.
+         * See https://github.com/elastic/elasticsearch/issues/141579
+         */
+        FIX_PROPAGATE_NULLABLE_OR_DISJUNCTION,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullable.java
@@ -25,8 +25,9 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 // a IS NULL AND a IS NOT NULL -> FALSE
-// a IS NULL AND a > 10 -> a IS NULL and FALSE
-// can be extended to handle null conditions where available
+// a IS NULL AND a > 10 -> a IS NULL AND null > 10 (FoldNull folds to null in the next pass)
+// (a IS NOT NULL OR p) AND a IS NULL -> OR(false, p) AND a IS NULL (BooleanSimplification then yields p AND a IS NULL)
+// (a IS NULL OR p) AND a IS NOT NULL -> OR(false, p) AND a IS NOT NULL (BooleanSimplification then yields p AND a IS NOT NULL)
 public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<And> {
 
     public PropagateNullable() {
@@ -102,19 +103,53 @@ public class PropagateNullable extends OptimizerRules.OptimizerExpressionRule<An
         return modified;
     }
 
-    // placeholder for non-null
     protected Expression nonNullify(Expression exp, Expression nonNullExp) {
-        return exp;
+        return substituteNullability(exp, nonNullExp, false);
     }
 
     protected Expression nullify(Expression exp, Expression nullExp) {
+        Expression base = exp;
         if (exp instanceof Coalesce) {
+            // Remove direct COALESCE arguments that are exactly the null field; the remaining
+            // arguments may still reference the field and are handled by substituteNullability below.
             List<Expression> newChildren = new ArrayList<>(exp.children());
             newChildren.removeIf(e -> e.semanticEquals(nullExp));
             if (newChildren.size() != exp.children().size() && newChildren.size() > 0) { // coalesce needs at least one input
-                return exp.replaceChildren(newChildren);
+                base = exp.replaceChildren(newChildren);
             }
         }
-        return Literal.of(exp, null);
+        return substituteNullability(base, nullExp, true);
+    }
+
+    /**
+     * Substitutes {@code IS NULL} and {@code IS NOT NULL} predicates — and, when the field is known to be {@code NULL},
+     * direct field references — throughout {@code exp}.
+     * <p>
+     * When {@code isNullResult} is {@code true} (field constrained to {@code IS NULL}):
+     * direct field occurrences become {@code null}, {@code IS NULL(field)} becomes {@code true},
+     * {@code IS NOT NULL(field)} becomes {@code false}.
+     * <p>
+     * When {@code isNullResult} is {@code false} (field constrained to {@code IS NOT NULL}):
+     * only the predicate forms are substituted ({@code IS NULL} → {@code false},
+     * {@code IS NOT NULL} → {@code true}); the field value itself is left intact because its
+     * concrete value is unknown.
+     * <p>
+     * This preserves surviving OR branches instead of discarding them. For example:
+     * {@code (a IS NOT NULL OR p) AND a IS NULL} → {@code OR(false, p) AND a IS NULL},
+     * which {@code BooleanSimplification} then reduces to {@code p AND a IS NULL}.
+     */
+    private static Expression substituteNullability(Expression exp, Expression field, boolean isNullResult) {
+        return exp.transformDown(e -> {
+            if (isNullResult && e.semanticEquals(field)) {
+                return Literal.of(e, null);
+            }
+            if (e instanceof IsNull isNull && isNull.field().semanticEquals(field)) {
+                return Literal.of(e, isNullResult);
+            }
+            if (e instanceof IsNotNull isNotNull && isNotNull.field().semanticEquals(field)) {
+                return Literal.of(e, isNullResult == false);
+            }
+            return e;
+        });
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -54,8 +54,10 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.Wild
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLikeList;
 import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
 import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
@@ -762,8 +764,96 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         var source = as(filter.child(), EsRelation.class);
     }
 
-    /*
-     * Limit[1000[INTEGER],false]
+    public void testIsNullFilterDoesNotPruneDisjunctionBranch() {
+        // (nullable IS NOT NULL OR emp_no > 10000) AND nullable IS NULL simplifies to
+        // (emp_no > 10000) AND nullable IS NULL — the surviving OR branch must not be pruned.
+        var plan = localPlan("""
+            FROM test
+            | EVAL nullable = languages
+            | KEEP emp_no, nullable
+            | WHERE nullable IS NOT NULL OR emp_no > 10000
+            | WHERE nullable IS NULL
+            """);
+
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var conjuncts = Predicates.splitAnd(filter.condition());
+        assertThat(conjuncts, hasSize(2));
+
+        var residualBranch = conjuncts.stream()
+            .filter(GreaterThan.class::isInstance)
+            .map(GreaterThan.class::cast)
+            .findFirst()
+            .orElseThrow();
+        var residualField = as(residualBranch.left(), FieldAttribute.class);
+        assertEquals("emp_no", residualField.name());
+
+        var isNull = conjuncts.stream().filter(IsNull.class::isInstance).map(IsNull.class::cast).findFirst().orElseThrow();
+        String nullableName = Expressions.name(isNull.field());
+        assertTrue(
+            "expected nullable field null-check to be preserved",
+            "nullable".equals(nullableName) || "languages".equals(nullableName)
+        );
+        assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
+    }
+
+    public void testIsNullOrDisjunctionWithSeparateWhereClauses() {
+        // Two separate WHERE clauses are merged by PushDownAndCombineFilters into the same pattern,
+        // so the surviving OR branch must also be preserved when the clauses come from different pipes.
+        var plan = localPlan("""
+            FROM test
+            | WHERE gender IS NOT NULL OR emp_no > 10015
+            | WHERE gender IS NULL
+            """);
+
+        var limit = as(plan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var conjuncts = Predicates.splitAnd(filter.condition());
+        assertThat("surviving branch and IS NULL must both be present", conjuncts, hasSize(2));
+
+        assertTrue("expected emp_no GreaterThan conjunct", conjuncts.stream().anyMatch(GreaterThan.class::isInstance));
+        assertTrue("expected gender IS NULL conjunct", conjuncts.stream().anyMatch(IsNull.class::isInstance));
+        assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
+    }
+
+    public void testIsNullOrDisjunctionWithEvalAlias() {
+        // EVAL introduces an alias; PropagateNullable must preserve the surviving OR branch
+        // even when the IS NULL targets an alias rather than a direct field.
+        var plan = localPlan("""
+            FROM test
+            | EVAL g = gender
+            | KEEP emp_no, g
+            | WHERE g IS NOT NULL OR emp_no > 10015
+            | WHERE g IS NULL
+            """);
+
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var conjuncts = Predicates.splitAnd(filter.condition());
+        assertThat("surviving branch and IS NULL must both be present", conjuncts, hasSize(2));
+        assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
+    }
+
+    public void testIsNullOrDisjunctionDoesNotPruneToEmptyRelation() {
+        // A salary-based surviving branch: (gender IS NOT NULL OR salary > 50000) AND gender IS NULL
+        // must keep the salary filter rather than pruning to empty.
+        var plan = localPlan("""
+            FROM test
+            | WHERE (gender IS NOT NULL OR salary > 50000) AND gender IS NULL
+            """);
+
+        var limit = as(plan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        var conjuncts = Predicates.splitAnd(filter.condition());
+        assertThat("surviving branch and IS NULL must both be present", conjuncts, hasSize(2));
+
+        assertTrue("expected salary GreaterThan conjunct", conjuncts.stream().anyMatch(GreaterThan.class::isInstance));
+        assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
+    }
+
+    /*     * Limit[1000[INTEGER],false]
      * \_Filter[RLIKE(first_name{f}#4, "VALÜ*", true)]
      *   \_EsRelation[test][_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
      */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -853,7 +853,8 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         assertThat("local plan should not be pruned to empty", filter.child(), not(instanceOf(LocalRelation.class)));
     }
 
-    /*     * Limit[1000[INTEGER],false]
+    /*
+     * Limit[1000[INTEGER],false]
      * \_Filter[RLIKE(first_name{f}#4, "VALÜ*", true)]
      *   \_EsRelation[test][_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
      */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
@@ -120,8 +120,8 @@ public class PropagateNullableTests extends ESTestCase {
             EMPTY,
             new And(
                 EMPTY,
-                greaterThanOf(new Div(EMPTY, new Add(EMPTY, nullInt, ONE, TEST_CFG), TWO), ONE),
-                greaterThanOf(new Add(EMPTY, nullInt, TWO, TEST_CFG), ONE)
+                greaterThanOf(new Div(EMPTY, new Add(EMPTY, nullInt, ONE), TWO), ONE),
+                greaterThanOf(new Add(EMPTY, nullInt, TWO), ONE)
             ),
             kept
         );
@@ -254,13 +254,13 @@ public class PropagateNullableTests extends ESTestCase {
         FieldAttribute fb = getFieldAttribute("b");
         var isNull = new IsNull(EMPTY, fa);
 
-        var addExpr = new Add(EMPTY, fb, fa, TEST_CFG);
+        var addExpr = new Add(EMPTY, fb, fa);
         var coalesce = new Coalesce(EMPTY, fa, List.of(addExpr));
         var and = new And(EMPTY, coalesce, isNull);
 
         Expression optimized = propagateNullable(and);
 
-        var expectedAdd = new Add(EMPTY, fb, nullOf(INTEGER), TEST_CFG);
+        var expectedAdd = new Add(EMPTY, fb, nullOf(INTEGER));
         var expectedCoalesce = new Coalesce(EMPTY, expectedAdd, List.of());
         assertEquals(new And(EMPTY, expectedCoalesce, isNull), optimized);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
@@ -23,7 +24,8 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TWO;
@@ -35,6 +37,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizer
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 
 public class PropagateNullableTests extends ESTestCase {
     private Expression propagateNullable(And e) {
@@ -70,16 +73,17 @@ public class PropagateNullableTests extends ESTestCase {
         assertEquals(FALSE, propagateNullable(and));
     }
 
-    // a IS NULL AND a > 1 => a IS NULL AND false
+    // a IS NULL AND a > 1 => a IS NULL AND null > 1
+    // (null > 1 folds to null in the next FoldNull pass)
     public void testIsNullAndComparison() {
         FieldAttribute fa = getFieldAttribute();
         IsNull isNull = new IsNull(EMPTY, fa);
 
         And and = new And(EMPTY, isNull, greaterThanOf(fa, ONE));
-        assertEquals(new And(EMPTY, isNull, nullOf(BOOLEAN)), propagateNullable(and));
+        assertEquals(new And(EMPTY, isNull, greaterThanOf(nullOf(INTEGER), ONE)), propagateNullable(and));
     }
 
-    // a IS NULL AND b < 1 AND c < 1 AND a < 1 => a IS NULL AND b < 1 AND c < 1 => a IS NULL AND b < 1 AND c < 1
+    // a IS NULL AND b < 1 AND c < 1 AND a < 1 => a IS NULL AND b < 1 AND c < 1 AND null < 1
     public void testIsNullAndMultipleComparison() {
         FieldAttribute fa = getFieldAttribute();
         IsNull isNull = new IsNull(EMPTY, fa);
@@ -89,11 +93,14 @@ public class PropagateNullableTests extends ESTestCase {
         And top = new And(EMPTY, and, lessThanOf(fa, ONE));
 
         Expression optimized = propagateNullable(top);
-        Expression expected = new And(EMPTY, and, nullOf(BOOLEAN));
+        // "and" (IsNull + LT(b) + LT(c)) is unchanged; LT(fa, ONE) becomes LT(null, ONE)
+        Expression expected = new And(EMPTY, and, lessThanOf(nullOf(INTEGER), ONE));
         assertEquals(Predicates.splitAnd(expected), Predicates.splitAnd(optimized));
     }
 
-    // ((a+1)/2) > 1 AND a + 2 AND a IS NULL AND b < 3 => NULL AND NULL AND a IS NULL AND b < 3
+    // ((a+1)/2) > 1 AND a+2 > 1 AND a IS NULL AND b < 3
+    // => ((null+1)/2) > 1 AND null+2 > 1 AND a IS NULL AND b < 3
+    // (the arithmetic folds to null > 1 in the next FoldNull pass)
     public void testIsNullAndDeeplyNestedExpression() {
         FieldAttribute fa = getFieldAttribute();
         IsNull isNull = new IsNull(EMPTY, fa);
@@ -107,8 +114,17 @@ public class PropagateNullableTests extends ESTestCase {
         And and = new And(EMPTY, nullified, kept);
 
         Expression optimized = propagateNullable(and);
-        Expression expected = new And(EMPTY, new And(EMPTY, nullOf(BOOLEAN), nullOf(BOOLEAN)), kept);
 
+        Literal nullInt = nullOf(INTEGER);
+        Expression expected = new And(
+            EMPTY,
+            new And(
+                EMPTY,
+                greaterThanOf(new Div(EMPTY, new Add(EMPTY, nullInt, ONE, TEST_CFG), TWO), ONE),
+                greaterThanOf(new Add(EMPTY, nullInt, TWO, TEST_CFG), ONE)
+            ),
+            kept
+        );
         assertEquals(Predicates.splitAnd(expected), Predicates.splitAnd(optimized));
     }
 
@@ -141,17 +157,264 @@ public class PropagateNullableTests extends ESTestCase {
         assertEquals(and, propagateNullable(and));
     }
 
-    public void testDoNotOptimizeIsNullAndMultipleComparisonWithConstants() {
+    // IS NULL applied to a constant: LT(ONE, ONE) has both children replaced with null
+    public void testIsNullAndMultipleComparisonWithConstants() {
         Literal a = ONE;
         Literal b = ONE;
+        FieldAttribute c = getFieldAttribute("c");
         IsNull aIsNull = new IsNull(EMPTY, a);
 
-        And bLT1_AND_cLT1 = new And(EMPTY, lessThanOf(b, ONE), lessThanOf(getFieldAttribute("c"), ONE));
+        And bLT1_AND_cLT1 = new And(EMPTY, lessThanOf(b, ONE), lessThanOf(c, ONE));
         And aIsNull_AND_bLT1_AND_cLT1 = new And(EMPTY, aIsNull, bLT1_AND_cLT1);
         And aIsNull_AND_bLT1_AND_cLT1_AND_aLT1 = new And(EMPTY, aIsNull_AND_bLT1_AND_cLT1, lessThanOf(a, ONE));
 
         Expression optimized = propagateNullable(aIsNull_AND_bLT1_AND_cLT1_AND_aLT1);
-        Literal nullLiteral = new Literal(EMPTY, null, BOOLEAN);
-        assertEquals(asList(aIsNull, nullLiteral, nullLiteral, nullLiteral), Predicates.splitAnd(optimized));
+        // ONE occurrences are replaced with null; LT(ONE, ONE) -> LT(null, null), LT(c, ONE) -> LT(c, null)
+        Literal nullInt = nullOf(INTEGER);
+        assertEquals(
+            List.of(aIsNull, lessThanOf(nullInt, nullInt), lessThanOf(c, nullInt), lessThanOf(nullInt, nullInt)),
+            Predicates.splitAnd(optimized)
+        );
+    }
+
+    // (a IS NOT NULL OR b > 1) AND a IS NULL => OR(false, b > 1) AND a IS NULL
+    // BooleanSimplification (next pass) will fold OR(false, b > 1) -> b > 1
+    public void testIsNullPreservesOrDisjunctionBranch() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        Expression gt = greaterThanOf(fb, ONE);
+        var or = new Or(EMPTY, new IsNotNull(EMPTY, fa), gt);
+        var and = new And(EMPTY, or, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var falseLiteral = new Literal(EMPTY, Boolean.FALSE, BOOLEAN);
+        var expectedOr = new Or(EMPTY, falseLiteral, gt);
+        assertEquals(new And(EMPTY, expectedOr, isNull), optimized);
+    }
+
+    // (a IS NULL OR b > 1) AND a IS NULL => OR(true, b > 1) AND a IS NULL
+    // BooleanSimplification (next pass) will fold OR(true, b > 1) -> true -> a IS NULL
+    public void testIsNullPreservesIsNullBranchInOr() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        Expression gt = greaterThanOf(fb, ONE);
+        var or = new Or(EMPTY, new IsNull(EMPTY, fa), gt);
+        var and = new And(EMPTY, or, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var trueLiteral = new Literal(EMPTY, Boolean.TRUE, BOOLEAN);
+        var expectedOr = new Or(EMPTY, trueLiteral, gt);
+        assertEquals(new And(EMPTY, expectedOr, isNull), optimized);
+    }
+
+    // (a > 5 OR b > 1) AND a IS NULL => (null > 5 OR b > 1) AND a IS NULL
+    // FoldNull (next pass) folds null > 5 -> null; BooleanSimplification folds OR(null, b > 1)
+    public void testIsNullNullifiesFieldReferenceInOr() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        Expression gt_b = greaterThanOf(fb, ONE);
+        var or = new Or(EMPTY, greaterThanOf(fa, ONE), gt_b);
+        var and = new And(EMPTY, or, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        Expression expectedOrLeft = greaterThanOf(nullOf(INTEGER), ONE);
+        var expectedOr = new Or(EMPTY, expectedOrLeft, gt_b);
+        assertEquals(new And(EMPTY, expectedOr, isNull), optimized);
+    }
+
+    // COALESCE(a, b) AND a IS NULL => COALESCE(b) AND a IS NULL
+    // Direct arg 'a' is removed from COALESCE; 'b' has no reference to 'a' so transformDown leaves it unchanged.
+    public void testCoalesceDirectArgNullified() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        var coalesce = new Coalesce(EMPTY, fa, List.of(fb));
+        var and = new And(EMPTY, coalesce, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var expectedCoalesce = new Coalesce(EMPTY, fb, List.of());
+        assertEquals(new And(EMPTY, expectedCoalesce, isNull), optimized);
+    }
+
+    // COALESCE(a, b + a) AND a IS NULL => COALESCE(b + null) AND a IS NULL
+    // Direct arg 'a' is removed; the nested 'a' inside 'b + a' is also substituted by transformDown.
+    public void testCoalesceDirectArgNullifiedAndNestedSubstituted() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        var addExpr = new Add(EMPTY, fb, fa, TEST_CFG);
+        var coalesce = new Coalesce(EMPTY, fa, List.of(addExpr));
+        var and = new And(EMPTY, coalesce, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var expectedAdd = new Add(EMPTY, fb, nullOf(INTEGER), TEST_CFG);
+        var expectedCoalesce = new Coalesce(EMPTY, expectedAdd, List.of());
+        assertEquals(new And(EMPTY, expectedCoalesce, isNull), optimized);
+    }
+
+    // COALESCE(a) AND a IS NULL => COALESCE(null) AND a IS NULL
+    // When all direct args match the null field and are removed, the Coalesce branch is skipped
+    // (no surviving children), so transformDown on the original COALESCE(a) substitutes a -> null.
+    public void testCoalesceAllArgsRemovedFallsBackToTransformDown() {
+        FieldAttribute fa = getFieldAttribute();
+        var isNull = new IsNull(EMPTY, fa);
+
+        var coalesce = new Coalesce(EMPTY, fa, List.of());
+        var and = new And(EMPTY, coalesce, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var expectedCoalesce = new Coalesce(EMPTY, nullOf(INTEGER), List.of());
+        assertEquals(new And(EMPTY, expectedCoalesce, isNull), optimized);
+    }
+
+    // (a IS NOT NULL OR (b > 1 AND a > 5)) AND a IS NULL
+    // => OR(false, AND(b > 1, null > 5)) AND a IS NULL
+    // The nested 'a > 5' inside the AND branch is also nullified via transformDown.
+    public void testIsNullInOrWithNestedAndBranch() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        var innerAnd = new And(EMPTY, greaterThanOf(fb, ONE), greaterThanOf(fa, ONE));
+        var or = new Or(EMPTY, new IsNotNull(EMPTY, fa), innerAnd);
+        var and = new And(EMPTY, or, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var expectedInnerAnd = new And(EMPTY, greaterThanOf(fb, ONE), greaterThanOf(nullOf(INTEGER), ONE));
+        var expectedOr = new Or(EMPTY, new Literal(EMPTY, Boolean.FALSE, DataType.BOOLEAN), expectedInnerAnd);
+        assertEquals(new And(EMPTY, expectedOr, isNull), optimized);
+    }
+
+    // (b IS NOT NULL OR c > 1) AND a IS NULL => unchanged
+    // Neither 'b' nor 'c' is 'a', so anyMatch returns false and the OR is not nullified.
+    public void testIsNullDoesNotModifyUnrelatedOrBranch() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        FieldAttribute fc = getFieldAttribute("c");
+        var isNull = new IsNull(EMPTY, fa);
+
+        var or = new Or(EMPTY, new IsNotNull(EMPTY, fb), greaterThanOf(fc, ONE));
+        var and = new And(EMPTY, or, isNull);
+
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // a IS NULL AND b IS NULL AND (a > 1 OR b > 2)
+    // => a IS NULL AND b IS NULL AND (null > 1 OR null > 2)
+    // Both null constraints sequentially substitute their field in the shared OR expression.
+    public void testMultipleIsNullConstraintsNullifyOr() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNullA = new IsNull(EMPTY, fa);
+        var isNullB = new IsNull(EMPTY, fb);
+
+        var or = new Or(EMPTY, greaterThanOf(fa, ONE), greaterThanOf(fb, TWO));
+        var and = new And(EMPTY, isNullA, new And(EMPTY, isNullB, or));
+
+        Expression optimized = propagateNullable(and);
+
+        Literal nullInt = nullOf(INTEGER);
+        var expectedOr = new Or(EMPTY, greaterThanOf(nullInt, ONE), greaterThanOf(nullInt, TWO));
+        assertEquals(List.of(isNullA, isNullB, expectedOr), Predicates.splitAnd(optimized));
+    }
+
+    // --- nonNullify tests (symmetric: field is IS NOT NULL) ---
+
+    // (a IS NULL OR b > 1) AND a IS NOT NULL => OR(false, b > 1) AND a IS NOT NULL
+    // BooleanSimplification (next pass) will fold OR(false, b > 1) -> b > 1
+    public void testIsNotNullPreservesOrDisjunctionBranch() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNotNull = new IsNotNull(EMPTY, fa);
+
+        Expression gt = greaterThanOf(fb, ONE);
+        var or = new Or(EMPTY, new IsNull(EMPTY, fa), gt);
+        var and = new And(EMPTY, or, isNotNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var falseLiteral = new Literal(EMPTY, Boolean.FALSE, BOOLEAN);
+        var expectedOr = new Or(EMPTY, falseLiteral, gt);
+        assertEquals(new And(EMPTY, expectedOr, isNotNull), optimized);
+    }
+
+    // (a IS NOT NULL OR b > 1) AND a IS NOT NULL => OR(true, b > 1) AND a IS NOT NULL
+    // BooleanSimplification (next pass) will fold OR(true, b > 1) -> true, then a IS NOT NULL
+    public void testIsNotNullPreservesIsNotNullBranchInOr() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNotNull = new IsNotNull(EMPTY, fa);
+
+        Expression gt = greaterThanOf(fb, ONE);
+        var or = new Or(EMPTY, new IsNotNull(EMPTY, fa), gt);
+        var and = new And(EMPTY, or, isNotNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var trueLiteral = new Literal(EMPTY, Boolean.TRUE, BOOLEAN);
+        var expectedOr = new Or(EMPTY, trueLiteral, gt);
+        assertEquals(new And(EMPTY, expectedOr, isNotNull), optimized);
+    }
+
+    // a > 1 AND a IS NOT NULL => unchanged
+    // nonNullify does NOT substitute the field value itself; we only know it is non-null.
+    public void testIsNotNullDoesNotSubstituteFieldReference() {
+        FieldAttribute fa = getFieldAttribute();
+        var isNotNull = new IsNotNull(EMPTY, fa);
+
+        var and = new And(EMPTY, greaterThanOf(fa, ONE), isNotNull);
+
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // (b IS NULL OR c > 1) AND a IS NOT NULL => unchanged
+    // Neither 'b' nor 'c' is 'a', so the OR is not touched.
+    public void testIsNotNullDoesNotModifyUnrelatedOrBranch() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        FieldAttribute fc = getFieldAttribute("c");
+        var isNotNull = new IsNotNull(EMPTY, fa);
+
+        var or = new Or(EMPTY, new IsNull(EMPTY, fb), greaterThanOf(fc, ONE));
+        var and = new And(EMPTY, or, isNotNull);
+
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // (a IS NOT NULL OR b > 1 OR c > 2) AND a IS NULL
+    // => OR(false, OR(b > 1, c > 2)) AND a IS NULL
+    // All three OR branches are preserved; IS_NOT_NULL(a) becomes false, the rest unchanged.
+    public void testIsNullInOrWithThreeBranches() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        FieldAttribute fc = getFieldAttribute("c");
+        var isNull = new IsNull(EMPTY, fa);
+
+        Expression gt_b = greaterThanOf(fb, ONE);
+        Expression gt_c = greaterThanOf(fc, TWO);
+        var innerOr = new Or(EMPTY, gt_b, gt_c);
+        var or = new Or(EMPTY, new IsNotNull(EMPTY, fa), innerOr);
+        var and = new And(EMPTY, or, isNull);
+
+        Expression optimized = propagateNullable(and);
+
+        var falseLiteral = new Literal(EMPTY, Boolean.FALSE, DataType.BOOLEAN);
+        var expectedOr = new Or(EMPTY, falseLiteral, innerOr);
+        assertEquals(new And(EMPTY, expectedOr, isNull), optimized);
     }
 }


### PR DESCRIPTION
This is closing (not fixing, because there is no reproduceable use case, nor there is a possible java execution path for that) https://github.com/elastic/elasticsearch/issues/141579. AI-assisted PR.

(cherry picked from commit 038d0b4f45f09523333ba8f20803d39fe84d78eb)
Backports https://github.com/elastic/elasticsearch/pull/145941