### PR TITLE
[9.4] ESQL: Only fill EsIndex#fieldToUnmappedIndices when unmapped_fields=load

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -85,6 +85,7 @@ import org.elasticsearch.xpack.esql.plan.QuerySettings;
 import org.elasticsearch.xpack.esql.plan.SettingsValidationContext;
 import org.elasticsearch.xpack.esql.plan.logical.Explain;
 import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
+import org.elasticsearch.xpack.esql.plan.logical.Insist;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
@@ -883,8 +884,11 @@ public class EsqlSession {
         ActionListener<Versioned<LogicalPlan>> logicalPlanListener
     ) {
         executionInfo.queryProfile().indicesResolutionMarker().start();
+        // TODO this is a quick hack to alleviate the pressure off of https://github.com/elastic/elasticsearch/issues/145920. A btter
+        // solution would be to just not track the unmapped indices at all, but that requires a more structural change.
+        boolean trackedUnmappedFieldIndices = unmappedResolution == UnmappedResolution.LOAD || parsed.anyMatch(p -> p instanceof Insist);
         SubscribableListener.<PreAnalysisResult>newForked(
-            l -> preAnalyzeMainIndices(preAnalysis, configuration, executionInfo, result, requestFilter, l)
+            l -> preAnalyzeMainIndices(preAnalysis, configuration, executionInfo, trackedUnmappedFieldIndices, result, requestFilter, l)
         ).andThenApply(r -> {
             if (r.indexResolution.isEmpty() == false // Rule out ROW case with no FROM clauses
                 && executionInfo.isCrossClusterSearch()
@@ -1243,6 +1247,7 @@ public class EsqlSession {
         PreAnalyzer.PreAnalysis preAnalysis,
         Configuration configuration,
         EsqlExecutionInfo executionInfo,
+        boolean trackUnmappedFieldIndices,
         PreAnalysisResult result,
         QueryBuilder requestFilter,
         ActionListener<PreAnalysisResult> listener
@@ -1264,7 +1269,16 @@ public class EsqlSession {
             forAll(
                 preAnalysis.indexes().entrySet().iterator(),
                 result,
-                (e, r, l) -> preAnalyzeMainIndices(e.getKey(), e.getValue(), preAnalysis, executionInfo, r, requestFilter, l),
+                (e, r, l) -> preAnalyzeMainIndices(
+                    e.getKey(),
+                    e.getValue(),
+                    preAnalysis,
+                    executionInfo,
+                    trackUnmappedFieldIndices,
+                    r,
+                    requestFilter,
+                    l
+                ),
                 listener
             );
         } else {
@@ -1277,6 +1291,7 @@ public class EsqlSession {
                     configuration.projectRouting(),
                     preAnalysis,
                     executionInfo,
+                    trackUnmappedFieldIndices,
                     r,
                     requestFilter,
                     l
@@ -1291,6 +1306,7 @@ public class EsqlSession {
         IndexMode indexMode,
         PreAnalyzer.PreAnalysis preAnalysis,
         EsqlExecutionInfo executionInfo,
+        boolean trackUnmappedFieldIndices,
         PreAnalysisResult result,
         QueryBuilder requestFilter,
         ActionListener<PreAnalysisResult> listener
@@ -1318,6 +1334,7 @@ public class EsqlSession {
                 preAnalysis.useAggregateMetricDoubleWhenNotSupported(),
                 preAnalysis.useDenseVectorWhenNotSupported(),
                 preAnalysis.hasTimeSeriesAggregation(),
+                trackUnmappedFieldIndices,
                 indicesExpressionGrouper,
                 listener.delegateFailureAndWrap((l, indexResolution) -> {
                     EsqlCCSUtils.updateExecutionInfoWithUnavailableClusters(executionInfo, indexResolution.inner().failures());
@@ -1333,6 +1350,7 @@ public class EsqlSession {
                             preAnalysis.useAggregateMetricDoubleWhenNotSupported(),
                             preAnalysis.useDenseVectorWhenNotSupported(),
                             false,
+                            trackUnmappedFieldIndices,
                             indicesExpressionGrouper,
                             retryListener
                         );
@@ -1348,6 +1366,7 @@ public class EsqlSession {
         String projectRouting,
         PreAnalyzer.PreAnalysis preAnalysis,
         EsqlExecutionInfo executionInfo,
+        boolean trackUnmappedFieldIndices,
         PreAnalysisResult result,
         QueryBuilder requestFilter,
         ActionListener<PreAnalysisResult> listener
@@ -1364,6 +1383,7 @@ public class EsqlSession {
             preAnalysis.useAggregateMetricDoubleWhenNotSupported(),
             preAnalysis.useDenseVectorWhenNotSupported(),
             preAnalysis.hasTimeSeriesAggregation(),
+            trackUnmappedFieldIndices,
             listener.delegateFailureAndWrap((l, indexResolution) -> {
                 EsqlCCSUtils.initCrossClusterState(indexResolution.inner(), executionInfo);
                 EsqlCCSUtils.updateExecutionInfoWithUnavailableClusters(executionInfo, indexResolution.inner().failures());
@@ -1382,6 +1402,7 @@ public class EsqlSession {
                         preAnalysis.useAggregateMetricDoubleWhenNotSupported(),
                         preAnalysis.useDenseVectorWhenNotSupported(),
                         false,
+                        trackUnmappedFieldIndices,
                         retryListener
                     );
                 });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -110,6 +110,7 @@ public class IndexResolver {
             false,
             false,
             false,
+            false,
             DO_NOT_GROUP,
             listener.map(Versioned::inner)
         );
@@ -145,6 +146,7 @@ public class IndexResolver {
         boolean useAggregateMetricDoubleWhenNotSupported,
         boolean useDenseVectorWhenNotSupported,
         boolean hasTimeSeriesAggregation,
+        boolean trackUnmappedFieldIndices,
         IndicesExpressionGrouper indicesExpressionGrouper,
         ActionListener<Versioned<IndexResolution>> listener
     ) {
@@ -156,6 +158,7 @@ public class IndexResolver {
             useAggregateMetricDoubleWhenNotSupported,
             useDenseVectorWhenNotSupported,
             hasTimeSeriesAggregation,
+            trackUnmappedFieldIndices,
             (indexPattern1, fieldCapabilitiesResponse) -> Maps.transformValues(
                 indicesExpressionGrouper.groupIndices(IndicesOptions.DEFAULT, Strings.splitStringByCommaToArray(indexPattern1), false),
                 v -> List.of(v.indices())
@@ -182,6 +185,7 @@ public class IndexResolver {
         // Same as above
         boolean useDenseVectorWhenNotSupported,
         boolean hasTimeSeriesAggregation,
+        boolean trackUnmappedFieldIndices,
         ActionListener<Versioned<IndexResolution>> listener
     ) {
         doResolveIndices(
@@ -192,6 +196,7 @@ public class IndexResolver {
             useAggregateMetricDoubleWhenNotSupported,
             useDenseVectorWhenNotSupported,
             hasTimeSeriesAggregation,
+            trackUnmappedFieldIndices,
             (indexPattern1, fieldCapabilitiesResponse) -> Maps.transformValues(
                 EsqlResolvedIndexExpression.from(fieldCapabilitiesResponse),
                 v -> List.copyOf(v.expression())
@@ -208,6 +213,7 @@ public class IndexResolver {
         boolean useAggregateMetricDoubleWhenNotSupported,
         boolean useDenseVectorWhenNotSupported,
         boolean hasTimeSeriesAggregation,
+        boolean trackUnmappedFieldIndices,
         OriginalIndexExtractor originalIndexExtractor,
         ActionListener<Versioned<IndexResolution>> listener
     ) {
@@ -237,7 +243,10 @@ public class IndexResolver {
             );
 
             l.onResponse(
-                new Versioned<>(mergedMappings(indexPattern, allowEmpty, info, originalIndexExtractor), info.minTransportVersion())
+                new Versioned<>(
+                    mergedMappings(indexPattern, allowEmpty, info, trackUnmappedFieldIndices, originalIndexExtractor),
+                    info.minTransportVersion()
+                )
             );
         }));
     }
@@ -296,6 +305,7 @@ public class IndexResolver {
         String indexPattern,
         boolean allowEmpty,
         FieldsInfo fieldsInfo,
+        boolean trackUnmappedFieldIndices,
         OriginalIndexExtractor originalIndexExtractor
     ) {
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION); // too expensive to run this on a transport worker
@@ -306,18 +316,23 @@ public class IndexResolver {
         }
 
         // For each field name, store a list of the field caps responses from each index
-        var collectedFieldCaps = collectFieldCaps(fieldsInfo.caps);
+        var collectedFieldCaps = collectFieldCaps(fieldsInfo.caps, trackUnmappedFieldIndices);
         Map<String, IndexFieldCapabilitiesWithSourceHash> fieldsCaps = collectedFieldCaps.fieldsCaps;
-        Map<String, Integer> indexMappingHashDuplicates = collectedFieldCaps.indexMappingHashDuplicates;
-        Map<String, Set<String>> fieldToMappedIndices = collectedFieldCaps.fieldToMappedIndices;
-        Set<String> allIndexNames = indexResponses.stream().map(FieldCapabilitiesIndexResponse::getIndexName).collect(Collectors.toSet());
 
         // Build hierarchical fields - it's easier to do it in sorted order so the object fields come first.
         // TODO flattened is simpler - could we get away with that?
         String[] names = fieldsCaps.keySet().toArray(new String[0]);
         Arrays.sort(names);
         Map<String, EsField> rootFields = new HashMap<>();
-        Map<String, Set<String>> fieldToUnmappedIndices = new HashMap<>();
+        Map<String, Set<String>> fieldToUnmappedIndices;
+        Set<String> allIndexNames;
+        if (trackUnmappedFieldIndices) {
+            fieldToUnmappedIndices = new HashMap<>();
+            allIndexNames = indexResponses.stream().map(FieldCapabilitiesIndexResponse::getIndexName).collect(Collectors.toSet());
+        } else {
+            fieldToUnmappedIndices = Map.of();
+            allIndexNames = null;
+        }
         for (String name : names) {
             Map<String, EsField> fields = rootFields;
             String fullName = name;
@@ -354,10 +369,12 @@ public class IndexResolver {
                     new HashMap<>()
                 );
             fields.put(name, field);
-            Set<String> unmappedIndices = new TreeSet<>(allIndexNames);
-            unmappedIndices.removeAll(fieldToMappedIndices.getOrDefault(fullName, Set.of()));
-            if (unmappedIndices.isEmpty() == false) {
-                fieldToUnmappedIndices.put(fullName, unmappedIndices);
+            if (trackUnmappedFieldIndices) {
+                Set<String> unmappedIndices = new TreeSet<>(allIndexNames);
+                unmappedIndices.removeAll(collectedFieldCaps.fieldToMappedIndices.getOrDefault(fullName, Set.of()));
+                if (unmappedIndices.isEmpty() == false) {
+                    fieldToUnmappedIndices.put(fullName, unmappedIndices);
+                }
             }
         }
 
@@ -402,10 +419,10 @@ public class IndexResolver {
         Map<String, Set<String>> fieldToMappedIndices
     ) {}
 
-    private static CollectedFieldCaps collectFieldCaps(FieldCapabilitiesResponse fieldCapsResponse) {
+    private static CollectedFieldCaps collectFieldCaps(FieldCapabilitiesResponse fieldCapsResponse, boolean trackUnmappedFieldIndices) {
         Map<String, Integer> indexMappingHashToDuplicateCount = new HashMap<>();
         Map<String, IndexFieldCapabilitiesWithSourceHash> fieldsCaps = new HashMap<>();
-        Map<String, Set<String>> fieldToMappedIndices = new HashMap<>();
+        Map<String, Set<String>> fieldToMappedIndices = trackUnmappedFieldIndices ? new HashMap<>() : null;
 
         for (FieldCapabilitiesIndexResponse response : fieldCapsResponse.getIndexResponses()) {
             boolean isNew = indexMappingHashToDuplicateCount.compute(response.getIndexMappingHash(), (k, v) -> v == null ? 1 : v + 1) <= 1;
@@ -422,7 +439,9 @@ public class IndexResolver {
                     ).fieldCapabilities;
                     all.add(fc);
                 }
-                fieldToMappedIndices.computeIfAbsent(fc.name(), k -> new HashSet<>()).add(indexName);
+                if (trackUnmappedFieldIndices) {
+                    fieldToMappedIndices.computeIfAbsent(fc.name(), k -> new HashSet<>()).add(indexName);
+                }
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
@@ -150,6 +150,16 @@ public final class AnalyzerTestUtils {
     }
 
     public static IndexResolution mergedResolution(String indexPattern, FieldCapabilitiesResponse caps) {
-        return IndexResolver.mergedMappings(indexPattern, false, fieldsInfoOnCurrentVersion(caps), IndexResolver.DO_NOT_GROUP);
+        return mergedResolution(indexPattern, caps, false);
+    }
+
+    public static IndexResolution mergedResolution(String indexPattern, FieldCapabilitiesResponse caps, boolean trackUnmappedFieldIndices) {
+        return IndexResolver.mergedMappings(
+            indexPattern,
+            false,
+            fieldsInfoOnCurrentVersion(caps),
+            trackUnmappedFieldIndices,
+            IndexResolver.DO_NOT_GROUP
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3352,7 +3352,7 @@ public class AnalyzerTests extends ESTestCase {
             ),
             List.of()
         );
-        IndexResolution resolution = mergedResolution("foo,bar", caps);
+        IndexResolution resolution = mergedResolution("foo,bar", caps, true);
 
         String query = "FROM foo, bar | INSIST_🐔 message";
         var plan = analyzer().addIndex(resolution).query(query);
@@ -3373,7 +3373,7 @@ public class AnalyzerTests extends ESTestCase {
             ),
             List.of()
         );
-        IndexResolution resolution = mergedResolution("foo,bar", caps);
+        IndexResolution resolution = mergedResolution("foo,bar", caps, true);
         var plan = analyzer().addIndex(resolution).query("FROM foo, bar | INSIST_🐔 message");
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
@@ -3396,7 +3396,7 @@ public class AnalyzerTests extends ESTestCase {
             ),
             List.of()
         );
-        IndexResolution resolution = mergedResolution("foo,bar", caps);
+        IndexResolution resolution = mergedResolution("foo,bar", caps, true);
         var plan = analyzer().addIndex(resolution).query("FROM foo, bar | INSIST_🐔 message");
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
@@ -3419,7 +3419,7 @@ public class AnalyzerTests extends ESTestCase {
             ),
             List.of()
         );
-        IndexResolution resolution = mergedResolution("foo,bar", caps);
+        IndexResolution resolution = mergedResolution("foo,bar", caps, true);
         var plan = analyzer().addIndex(resolution).query("FROM foo, bar | INSIST_🐔 message");
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
@@ -3441,6 +3441,7 @@ public class AnalyzerTests extends ESTestCase {
                 "foo",
                 false,
                 new IndexResolver.FieldsInfo(caps, TransportVersion.minimumCompatible(), false, true, true, false),
+                false,
                 IndexResolver.DO_NOT_GROUP
             );
             var plan = analyzer().addIndex(resolution).query("FROM foo");
@@ -3452,6 +3453,7 @@ public class AnalyzerTests extends ESTestCase {
                 "foo",
                 false,
                 new IndexResolver.FieldsInfo(caps, TransportVersion.minimumCompatible(), false, true, false, false),
+                false,
                 IndexResolver.DO_NOT_GROUP
             );
             var plan = analyzer().addIndex(resolution).query("FROM foo");
@@ -3476,6 +3478,7 @@ public class AnalyzerTests extends ESTestCase {
                 "foo",
                 false,
                 new IndexResolver.FieldsInfo(caps, TransportVersion.minimumCompatible(), false, true, true, false),
+                false,
                 IndexResolver.DO_NOT_GROUP
             );
             var plan = analyzer().addIndex(resolution).query("FROM foo");
@@ -3490,6 +3493,7 @@ public class AnalyzerTests extends ESTestCase {
                 "foo",
                 false,
                 new IndexResolver.FieldsInfo(caps, TransportVersion.minimumCompatible(), false, false, true, false),
+                false,
                 IndexResolver.DO_NOT_GROUP
             );
             var plan = analyzer().addIndex(resolution).query("FROM foo");
@@ -3508,6 +3512,7 @@ public class AnalyzerTests extends ESTestCase {
             "test",
             false,
             fieldsInfoOnCurrentVersion(caps, false),
+            false,
             (p, r) -> Map.of()
         );
         var plan = analyzer().addIndex(resolution).query("FROM test | KEEP status");
@@ -3527,6 +3532,7 @@ public class AnalyzerTests extends ESTestCase {
             "test",
             false,
             fieldsInfoOnCurrentVersion(caps, true),
+            false,
             (p, r) -> Map.of()
         );
         assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));
@@ -3545,6 +3551,7 @@ public class AnalyzerTests extends ESTestCase {
             "test",
             false,
             fieldsInfoOnCurrentVersion(caps, false),
+            false,
             (p, r) -> Map.of()
         );
         var plan = analyzer().addIndex(resolution).query("TS test | KEEP status");
@@ -3563,6 +3570,7 @@ public class AnalyzerTests extends ESTestCase {
             "test",
             false,
             fieldsInfoOnCurrentVersion(caps, true),
+            false,
             (p, r) -> Map.of()
         );
         assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));
@@ -3903,6 +3911,7 @@ public class AnalyzerTests extends ESTestCase {
                     List.of()
                 )
             ),
+            false,
             IndexResolver.DO_NOT_GROUP
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -642,7 +642,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar", caps, true));
         for (String suffix : TYPE_CONFLICT_QUERY_SUFFIXES) {
             typeConflictVerificationFailure(setUnmappedLoad("FROM foo, bar " + suffix), resolutions);
         }
@@ -659,7 +659,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps, true));
         for (String suffix : TYPE_CONFLICT_QUERY_SUFFIXES) {
             typeConflictVerificationFailure(setUnmappedLoad("FROM foo, bar, baz " + suffix), resolutions);
         }
@@ -676,7 +676,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps, true));
         for (String suffix : TYPE_CONFLICT_QUERY_SUFFIXES) {
             typeConflictVerificationFailure(setUnmappedLoad("FROM foo, bar, baz " + suffix), resolutions);
         }
@@ -692,7 +692,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar", caps, true));
         for (String suffix : TYPE_CONFLICT_QUERY_SUFFIXES) {
             typeConflictVerificationFailure(setUnmappedLoad("FROM foo, bar " + suffix), resolutions);
         }
@@ -708,7 +708,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar", caps, true));
         TestAnalyzer ta = analyzer();
         for (var entry : resolutions.entrySet()) {
             ta.addIndex(entry.getKey().indexPattern(), entry.getValue());
@@ -731,7 +731,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
             ),
             List.of()
         );
-        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps));
+        var resolutions = indexResolutions(mergedResolution("foo,bar,baz", caps, true));
         TestAnalyzer ta = analyzer();
         for (var entry : resolutions.entrySet()) {
             ta.addIndex(entry.getKey().indexPattern(), entry.getValue());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -58,6 +58,7 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
             "idx-*",
             false,
             new IndexResolver.FieldsInfo(caps, TransportVersion.current(), false, false, false, false),
+            false,
             IndexResolver.DO_NOT_GROUP
         );
         EsField f = resolution.get().mapping().get(field);


### PR DESCRIPTION
Manual backport of #145991 to 9.4.