### PR TITLE
[9.2] Throw a 400 error for malformed parsing input when missing element end (#145777)

### DIFF
--- a/docs/changelog/145777.yaml
+++ b/docs/changelog/145777.yaml
@@ -1,0 +1,5 @@
+area: "Infra/Core"
+issues: []
+pr: 145777
+summary: Throw a 400 error for malformed parsing input when missing element end
+type: bug

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
@@ -640,7 +640,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                  * for having a cheap test.
                  */
                 if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
-                    throwMustEndOn(currentFieldName, XContentParser.Token.END_OBJECT);
+                    throwMustEndOn(parser, currentFieldName, XContentParser.Token.END_OBJECT);
                 }
             }
             case START_ARRAY -> {
@@ -654,7 +654,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                  * for having a cheap test.
                  */
                 if (parser.currentToken() != XContentParser.Token.END_ARRAY) {
-                    throwMustEndOn(currentFieldName, XContentParser.Token.END_ARRAY);
+                    throwMustEndOn(parser, currentFieldName, XContentParser.Token.END_ARRAY);
                 }
             }
             case END_OBJECT, END_ARRAY, FIELD_NAME -> throw throwUnexpectedToken(parser, token);
@@ -668,8 +668,8 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
         }
     }
 
-    private static void throwMustEndOn(String currentFieldName, XContentParser.Token token) {
-        throw new IllegalStateException("parser for [" + currentFieldName + "] did not end on " + token);
+    private static void throwMustEndOn(XContentParser parser, String currentFieldName, XContentParser.Token token) {
+        throw new XContentParseException(parser.getTokenLocation(), "parser for [" + currentFieldName + "] did not end on " + token);
     }
 
     private XContentParseException throwUnexpectedToken(XContentParser parser, XContentParser.Token token) {

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -763,16 +763,19 @@ public class ObjectParserTests extends ESTestCase {
 
         assertEquals("i", parser.parse(createParser(JsonXContent.jsonXContent, "{\"body\": \"i\"}"), null).get());
         Exception garbageException = expectThrows(
-            IllegalStateException.class,
+            XContentParseException.class,
             () -> parser.parse(createParser(JsonXContent.jsonXContent, """
                 {"noop": {"garbage": "shouldn't"}}
                 """), null)
         );
-        assertEquals("parser for [noop] did not end on END_OBJECT", garbageException.getMessage());
-        Exception sneakyException = expectThrows(IllegalStateException.class, () -> parser.parse(createParser(JsonXContent.jsonXContent, """
-            {"noop": {"body": "shouldn't"}}
-            """), null));
-        assertEquals("parser for [noop] did not end on END_OBJECT", sneakyException.getMessage());
+        assertThat(garbageException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
+        Exception sneakyException = expectThrows(
+            XContentParseException.class,
+            () -> parser.parse(createParser(JsonXContent.jsonXContent, """
+                {"noop": {"body": "shouldn't"}}
+                """), null)
+        );
+        assertThat(sneakyException.getMessage(), containsString("parser for [noop] did not end on END_OBJECT"));
     }
 
     public void testNoopDeclareField() throws IOException {
@@ -782,10 +785,10 @@ public class ObjectParserTests extends ESTestCase {
 
         assertEquals("i", parser.parse(createParser(JsonXContent.jsonXContent, "{\"body\": \"i\"}"), null).get());
         Exception e = expectThrows(
-            IllegalStateException.class,
+            XContentParseException.class,
             () -> parser.parse(createParser(JsonXContent.jsonXContent, "{\"noop\": [\"ignored\"]}"), null)
         );
-        assertEquals("parser for [noop] did not end on END_ARRAY", e.getMessage());
+        assertThat(e.getMessage(), containsString("parser for [noop] did not end on END_ARRAY"));
     }
 
     public void testNoopDeclareObjectArray() {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Throw a 400 error for malformed parsing input when missing element end (#145777)