### PR TITLE
Optimize away some hot stream operations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
+++ b/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.StreamsMetadata;
 import org.elasticsearch.core.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 public enum StreamType {
@@ -21,6 +20,9 @@ public enum StreamType {
     LOGS("logs"),
     LOGS_ECS("logs.ecs"),
     LOGS_OTEL("logs.otel");
+
+    // an allocation-free version of values() for hot code
+    private static final List<StreamType> VALUES = List.of(values());
 
     private final String streamName;
 
@@ -62,7 +64,7 @@ public enum StreamType {
      */
     @Nullable
     public static StreamType exactEnabledStreamMatch(ProjectMetadata projectMetadata, String indexName) {
-        return Arrays.stream(values())
+        return VALUES.stream()
             .filter(t -> t.streamTypeIsEnabled(projectMetadata))
             .filter(t -> t.getStreamName().equals(indexName))
             .findFirst()
@@ -81,13 +83,11 @@ public enum StreamType {
     @Nullable
     public static StreamType enabledParentStreamOf(ProjectMetadata projectMetadata, String indexName) {
         // Check for exact names first, in which case indexing is allowed
-        if (Arrays.stream(values())
-            .filter(t -> t.streamTypeIsEnabled(projectMetadata))
-            .anyMatch(t -> t.getStreamName().equals(indexName))) {
+        if (VALUES.stream().filter(t -> t.streamTypeIsEnabled(projectMetadata)).anyMatch(t -> t.getStreamName().equals(indexName))) {
             return null;
         } else {
             // Check that any enabled stream type isn't targeted by the index
-            List<StreamType> matchingStreamTypes = Arrays.stream(values())
+            List<StreamType> matchingStreamTypes = VALUES.stream()
                 .filter(t -> t.streamTypeIsEnabled(projectMetadata))
                 .filter(t -> t.matchesStreamPrefix(indexName))
                 .toList();

--- a/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
+++ b/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.StreamsMetadata;
 import org.elasticsearch.core.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public enum StreamType {
@@ -63,12 +64,14 @@ public enum StreamType {
      * For a given index name, return the StreamType that it matches exactly.
      */
     @Nullable
+    // n.b. this method is hot enough to warrant being unrolled as loops rather than written as streams
     public static StreamType exactEnabledStreamMatch(ProjectMetadata projectMetadata, String indexName) {
-        return VALUES.stream()
-            .filter(t -> t.streamTypeIsEnabled(projectMetadata))
-            .filter(t -> t.getStreamName().equals(indexName))
-            .findFirst()
-            .orElse(null);
+        for (StreamType type : VALUES) {
+            if (type.streamTypeIsEnabled(projectMetadata) && type.getStreamName().equals(indexName)) {
+                return type;
+            }
+        }
+        return null;
     }
 
     /**
@@ -81,24 +84,36 @@ public enum StreamType {
      * If no enabled stream type matches, returns null.
      */
     @Nullable
+    // n.b. this method is hot enough to warrant being unrolled as loops rather than written as streams
     public static StreamType enabledParentStreamOf(ProjectMetadata projectMetadata, String indexName) {
         // Check for exact names first, in which case indexing is allowed
-        if (VALUES.stream().filter(t -> t.streamTypeIsEnabled(projectMetadata)).anyMatch(t -> t.getStreamName().equals(indexName))) {
-            return null;
-        } else {
-            // Check that any enabled stream type isn't targeted by the index
-            List<StreamType> matchingStreamTypes = VALUES.stream()
-                .filter(t -> t.streamTypeIsEnabled(projectMetadata))
-                .filter(t -> t.matchesStreamPrefix(indexName))
-                .toList();
-            if (matchingStreamTypes.isEmpty()) {
+        for (StreamType type : VALUES) {
+            if (type.streamTypeIsEnabled(projectMetadata) && type.getStreamName().equals(indexName)) {
                 return null;
-            } else if (matchingStreamTypes.size() == 1) {
-                return matchingStreamTypes.getFirst();
-            } else {
-                // Try to return the most fine-grained stream type, otherwise `LOGS`
-                return matchingStreamTypes.stream().filter(s -> s != LOGS).findFirst().orElse(LOGS);
             }
+        }
+
+        List<StreamType> matchingTypes = null;
+        for (StreamType type : VALUES) {
+            if (type.streamTypeIsEnabled(projectMetadata) && type.matchesStreamPrefix(indexName)) {
+                if (matchingTypes == null) {
+                    matchingTypes = new ArrayList<>(VALUES.size());
+                }
+                matchingTypes.add(type);
+            }
+        }
+        if (matchingTypes == null) {
+            return null;
+        } else if (matchingTypes.size() == 1) {
+            return matchingTypes.getFirst();
+        } else {
+            // Try to return the most fine-grained stream type, otherwise `LOGS`
+            for (StreamType type : matchingTypes) {
+                if (type != LOGS) {
+                    return type;
+                }
+            }
+            return LOGS;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
+++ b/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
@@ -71,11 +71,11 @@ public enum StreamType {
 
     /**
      * For a given index name, return the enabled stream of which it would be part.
-     *
+     * <p>
      * For example, for an index 'logs.ecs.foo' if the LOGS_ECS stream type is enabled,
      * this will return LOGS_ECS. If LOGS_ECS were not enabled but LOGS was, then LOGS
      * would be returned. If neither were enabled, null would be returned.
-     *
+     * <p>
      * If no enabled stream type matches, returns null.
      */
     @Nullable

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -252,7 +252,11 @@ public class BinaryFieldMapper extends FieldMapper {
             try {
                 bytesList.sort(Arrays::compareUnsigned);
                 CollectionUtils.uniquify(bytesList, Arrays::compareUnsigned);
-                int bytesSize = bytesList.stream().map(a -> a.length).reduce(0, Integer::sum);
+                // avoiding a streaming map/reduce for efficiency reasons
+                int bytesSize = 0;
+                for (byte[] bytes : bytesList) {
+                    bytesSize += bytes.length;
+                }
                 int n = bytesList.size();
                 BytesStreamOutput out = new BytesStreamOutput(bytesSize + (n + 1) * 5);
                 out.writeVInt(n);  // write total number of values


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/144853 (tangentially, these aren't really **mapping** optimizations, they're just optimizations that I've come across or been pointed at while I'm otherwise optimizing mapping code)

This is mostly just the usual rewriting of fluent API streaming code into old-and-janky-but-fast collections code. I don't think it's enormously less readable than the streaming version.

<img width="1916" height="533" alt="Screenshot 2026-04-13 at 2 39 28 PM" src="https://github.com/user-attachments/assets/517843d7-c51a-4734-8e58-12de9b6c5f93" />

`doStreamsChecks` ends up eating ~0.5% of all CPU during the indexing phase of one of our higher priority benchmarks.

-----

edit: rewriting it saves us ~0.3% of all CPU (it goes from ~0.5% to ~0.2%)

<img width="2097" height="248" alt="Screenshot 2026-04-13 at 2 52 34 PM" src="https://github.com/user-attachments/assets/f9af8afa-d1e1-4eaf-8691-d7bb0cc6c265" />
