### PR TITLE
Fix pass by reference ESQL test agg collision bug

### DIFF
--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/BlockTestUtils.java
@@ -513,7 +513,7 @@ public class BlockTestUtils {
         }
         bytes.appendBytesRef(v);
         int o = dedupe.size();
-        dedupe.put(v, o);
+        dedupe.put(BytesRef.deepCopyOf(v), o);
         return o;
     }
 }


### PR DESCRIPTION
This addresses the `CountDistinctTests` and `CountDistinctOverTimeTests` failures reported in #145409. The root cause was not in the `COUNT_DISTINCT` agg itself, but in the test helper at `BlockTestUtils.java`, which sometimes rewrites `BytesRef` pages into ordinal-backed blocks. That helper was using a mutable scratch `BytesRef` as the map's key while building the dictionary, so hash collisions could cause two distinct values to collapse to the same ordinal and undercount distinct values. Storing a deep copy of the `BytesRef` fixes the ordinal conversion.

edit: the separately reported SumLongGroupingAggregatorFunctionTests flake did not reproduce on the more recent main and appears to have diverged since the original report, will close the original ticket once it's in - if it reappears, we'll review