### PR TITLE
[CI] Allow skipping bc upgrade tests via env variable

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+if [[ "${SKIP_BC_UPGRADE_TESTS:-}" == "true" ]]; then
+  echo "SKIP_BC_UPGRADE_TESTS is set. Skipping BC upgrade tests."
+  exit 0
+fi
+
 echo "Selecting the most recent build from branch [$BUILDKITE_BRANCH]."
 
 # Select the most recent build from the current branch.


### PR DESCRIPTION
## Summary
- Adds a `SKIP_BC_UPGRADE_TESTS` environment variable check to `.buildkite/scripts/run-bc-upgrade-tests.sh`
- When set to `true` on an intake pipeline build, the bc-upgrade tests exit early (exit 0) without fetching manifests or uploading the 6-part test matrix
- Follows the existing graceful-skip pattern already used in the script for missing manifests or version mismatches

## Usage
Set `SKIP_BC_UPGRADE_TESTS=true` as a build-level environment variable when triggering the `elasticsearch-intake` pipeline (via Buildkite UI or API).