### PR TITLE
Optimize long delegate chains

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -375,12 +375,12 @@ public abstract class DocumentParserContext {
 
     /**
      * Adds an ignored field from the parser context, capturing an object or an array.
-     *
+     * <p>
      * In case of nested arrays, i.e. capturing an array within an array, elements tracked as ignored fields may interfere with
      * the rest, as ignored source contents take precedence over regular field contents with the same leaf name. To prevent
      * missing array elements from synthetic source, all array elements get recorded in ignored source. Otherwise, just the value in
      * the current parsing context gets captured.
-     *
+     * <p>
      * In both cases, a new parser sub-context gets created from the current {@link DocumentParserContext} and returned, indicating
      * that the source for the sub-context has been captured, to avoid double-storing parts of its contents to ignored source.
      */
@@ -414,7 +414,7 @@ public abstract class DocumentParserContext {
      * Clones the current context to mark it as an array, if it's not already marked, or restore it if it's within a nested object.
      * Applies to synthetic source only.
      */
-    public final DocumentParserContext maybeCloneForArray(Mapper mapper) throws IOException {
+    public final DocumentParserContext maybeCloneForArray(Mapper mapper) {
         if (canAddIgnoredField()
             && mapper instanceof ObjectMapper
             && mapper instanceof NestedObjectMapper == false
@@ -428,7 +428,7 @@ public abstract class DocumentParserContext {
 
     /**
      * Add the given {@code field} to the _field_names field
-     *
+     * <p>
      * Use this if an exists query run against the field cannot use docvalues
      * or norms.
      */
@@ -1046,7 +1046,7 @@ public abstract class DocumentParserContext {
         }
 
         @Override
-        public Token nextToken() throws IOException {
+        public Token nextToken() {
             if (state == State.FIELD) {
                 state = State.VALUE;
                 return delegate().currentToken();
@@ -1063,7 +1063,7 @@ public abstract class DocumentParserContext {
         }
 
         @Override
-        public String currentName() throws IOException {
+        public String currentName() {
             return field;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -49,12 +49,20 @@ public abstract class DocumentParserContext {
      */
     private static class Wrapper extends DocumentParserContext {
         private final DocumentParserContext in;
-        private final boolean isWithinCopyTo; // cached to avoid method chain overhead and dynamic dispatch
+
+        // cached to avoid method chain overhead and dynamic dispatch
+        private final boolean isWithinCopyTo;
+        private final ContentPath path;
+        private final XContentParser parser;
+        private final LuceneDocument doc;
 
         private Wrapper(ObjectMapper parent, DocumentParserContext in) {
             super(parent, parent.dynamic == null ? in.dynamic : parent.dynamic, in);
             this.in = in;
             this.isWithinCopyTo = in.isWithinCopyTo();
+            this.path = in.path();
+            this.parser = in.parser();
+            this.doc = in.doc();
         }
 
         // Used to create a copy_to context.
@@ -63,6 +71,9 @@ public abstract class DocumentParserContext {
             super(root, ObjectMapper.Dynamic.getRootDynamic(in.mappingLookup()), in);
             this.in = in;
             this.isWithinCopyTo = in.isWithinCopyTo();
+            this.path = in.path();
+            this.parser = in.parser();
+            this.doc = in.doc();
         }
 
         @Override
@@ -77,12 +88,12 @@ public abstract class DocumentParserContext {
 
         @Override
         public ContentPath path() {
-            return in.path();
+            return path;
         }
 
         @Override
         public XContentParser parser() {
-            return in.parser();
+            return parser;
         }
 
         @Override
@@ -92,7 +103,7 @@ public abstract class DocumentParserContext {
 
         @Override
         public LuceneDocument doc() {
-            return in.doc();
+            return doc;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 /**
  * An XContentParser that reinterprets field names containing dots as an object structure.
- *
+ * <p>
  * A field name named {@code "foo.bar.baz":...} will be parsed instead as {@code 'foo':{'bar':{'baz':...}}}.
  * The token location is preserved so that error messages refer to the original content being parsed.
  * This parser can output duplicate keys, but that is fine given that it's used for document parsing. The mapping
@@ -444,7 +444,7 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
         }
 
         @Override
-        public Token nextToken() throws IOException {
+        public Token nextToken() {
             return null;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -39,10 +39,12 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
 
         private final ContentPath contentPath;
         final Deque<XContentParser> parsers = new ArrayDeque<>();
+        private XContentParser delegate; // cached top of stack — avoids peek() on every delegate() call
 
         WrappingParser(XContentParser in, ContentPath contentPath) throws IOException {
             this.contentPath = contentPath;
             parsers.push(in);
+            this.delegate = in;
             if (in.currentToken() == Token.FIELD_NAME) {
                 expandDots(in);
             }
@@ -56,12 +58,12 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
         @Override
         public Token nextToken() throws IOException {
             Token token;
-            XContentParser delegate;
             // cache object field (even when final this is a valid optimization, see https://openjdk.org/jeps/8132243)
             var parsers = this.parsers;
-            while ((token = (delegate = parsers.peek()).nextToken()) == null) {
+            while ((token = (this.delegate = parsers.peek()).nextToken()) == null) {
                 parsers.pop();
                 if (parsers.isEmpty()) {
+                    this.delegate = null;
                     return null;
                 }
             }
@@ -147,7 +149,9 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
                 }
                 subParser = new SingletonValueXContentParser(delegate);
             }
-            parsers.push(new DotExpandingXContentParser(subParser, subpaths, location, contentPath));
+            var expanded = new DotExpandingXContentParser(subParser, subpaths, location, contentPath);
+            parsers.push(expanded);
+            this.delegate = expanded;
         }
 
         private static void throwExpectedOpen(Token token) {
@@ -178,7 +182,7 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
 
         @Override
         protected XContentParser delegate() {
-            return parsers.peek();
+            return delegate;
         }
 
         /*


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/144853

These costs show up and become non-trivial with incoming documents that are more deeply nested -- if you have umpteen fields in a single json object, then these changes wouldn't matter, but if you have a lot of nested maps, well, then it matters more than you might guess.

Here's a before:

<img width="1713" height="871" alt="Screenshot 2026-04-13 at 11 41 28 AM" src="https://github.com/user-attachments/assets/d8075e92-9822-4b88-b3ee-3274df925222" />

And an after:

<img width="1712" height="847" alt="Screenshot 2026-04-13 at 11 41 43 AM" src="https://github.com/user-attachments/assets/7b85ce1d-6b48-4c42-a059-c2d07e29dd65" />

-----

Here are some zoomed-in stacks from the before side that show the value of 679bd8de01625fdba9e66914259c7a5f8f32e5a0.

<img width="1708" height="366" alt="Screenshot 2026-04-13 at 11 45 13 AM" src="https://github.com/user-attachments/assets/5f251bb9-414b-4f68-9ba2-df76adde0f3a" />

<img width="1713" height="255" alt="Screenshot 2026-04-13 at 11 44 57 AM" src="https://github.com/user-attachments/assets/4c7ec357-7948-44b2-8730-51e8ac6285e6" />

(Note: the second screenshot here is just the area from the first that's been highlighted with the red rectangle -- see here we're paying the method call and vtable overhead at each level, which is to say that these nested method delegates JIT pretty poorly.)

-----

For 151185ac851b93355f9f77ee6991759a80d5b643, we're currently paying ArrayDeque overhead on gets and puts, but we can skip the overhead on gets (extremely common!) and only pay it on puts (comparatively less common).