### PR TITLE
Backport #145981 ([Entity Store] Add permissions for Entity Store datastream) to 9.4

### DIFF
--- a/docs/changelog/145981.yaml
+++ b/docs/changelog/145981.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 145981
+summary: "[Entity Store] Add permissions for Entity Store datastream"
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -666,6 +666,10 @@ class KibanaOwnedReservedRoleDescriptors {
                     .privileges("create_index", "manage", "read", "write")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".entities.*updates*")
+                    .privileges("create_index", "manage", "read", "write")
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".entities.*reset*")
                     .privileges("create_index", "manage", "read", "write")
                     .build(),


### PR DESCRIPTION
This is a backport of #145981 to `9.4` branch.
Towards https://github.com/elastic/security-team/issues/16781

* roles: add entity store updates permissions
* Update docs/changelog/145981.yaml
