### PR TITLE
[9.3] Use IllegalArgumentException over RepositoryException for readonly-repository checks (#146147)

### DIFF
--- a/docs/changelog/140200.yaml
+++ b/docs/changelog/140200.yaml
@@ -1,0 +1,6 @@
+pr: 140200
+summary: Use `IllegalArgumentException` over `RepositoryException` for readonly-repository
+  checks
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1098,7 +1098,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> try deleting snapshot");
         assertRequestBuilderThrows(
             client.admin().cluster().prepareDeleteSnapshot(TEST_REQUEST_TIMEOUT, "readonly-repo", "test-snap"),
-            RepositoryException.class,
+            IllegalArgumentException.class,
             "repository is readonly"
         );
 
@@ -1109,7 +1109,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, "readonly-repo", "test-snap-2")
                 .setWaitForCompletion(true)
                 .setIndices("test-idx"),
-            RepositoryException.class,
+            IllegalArgumentException.class,
             "cannot create snapshot in a readonly repository"
         );
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2850,7 +2850,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     // Last resort check: we shouldn't have been able to mark the repository as readonly while the operation that led to
                     // this writeIndexGen() call was in progress, and conversely shouldn't have started any such operation if the repo
                     // was already readonly, but these invariants are not obviously true and it is disastrous to proceed here.
-                    throw new RepositoryException(meta.name(), "repository is readonly, cannot update root blob");
+                    throw new IllegalArgumentException("[" + meta.name() + "] repository is readonly, cannot update root blob");
                 }
 
                 final long genInState = meta.generation();

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -272,7 +272,9 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
         final SnapshotId snapshotId = new SnapshotId(snapshotName, request.uuid());
         Repository repository = repositoriesService.repository(projectId, request.repository());
         if (repository.isReadOnly()) {
-            listener.onFailure(new RepositoryException(repository.getMetadata().name(), "cannot create snapshot in a readonly repository"));
+            listener.onFailure(
+                new IllegalArgumentException("[" + repository.getMetadata().name() + "] cannot create snapshot in a readonly repository")
+            );
             return;
         }
         submitCreateSnapshotRequest(
@@ -3116,7 +3118,7 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                         final var projectMetadata = state.metadata().getProject(task.snapshot.getProjectId());
                         final var repoMeta = RepositoriesMetadata.get(projectMetadata).repository(task.snapshot.getRepository());
                         if (RepositoriesService.isReadOnly(repoMeta.settings())) {
-                            taskContext.onFailure(new RepositoryException(repoMeta.name(), "repository is readonly"));
+                            taskContext.onFailure(new IllegalArgumentException("[" + repoMeta.name() + "] repository is readonly"));
                             continue;
                         }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsServiceUtils.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsServiceUtils.java
@@ -49,7 +49,6 @@ import org.elasticsearch.repositories.ProjectRepo;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
-import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.repositories.ShardGeneration;
@@ -126,7 +125,7 @@ public class SnapshotsServiceUtils {
     public static void ensureNotReadOnly(final ProjectMetadata projectMetadata, final String repositoryName) {
         final var repositoryMetadata = RepositoriesMetadata.get(projectMetadata).repository(repositoryName);
         if (RepositoriesService.isReadOnly(repositoryMetadata.settings())) {
-            throw new RepositoryException(repositoryMetadata.name(), "repository is readonly");
+            throw new IllegalArgumentException("[" + repositoryMetadata.name() + "] repository is readonly");
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -239,7 +239,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
                         containsString("[test-repo] Failed to execute cluster state update [set pending repository generation")
                     );
                     assertThat(
-                        asInstanceOf(RepositoryException.class, e.getCause()).getMessage(),
+                        asInstanceOf(IllegalArgumentException.class, e.getCause()).getMessage(),
                         containsString("[test-repo] repository is readonly, cannot update root blob")
                     );
                     l.onResponse(null);


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Use IllegalArgumentException over RepositoryException for readonly-repository checks (#146147)