### PR TITLE
[ES|QL] Fix a bug in parsing index pattern and subquery in convertSubqueryToRemoteIndices used by MultiClusterSpecIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -324,15 +324,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
   issue: https://github.com/elastic/elasticsearch/issues/146137
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:subquery.subqueryInFromWithNoFieldCountEmptyInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/146178
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:subquery.subqueryInFromWithNoFieldCountOneInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/146179
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:subquery.subqueryInFromWithNoFieldCountStarInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/146180
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1671,8 +1671,10 @@ public final class EsqlTestUtils {
         for (String indexPatternOrSubquery : indexPatternsAndSubqueries) {
             // remove the from keyword if it's there
             indexPatternOrSubquery = indexPatternOrSubquery.strip();
-            if (indexPatternOrSubquery.toLowerCase(Locale.ROOT).startsWith("from ")) {
-                indexPatternOrSubquery = indexPatternOrSubquery.strip().substring(5);
+            if (indexPatternOrSubquery.length() > 4
+                && indexPatternOrSubquery.substring(0, 4).toLowerCase(Locale.ROOT).equals("from")
+                && Character.isWhitespace(indexPatternOrSubquery.charAt(4))) {
+                indexPatternOrSubquery = indexPatternOrSubquery.substring(4).strip();
             }
             // substitute the index patterns or subquery with remote index patterns
             if (isSubquery(indexPatternOrSubquery)) {


### PR DESCRIPTION
Fixes: #146178
Fixes: #146179 
Fixes: #146180
