### PR TITLE
[9.4] Fix flaky GCS ADC fallback test by isolating in own JVM

### DIFF
--- a/modules/repository-gcs/build.gradle
+++ b/modules/repository-gcs/build.gradle
@@ -288,6 +288,20 @@ tasks.register('gcsThirdPartyTest') {
   dependsOn 'yamlRestTest', gcsThirdPartyTest
 }
 
+// Run the ADC fallback test in its own JVM so the DefaultCredentialsProvider singleton
+// (cachedCredentials, checkedComputeEngine) starts with a clean state. Sharing a JVM with
+// other tests causes flaky failures when the singleton is primed before this test runs.
+tasks.named("test").configure {
+  exclude '**/GoogleCloudStorageAdcTests.class'
+}
+
+def gcsAdcTest = tasks.register("gcsAdcTest", Test) {
+  setTestClassesDirs(sourceSets.test.output.classesDirs)
+  setClasspath(sourceSets.test.runtimeClasspath)
+  include '**/GoogleCloudStorageAdcTests.class'
+  environment.remove('GOOGLE_APPLICATION_CREDENTIALS')
+}
+
 tasks.named('check') {
-  dependsOn gcsThirdPartyTest
+  dependsOn gcsThirdPartyTest, gcsAdcTest
 }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageAdcTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageAdcTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.gcs;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
+
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * This test class runs in its own JVM (via the {@code gcsAdcTest} Gradle task) so that the
+ * {@code DefaultCredentialsProvider} singleton starts with a clean state. The singleton caches
+ * credentials and tracks whether the GCE metadata server has been checked; sharing a JVM with
+ * other tests can prime that state and cause flaky failures.
+ */
+public class GoogleCloudStorageAdcTests extends ESTestCase {
+
+    /**
+     * Verifies that when no explicit credentials are configured and no credential files are found,
+     * the GCS service correctly falls back to obtaining credentials from the GCP metadata server
+     * via Application Default Credentials.
+     */
+    public void testApplicationDefaultCredentialsFallbackToComputeEngine() throws IOException {
+        final AtomicBoolean metadataServerContacted = new AtomicBoolean(false);
+
+        // Mock HTTP transport that simulates the GCP metadata server.
+        // DefaultCredentialsProvider uses this transport to detect GCE and obtain tokens
+        // when no file-based credentials are found (File.isFile returns false due to entitlements).
+        final HttpTransportFactory mockMetadataTransportFactory = () -> new HttpTransport() {
+            @Override
+            protected LowLevelHttpRequest buildRequest(String method, String url) {
+                metadataServerContacted.set(true);
+                final byte[] responseBody = url.contains("token")
+                    ? "{\"access_token\":\"test-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}".getBytes(UTF_8)
+                    : new byte[0];
+                return new LowLevelHttpRequest() {
+                    @Override
+                    public void addHeader(String name, String value) {}
+
+                    @Override
+                    public LowLevelHttpResponse execute() {
+                        return new LowLevelHttpResponse() {
+                            @Override
+                            public InputStream getContent() {
+                                return new ByteArrayInputStream(responseBody);
+                            }
+
+                            @Override
+                            public String getContentEncoding() {
+                                return null;
+                            }
+
+                            @Override
+                            public long getContentLength() {
+                                return responseBody.length;
+                            }
+
+                            @Override
+                            public String getContentType() {
+                                return "application/json";
+                            }
+
+                            @Override
+                            public String getStatusLine() {
+                                return "HTTP/1.1 200 OK";
+                            }
+
+                            @Override
+                            public int getStatusCode() {
+                                return 200;
+                            }
+
+                            @Override
+                            public String getReasonPhrase() {
+                                return "OK";
+                            }
+
+                            @Override
+                            public int getHeaderCount() {
+                                return 1;
+                            }
+
+                            @Override
+                            public String getHeaderName(int index) {
+                                return "Metadata-Flavor";
+                            }
+
+                            @Override
+                            public String getHeaderValue(int index) {
+                                return "Google";
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        final var clusterService = ClusterServiceUtils.createClusterService(new DeterministicTaskQueue().getThreadPool());
+
+        // Override createStorageOptions to use our mock transport for Application Default
+        // Credentials, simulating what happens on a GCP VM when no credentials_file is set.
+        final GoogleCloudStorageService service = new GoogleCloudStorageService(clusterService, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            @Override
+            StorageOptions createStorageOptions(
+                GoogleCloudStorageClientSettings gcsClientSettings,
+                HttpTransportOptions httpTransportOptions
+            ) {
+                assertNull("Test expects no explicit credential to be configured", gcsClientSettings.getCredential());
+                try {
+                    return StorageOptions.newBuilder()
+                        .setCredentials(GoogleCredentials.getApplicationDefault(mockMetadataTransportFactory))
+                        .build();
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to obtain Application Default Credentials from mock metadata server", e);
+                }
+            }
+        };
+
+        final Settings settings = Settings.builder()
+            .put(GoogleCloudStorageClientSettings.ENDPOINT_SETTING.getConcreteSettingForNamespace("default").getKey(), "http://unused")
+            .build();
+        service.refreshAndClearCache(GoogleCloudStorageClientSettings.load(settings));
+
+        final var storage = service.client(projectIdForClusterClient(), "default", "repo", new GcsRepositoryStatsCollector());
+        assertThat(storage.getOptions().getCredentials(), notNullValue());
+        assertTrue(
+            "GCP metadata server should have been contacted to obtain Application Default Credentials",
+            metadataServerContacted.get()
+        );
+    }
+
+    private ProjectId projectIdForClusterClient() {
+        return randomBoolean() ? ProjectId.DEFAULT : null;
+    }
+}

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -9,13 +9,7 @@
 
 package org.elasticsearch.repositories.gcs;
 
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.LowLevelHttpRequest;
-import com.google.api.client.http.LowLevelHttpResponse;
-import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.http.HttpTransportOptions;
-import com.google.cloud.storage.StorageOptions;
 
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -37,9 +31,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -48,13 +39,10 @@ import java.security.KeyPairGenerator;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -210,132 +198,6 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
             assertNotSame(repo1Client, repo2Client);
             assertSame(repo1Client, repo1ClientSecondInstance);
         }
-    }
-
-    /**
-     * Verifies that when no explicit credentials are configured and no credential files are found
-     * (either because they genuinely don't exist, or because {@code File.isFile()} returns
-     * {@code false} due to entitlement enforcement), the GCS service correctly falls back to
-     * obtaining credentials from the GCP metadata server via Application Default Credentials.
-     *
-     * <p>This test exercises the code path that was broken when {@code NotEntitledException}
-     * stopped extending {@code AccessControlException}: {@code DefaultCredentialsProvider}
-     * explicitly catches {@code AccessControlException} when checking credential file paths,
-     * silently skipping to the metadata server fallback. When {@code File.isFile()} threw a
-     * {@code NotEntitledException} that no longer extended {@code AccessControlException}, the
-     * exception propagated instead of being swallowed, preventing credential discovery entirely.
-     *
-     * <p>The fix — returning {@code false} from {@code File.isFile()} when access is denied —
-     * causes {@code DefaultCredentialsProvider} to treat the credential file as absent and
-     * naturally fall through to the metadata server. This test documents and protects that path.
-     */
-    public void testApplicationDefaultCredentialsFallbackToComputeEngine() throws IOException {
-        final AtomicBoolean metadataServerContacted = new AtomicBoolean(false);
-
-        // Mock HTTP transport that simulates the GCP metadata server.
-        // DefaultCredentialsProvider uses this transport to detect GCE and obtain tokens
-        // when no file-based credentials are found.
-        final HttpTransportFactory mockMetadataTransportFactory = () -> new HttpTransport() {
-            @Override
-            protected LowLevelHttpRequest buildRequest(String method, String url) {
-                metadataServerContacted.set(true);
-                final byte[] responseBody = url.contains("token")
-                    ? "{\"access_token\":\"test-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}".getBytes(UTF_8)
-                    : new byte[0];
-                return new LowLevelHttpRequest() {
-                    @Override
-                    public void addHeader(String name, String value) {}
-
-                    @Override
-                    public LowLevelHttpResponse execute() {
-                        return new LowLevelHttpResponse() {
-                            @Override
-                            public InputStream getContent() {
-                                return new ByteArrayInputStream(responseBody);
-                            }
-
-                            @Override
-                            public String getContentEncoding() {
-                                return null;
-                            }
-
-                            @Override
-                            public long getContentLength() {
-                                return responseBody.length;
-                            }
-
-                            @Override
-                            public String getContentType() {
-                                return "application/json";
-                            }
-
-                            @Override
-                            public String getStatusLine() {
-                                return "HTTP/1.1 200 OK";
-                            }
-
-                            @Override
-                            public int getStatusCode() {
-                                return 200;
-                            }
-
-                            @Override
-                            public String getReasonPhrase() {
-                                return "OK";
-                            }
-
-                            @Override
-                            public int getHeaderCount() {
-                                return 1;
-                            }
-
-                            @Override
-                            public String getHeaderName(int index) {
-                                return "Metadata-Flavor";
-                            }
-
-                            @Override
-                            public String getHeaderValue(int index) {
-                                return "Google";
-                            }
-                        };
-                    }
-                };
-            }
-        };
-
-        final var clusterService = ClusterServiceUtils.createClusterService(new DeterministicTaskQueue().getThreadPool());
-
-        // Override createStorageOptions to use our mock transport for Application Default
-        // Credentials, simulating what happens on a GCP VM when no credentials_file is set.
-        final GoogleCloudStorageService service = new GoogleCloudStorageService(clusterService, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
-            @Override
-            StorageOptions createStorageOptions(
-                GoogleCloudStorageClientSettings gcsClientSettings,
-                HttpTransportOptions httpTransportOptions
-            ) {
-                assertNull("Test expects no explicit credential to be configured", gcsClientSettings.getCredential());
-                try {
-                    return StorageOptions.newBuilder()
-                        .setCredentials(GoogleCredentials.getApplicationDefault(mockMetadataTransportFactory))
-                        .build();
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to obtain Application Default Credentials from mock metadata server", e);
-                }
-            }
-        };
-
-        final Settings settings = Settings.builder()
-            .put(GoogleCloudStorageClientSettings.ENDPOINT_SETTING.getConcreteSettingForNamespace("default").getKey(), "http://unused")
-            .build();
-        service.refreshAndClearCache(GoogleCloudStorageClientSettings.load(settings));
-
-        final var storage = service.client(projectIdForClusterClient(), "default", "repo", new GcsRepositoryStatsCollector());
-        assertThat(storage.getOptions().getCredentials(), notNullValue());
-        assertTrue(
-            "GCP metadata server should have been contacted to obtain Application Default Credentials",
-            metadataServerContacted.get()
-        );
     }
 
     private byte[] serviceAccountFileContent(String projectId) throws Exception {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -243,9 +243,6 @@ tests:
 - class: org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageIT
   method: testScaleWhileShrinking
   issue: https://github.com/elastic/elasticsearch/issues/145669
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageServiceTests
-  method: testApplicationDefaultCredentialsFallbackToComputeEngine
-  issue: https://github.com/elastic/elasticsearch/issues/145689
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testAverageWriteLoadMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/145855


### PR DESCRIPTION
Backport of #146013 to 9.4.