### PR TITLE
Switch PromQL pipeline to collapsed MV output

### DIFF
--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListener.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryResponseListener.java
@@ -24,8 +24,6 @@ import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +37,9 @@ import java.util.Map;
  *   <li>{@link QueryMode#INSTANT} — {@code resultType: "vector"}, each series has a single {@code value} pair
  *       (the last sample, since rows arrive ascending by timestamp).</li>
  * </ul>
+ *
+ * <p>The ES|QL PROMQL command runs with {@code collapsed=true}, so each row in the response
+ * represents one complete time series with multi-valued {@code value} and {@code step} columns.
  *
  * @see <a href="https://prometheus.io/docs/prometheus/latest/querying/api/">Prometheus HTTP API</a>
  */
@@ -97,13 +98,13 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
     /**
      * Converts an ES|QL response into a Prometheus-compatible JSON response.
      *
-     * <p>The ES|QL PROMQL command, combined with {@code | EVAL step = TO_LONG(step)}, produces
-     * rows with the following column order (EVAL appends the converted step at the end):
+     * <p>Each row is one collapsed time series produced by {@code TimeSeriesCollapseOperator}.
+     * Column layout (EVAL appends the converted step at the end):
      * <ol>
-     *   <li>Column 0: value ({@code double})</li>
+     *   <li>Column 0: {@code value} ({@code double} or {@code List<Double>}) — one value per step</li>
      *   <li>Columns 1..N-2: either a single {@code _timeseries} keyword column (JSON labels)
-     *       or individual dimension/label columns</li>
-     *   <li>Column N-1 (last): step ({@code long}, epoch milliseconds)</li>
+     *       or individual dimension/label columns (single-valued)</li>
+     *   <li>Column N-1 (last): {@code step} ({@code long} or {@code List<Long>}, epoch milliseconds)</li>
      * </ol>
      */
     static XContentBuilder convertToPrometheusJson(EsqlResponse response, QueryMode mode) throws IOException {
@@ -122,44 +123,78 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
         // Column 1 is either _timeseries (a JSON blob) or the first of the individual dimension columns
         final boolean useSeriesCol = columns.size() > 2 && MetadataAttribute.TIMESERIES.equals(columns.get(DIMENSION_COL_START_IDX).name());
 
-        Map<String, SeriesData> seriesMap = new LinkedHashMap<>();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field("status", "success");
+        builder.startObject("data");
+        builder.field("resultType", mode == QueryMode.RANGE ? "matrix" : "vector");
+        builder.startArray("result");
+        int seriesCount = 0;
         boolean truncated = false;
 
         for (Iterable<Object> row : response.rows()) {
             Object[] values = toArray(row, columns.size());
 
-            String seriesKey;
-            Map<String, String> metric;
+            // Both value and step are multi-valued (one entry per step) due to TimeSeriesCollapse.
+            // A single-step series produces a plain scalar instead of a List.
+            List<Object> valueList = toList(values[VALUE_COL_IDX]);
+            List<Object> stepList = toList(values[stepColIdx]);
 
+            if (valueList == null || stepList == null || valueList.isEmpty()) {
+                continue; // series with no data in range
+            }
+
+            if (seriesCount >= limit) {
+                truncated = true;
+                continue;
+            }
+
+            builder.startObject();
+
+            // metric labels
+            builder.startObject("metric");
             if (useSeriesCol) {
-                seriesKey = values[DIMENSION_COL_START_IDX] != null ? values[DIMENSION_COL_START_IDX].toString() : "{}";
-                metric = null;
+                String seriesJson = values[DIMENSION_COL_START_IDX] != null ? values[DIMENSION_COL_START_IDX].toString() : "{}";
+                writeMetricFromSeriesJson(builder, seriesJson);
             } else {
-                StringBuilder keyBuilder = new StringBuilder();
-                metric = new LinkedHashMap<>();
                 for (int i = DIMENSION_COL_START_IDX; i < stepColIdx; i++) {
-                    String label = columns.get(i).name();
-                    String value = values[i] != null ? values[i].toString() : "";
-                    metric.put(label, value);
-                    keyBuilder.append(label).append('\0').append(value).append('\0');
+                    builder.field(columns.get(i).name(), values[i] != null ? values[i].toString() : "");
                 }
-                seriesKey = keyBuilder.toString();
+            }
+            builder.endObject(); // metric
+
+            if (mode == QueryMode.RANGE) {
+                // values — parallel arrays of (timestamp_seconds, value_string)
+                builder.startArray("values");
+                for (int i = 0; i < valueList.size(); i++) {
+                    builder.startArray();
+                    builder.value(parseTimestamp(stepList.get(i)));
+                    builder.value(formatSampleValue(valueList.get(i)));
+                    builder.endArray();
+                }
+                builder.endArray(); // values
+            } else {
+                // Instant query: emit the last sample (rows arrive in ascending timestamp order)
+                int last = valueList.size() - 1;
+                builder.startArray("value");
+                builder.value(parseTimestamp(stepList.get(last)));
+                builder.value(formatSampleValue(valueList.get(last)));
+                builder.endArray(); // value
             }
 
-            SeriesData series = seriesMap.get(seriesKey);
-            if (series == null) {
-                if (seriesMap.size() >= limit) {
-                    truncated = true;
-                    continue;
-                }
-                series = new SeriesData(useSeriesCol ? seriesKey : null, metric);
-                seriesMap.put(seriesKey, series);
-            }
-            series.values.add(new double[] { parseTimestamp(values[stepColIdx]) });
-            series.stringValues.add(formatSampleValue(values[VALUE_COL_IDX]));
+            builder.endObject(); // result entry
+            seriesCount++;
         }
 
-        return buildSuccessJson(seriesMap, mode, truncated);
+        builder.endArray(); // result
+        builder.endObject(); // data
+        if (truncated) {
+            builder.startArray("warnings");
+            builder.value("results truncated due to limit");
+            builder.endArray();
+        }
+        builder.endObject(); // root
+        return builder;
     }
 
     private static Object[] toArray(Iterable<Object> row, int size) {
@@ -171,6 +206,21 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
             }
         }
         return arr;
+    }
+
+    /**
+     * Converts a single value or {@code List} to a {@code List<Object>}.
+     * Returns {@code null} if {@code value} is {@code null}.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Object> toList(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof List<?> list) {
+            return (List<Object>) list;
+        }
+        return List.of(value);
     }
 
     /**
@@ -203,60 +253,6 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
         return value.toString();
     }
 
-    private static XContentBuilder buildSuccessJson(Map<String, SeriesData> seriesMap, QueryMode mode, boolean truncated)
-        throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        builder.startObject();
-        builder.field("status", "success");
-        builder.startObject("data");
-        builder.field("resultType", mode == QueryMode.RANGE ? "matrix" : "vector");
-        builder.startArray("result");
-
-        for (SeriesData series : seriesMap.values()) {
-            builder.startObject();
-
-            builder.startObject("metric");
-            if (series.rawSeriesJson != null) {
-                writeMetricFromSeriesJson(builder, series.rawSeriesJson);
-            } else if (series.labels != null) {
-                for (Map.Entry<String, String> entry : series.labels.entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue());
-                }
-            }
-            builder.endObject(); // metric
-
-            if (mode == QueryMode.RANGE) {
-                builder.startArray("values");
-                for (int i = 0; i < series.values.size(); i++) {
-                    builder.startArray();
-                    builder.value(series.values.get(i)[0]);
-                    builder.value(series.stringValues.get(i));
-                    builder.endArray();
-                }
-                builder.endArray(); // values
-            } else {
-                // Instant query: emit the last sample (rows arrive ascending by timestamp)
-                int last = series.values.size() - 1;
-                builder.startArray("value");
-                builder.value(series.values.get(last)[0]);
-                builder.value(series.stringValues.get(last));
-                builder.endArray(); // value
-            }
-
-            builder.endObject(); // result entry
-        }
-
-        builder.endArray(); // result
-        builder.endObject(); // data
-        if (truncated) {
-            builder.startArray("warnings");
-            builder.value("results truncated due to limit");
-            builder.endArray();
-        }
-        builder.endObject(); // root
-        return builder;
-    }
-
     /**
      * Writes metric labels from a {@code _timeseries} JSON value.
      * <ul>
@@ -285,18 +281,6 @@ class PrometheusQueryResponseListener implements ActionListener<EsqlQueryRespons
             } else if (entry.getValue() != null) {
                 builder.field(key, entry.getValue().toString());
             }
-        }
-    }
-
-    static class SeriesData {
-        final String rawSeriesJson;
-        final Map<String, String> labels;
-        final List<double[]> values = new ArrayList<>();
-        final List<String> stringValues = new ArrayList<>();
-
-        SeriesData(String rawSeriesJson, Map<String, String> labels) {
-            this.rawSeriesJson = rawSeriesJson;
-            this.labels = labels;
         }
     }
 }

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilder.java
@@ -8,11 +8,9 @@
 package org.elasticsearch.xpack.prometheus.rest;
 
 import org.elasticsearch.xpack.esql.core.expression.Alias;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedTimestamp;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToLong;
 import org.elasticsearch.xpack.esql.parser.PromqlParser;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
@@ -20,7 +18,6 @@ import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.SourceCommand;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
@@ -73,21 +70,27 @@ class PromqlQueryPlanBuilder {
             Literal.NULL,
             Literal.timeDuration(Source.EMPTY, DEFAULT_SCRAPE_INTERVAL),
             PrometheusQueryResponseListener.VALUE_COLUMN,
-            new UnresolvedTimestamp(Source.EMPTY)
+            new UnresolvedTimestamp(Source.EMPTY),
+            true // collapsed: emit tsid-contiguous rows with inline null-fill for MV collapse
         );
 
-        // TO_LONG converts the step datetime to epoch millis, avoiding the need to parse a date string in the response listener.
-        Alias stepAlias = new Alias(Source.EMPTY, promqlCommand.stepColumnName(), new ToLong(Source.EMPTY, promqlCommand.stepAttribute()));
+        // TO_LONG converts the step datetime to epoch millis so the response listener reads Long values directly.
+        // Applied before TimeSeriesCollapse so the MV step column contains Long values.
+        Alias stepAlias = new Alias(
+            Source.EMPTY,
+            promqlCommand.stepColumnName(),
+            new ToLong(
+                Source.EMPTY,
+                promqlCommand.output().stream().filter(a -> a.name().equals(promqlCommand.stepColumnName())).findFirst().get()
+            )
+        );
         // Eval's mergeOutputAttributes drops step(datetime) and appends step_alias(long) at the end,
         // producing [value, ...dimensions, step(long)] — the order the response listener expects.
         Eval eval = new Eval(Source.EMPTY, promqlCommand, List.of(stepAlias));
 
-        // Sort by step (timestamp) ascending so Prometheus clients receive values in chronological order.
-        Attribute stepOutput = stepAlias.toAttribute();
-        Order stepOrder = new Order(Source.EMPTY, stepOutput, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
-        OrderBy orderBy = new OrderBy(Source.EMPTY, eval, List.of(stepOrder));
-
-        return new EsqlStatement(orderBy, List.of());
+        // No OrderBy: steps are chronologically ordered by construction (TimeSeriesAggregationOperator
+        // iterates [minTimestamp, maxTimestamp] forward, and TimeSeriesCollapseOperator preserves order).
+        return new EsqlStatement(eval, List.of());
     }
 
     private static Duration parseStep(Source source, String value) {

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilderTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PromqlQueryPlanBuilderTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.InstantSelector;
@@ -25,12 +24,14 @@ public class PromqlQueryPlanBuilderTests extends ESTestCase {
 
     public void testBuildStatementPlanStructure() {
         EsqlStatement statement = PromqlQueryPlanBuilder.buildStatement("up", "*", "2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z", "15s");
-        assertThat(statement.plan(), instanceOf(OrderBy.class));
-        Eval eval = (Eval) ((OrderBy) statement.plan()).child();
+        // Top-level plan is Eval (no OrderBy — timestamps are chronologically ordered by construction)
+        assertThat(statement.plan(), instanceOf(Eval.class));
+        Eval eval = (Eval) statement.plan();
         assertThat(eval.fields().size(), equalTo(1));
         assertThat(eval.fields().get(0).name(), equalTo("step"));
         assertThat(eval.child(), instanceOf(PromqlCommand.class));
         PromqlCommand promqlCommand = (PromqlCommand) eval.child();
+        assertThat(promqlCommand.isCollapsed(), equalTo(true));
         assertThat(promqlCommand.valueColumnName(), equalTo("value"));
         assertThat(promqlCommand.isRangeQuery(), equalTo(true));
         assertThat(promqlCommand.child(), instanceOf(UnresolvedRelation.class));
@@ -49,9 +50,10 @@ public class PromqlQueryPlanBuilderTests extends ESTestCase {
             "2025-01-01T01:00:00Z",
             "15s"
         );
-        assertThat(statement.plan(), instanceOf(OrderBy.class));
-        Eval eval = (Eval) ((OrderBy) statement.plan()).child();
+        assertThat(statement.plan(), instanceOf(Eval.class));
+        Eval eval = (Eval) statement.plan();
         PromqlCommand promqlCommand = (PromqlCommand) eval.child();
+        assertThat(promqlCommand.isCollapsed(), equalTo(true));
         assertThat(promqlCommand.valueColumnName(), equalTo("value"));
         assertThat(((UnresolvedRelation) promqlCommand.child()).indexPattern().indexPattern(), equalTo("metrics-*"));
         assertThat(promqlCommand.hasTimeRange(), equalTo(true));
@@ -67,8 +69,8 @@ public class PromqlQueryPlanBuilderTests extends ESTestCase {
             "2025-01-01T01:00:00Z",
             "15s"
         );
-        assertThat(statement.plan(), instanceOf(OrderBy.class));
-        Eval eval = (Eval) ((OrderBy) statement.plan()).child();
+        assertThat(statement.plan(), instanceOf(Eval.class));
+        Eval eval = (Eval) statement.plan();
         assertThat(eval.fields().size(), equalTo(1));
         assertThat(eval.fields().get(0).name(), equalTo("step"));
         assertThat(eval.child(), instanceOf(PromqlCommand.class));
@@ -76,10 +78,11 @@ public class PromqlQueryPlanBuilderTests extends ESTestCase {
 
     public void testBuildStatementWithNumericStep() {
         EsqlStatement statement = PromqlQueryPlanBuilder.buildStatement("up", "*", "1735689600", "1735693200", "60");
-        assertThat(statement.plan(), instanceOf(OrderBy.class));
-        Eval eval = (Eval) ((OrderBy) statement.plan()).child();
+        assertThat(statement.plan(), instanceOf(Eval.class));
+        Eval eval = (Eval) statement.plan();
         assertThat(eval.child(), instanceOf(PromqlCommand.class));
         PromqlCommand promqlCommand = (PromqlCommand) eval.child();
+        assertThat(promqlCommand.isCollapsed(), equalTo(true));
         assertThat(((UnresolvedRelation) promqlCommand.child()).indexPattern().indexPattern(), equalTo("*"));
         assertThat(promqlCommand.hasTimeRange(), equalTo(true));
         assertThat(promqlCommand.step().value(), equalTo(Duration.ofSeconds(60)));


### PR DESCRIPTION
`PromqlQueryPlanBuilder` now sets `collapsed=true` on `PromqlCommand`, enabling the `TimeSeriesAggregationOperator` to emit tsid-contiguous rows that are collapsed into one multi-valued row per series by `TimeSeriesCollapseOperator`. The `OrderBy` wrapper is removed since timestamps are chronologically ordered by construction.

`PrometheusQueryRangeResponseListener` is rewritten to read the multi-valued `value` and `step` columns directly from each row (one row = one series), eliminating the `LinkedHashMap` grouping step. The `toList()` helper handles both scalar and `List` values from `EsqlResponse`.

Closes #146054

> [!NOTE]
> Stacked PR. Merge after: #146048, #146049, #146050, #146051, #146052.

## Stacking order

* #146048
  * #146049
    * #146050
      * #146051
        * #146052
          * #146053 **(this PR)**