### PR TITLE
[9.3] Allow skipping bc upgrade tests via env variable (#146172)

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+if [[ "${SKIP_BC_UPGRADE_TESTS:-}" == "true" ]]; then
+  echo "SKIP_BC_UPGRADE_TESTS is set. Skipping BC upgrade tests."
+  exit 0
+fi
+
 echo "Selecting the most recent build from branch [$BUILDKITE_BRANCH]."
 
 # Select the most recent build from the current branch.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Allow skipping bc upgrade tests via env variable (#146172)](https://github.com/elastic/elasticsearch/pull/146172)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)