### PR TITLE
ES|QL GenerativeRestTest add error message

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -98,6 +98,9 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         // throwing IllegalArgumentException via PackedValuesBlockHash
         // see https://github.com/elastic/elasticsearch/issues/145694
         "Found a single entry with .* entries",
+        // text fields may become keyword fields as a result of certain operations, which can cause fork to
+        // generate conflicting data types
+        "conflicting data types in FORK branches: \\[TEXT\\] and \\[KEYWORD\\]",
 
         // Awaiting fixes for query failure
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
@@ -194,10 +194,6 @@ public class EsqlQueryGenerator {
             }
             commandGenerator = isTimeSeries && canGenerateTimeSeries ? randomMetricsPipeCommandGenerator() : randomPipeCommandGenerator();
             if (isTimeSeries) {
-                if (commandGenerator.equals(ForkGenerator.INSTANCE)) {
-                    // don't fork with TS command until this is resolved: https://github.com/elastic/elasticsearch/issues/136927
-                    continue;
-                }
                 if (commandGenerator.equals(TimeSeriesStatsGenerator.INSTANCE) || commandGenerator.equals(StatsGenerator.INSTANCE)) {
                     if (canGenerateTimeSeries == false) {
                         // Don't generate multiple stats commands in a single query for TS


### PR DESCRIPTION
Add accepted error message when results of fork causes a data type to change from text to keyword, causing conflicting data types.

Closes #136927
