### PR TITLE
Remove muted test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -258,9 +258,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
   method: testGetWaitForCompletionDuringRelocation
   issue: https://github.com/elastic/elasticsearch/issues/145931
-- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
-  method: testGetReindexFollowsRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/144364
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145900


### PR DESCRIPTION
`ReindexGetRelocationIT.testGetReindexFollowsRelocation` was fixed by #144677 but the test was never unmuted

Relates: https://github.com/elastic/elasticsearch/issues/144364

