### PR TITLE
[ES|QL] approximation: no changepoint before stats (#146038)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/approximation.csv-spec
@@ -60,7 +60,6 @@ count:long | _approximation_confidence_interval(count):long | _approximation_cer
 ;
 
 
-// Does not run as a CSV test, because this needs filter pushdown (of sv!=null)
 Exact total single-valued field count
 required_capability: approximation_v6
 request_stored: skip
@@ -159,7 +158,6 @@ count:long     | count2:long    | countValue:long  | _approximation_confidence_i
 ;
 
 
-// Does not run as a CSV test, because this needs filter pushdown
 Exact count with where on single-valued data
 required_capability: approximation_v6
 request_stored: skip

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/Approximation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/Approximation.java
@@ -138,7 +138,6 @@ public class Approximation {
      */
     static final Set<Class<? extends LogicalPlan>> SUPPORTED_COMMANDS = Set.of(
         Aggregate.class,
-        ChangePoint.class,
         Completion.class,
         Dissect.class,
         Enrich.class,
@@ -171,7 +170,9 @@ public class Approximation {
         // Same for LIMIT BY, SORT, or SORT + LIMIT BY
         LimitBy.class,
         TopN.class,
-        TopNBy.class
+        TopNBy.class,
+        // CHANGE_POINT implicitly uses LIMIT
+        ChangePoint.class
     );
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationTests.java
@@ -32,7 +32,7 @@ public class ApproximationTests extends ApproximationTestCase {
 
     public void testVerify_validQuery() throws Exception {
         verify("FROM test | WHERE emp_no<99 | SORT last_name | MV_EXPAND salary | STATS COUNT() BY gender");
-        verify("FROM test | CHANGE_POINT salary ON emp_no | EVAL x=1 | DROP emp_no | STATS SUM(salary) BY x");
+        verify("FROM test | EVAL x=1 | DROP emp_no | STATS sum=SUM(salary) BY x | CHANGE_POINT sum ON x");
         verify("FROM test | KEEP gender, emp_no | RENAME gender AS whatever | STATS MEDIAN(emp_no) | LIMIT 1000");
         verify("FROM test | EVAL blah=1 | GROK last_name \"%{IP:x}\" | SAMPLE 0.1 | STATS a=COUNT() | LIMIT 100 | SORT a");
         verify("ROW i=[1,2,3] | EVAL x=TO_STRING(i) | DISSECT x \"%{x}\" | STATS i=10*POW(PERCENTILE(i, 0.5), 2) | LIMIT 10");
@@ -120,6 +120,12 @@ public class ApproximationTests extends ApproximationTestCase {
         assertError(
             "FROM test | LIMIT 1000 | STATS COUNT()",
             equalTo("line 1:13: approximation not supported: query with [LIMIT 1000] before [STATS] cannot be approximated")
+        );
+        assertError(
+            "FROM test | CHANGE_POINT salary ON emp_no | EVAL x=1 | DROP emp_no | STATS SUM(salary) BY x",
+            equalTo(
+                "line 1:13: approximation not supported: query with [CHANGE_POINT salary ON emp_no] before [STATS] cannot be approximated"
+            )
         );
     }
 


### PR DESCRIPTION
backport of #146038
