### PR TITLE
[9.4] Ensure bloom filter is not shared across threads (#146002)

### DIFF
--- a/docs/changelog/146002.yaml
+++ b/docs/changelog/146002.yaml
@@ -1,0 +1,5 @@
+area: Codec
+issues: []
+pr: 146002
+summary: Ensure bloom filter is not shared across threads
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/BloomFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/BloomFilter.java
@@ -9,19 +9,12 @@
 
 package org.elasticsearch.index.codec.bloomfilter;
 
-import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.mapper.IdFieldMapper;
 
-import java.io.Closeable;
 import java.io.IOException;
 
-public interface BloomFilter extends Closeable {
+public interface BloomFilter {
     BloomFilter NO_FILTER = new BloomFilter() {
-        @Override
-        public void close() {
-
-        }
 
         @Override
         public boolean mayContainValue(String field, BytesRef term) {
@@ -60,51 +53,4 @@ public interface BloomFilter extends Closeable {
      */
     double saturation() throws IOException;
 
-    static BloomFilter getBloomFilterForId(SegmentReadState state) throws IOException {
-        var codec = state.segmentInfo.getCodec();
-        final var docValuesProducer = codec.docValuesFormat().fieldsProducer(state);
-        boolean success = false;
-        try {
-            var idFieldInfo = state.fieldInfos.fieldInfo(IdFieldMapper.NAME);
-            assert idFieldInfo != null;
-
-            var binaryDocValuesProducer = docValuesProducer.getBinary(idFieldInfo);
-            if (binaryDocValuesProducer instanceof BloomFilter bloomFilter) {
-                success = true;
-                return new BloomFilter() {
-                    @Override
-                    public boolean mayContainValue(String field, BytesRef term) throws IOException {
-                        return bloomFilter.mayContainValue(field, term);
-                    }
-
-                    @Override
-                    public long sizeInBytes() {
-                        return bloomFilter.sizeInBytes();
-                    }
-
-                    @Override
-                    public void close() throws IOException {
-                        docValuesProducer.close();
-                    }
-
-                    @Override
-                    public double saturation() throws IOException {
-                        return bloomFilter.saturation();
-                    }
-
-                    @Override
-                    public String toString() {
-                        return bloomFilter.toString();
-                    }
-                };
-            } else {
-                docValuesProducer.close();
-                return BloomFilter.NO_FILTER;
-            }
-        } finally {
-            if (success == false) {
-                docValuesProducer.close();
-            }
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/DelegatingBloomFilterFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/DelegatingBloomFilterFieldsProducer.java
@@ -48,13 +48,13 @@ public class DelegatingBloomFilterFieldsProducer extends FieldsProducer {
     };
 
     private final FieldsProducer delegate;
-    private final BloomFilter bloomFilter;
+    private final IdBloomFilterSupplier idBloomFilterSupplier;
     private final LongAdder checks;
     private final LongAdder falsePositives;
 
-    public DelegatingBloomFilterFieldsProducer(FieldsProducer delegate, BloomFilter bloomFilter) {
+    public DelegatingBloomFilterFieldsProducer(FieldsProducer delegate, IdBloomFilterSupplier idBloomFilterSupplier) {
         this.delegate = delegate;
-        this.bloomFilter = bloomFilter;
+        this.idBloomFilterSupplier = idBloomFilterSupplier;
         boolean trace = logger.isTraceEnabled();
         this.checks = trace ? new LongAdder() : NO_OP;
         this.falsePositives = trace ? new LongAdder() : NO_OP;
@@ -65,6 +65,7 @@ public class DelegatingBloomFilterFieldsProducer extends FieldsProducer {
         if (logger.isTraceEnabled() && checks != NO_OP) {
             long totalChecks = checks.sum();
             long totalFalsePositives = falsePositives.sum();
+            var bloomFilter = idBloomFilterSupplier.createBloomFilterInstance();
             logger.trace(
                 "bloom filter [{}]: saturation={} checks={} false_positives={} fpr={}",
                 bloomFilter,
@@ -74,7 +75,7 @@ public class DelegatingBloomFilterFieldsProducer extends FieldsProducer {
                 totalChecks > 0 ? String.format(Locale.ROOT, "%.2e", (double) totalFalsePositives / totalChecks) : "n/a"
             );
         }
-        IOUtils.close(delegate, bloomFilter);
+        IOUtils.close(delegate, idBloomFilterSupplier);
     }
 
     @Override
@@ -91,6 +92,7 @@ public class DelegatingBloomFilterFieldsProducer extends FieldsProducer {
     public Terms terms(String field) throws IOException {
         assert FIELD_NAMES.contains(field) : "Expected one of " + FIELD_NAMES + " but got " + field;
         final Terms terms = delegate.terms(field);
+        final BloomFilter bloomFilter = idBloomFilterSupplier.createBloomFilterInstance();
         return new FilterLeafReader.FilterTerms(terms) {
             @Override
             public TermsEnum iterator() throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormat.java
@@ -889,9 +889,6 @@ public class ES94BloomFilterDocValuesFormat extends DocValuesFormat {
             return null;
         }
 
-        @Override
-        public void close() throws IOException {}
-
         void checkIntegrity() throws IOException {
             checkIntegrityFn.run();
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/IdBloomFilterSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/IdBloomFilterSupplier.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.bloomfilter;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.mapper.IdFieldMapper;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Owns the {@link DocValuesProducer} dedicated to bloom-filter lookups and vends per-caller
+ * {@link BloomFilter} instances from it.
+ *
+ * <p>Thread-safety contract: {@link DocValuesProducer#getBinary} returns a new, independent
+ * {@link org.apache.lucene.index.BinaryDocValues} reader on every call, each backed by its own
+ * I/O buffer. Callers must therefore invoke {@link #createBloomFilterInstance()} once per logical
+ * lookup context (e.g. once per {@link org.apache.lucene.index.TermsEnum} obtained via
+ * {@link org.apache.lucene.index.Terms#iterator()}) and must not share the returned
+ * {@link BloomFilter} across threads. Sharing a single {@link BloomFilter} across threads would
+ * race on the mutable buffer state of its underlying
+ * {@link org.apache.lucene.store.RandomAccessInput}.
+ */
+public class IdBloomFilterSupplier implements Closeable {
+    private final DocValuesProducer docValuesProducer;
+    private final FieldInfo idFieldInfo;
+
+    public IdBloomFilterSupplier(SegmentReadState state) throws IOException {
+        var codec = state.segmentInfo.getCodec();
+        // Erase the segment suffix (used only for reading postings)
+        SegmentReadState segmentReadState = new SegmentReadState(state, "");
+        var idFieldInfo = state.fieldInfos.fieldInfo(IdFieldMapper.NAME);
+        if (idFieldInfo == null) {
+            throw new IllegalStateException(IdFieldMapper.NAME + " field not found");
+        }
+        if (idFieldInfo.getDocValuesType() != DocValuesType.BINARY) {
+            throw new IllegalStateException(IdFieldMapper.NAME + " bloom filter field must be of type binary");
+        }
+
+        this.idFieldInfo = idFieldInfo;
+        this.docValuesProducer = codec.docValuesFormat().fieldsProducer(segmentReadState);
+    }
+
+    /**
+     * Returns a {@link BloomFilter} for the {@code _id} field backed by a freshly obtained
+     * reader from the underlying {@link DocValuesProducer}. Must be called once per lookup
+     * context; the returned instance must not be shared across threads.
+     */
+    public BloomFilter createBloomFilterInstance() throws IOException {
+        var binaryDocValuesProducer = docValuesProducer.getBinary(idFieldInfo);
+        if (binaryDocValuesProducer instanceof BloomFilter bloomFilter) {
+            return bloomFilter;
+        } else {
+            return BloomFilter.NO_FILTER;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(docValuesProducer);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
@@ -18,8 +18,8 @@ import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.index.codec.bloomfilter.BloomFilter;
 import org.elasticsearch.index.codec.bloomfilter.DelegatingBloomFilterFieldsProducer;
+import org.elasticsearch.index.codec.bloomfilter.IdBloomFilterSupplier;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.SyntheticIdField;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
@@ -44,20 +44,21 @@ public class TSDBSyntheticIdPostingsFormat extends PostingsFormat {
     @Override
     public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
         DocValuesProducer docValuesProducer = null;
+        IdBloomFilterSupplier idBloomFilterSupplier = null;
         boolean success = false;
         try {
             var codec = state.segmentInfo.getCodec();
             // Erase the segment suffix (used only for reading postings)
             SegmentReadState segmentReadState = new SegmentReadState(state, "");
 
-            BloomFilter bloomFilter = BloomFilter.getBloomFilterForId(segmentReadState);
             docValuesProducer = codec.docValuesFormat().fieldsProducer(segmentReadState);
             var fieldsProducer = new TSDBSyntheticIdFieldsProducer(state, docValuesProducer);
+            idBloomFilterSupplier = new IdBloomFilterSupplier(state);
             success = true;
-            return new DelegatingBloomFilterFieldsProducer(fieldsProducer, bloomFilter);
+            return new DelegatingBloomFilterFieldsProducer(fieldsProducer, idBloomFilterSupplier);
         } finally {
             if (success == false) {
-                IOUtils.close(docValuesProducer);
+                IOUtils.close(docValuesProducer, idBloomFilterSupplier);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormatTests.java
@@ -260,17 +260,17 @@ public class ES94BloomFilterDocValuesFormatTests extends ESTestCase {
     private void assertBloomFilterTestsPositiveForExistingDocs(IndexWriter writer, List<BytesRef> indexedIds) throws IOException {
         try (var directoryReader = StandardDirectoryReader.open(writer)) {
             for (LeafReaderContext leaf : directoryReader.leaves()) {
-                try (var bloomFilter = getBloomFilter(leaf)) {
-                    // the bloom filter reader is null only if the _id field is not stored during indexing
-                    assertThat(bloomFilter, is(not(nullValue())));
+                var bloomFilter = getBloomFilter(leaf);
+                // the bloom filter reader is null only if the _id field is not stored during indexing
+                assertThat(bloomFilter, is(not(nullValue())));
 
-                    for (BytesRef indexedId : indexedIds) {
-                        assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, indexedId), is(true));
-                    }
-                    assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, new BytesRef("random")), is(oneOf(true, false)));
-
-                    assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, new BytesRef("12345")), is(oneOf(true, false)));
+                for (BytesRef indexedId : indexedIds) {
+                    assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, indexedId), is(true));
                 }
+                assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, new BytesRef("random")), is(oneOf(true, false)));
+
+                assertThat(bloomFilter.mayContainValue(IdFieldMapper.NAME, new BytesRef("12345")), is(oneOf(true, false)));
+
             }
 
             var storedFields = directoryReader.storedFields();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -21,6 +21,8 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -64,11 +66,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.time.FormatNames.STRICT_DATE_OPTIONAL_TIME;
 import static org.elasticsearch.index.mapper.TsidExtractingIdFieldMapper.createSyntheticId;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -476,14 +481,83 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
         });
     }
 
+    public void testConcurrentSeekExactNIOFSDirectory() throws IOException {
+        // We test directly with a NIOFSDirectory since it uses mutable non-thread safe IndexInputs instead of MMap IndexInputs
+        // that are less prone to concurrency issues.
+        doTestConcurrentSeekExact(new NIOFSDirectory(createTempDir()));
+    }
+
+    public void testConcurrentSeekExactRandomDirectory() throws IOException {
+        final var directory = newDirectory();
+        directory.setCheckIndexOnClose(false);
+        doTestConcurrentSeekExact(directory);
+    }
+
+    private void doTestConcurrentSeekExact(Directory directory) throws IOException {
+        runTestWithRandomDocs(directory, 25, 100, (writer, finalDocs) -> {
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat(reader.leaves(), hasSize(1));
+                final var leafReader = reader.leaves().getFirst().reader();
+                final var ids = new ArrayList<>(finalDocs.keySet());
+
+                // N threads each do terms("_id").iterator().seekExact(id), mirroring the
+                // PerThreadIDVersionAndSeqNoLookup pattern: each thread has its own TermsEnum
+                // but all share the same DelegatingBloomFilterFieldsProducer and its underlying BloomFilter.
+                final int numThreads = 16;
+                final int iterationsPerThread = 1_000;
+                final var errors = new CopyOnWriteArrayList<Throwable>();
+                final var startLatch = new CountDownLatch(1);
+                final var doneLatch = new CountDownLatch(numThreads);
+
+                for (int t = 0; t < numThreads; t++) {
+                    final int threadIdx = t;
+                    new Thread(() -> {
+                        try {
+                            final TermsEnum termsEnum = leafReader.terms(IdFieldMapper.NAME).iterator();
+                            startLatch.await();
+                            for (int i = 0; i < iterationsPerThread; i++) {
+                                final BytesRef id = ids.get((i + threadIdx) % ids.size());
+                                termsEnum.seekExact(id);
+                            }
+                        } catch (Throwable e) {
+                            logger.error("unexpected exception", e);
+                            errors.add(e);
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    }, "seek-thread-" + t).start();
+                }
+
+                startLatch.countDown();
+                safeAwait(doneLatch);
+                assertThat(errors, empty());
+            }
+        });
+    }
+
     /**
      * Indexes random documents with synthetic id in a time-series Lucene index.
      *
      * See {@link #runTest(CheckedBiConsumer)}.
      */
     public static void runTestWithRandomDocs(CheckedBiConsumer<IndexWriter, TreeMap<BytesRef, Doc>, IOException> test) throws IOException {
+        final var directory = newDirectory();
+        directory.setCheckIndexOnClose(false);
+        runTestWithRandomDocs(directory, test);
+    }
+
+    public static void runTestWithRandomDocs(Directory directory, CheckedBiConsumer<IndexWriter, TreeMap<BytesRef, Doc>, IOException> test)
+        throws IOException {
+        runTestWithRandomDocs(directory, randomIntBetween(1, 25), randomIntBetween(1, 100), test);
+    }
+
+    private static void runTestWithRandomDocs(
+        Directory directory,
+        int maxHosts,
+        int maxMetricsPerHost,
+        CheckedBiConsumer<IndexWriter, TreeMap<BytesRef, Doc>, IOException> test
+    ) throws IOException {
         final int routing = randomNonNegativeInt();
-        final int maxHosts = randomIntBetween(1, 25);
 
         // Generate a list of unique random documents
         // Note: some documents will be later updated to a newer version so that 1 synthetic term have more than 1 posting (doc)
@@ -491,14 +565,13 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
         for (int host = 0; host < maxHosts; host++) {
             var timestamp = Instant.now();
 
-            int maxMetricsPerHost = randomIntBetween(1, 100);
             for (int metric = 0; metric < maxMetricsPerHost; metric++) {
                 randomDocs.add(new Doc(timestamp.toEpochMilli(), "vm-prod-" + host, "cpu-load", metric, 1, routing));
                 timestamp = timestamp.plus(randomIntBetween(1, 59), randomFrom(ChronoUnit.MILLIS, ChronoUnit.SECONDS, ChronoUnit.MINUTES));
             }
         }
 
-        runTest((writer, parser) -> {
+        runTest(directory, (writer, parser) -> {
             // Last version of docs, keyed by their synthetic id term
             final var finalDocs = new TreeMap<BytesRef, Doc>();
 
@@ -554,18 +627,22 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
      * best way to stay close to the default options of time-series indices, while keeping it light enough for unit tests.
      */
     private static void runTest(CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test) throws IOException {
+        final var directory = newDirectory();
+        // Checking the index on close requires to support Terms#getMin()/getMax() methods on invalid (or incomplete) terms, something
+        // that is not supported in TSDBSyntheticIdFieldsProducer today.
+        //
+        // TODO would be nice to enable check-index-on-close
+        directory.setCheckIndexOnClose(false);
+        runTest(directory, test);
+    }
+
+    private static void runTest(Directory directory, CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test) throws IOException {
         final var indexName = randomIdentifier();
         final var indexSettings = buildIndexSettings(indexName);
         final var mapperService = buildMapperService(indexSettings);
         final var documentParser = buildDocumentParser(mapperService);
 
-        try (var directory = newDirectory()) {
-            // Checking the index on close requires to support Terms#getMin()/getMax() methods on invalid (or incomplete) terms, something
-            // that is not supported in TSDBSyntheticIdFieldsProducer today.
-            //
-            // TODO would be nice to enable check-index-on-close
-            directory.setCheckIndexOnClose(false);
-
+        try (directory) {
             final var indexWriterConfig = newIndexWriterConfig();
             indexWriterConfig.setCodec(
                 new ES93TSDBDefaultCompressionLucene103Codec(


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Ensure bloom filter is not shared across threads (#146002)