### PR TITLE
Add documentation examples for tdigest ES|QL aggregations

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/examples/avg.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/avg.md
@@ -34,4 +34,16 @@ TS exp_histo_sample
 | --- |
 | 0.1666 |
 
+`AVG` can also operate on `tdigest` and casted `histogram` fields, computing the average of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS average = ROUND(AVG(responseTime::tdigest), 4)
+```
+
+| average:double |
+| --- |
+| 0.1666 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/count.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/count.md
@@ -105,4 +105,16 @@ TS exp_histo_sample
 | --- |
 | 8841 |
 
+`COUNT` can also operate on `tdigest` and casted `histogram` fields, returning the total number of values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS cnt = COUNT(responseTime::tdigest)
+```
+
+| cnt:long |
+| --- |
+| 8841 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/max.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/max.md
@@ -34,4 +34,16 @@ TS exp_histo_sample
 | --- |
 | 6.7862 |
 
+`MAX` can also operate on `tdigest` and casted `histogram` fields, returning the maximum of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS maximum = ROUND(MAX(responseTime::tdigest), 4)
+```
+
+| maximum:double |
+| --- |
+| 6.7862 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/median.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/median.md
@@ -34,4 +34,16 @@ TS exp_histo_sample
 | --- |
 | 0.0211 |
 
+`MEDIAN` can also operate on `tdigest` and casted `histogram` fields, approximating the median of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS p50 = ROUND(MEDIAN(responseTime::tdigest), 2)
+```
+
+| p50:double |
+| --- |
+| 0.02 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/min.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/min.md
@@ -34,4 +34,16 @@ TS exp_histo_sample
 | --- |
 | 2.0E-4 |
 
+`MIN` can also operate on `tdigest` and casted `histogram` fields, returning the minimum of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS minimum = ROUND(MIN(responseTime::tdigest), 4)
+```
+
+| minimum:double |
+| --- |
+| 2.0E-4 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/percentile.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/percentile.md
@@ -36,4 +36,16 @@ TS exp_histo_sample
 | --- |
 | 1.0433 |
 
+`PERCENTILE` can also operate on `tdigest` and casted `histogram` fields, approximating the percentile of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS p95 = ROUND(PERCENTILE(responseTime::tdigest, 95), 2)
+```
+
+| p95:double |
+| --- |
+| 0.7 |
+
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/sum.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/sum.md
@@ -34,4 +34,16 @@ TS exp_histo_sample
 | --- |
 | 1472.74 |
 
+`SUM` can also operate on `tdigest` and casted `histogram` fields, computing the sum of the values which were used to construct the digests.
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS total = ROUND(SUM(responseTime::tdigest), 2)
+```
+
+| total:double |
+| --- |
+| 1472.74 |
+
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/avg.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/avg.json
@@ -80,7 +80,8 @@
   "examples" : [
     "FROM employees\n| STATS AVG(height)",
     "FROM employees\n| STATS avg_salary_change = ROUND(AVG(MV_AVG(salary_change)), 10)",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS average = ROUND(AVG(responseTime), 4)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS average = ROUND(AVG(responseTime), 4)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS average = ROUND(AVG(responseTime::tdigest), 4)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/count.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/count.json
@@ -277,7 +277,8 @@
     "FROM employees\n| STATS\n    gte20 = COUNT(*) WHERE height >= 2,\n    lte18 = COUNT(*) WHERE height <= 1.8",
     "ROW mv = [1, 2], n = NULL, t = TRUE, f = FALSE\n| STATS COUNT(mv), COUNT(n), COUNT(t), COUNT(f)",
     "ROW n=1\n| STATS COUNT(n > 0 OR NULL), COUNT(n < 0 OR NULL)",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS cnt = COUNT(responseTime)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS cnt = COUNT(responseTime)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS cnt = COUNT(responseTime::tdigest)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/max.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/max.json
@@ -176,7 +176,8 @@
   "examples" : [
     "FROM employees\n| STATS MAX(languages)",
     "FROM employees\n| STATS max_avg_salary_change = MAX(MV_AVG(salary_change))",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS maximum = ROUND(MAX(responseTime), 4)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS maximum = ROUND(MAX(responseTime), 4)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS maximum = ROUND(MAX(responseTime::tdigest), 4)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/median.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/median.json
@@ -69,7 +69,8 @@
   "examples" : [
     "FROM employees\n| STATS MEDIAN(salary), PERCENTILE(salary, 50)",
     "FROM employees\n| STATS median_max_salary_change = MEDIAN(MV_MAX(salary_change))",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS p50 = ROUND(MEDIAN(responseTime), 4)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS p50 = ROUND(MEDIAN(responseTime), 4)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS p50 = ROUND(MEDIAN(responseTime::tdigest), 2)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/min.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/min.json
@@ -176,7 +176,8 @@
   "examples" : [
     "FROM employees\n| STATS MIN(languages)",
     "FROM employees\n| STATS min_avg_salary_change = MIN(MV_AVG(salary_change))",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS minimum = ROUND(MIN(responseTime), 4)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS minimum = ROUND(MIN(responseTime), 4)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS minimum = ROUND(MIN(responseTime::tdigest), 4)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/percentile.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/percentile.json
@@ -278,7 +278,8 @@
   "examples" : [
     "FROM employees\n| STATS p0 = PERCENTILE(salary,  0)\n     , p50 = PERCENTILE(salary, 50)\n     , p99 = PERCENTILE(salary, 99)",
     "FROM employees\n| STATS p80_max_salary_change = PERCENTILE(MV_MAX(salary_change), 80)",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS p99 = ROUND(PERCENTILE(responseTime, 99), 4)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS p99 = ROUND(PERCENTILE(responseTime, 99), 4)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS p95 = ROUND(PERCENTILE(responseTime::tdigest, 95), 2)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/sum.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/sum.json
@@ -92,7 +92,8 @@
   "examples" : [
     "FROM employees\n| STATS SUM(languages)",
     "FROM employees\n| STATS total_salary_changes = SUM(MV_MAX(salary_change))",
-    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS total = ROUND(SUM(responseTime), 2)"
+    "TS exp_histo_sample\n| WHERE instance == \"instance-0\"\n| STATS total = ROUND(SUM(responseTime), 2)",
+    "TS histogram_timeseries_index\n| WHERE instance == \"instance-0\"\n| STATS total = ROUND(SUM(responseTime::tdigest), 2)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
@@ -801,3 +801,140 @@ TS tdigest_timeseries_index
 time:datetime            | first_count:long | last_count:long
 2025-09-25T00:00:00.000Z | 135              | 142
 ;
+
+// -------------------------------------------------------------------------------
+// Documentation examples for aggregations with tdigest
+// -------------------------------------------------------------------------------
+
+sum for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+
+// tag::sumTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS total = ROUND(SUM(responseTime::tdigest), 2)
+// end::sumTDigestForDocs[]
+;
+
+// tag::sumTDigestForDocs-result[]
+total:double
+1472.74
+// end::sumTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+avg for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+
+// tag::avgTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS average = ROUND(AVG(responseTime::tdigest), 4)
+// end::avgTDigestForDocs[]
+;
+
+// tag::avgTDigestForDocs-result[]
+average:double
+0.1666
+// end::avgTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+min for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+
+// tag::minTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS minimum = ROUND(MIN(responseTime::tdigest), 4)
+// end::minTDigestForDocs[]
+;
+
+// tag::minTDigestForDocs-result[]
+minimum:double
+2.0E-4
+// end::minTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+max for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+
+// tag::maxTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS maximum = ROUND(MAX(responseTime::tdigest), 4)
+// end::maxTDigestForDocs[]
+;
+
+// tag::maxTDigestForDocs-result[]
+maximum:double
+6.7862
+// end::maxTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+median for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: tdigest_median
+required_capability: ts_command_v0
+
+// tag::medianTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS p50 = ROUND(MEDIAN(responseTime::tdigest), 2)
+// end::medianTDigestForDocs[]
+;
+
+// tag::medianTDigestForDocs-result[]
+p50:double
+0.02
+// end::medianTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+percentile for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+
+// tag::percentileTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS p95 = ROUND(PERCENTILE(responseTime::tdigest, 95), 2)
+// end::percentileTDigestForDocs[]
+;
+
+// tag::percentileTDigestForDocs-result[]
+p95:double
+0.7
+// end::percentileTDigestForDocs-result[]
+;
+
+// -------------------------------------------------------------------------------
+
+count for tdigest docs
+required_capability: casting_operator_for_histogram_types
+required_capability: ts_command_v0
+required_capability: count_of_histogram_types
+
+// tag::countTDigestForDocs[]
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS cnt = COUNT(responseTime::tdigest)
+// end::countTDigestForDocs[]
+;
+
+// tag::countTDigestForDocs-result[]
+cnt:long
+8841
+// end::countTDigestForDocs-result[]
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Avg.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Avg.java
@@ -56,6 +56,12 @@ public class Avg extends AggregateFunction implements SurrogateExpression, Aggre
                     + "computing the average of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "avgExpHistoForDocs"
+            ),
+            @Example(
+                description = "`AVG` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "computing the average of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "avgTDigestForDocs"
             ) }
     )
     public Avg(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -81,6 +81,12 @@ public class Count extends AggregateFunction implements ToAggregator, SurrogateE
                     + "returning the total number of values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "countExpHistoForDocs"
+            ),
+            @Example(
+                description = "`COUNT` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "returning the total number of values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "countTDigestForDocs"
             ) }
     )
     public Count(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Max.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Max.java
@@ -81,6 +81,12 @@ public class Max extends AggregateFunction implements ToAggregator, SurrogateExp
                     + "returning the maximum of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "maxExpHistoForDocs"
+            ),
+            @Example(
+                description = "`MAX` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "returning the maximum of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "maxTDigestForDocs"
             ) }
     )
     public Max(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Median.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Median.java
@@ -61,6 +61,12 @@ public class Median extends AggregateFunction implements SurrogateExpression {
                     + "approximating the median of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "medianExpHistoForDocs"
+            ),
+            @Example(
+                description = "`MEDIAN` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "approximating the median of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "medianTDigestForDocs"
             ) }
     )
     public Median(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Min.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Min.java
@@ -81,6 +81,12 @@ public class Min extends AggregateFunction implements ToAggregator, SurrogateExp
                     + "returning the minimum of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "minExpHistoForDocs"
+            ),
+            @Example(
+                description = "`MIN` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "returning the minimum of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "minTDigestForDocs"
             ) }
     )
     public Min(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
@@ -80,6 +80,12 @@ public class Percentile extends NumericAggregate implements SurrogateExpression 
                     + "approximating the percentile of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "percentileExpHistoForDocs"
+            ),
+            @Example(
+                description = "`PERCENTILE` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "approximating the percentile of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "percentileTDigestForDocs"
             ) }
     )
     public Percentile(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sum.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sum.java
@@ -103,6 +103,12 @@ public class Sum extends NumericAggregate implements SurrogateExpression, Transp
                     + "computing the sum of the values which were used to construct the histograms.",
                 file = "exponential_histogram",
                 tag = "sumExpHistoForDocs"
+            ),
+            @Example(
+                description = "`SUM` can also operate on `tdigest` and casted `histogram` fields, "
+                    + "computing the sum of the values which were used to construct the digests.",
+                file = "tdigest",
+                tag = "sumTDigestForDocs"
             ) }
     )
     public Sum(


### PR DESCRIPTION
Follow up for #145872. Adds documentation examples for ES|QL aggregations on `tdigest` / `histogram`.