### PR TITLE
Remove assertion that throws Error which is not caught by the try/cat…

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContextHelper.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContextHelper.java
@@ -138,7 +138,6 @@ public class SnapshotShardContextHelper {
         } else {
             assert snapshotStatus != null : "only snapshot running locally can receive concurrent abort notification at this stage";
             maybeEnsureNotAborted(snapshotStatus);
-            assert false : shardId + " commit released earlier with status " + snapshotStatus;
             throw new IndexShardSnapshotFailedException(shardId, "commit released while starting snapshot " + snapshotId);
         }
     }


### PR DESCRIPTION
When this assertion is thrown the BlobStoreRepository (line: 3756) doesn't catch the exception and does not abort a snapshot. 

This causes test failures which end up in an inconsistent state.

