### PR TITLE
Add TimeSeriesCollapse plan nodes

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesCollapse;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.promql.AcrossSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
@@ -79,6 +80,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.core.expression.MetadataAttribute.isTimeSeriesAttributeName;
 import static org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction.withFilter;
@@ -214,6 +216,16 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         plan = applyProjection(promqlCommand, plan);
 
         plan = applyNullOutputFilter(promqlCommand, plan);
+
+        if (promqlCommand.isCollapsed()) {
+            String stepName = promqlCommand.stepColumnName();
+            String valueName = promqlCommand.valueColumnName();
+            List<Attribute> collapseAttributes = plan.output()
+                .stream()
+                .filter(a -> a.name().equals(stepName) || a.name().equals(valueName))
+                .collect(Collectors.toList());
+            plan = new TimeSeriesCollapse(promqlCommand.source(), plan, collapseAttributes);
+        }
 
         return plan;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -224,6 +224,8 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
                 .stream()
                 .filter(a -> a.name().equals(stepName) || a.name().equals(valueName))
                 .collect(Collectors.toList());
+            assert collapseAttributes.size() == 2
+                : "expected step [" + stepName + "] and value [" + valueName + "] in output, found " + collapseAttributes;
             plan = new TimeSeriesCollapse(promqlCommand.source(), plan, collapseAttributes);
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -80,7 +80,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.core.expression.MetadataAttribute.isTimeSeriesAttributeName;
 import static org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction.withFilter;
@@ -220,13 +219,18 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         if (promqlCommand.isCollapsed()) {
             String stepName = promqlCommand.stepColumnName();
             String valueName = promqlCommand.valueColumnName();
-            List<Attribute> collapseAttributes = plan.output()
-                .stream()
-                .filter(a -> a.name().equals(stepName) || a.name().equals(valueName))
-                .collect(Collectors.toList());
-            assert collapseAttributes.size() == 2
-                : "expected step [" + stepName + "] and value [" + valueName + "] in output, found " + collapseAttributes;
-            plan = new TimeSeriesCollapse(promqlCommand.source(), plan, collapseAttributes);
+            Attribute timestamp = null;
+            Attribute value = null;
+            for (Attribute a : plan.output()) {
+                if (a.name().equals(stepName)) {
+                    timestamp = a;
+                } else if (a.name().equals(valueName)) {
+                    value = a;
+                }
+            }
+            assert timestamp != null && value != null
+                : "expected step [" + stepName + "] and value [" + valueName + "] in output " + plan.output();
+            plan = new TimeSeriesCollapse(promqlCommand.source(), plan, timestamp, List.of(value));
         }
 
         return plan;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.SampledAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesCollapse;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
@@ -69,6 +70,7 @@ import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 import org.elasticsearch.xpack.esql.plan.physical.SubqueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesCollapseExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNByExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.TsInfoExec;
@@ -118,6 +120,7 @@ public class PlanWritables {
             SampledAggregate.ENTRY,
             Subquery.ENTRY,
             TimeSeriesAggregate.ENTRY,
+            TimeSeriesCollapse.ENTRY,
             TopN.ENTRY,
             TopNBy.ENTRY,
             UriParts.ENTRY,
@@ -156,6 +159,7 @@ public class PlanWritables {
             ShowExec.ENTRY,
             SubqueryExec.ENTRY,
             TimeSeriesAggregateExec.ENTRY,
+            TimeSeriesCollapseExec.ENTRY,
             TopNExec.ENTRY,
             TopNByExec.ENTRY,
             UriPartsExec.ENTRY,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapse.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Logical plan node that stream-collapses label-contiguous expanded rows into one multi-valued
+ * row per series. The {@code collapseAttributes} columns become multi-valued; all other columns
+ * remain single-valued (dimension/label columns).
+ * <p>
+ * This node is injected by the PromQL translation rules at the top of the translated plan when
+ * {@link org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand#isCollapsed()} is true.
+ * That flag is set either when the user writes {@code TS_COLLAPSE} directly after a {@code PROMQL}
+ * command, or when the Prometheus {@code query_range} plan builder sets it automatically,
+ * enabling {@code PrometheusQueryResponseListener} to read one MV row per series.
+ */
+public class TimeSeriesCollapse extends UnaryPlan {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        LogicalPlan.class,
+        "TimeSeriesCollapse",
+        TimeSeriesCollapse::new
+    );
+
+    private final List<Attribute> collapseAttributes;
+
+    public TimeSeriesCollapse(Source source, LogicalPlan child, List<Attribute> collapseAttributes) {
+        super(source, child);
+        this.collapseAttributes = collapseAttributes;
+    }
+
+    private TimeSeriesCollapse(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteableCollection(collapseAttributes);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    public List<Attribute> collapseAttributes() {
+        return collapseAttributes;
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return child().outputSet();
+    }
+
+    @Override
+    public boolean expressionsResolved() {
+        return collapseAttributes.stream().allMatch(Attribute::resolved);
+    }
+
+    @Override
+    public TimeSeriesCollapse replaceChild(LogicalPlan newChild) {
+        return new TimeSeriesCollapse(source(), newChild, collapseAttributes);
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return child().output();
+    }
+
+    @Override
+    protected NodeInfo<? extends LogicalPlan> info() {
+        return NodeInfo.create(this, TimeSeriesCollapse::new, child(), collapseAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), collapseAttributes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        TimeSeriesCollapse other = (TimeSeriesCollapse) obj;
+        return Objects.equals(collapseAttributes, other.collapseAttributes);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapse.java
@@ -22,8 +22,8 @@ import java.util.Objects;
 
 /**
  * Logical plan node that stream-collapses label-contiguous expanded rows into one multi-valued
- * row per series. The {@code collapseAttributes} columns become multi-valued; all other columns
- * remain single-valued (dimension/label columns).
+ * row per series. The {@code timestamp} column and every column in {@code values} become
+ * multi-valued; all other columns remain single-valued (dimension/label columns).
  * <p>
  * This node is injected by the PromQL translation rules at the top of the translated plan when
  * {@link org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand#isCollapsed()} is true.
@@ -38,17 +38,20 @@ public class TimeSeriesCollapse extends UnaryPlan {
         TimeSeriesCollapse::new
     );
 
-    private final List<Attribute> collapseAttributes;
+    private final Attribute timestamp;
+    private final List<Attribute> values;
 
-    public TimeSeriesCollapse(Source source, LogicalPlan child, List<Attribute> collapseAttributes) {
+    public TimeSeriesCollapse(Source source, LogicalPlan child, Attribute timestamp, List<Attribute> values) {
         super(source, child);
-        this.collapseAttributes = collapseAttributes;
+        this.timestamp = timestamp;
+        this.values = values;
     }
 
     private TimeSeriesCollapse(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(LogicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
             in.readNamedWriteableCollectionAsList(Attribute.class)
         );
     }
@@ -57,7 +60,8 @@ public class TimeSeriesCollapse extends UnaryPlan {
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
         out.writeNamedWriteable(child());
-        out.writeNamedWriteableCollection(collapseAttributes);
+        out.writeNamedWriteable(timestamp);
+        out.writeNamedWriteableCollection(values);
     }
 
     @Override
@@ -65,8 +69,12 @@ public class TimeSeriesCollapse extends UnaryPlan {
         return ENTRY.name;
     }
 
-    public List<Attribute> collapseAttributes() {
-        return collapseAttributes;
+    public Attribute timestamp() {
+        return timestamp;
+    }
+
+    public List<Attribute> values() {
+        return values;
     }
 
     @Override
@@ -76,12 +84,12 @@ public class TimeSeriesCollapse extends UnaryPlan {
 
     @Override
     public boolean expressionsResolved() {
-        return collapseAttributes.stream().allMatch(Attribute::resolved);
+        return timestamp.resolved() && values.stream().allMatch(Attribute::resolved);
     }
 
     @Override
     public TimeSeriesCollapse replaceChild(LogicalPlan newChild) {
-        return new TimeSeriesCollapse(source(), newChild, collapseAttributes);
+        return new TimeSeriesCollapse(source(), newChild, timestamp, values);
     }
 
     @Override
@@ -91,12 +99,12 @@ public class TimeSeriesCollapse extends UnaryPlan {
 
     @Override
     protected NodeInfo<? extends LogicalPlan> info() {
-        return NodeInfo.create(this, TimeSeriesCollapse::new, child(), collapseAttributes);
+        return NodeInfo.create(this, TimeSeriesCollapse::new, child(), timestamp, values);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), collapseAttributes);
+        return Objects.hash(super.hashCode(), timestamp, values);
     }
 
     @Override
@@ -105,6 +113,6 @@ public class TimeSeriesCollapse extends UnaryPlan {
             return false;
         }
         TimeSeriesCollapse other = (TimeSeriesCollapse) obj;
-        return Objects.equals(collapseAttributes, other.collapseAttributes);
+        return Objects.equals(timestamp, other.timestamp) && Objects.equals(values, other.values);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExec.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Physical plan node corresponding to {@link org.elasticsearch.xpack.esql.plan.logical.TimeSeriesCollapse}.
+ * Produces one multi-valued row per series from tsid-contiguous expanded input.
+ */
+public class TimeSeriesCollapseExec extends UnaryExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "TimeSeriesCollapseExec",
+        TimeSeriesCollapseExec::new
+    );
+
+    private final List<Attribute> collapseAttributes;
+
+    public TimeSeriesCollapseExec(Source source, PhysicalPlan child, List<Attribute> collapseAttributes) {
+        super(source, child);
+        this.collapseAttributes = collapseAttributes;
+    }
+
+    private TimeSeriesCollapseExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteableCollection(collapseAttributes);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    public List<Attribute> collapseAttributes() {
+        return collapseAttributes;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return child().output();
+    }
+
+    @Override
+    protected NodeInfo<TimeSeriesCollapseExec> info() {
+        return NodeInfo.create(this, TimeSeriesCollapseExec::new, child(), collapseAttributes);
+    }
+
+    @Override
+    public TimeSeriesCollapseExec replaceChild(PhysicalPlan newChild) {
+        return new TimeSeriesCollapseExec(source(), newChild, collapseAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child(), collapseAttributes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        TimeSeriesCollapseExec other = (TimeSeriesCollapseExec) obj;
+        return Objects.equals(child(), other.child()) && Objects.equals(collapseAttributes, other.collapseAttributes);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExec.java
@@ -30,17 +30,20 @@ public class TimeSeriesCollapseExec extends UnaryExec {
         TimeSeriesCollapseExec::new
     );
 
-    private final List<Attribute> collapseAttributes;
+    private final Attribute timestamp;
+    private final List<Attribute> values;
 
-    public TimeSeriesCollapseExec(Source source, PhysicalPlan child, List<Attribute> collapseAttributes) {
+    public TimeSeriesCollapseExec(Source source, PhysicalPlan child, Attribute timestamp, List<Attribute> values) {
         super(source, child);
-        this.collapseAttributes = collapseAttributes;
+        this.timestamp = timestamp;
+        this.values = values;
     }
 
     private TimeSeriesCollapseExec(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
             in.readNamedWriteableCollectionAsList(Attribute.class)
         );
     }
@@ -49,7 +52,8 @@ public class TimeSeriesCollapseExec extends UnaryExec {
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
         out.writeNamedWriteable(child());
-        out.writeNamedWriteableCollection(collapseAttributes);
+        out.writeNamedWriteable(timestamp);
+        out.writeNamedWriteableCollection(values);
     }
 
     @Override
@@ -57,8 +61,12 @@ public class TimeSeriesCollapseExec extends UnaryExec {
         return ENTRY.name;
     }
 
-    public List<Attribute> collapseAttributes() {
-        return collapseAttributes;
+    public Attribute timestamp() {
+        return timestamp;
+    }
+
+    public List<Attribute> values() {
+        return values;
     }
 
     @Override
@@ -68,17 +76,17 @@ public class TimeSeriesCollapseExec extends UnaryExec {
 
     @Override
     protected NodeInfo<TimeSeriesCollapseExec> info() {
-        return NodeInfo.create(this, TimeSeriesCollapseExec::new, child(), collapseAttributes);
+        return NodeInfo.create(this, TimeSeriesCollapseExec::new, child(), timestamp, values);
     }
 
     @Override
     public TimeSeriesCollapseExec replaceChild(PhysicalPlan newChild) {
-        return new TimeSeriesCollapseExec(source(), newChild, collapseAttributes);
+        return new TimeSeriesCollapseExec(source(), newChild, timestamp, values);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(child(), collapseAttributes);
+        return Objects.hash(child(), timestamp, values);
     }
 
     @Override
@@ -90,6 +98,6 @@ public class TimeSeriesCollapseExec extends UnaryExec {
             return false;
         }
         TimeSeriesCollapseExec other = (TimeSeriesCollapseExec) obj;
-        return Objects.equals(child(), other.child()) && Objects.equals(collapseAttributes, other.collapseAttributes);
+        return Objects.equals(child(), other.child()) && Objects.equals(timestamp, other.timestamp) && Objects.equals(values, other.values);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -59,6 +59,7 @@ import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator.SourceOperatorFactory;
 import org.elasticsearch.compute.operator.SparklineGenerateEmptyBucketsOperator;
 import org.elasticsearch.compute.operator.StringExtractOperator;
+import org.elasticsearch.compute.operator.TimeSeriesCollapseOperator;
 import org.elasticsearch.compute.operator.TsInfoOperator;
 import org.elasticsearch.compute.operator.exchange.ExchangeSink;
 import org.elasticsearch.compute.operator.exchange.ExchangeSinkOperator.ExchangeSinkOperatorFactory;
@@ -165,6 +166,7 @@ import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 import org.elasticsearch.xpack.esql.plan.physical.SparklineGenerateEmptyBucketsExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesCollapseExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNByExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.TsInfoExec;
@@ -333,6 +335,8 @@ public class LocalExecutionPlanner {
             return planLimit(limit, context);
         } else if (node instanceof MvExpandExec mvExpand) {
             return planMvExpand(mvExpand, context);
+        } else if (node instanceof TimeSeriesCollapseExec tsCollapse) {
+            return planTimeSeriesCollapse(tsCollapse, context);
         } else if (node instanceof RerankExec rerank) {
             return planRerank(rerank, context);
         } else if (node instanceof ChangePointExec changePoint) {
@@ -1541,6 +1545,30 @@ public class LocalExecutionPlanner {
             new MvExpandOperator.Factory(source.layout.get(mvExpandExec.target().id()).channel(), blockSize),
             layout.build()
         );
+    }
+
+    private PhysicalOperation planTimeSeriesCollapse(TimeSeriesCollapseExec collapse, LocalExecutionPlannerContext context) {
+        PhysicalOperation source = plan(collapse.child(), context);
+        Layout layout = source.layout;
+
+        Set<NameId> collapseIds = collapse.collapseAttributes().stream().map(Attribute::id).collect(java.util.stream.Collectors.toSet());
+
+        int[] collapseChannels = collapse.collapseAttributes().stream().mapToInt(a -> layout.get(a.id()).channel()).toArray();
+
+        int[] keyChannels = collapse.output()
+            .stream()
+            .filter(a -> collapseIds.contains(a.id()) == false)
+            .mapToInt(a -> layout.get(a.id()).channel())
+            .toArray();
+
+        int timestampChannel = collapse.collapseAttributes()
+            .stream()
+            .filter(a -> a.dataType() == DataType.DATETIME)
+            .mapToInt(a -> layout.get(a.id()).channel())
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("TimeSeriesCollapseExec has no DATETIME collapse attribute"));
+
+        return source.with(new TimeSeriesCollapseOperator.Factory(keyChannels, collapseChannels, timestampChannel), layout);
     }
 
     private PhysicalOperation planChangePoint(ChangePointExec changePoint, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1552,26 +1552,23 @@ public class LocalExecutionPlanner {
         PhysicalOperation source = plan(collapse.child(), context);
         Layout layout = source.layout;
 
-        List<Attribute> collapseAttributes = collapse.collapseAttributes();
-        int[] collapseChannels = new int[collapseAttributes.size()];
-        Set<NameId> collapseIds = new HashSet<>(collapseAttributes.size());
-        int timestampChannel = -1;
-        for (int i = 0; i < collapseAttributes.size(); i++) {
-            Attribute a = collapseAttributes.get(i);
-            int channel = layout.get(a.id()).channel();
-            collapseChannels[i] = channel;
-            collapseIds.add(a.id());
-            if (a.dataType() == DataType.DATETIME) {
-                timestampChannel = channel;
-            }
-        }
-        if (timestampChannel == -1) {
-            throw new IllegalStateException("TimeSeriesCollapseExec has no DATETIME collapse attribute");
+        List<Attribute> values = collapse.values();
+        int timestampChannel = layout.get(collapse.timestamp().id()).channel();
+        int[] collapseChannels = new int[values.size() + 1];
+        collapseChannels[0] = timestampChannel;
+        Set<NameId> collapsedIds = new HashSet<>(values.size() + 1);
+        collapsedIds.add(collapse.timestamp().id());
+        for (int i = 0; i < values.size(); i++) {
+            Attribute v = values.get(i);
+            collapseChannels[i + 1] = layout.get(v.id()).channel();
+            collapsedIds.add(v.id());
         }
 
+        // keyChannels are the dimension/label columns that stay single-valued across the collapse:
+        // everything in the input that isn't the timestamp or a collapsed value.
         int[] keyChannels = collapse.output()
             .stream()
-            .filter(a -> collapseIds.contains(a.id()) == false)
+            .filter(a -> collapsedIds.contains(a.id()) == false)
             .mapToInt(a -> layout.get(a.id()).channel())
             .toArray();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -182,6 +182,7 @@ import org.elasticsearch.xpack.esql.session.EsqlCCSUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1551,22 +1552,28 @@ public class LocalExecutionPlanner {
         PhysicalOperation source = plan(collapse.child(), context);
         Layout layout = source.layout;
 
-        Set<NameId> collapseIds = collapse.collapseAttributes().stream().map(Attribute::id).collect(java.util.stream.Collectors.toSet());
-
-        int[] collapseChannels = collapse.collapseAttributes().stream().mapToInt(a -> layout.get(a.id()).channel()).toArray();
+        List<Attribute> collapseAttributes = collapse.collapseAttributes();
+        int[] collapseChannels = new int[collapseAttributes.size()];
+        Set<NameId> collapseIds = new HashSet<>(collapseAttributes.size());
+        int timestampChannel = -1;
+        for (int i = 0; i < collapseAttributes.size(); i++) {
+            Attribute a = collapseAttributes.get(i);
+            int channel = layout.get(a.id()).channel();
+            collapseChannels[i] = channel;
+            collapseIds.add(a.id());
+            if (a.dataType() == DataType.DATETIME) {
+                timestampChannel = channel;
+            }
+        }
+        if (timestampChannel == -1) {
+            throw new IllegalStateException("TimeSeriesCollapseExec has no DATETIME collapse attribute");
+        }
 
         int[] keyChannels = collapse.output()
             .stream()
             .filter(a -> collapseIds.contains(a.id()) == false)
             .mapToInt(a -> layout.get(a.id()).channel())
             .toArray();
-
-        int timestampChannel = collapse.collapseAttributes()
-            .stream()
-            .filter(a -> a.dataType() == DataType.DATETIME)
-            .mapToInt(a -> layout.get(a.id()).channel())
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("TimeSeriesCollapseExec has no DATETIME collapse attribute"));
 
         return source.with(new TimeSeriesCollapseOperator.Factory(keyChannels, collapseChannels, timestampChannel), layout);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.plan.logical.SampledAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.SparklineGenerateEmptyBuckets;
 import org.elasticsearch.xpack.esql.plan.logical.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesCollapse;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UriParts;
 import org.elasticsearch.xpack.esql.plan.logical.UserAgent;
@@ -56,6 +57,7 @@ import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 import org.elasticsearch.xpack.esql.plan.physical.SparklineGenerateEmptyBucketsExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesCollapseExec;
 import org.elasticsearch.xpack.esql.plan.physical.UriPartsExec;
 import org.elasticsearch.xpack.esql.plan.physical.UserAgentExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.CompletionExec;
@@ -146,6 +148,10 @@ public class MapperUtils {
 
         if (p instanceof MvExpand mvExpand) {
             return new MvExpandExec(mvExpand.source(), child, mvExpand.target(), mvExpand.expanded());
+        }
+
+        if (p instanceof TimeSeriesCollapse collapse) {
+            return new TimeSeriesCollapseExec(collapse.source(), child, collapse.collapseAttributes());
         }
 
         if (p instanceof ChangePoint changePoint) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
@@ -151,7 +151,7 @@ public class MapperUtils {
         }
 
         if (p instanceof TimeSeriesCollapse collapse) {
-            return new TimeSeriesCollapseExec(collapse.source(), child, collapse.collapseAttributes());
+            return new TimeSeriesCollapseExec(collapse.source(), child, collapse.timestamp(), collapse.values());
         }
 
         if (p instanceof ChangePoint changePoint) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapseSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapseSerializationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TimeSeriesCollapseSerializationTests extends AbstractLogicalPlanSerializationTests<TimeSeriesCollapse> {
+    @Override
+    protected TimeSeriesCollapse createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        List<Attribute> collapseAttributes = randomFieldAttributes(1, 5, false);
+        return new TimeSeriesCollapse(source, child, collapseAttributes);
+    }
+
+    @Override
+    protected TimeSeriesCollapse mutateInstance(TimeSeriesCollapse instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<Attribute> collapseAttributes = instance.collapseAttributes();
+        switch (between(0, 1)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> collapseAttributes = randomValueOtherThan(collapseAttributes, () -> randomFieldAttributes(1, 5, false));
+            default -> throw new IllegalStateException();
+        }
+        return new TimeSeriesCollapse(instance.source(), child, collapseAttributes);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapseSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesCollapseSerializationTests.java
@@ -18,20 +18,23 @@ public class TimeSeriesCollapseSerializationTests extends AbstractLogicalPlanSer
     protected TimeSeriesCollapse createTestInstance() {
         Source source = randomSource();
         LogicalPlan child = randomChild(0);
-        List<Attribute> collapseAttributes = randomFieldAttributes(1, 5, false);
-        return new TimeSeriesCollapse(source, child, collapseAttributes);
+        Attribute timestamp = randomFieldAttributes(1, 1, false).get(0);
+        List<Attribute> values = randomFieldAttributes(1, 5, false);
+        return new TimeSeriesCollapse(source, child, timestamp, values);
     }
 
     @Override
     protected TimeSeriesCollapse mutateInstance(TimeSeriesCollapse instance) throws IOException {
         LogicalPlan child = instance.child();
-        List<Attribute> collapseAttributes = instance.collapseAttributes();
-        switch (between(0, 1)) {
+        Attribute timestamp = instance.timestamp();
+        List<Attribute> values = instance.values();
+        switch (between(0, 2)) {
             case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
-            case 1 -> collapseAttributes = randomValueOtherThan(collapseAttributes, () -> randomFieldAttributes(1, 5, false));
+            case 1 -> timestamp = randomValueOtherThan(timestamp, () -> randomFieldAttributes(1, 1, false).get(0));
+            case 2 -> values = randomValueOtherThan(values, () -> randomFieldAttributes(1, 5, false));
             default -> throw new IllegalStateException();
         }
-        return new TimeSeriesCollapse(instance.source(), child, collapseAttributes);
+        return new TimeSeriesCollapse(instance.source(), child, timestamp, values);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExecSerializationTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+
+public class TimeSeriesCollapseExecSerializationTests extends AbstractPhysicalPlanSerializationTests<TimeSeriesCollapseExec> {
+    @Override
+    protected TimeSeriesCollapseExec createTestInstance() {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(0);
+        List<Attribute> collapseAttributes = randomFieldAttributes(1, 5, false);
+        return new TimeSeriesCollapseExec(source, child, collapseAttributes);
+    }
+
+    @Override
+    protected TimeSeriesCollapseExec mutateInstance(TimeSeriesCollapseExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        List<Attribute> collapseAttributes = instance.collapseAttributes();
+        switch (between(0, 1)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> collapseAttributes = randomValueOtherThan(collapseAttributes, () -> randomFieldAttributes(1, 5, false));
+            default -> throw new IllegalStateException();
+        }
+        return new TimeSeriesCollapseExec(instance.source(), child, collapseAttributes);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesCollapseExecSerializationTests.java
@@ -20,20 +20,23 @@ public class TimeSeriesCollapseExecSerializationTests extends AbstractPhysicalPl
     protected TimeSeriesCollapseExec createTestInstance() {
         Source source = randomSource();
         PhysicalPlan child = randomChild(0);
-        List<Attribute> collapseAttributes = randomFieldAttributes(1, 5, false);
-        return new TimeSeriesCollapseExec(source, child, collapseAttributes);
+        Attribute timestamp = randomFieldAttributes(1, 1, false).get(0);
+        List<Attribute> values = randomFieldAttributes(1, 5, false);
+        return new TimeSeriesCollapseExec(source, child, timestamp, values);
     }
 
     @Override
     protected TimeSeriesCollapseExec mutateInstance(TimeSeriesCollapseExec instance) throws IOException {
         PhysicalPlan child = instance.child();
-        List<Attribute> collapseAttributes = instance.collapseAttributes();
-        switch (between(0, 1)) {
+        Attribute timestamp = instance.timestamp();
+        List<Attribute> values = instance.values();
+        switch (between(0, 2)) {
             case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
-            case 1 -> collapseAttributes = randomValueOtherThan(collapseAttributes, () -> randomFieldAttributes(1, 5, false));
+            case 1 -> timestamp = randomValueOtherThan(timestamp, () -> randomFieldAttributes(1, 1, false).get(0));
+            case 2 -> values = randomValueOtherThan(values, () -> randomFieldAttributes(1, 5, false));
             default -> throw new IllegalStateException();
         }
-        return new TimeSeriesCollapseExec(instance.source(), child, collapseAttributes);
+        return new TimeSeriesCollapseExec(instance.source(), child, timestamp, values);
     }
 
     @Override


### PR DESCRIPTION
Adds the logical and physical plan nodes for `TimeSeriesCollapse`:

- `TimeSeriesCollapse` (logical plan node): unary plan wrapping a `PromqlCommand`; carries the list of attributes to collapse into multi-valued columns
- `TimeSeriesCollapseExec` (physical plan node): mirrors the logical node; wires to `TimeSeriesCollapseOperator.Factory`
- `TranslatePromqlToEsqlPlan`: injects a `TimeSeriesCollapse` node when the `PromqlCommand` has `collapsed=true`
- `LocalExecutionPlanner`: maps `TimeSeriesCollapseExec` to `TimeSeriesCollapseOperator`
- `MapperUtils`: maps `TimeSeriesCollapse` to `TimeSeriesCollapseExec`
- `PlanWritables`: registers serialization entries for both nodes

> [!NOTE]
> Stacked PR. Merge after: #146048, #146049, #146050.

## Stacking order

* #146048
  * #146049
    * #146050
      * #146051 **(this PR)**
        * #146052
          * #146053