### PR TITLE
Remove XPackLicenseState from DLS/FLS request interceptors

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1132,20 +1132,20 @@ public class Security extends Plugin
         systemIndices.getMainIndexManager().addStateListener(authcService.get()::onSecurityIndexStateChange);
         dlsFlsEnabled.set(XPackSettings.DLS_FLS_ENABLED.get(settings));
         Set<RequestInterceptor> requestInterceptors = Sets.newHashSet(
-            new ResizeRequestInterceptor(threadPool, getLicenseState(), auditTrailService, dlsFlsEnabled.get()),
-            new IndicesAliasesRequestInterceptor(threadPool.getThreadContext(), getLicenseState(), auditTrailService, dlsFlsEnabled.get())
+            new ResizeRequestInterceptor(threadPool, auditTrailService, dlsFlsEnabled.get()),
+            new IndicesAliasesRequestInterceptor(threadPool.getThreadContext(), auditTrailService, dlsFlsEnabled.get())
         );
 
         if (dlsFlsEnabled.get()) {
             requestInterceptors.addAll(
                 Arrays.asList(
-                    new SearchRequestInterceptor(threadPool, getLicenseState()),
-                    new ShardSearchRequestInterceptor(threadPool, getLicenseState()),
-                    new UpdateRequestInterceptor(threadPool, getLicenseState()),
-                    new BulkShardRequestInterceptor(threadPool, getLicenseState()),
+                    new SearchRequestInterceptor(threadPool),
+                    new ShardSearchRequestInterceptor(threadPool),
+                    new UpdateRequestInterceptor(threadPool),
+                    new BulkShardRequestInterceptor(threadPool),
                     new DlsFlsLicenseRequestInterceptor(threadPool.getThreadContext(), getLicenseState()),
-                    new SearchRequestCacheDisablingInterceptor(threadPool, getLicenseState()),
-                    new ValidateRequestInterceptor(threadPool, getLicenseState()),
+                    new SearchRequestCacheDisablingInterceptor(threadPool),
+                    new ValidateRequestInterceptor(threadPool),
                     new ViewDlsFlsRequestInterceptor(
                         threadPool.getThreadContext(),
                         () -> projectResolver.getProjectMetadata(clusterService.state())

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
@@ -22,8 +21,6 @@ import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.Authoriza
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.RequestInfo;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
 /**
@@ -34,11 +31,9 @@ public class BulkShardRequestInterceptor implements RequestInterceptor {
     private static final Logger logger = LogManager.getLogger(BulkShardRequestInterceptor.class);
 
     private final ThreadContext threadContext;
-    private final XPackLicenseState licenseState;
 
-    public BulkShardRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
+    public BulkShardRequestInterceptor(ThreadPool threadPool) {
         this.threadContext = threadPool.getThreadContext();
-        this.licenseState = licenseState;
     }
 
     @Override
@@ -47,9 +42,8 @@ public class BulkShardRequestInterceptor implements RequestInterceptor {
         AuthorizationEngine authzEngine,
         AuthorizationInfo authorizationInfo
     ) {
-        final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-        final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-        if (requestInfo.getRequest() instanceof BulkShardRequest bulkShardRequest && (isDlsLicensed || isFlsLicensed)) {
+        if (requestInfo.getRequest() instanceof BulkShardRequest bulkShardRequest
+            && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
             IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
             // this uses the {@code BulkShardRequest#index()} because the {@code bulkItemRequest#index()}
             // can still be an unresolved date math expression

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
@@ -22,8 +21,6 @@ import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessCo
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
 /**
@@ -33,12 +30,10 @@ import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceFi
 abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements RequestInterceptor {
 
     private final ThreadContext threadContext;
-    private final XPackLicenseState licenseState;
     private final Logger logger;
 
-    FieldAndDocumentLevelSecurityRequestInterceptor(ThreadContext threadContext, XPackLicenseState licenseState) {
+    FieldAndDocumentLevelSecurityRequestInterceptor(ThreadContext threadContext) {
         this.threadContext = threadContext;
-        this.licenseState = licenseState;
         this.logger = LogManager.getLogger(getClass());
     }
 
@@ -48,12 +43,10 @@ abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements Reques
         AuthorizationEngine authorizationEngine,
         AuthorizationInfo authorizationInfo
     ) {
-        final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-        final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
         if (requestInfo.getRequest() instanceof IndicesRequest indicesRequest
             && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
             && supports(indicesRequest)
-            && (isDlsLicensed || isFlsLicensed)) {
+            && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
             final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
             final Map<String, IndicesAccessControl.IndexAccessControl> accessControlByIndex = new HashMap<>();
             for (String index : requestIndices(indicesRequest)) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
@@ -30,25 +29,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.support.ContextPreservingActionListener.wrapPreservingContext;
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
 public final class IndicesAliasesRequestInterceptor implements RequestInterceptor {
 
     private final ThreadContext threadContext;
-    private final XPackLicenseState licenseState;
     private final AuditTrailService auditTrailService;
     private final boolean dlsFlsEnabled;
 
-    public IndicesAliasesRequestInterceptor(
-        ThreadContext threadContext,
-        XPackLicenseState licenseState,
-        AuditTrailService auditTrailService,
-        boolean dlsFlsEnabled
-    ) {
+    public IndicesAliasesRequestInterceptor(ThreadContext threadContext, AuditTrailService auditTrailService, boolean dlsFlsEnabled) {
         this.threadContext = threadContext;
-        this.licenseState = licenseState;
         this.auditTrailService = auditTrailService;
         this.dlsFlsEnabled = dlsFlsEnabled;
     }
@@ -61,10 +51,8 @@ public final class IndicesAliasesRequestInterceptor implements RequestIntercepto
     ) {
         if (requestInfo.getRequest() instanceof IndicesAliasesRequest request) {
             final AuditTrail auditTrail = auditTrailService.get();
-            final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-            final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
             IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
-            if (dlsFlsEnabled && (isDlsLicensed || isFlsLicensed)) {
+            if (dlsFlsEnabled && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
                 for (IndicesAliasesRequest.AliasActions aliasAction : request.getAliasActions()) {
                     if (aliasAction.actionType() == IndicesAliasesRequest.AliasActions.Type.ADD) {
                         for (String index : aliasAction.indices()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
@@ -25,26 +24,17 @@ import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import java.util.Collections;
 
 import static org.elasticsearch.action.support.ContextPreservingActionListener.wrapPreservingContext;
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 import static org.elasticsearch.xpack.security.audit.AuditUtil.extractRequestId;
 
 public final class ResizeRequestInterceptor implements RequestInterceptor {
 
     private final ThreadContext threadContext;
-    private final XPackLicenseState licenseState;
     private final AuditTrailService auditTrailService;
     private final boolean dlsFlsEnabled;
 
-    public ResizeRequestInterceptor(
-        ThreadPool threadPool,
-        XPackLicenseState licenseState,
-        AuditTrailService auditTrailService,
-        boolean dlsFlsEnabled
-    ) {
+    public ResizeRequestInterceptor(ThreadPool threadPool, AuditTrailService auditTrailService, boolean dlsFlsEnabled) {
         this.threadContext = threadPool.getThreadContext();
-        this.licenseState = licenseState;
         this.auditTrailService = auditTrailService;
         this.dlsFlsEnabled = dlsFlsEnabled;
     }
@@ -57,9 +47,7 @@ public final class ResizeRequestInterceptor implements RequestInterceptor {
     ) {
         if (requestInfo.getRequest() instanceof ResizeRequest request) {
             final AuditTrail auditTrail = auditTrailService.get();
-            final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-            final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-            if (dlsFlsEnabled && (isDlsLicensed || isFlsLicensed)) {
+            if (dlsFlsEnabled && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
                 IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
                 IndicesAccessControl.IndexAccessControl indexAccessControl = indicesAccessControl.getIndexPermissions(
                     request.getSourceIndex()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.authz.interceptor;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportActionProxy;
@@ -18,18 +17,14 @@ import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessCo
 
 import java.util.Arrays;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
-import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.INDICES_PERMISSIONS_VALUE;
 
 public class SearchRequestCacheDisablingInterceptor implements RequestInterceptor {
 
     private final ThreadContext threadContext;
-    private final XPackLicenseState licenseState;
 
-    public SearchRequestCacheDisablingInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
+    public SearchRequestCacheDisablingInterceptor(ThreadPool threadPool) {
         this.threadContext = threadPool.getThreadContext();
-        this.licenseState = licenseState;
     }
 
     @Override
@@ -38,12 +33,10 @@ public class SearchRequestCacheDisablingInterceptor implements RequestIntercepto
         AuthorizationEngine authorizationEngine,
         AuthorizationEngine.AuthorizationInfo authorizationInfo
     ) {
-        final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-        final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
         if (requestInfo.getRequest() instanceof SearchRequest searchRequest
             && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
             && hasRemoteIndices(searchRequest)
-            && (isDlsLicensed || isFlsLicensed)) {
+            && DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions(threadContext)) {
             final IndicesAccessControl indicesAccessControl = INDICES_PERMISSIONS_VALUE.get(threadContext);
             if (indicesAccessControl.getFieldAndDocumentLevelSecurityUsage() != IndicesAccessControl.DlsFlsUsage.NONE) {
                 searchRequest.requestCache(false);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
@@ -19,8 +18,8 @@ import java.util.Map;
 
 public class SearchRequestInterceptor extends FieldAndDocumentLevelSecurityRequestInterceptor {
 
-    public SearchRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
-        super(threadPool.getThreadContext(), licenseState);
+    public SearchRequestInterceptor(ThreadPool threadPool) {
+        super(threadPool.getThreadContext());
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
@@ -24,8 +23,8 @@ public class ShardSearchRequestInterceptor extends FieldAndDocumentLevelSecurity
 
     private static final Logger logger = LogManager.getLogger(ShardSearchRequestInterceptor.class);
 
-    public ShardSearchRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
-        super(threadPool.getThreadContext(), licenseState);
+    public ShardSearchRequestInterceptor(ThreadPool threadPool) {
+        super(threadPool.getThreadContext());
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/UpdateRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/UpdateRequestInterceptor.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
@@ -26,8 +25,8 @@ import java.util.Map;
  */
 public class UpdateRequestInterceptor extends FieldAndDocumentLevelSecurityRequestInterceptor {
 
-    public UpdateRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
-        super(threadPool.getThreadContext(), licenseState);
+    public UpdateRequestInterceptor(ThreadPool threadPool) {
+        super(threadPool.getThreadContext());
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ValidateRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ValidateRequestInterceptor.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
@@ -19,8 +18,8 @@ import java.util.Map;
 
 public class ValidateRequestInterceptor extends FieldAndDocumentLevelSecurityRequestInterceptor {
 
-    public ValidateRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState) {
-        super(threadPool.getThreadContext(), licenseState);
+    public ValidateRequestInterceptor(ThreadPool threadPool) {
+        super(threadPool.getThreadContext());
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -67,7 +66,6 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         MockLicenseState licenseState = mock(MockLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isAllowed(Security.AUDITING_FEATURE)).thenReturn(true);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         AuditTrailService auditTrailService = new AuditTrailService(null, licenseState);
         Authentication authentication = AuthenticationTestHelper.builder()
@@ -105,7 +103,6 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         new SecurityContext(Settings.EMPTY, threadContext).putIndicesAccessControl(accessControl);
         IndicesAliasesRequestInterceptor interceptor = new IndicesAliasesRequestInterceptor(
             threadContext,
-            licenseState,
             auditTrailService,
             dlsFlsFeatureEnabled
         );
@@ -139,7 +136,6 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         MockLicenseState licenseState = mock(MockLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isAllowed(Security.AUDITING_FEATURE)).thenReturn(true);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(randomBoolean());
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         AuditTrailService auditTrailService = new AuditTrailService(null, licenseState);
         Authentication authentication = AuthenticationTestHelper.builder()
@@ -152,12 +148,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         final String action = TransportIndicesAliasesAction.NAME;
         IndicesAccessControl accessControl = new IndicesAccessControl(true, Collections.emptyMap());
         new SecurityContext(Settings.EMPTY, threadContext).putIndicesAccessControl(accessControl);
-        IndicesAliasesRequestInterceptor interceptor = new IndicesAliasesRequestInterceptor(
-            threadContext,
-            licenseState,
-            auditTrailService,
-            false
-        );
+        IndicesAliasesRequestInterceptor interceptor = new IndicesAliasesRequestInterceptor(threadContext, auditTrailService, false);
 
         final IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         if (randomBoolean()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -69,7 +68,6 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         MockLicenseState licenseState = mock(MockLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isAllowed(Security.AUDITING_FEATURE)).thenReturn(true);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -106,7 +104,6 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
 
         ResizeRequestInterceptor resizeRequestInterceptor = new ResizeRequestInterceptor(
             threadPool,
-            licenseState,
             auditTrailService,
             dlsFlsFeatureEnabled
         );
@@ -137,7 +134,6 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         MockLicenseState licenseState = mock(MockLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isAllowed(Security.AUDITING_FEATURE)).thenReturn(true);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -148,7 +144,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
             .build();
         IndicesAccessControl accessControl = new IndicesAccessControl(true, Collections.emptyMap());
         new SecurityContext(Settings.EMPTY, threadContext).putIndicesAccessControl(accessControl);
-        ResizeRequestInterceptor resizeRequestInterceptor = new ResizeRequestInterceptor(threadPool, licenseState, auditTrailService, true);
+        ResizeRequestInterceptor resizeRequestInterceptor = new ResizeRequestInterceptor(threadPool, auditTrailService, true);
 
         AuthorizationEngine mockEngine = mock(AuthorizationEngine.class);
         {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptorTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.ArrayUtils;
-import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -38,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -50,16 +48,13 @@ public class SearchRequestCacheDisablingInterceptorTests extends ESTestCase {
 
     private ClusterService clusterService;
     private ThreadPool threadPool;
-    private MockLicenseState licenseState;
     private SearchRequestCacheDisablingInterceptor interceptor;
 
     @Before
     public void init() {
         threadPool = new TestThreadPool("search request interceptor tests");
-        licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         clusterService = mock(ClusterService.class);
-        interceptor = new SearchRequestCacheDisablingInterceptor(threadPool, licenseState);
+        interceptor = new SearchRequestCacheDisablingInterceptor(threadPool);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptorTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -27,24 +26,19 @@ import org.junit.Before;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SearchRequestInterceptorTests extends ESTestCase {
 
     private ClusterService clusterService;
     private ThreadPool threadPool;
-    private MockLicenseState licenseState;
     private SearchRequestInterceptor interceptor;
 
     @Before
     public void init() {
         threadPool = new TestThreadPool("search request interceptor tests");
-        licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         clusterService = mock(ClusterService.class);
-        interceptor = new SearchRequestInterceptor(threadPool, licenseState);
+        interceptor = new SearchRequestInterceptor(threadPool);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptorTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -27,7 +26,6 @@ import org.junit.Before;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -41,9 +39,7 @@ public class ShardSearchRequestInterceptorTests extends ESTestCase {
     @Before
     public void init() {
         threadPool = new TestThreadPool("shard search request interceptor tests");
-        MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
-        interceptor = new ShardSearchRequestInterceptor(threadPool, licenseState);
+        interceptor = new ShardSearchRequestInterceptor(threadPool);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ValidateRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ValidateRequestInterceptorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryReques
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -25,23 +24,18 @@ import org.junit.Before;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ValidateRequestInterceptorTests extends ESTestCase {
 
     private ThreadPool threadPool;
-    private MockLicenseState licenseState;
     private ValidateRequestInterceptor interceptor;
 
     @Before
     public void init() {
         threadPool = new TestThreadPool("validate request interceptor tests");
-        licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
-        interceptor = new ValidateRequestInterceptor(threadPool, licenseState);
+        interceptor = new ValidateRequestInterceptor(threadPool);
     }
 
     @After


### PR DESCRIPTION
Replace license-based gating with role-based gating via `DlsFlsInterceptorUtils.isCurrentRoleNullOrHasDlsFlsPermissions` so interceptors only fire when the role actually uses DLS/FLS. License enforcement is unchanged in `DlsFlsLicenseRequestInterceptor`.