### PR TITLE
Fix vec_caps_override docs, add native vec logging to benchmarks

### DIFF
--- a/benchmarks/src/main/resources/log4j2-test.properties
+++ b/benchmarks/src/main/resources/log4j2-test.properties
@@ -23,3 +23,7 @@ appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] [%node_name]%marker
 rootLogger.level = error
 rootLogger.appenderRef.console.ref = console
 
+# Show native vector library capabilities during benchmarks
+logger.nativeVec.name = org.elasticsearch.nativeaccess.jdk.JdkVectorLibrary
+logger.nativeVec.level = info
+

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -61,7 +61,9 @@ public final class JdkVectorLibrary implements VectorLibrary {
      * This can be used to force binding to functions from a lower tier (e.g. AVX2 on a AVX-512
      * capable processor), or to disable native functions completely (by passing 0).
      * Usage: {@code -Des.vec_caps_override=1}.
-     * For benchmarks, add {@code --jvmArgsPrepend "-Des.vec_caps_override=..."} to {@code --args}.
+     * For benchmarks, add {@code --jvmArgsPrepend "--add-modules=jdk.incubator.vector -Des.vec_caps_override=..."}
+     * to {@code --args}. Note: {@code --jvmArgsPrepend} on the CLI replaces the {@code @Fork} annotation's
+     * {@code jvmArgsPrepend}, so {@code --add-modules=jdk.incubator.vector} must be included explicitly.
      *
      * @return the caps override value, or -1 if the property is not defined or invalid.
      */


### PR DESCRIPTION
## Summary
- Fix misleading `vec_caps_override` usage documentation in `JdkVectorLibrary` javadoc
- Add `JdkVectorLibrary` INFO logging to benchmark `log4j2-test.properties`

## Problem
JMH's `--jvmArgsPrepend` CLI flag **replaces** the `@Fork` annotation's `jvmArgsPrepend` rather than appending to it. The `@Fork` annotation on vector scorer benchmarks provides `--add-modules=jdk.incubator.vector`. When following the documented usage (`--jvmArgsPrepend "-Des.vec_caps_override=1"`), this strips the `--add-modules` flag, disabling the Panama Vector API entirely. Scoring silently falls back to scalar Java, producing misleadingly slow results that appear to be a valid AVX2 baseline.

## Fix
- Update the javadoc to include `--add-modules=jdk.incubator.vector` in the `--jvmArgsPrepend` example
- Enable `JdkVectorLibrary` INFO logging in benchmarks so the active `vec_caps` level is visible in JMH output, making it easy to verify the override is working

## Test plan
- [x] Run a benchmark with `--jvmArgsPrepend "--add-modules=jdk.incubator.vector -Des.vec_caps_override=1"` and verify `vec_caps=N; es.vec_caps_override=1; using [1]` appears in output