### PR TITLE
[ESQL] Remove hadoop-client-runtime from datasource plugins

### DIFF
--- a/docs/changelog/146206.yaml
+++ b/docs/changelog/146206.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146206
+summary: Remove hadoop-client-runtime from datasource plugins
+type: enhancement

--- a/docs/changelog/146206.yaml
+++ b/docs/changelog/146206.yaml
@@ -1,5 +1,6 @@
 area: ES|QL
-issues: []
+issues:
+ - 146203
 pr: 146206
 summary: Remove hadoop-client-runtime from datasource plugins
 type: enhancement

--- a/x-pack/plugin/esql-datasource-iceberg/build.gradle
+++ b/x-pack/plugin/esql-datasource-iceberg/build.gradle
@@ -108,15 +108,11 @@ dependencies {
     exclude group: 'org.checkerframework', module: 'checker-qual'
   }
   
-  // Hadoop dependencies - required at both compile time and runtime for Parquet operations.
-  // 
-  // The Hadoop Configuration class is needed because:
-  // 1. ParquetFileReader has method overloads that reference Configuration in their signatures
-  // 2. ParquetReadOptions.Builder() constructor creates HadoopParquetConfiguration internally,
-  //    which requires the Configuration class to be present even when using non-Hadoop code paths
-  // 3. parquet-hadoop-bundle includes shaded Parquet classes but not Hadoop Configuration
+  // Hadoop API types — hadoop-client-api provides Configuration, Path, FileSystem,
+  // and CompressionCodec interfaces referenced by parquet-hadoop-bundle's public API.
+  // hadoop-client-runtime is NOT required: Iceberg's ArrowReader uses Parquet internally
+  // but does not trigger code paths that need the shaded runtime classes.
   implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}")
-  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}")
   
   // Arrow dependencies for compile time - provided at runtime by x-pack-esql's arrow module
   compileOnly("org.apache.arrow:arrow-vector:${versions.arrow}")
@@ -288,7 +284,7 @@ tasks.named("thirdPartyAudit").configure {
     'com.github.benmanes.caffeine.cache.StripedBuffer',
     'com.github.benmanes.caffeine.cache.UnsafeAccess',
     'com.github.benmanes.caffeine.cache.UnsafeRefArrayAccess',
-    // Hadoop internal uses sun.misc.Unsafe
+    // Hadoop internal uses sun.misc.Unsafe (from hadoop-client-api)
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm',
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm$Slot',
     'org.apache.hadoop.io.FastByteComparisons$LexicographicalComparerHolder$UnsafeComparer',
@@ -297,63 +293,6 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.hadoop.service.launcher.InterruptEscalator',
     'org.apache.hadoop.service.launcher.IrqHandler',
     'org.apache.hadoop.util.SignalLogger$Handler',
-    // Hadoop shaded Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    // Hadoop shaded Avro uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeBooleanField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeByteField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCachedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCharField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCustomEncodedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeDoubleField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeFloatField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeIntField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeLongField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeObjectField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeShortField',
-    // Hadoop shaded Curator Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    'org.apache.hadoop.shaded.org.xbill.DNS.spi.DNSJavaNameServiceDescriptor',
-    // Hadoop thirdparty Protobuf uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.protobuf.MessageSchema',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$1',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android32MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android64MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$JvmMemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor',
-    // Hadoop thirdparty Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.thirdparty.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AbstractFutureState$UnsafeAtomicHelper',
     // Parquet shaded hashing uses sun.misc.Unsafe
     'shaded.parquet.net.openhft.hashing.HotSpotPrior7u6StringHash',
     'shaded.parquet.net.openhft.hashing.LongHashFunction',

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -38,7 +38,9 @@ dependencies {
     exclude group: 'org.xerial.snappy', module: 'snappy-java'
     // lz4-java is provided by the server (libs/lz4); exclude to prevent jar hell
     exclude group: 'at.yawk.lz4', module: 'lz4-java'
-    exclude group: 'com.aayushatharva.brotli4j', module: 'brotli4j'
+    exclude group: 'com.aayushatharva.brotli4', module: 'brotli4'
+    // hadoop-client-runtime not needed: ORC only uses Configuration(false) with simple set/get
+    exclude group: 'org.apache.hadoop', module: 'hadoop-client-runtime'
   }
 
   // Hive storage API - provides VectorizedRowBatch and ColumnVector classes used by ORC's
@@ -50,17 +52,23 @@ dependencies {
   // com.google.protobuf.MessageOrBuilder at runtime
   implementation('com.google.protobuf:protobuf-java:3.25.8')
 
-  // Hadoop dependencies - required because ORC's Reader API uses Hadoop Configuration,
-  // Path, and FileSystem in its public interfaces.
+  // Hadoop API types — ORC's Reader API uses Configuration, Path, and FileSystem in
+  // its public interfaces. hadoop-client-runtime is NOT required: ORC only uses
+  // Configuration(false) with simple set()/get() which don't trigger loading of
+  // shaded classes from the runtime jar.
   implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") {
-    exclude group: 'org.slf4j', module: 'slf4j-api'
-  }
-  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
 
   // Re-add slf4j-api at the platform version to avoid jar hell with x-pack-core
   runtimeOnly "org.slf4j:slf4j-api:${versions.slf4j}"
+
+  // hadoop-client-runtime is needed at test time because OrcFile.createWriter() triggers
+  // Configuration class initialization which requires shaded Woodstox classes.
+  // Not needed at runtime: the read path only uses Configuration(false) with simple set/get.
+  testImplementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -93,7 +101,7 @@ tasks.withType(org.elasticsearch.gradle.internal.AbstractDependenciesTask).confi
 tasks.named("thirdPartyAudit").configure {
   ignoreMissingClasses()
   ignoreViolations(
-    // Hadoop internal uses sun.misc.Unsafe
+    // Hadoop internal uses sun.misc.Unsafe (from hadoop-client-api)
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm',
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm$Slot',
     'org.apache.hadoop.io.FastByteComparisons$LexicographicalComparerHolder$UnsafeComparer',
@@ -102,63 +110,6 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.hadoop.service.launcher.InterruptEscalator',
     'org.apache.hadoop.service.launcher.IrqHandler',
     'org.apache.hadoop.util.SignalLogger$Handler',
-    // Hadoop shaded Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    // Hadoop shaded Avro uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeBooleanField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeByteField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCachedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCharField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCustomEncodedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeDoubleField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeFloatField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeIntField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeLongField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeObjectField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeShortField',
-    // Hadoop shaded Curator Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    'org.apache.hadoop.shaded.org.xbill.DNS.spi.DNSJavaNameServiceDescriptor',
-    // Hadoop thirdparty Protobuf uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.protobuf.MessageSchema',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$1',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android32MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android64MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$JvmMemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor',
-    // Hadoop thirdparty Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.thirdparty.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AbstractFutureState$UnsafeAtomicHelper',
     // Protobuf uses sun.misc.Unsafe
     'com.google.protobuf.MessageSchema',
     'com.google.protobuf.UnsafeUtil',

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -39,8 +39,6 @@ dependencies {
     // lz4-java is provided by the server (libs/lz4); exclude to prevent jar hell
     exclude group: 'at.yawk.lz4', module: 'lz4-java'
     exclude group: 'com.aayushatharva.brotli4j', module: 'brotli4j'
-    // hadoop-client-runtime not needed: ORC only uses Configuration(false) with simple set/get
-    exclude group: 'org.apache.hadoop', module: 'hadoop-client-runtime'
   }
 
   // Hive storage API - provides VectorizedRowBatch and ColumnVector classes used by ORC's
@@ -52,23 +50,19 @@ dependencies {
   // com.google.protobuf.MessageOrBuilder at runtime
   implementation('com.google.protobuf:protobuf-java:3.25.8')
 
-  // Hadoop API types — ORC's Reader API uses Configuration, Path, and FileSystem in
-  // its public interfaces. hadoop-client-runtime is NOT required: ORC only uses
-  // Configuration(false) with simple set()/get() which don't trigger loading of
-  // shaded classes from the runtime jar.
+  // Hadoop dependencies — required because ORC's Reader API uses Configuration,
+  // Path, and FileSystem in its public interfaces. Unlike Parquet/Iceberg,
+  // hadoop-client-runtime is also needed at runtime: FileSystem's static
+  // initializer references shaded Woodstox classes from the runtime jar.
   implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
+  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
 
   // Re-add slf4j-api at the platform version to avoid jar hell with x-pack-core
   runtimeOnly "org.slf4j:slf4j-api:${versions.slf4j}"
-
-  // hadoop-client-runtime is needed at test time because OrcFile.createWriter() triggers
-  // Configuration class initialization which requires shaded Woodstox classes.
-  // Not needed at runtime: the read path only uses Configuration(false) with simple set/get.
-  testImplementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") {
-    exclude group: 'org.slf4j', module: 'slf4j-api'
-  }
 
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -101,7 +95,7 @@ tasks.withType(org.elasticsearch.gradle.internal.AbstractDependenciesTask).confi
 tasks.named("thirdPartyAudit").configure {
   ignoreMissingClasses()
   ignoreViolations(
-    // Hadoop internal uses sun.misc.Unsafe (from hadoop-client-api)
+    // Hadoop internal uses sun.misc.Unsafe
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm',
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm$Slot',
     'org.apache.hadoop.io.FastByteComparisons$LexicographicalComparerHolder$UnsafeComparer',
@@ -110,6 +104,63 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.hadoop.service.launcher.InterruptEscalator',
     'org.apache.hadoop.service.launcher.IrqHandler',
     'org.apache.hadoop.util.SignalLogger$Handler',
+    // Hadoop shaded Guava uses sun.misc.Unsafe
+    'org.apache.hadoop.shaded.com.google.common.cache.Striped64',
+    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$1',
+    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$Cell',
+    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
+    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
+    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
+    'org.apache.hadoop.shaded.com.google.common.hash.Striped64',
+    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$1',
+    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$Cell',
+    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
+    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
+    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
+    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
+    // Hadoop shaded Avro uses sun.misc.Unsafe
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeBooleanField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeByteField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCachedField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCharField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCustomEncodedField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeDoubleField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeFloatField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeIntField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeLongField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeObjectField',
+    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeShortField',
+    // Hadoop shaded Curator Guava uses sun.misc.Unsafe
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$1',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$Cell',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$1',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$Cell',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
+    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
+    'org.apache.hadoop.shaded.org.xbill.DNS.spi.DNSJavaNameServiceDescriptor',
+    // Hadoop thirdparty Protobuf uses sun.misc.Unsafe
+    'org.apache.hadoop.thirdparty.protobuf.MessageSchema',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$1',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android32MemoryAccessor',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android64MemoryAccessor',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$JvmMemoryAccessor',
+    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor',
+    // Hadoop thirdparty Guava uses sun.misc.Unsafe
+    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
+    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
+    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
+    'org.apache.hadoop.thirdparty.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
+    'org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AbstractFutureState$UnsafeAtomicHelper',
     // Protobuf uses sun.misc.Unsafe
     'com.google.protobuf.MessageSchema',
     'com.google.protobuf.UnsafeUtil',

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     exclude group: 'org.xerial.snappy', module: 'snappy-java'
     // lz4-java is provided by the server (libs/lz4); exclude to prevent jar hell
     exclude group: 'at.yawk.lz4', module: 'lz4-java'
-    exclude group: 'com.aayushatharva.brotli4', module: 'brotli4'
+    exclude group: 'com.aayushatharva.brotli4j', module: 'brotli4j'
     // hadoop-client-runtime not needed: ORC only uses Configuration(false) with simple set/get
     exclude group: 'org.apache.hadoop', module: 'hadoop-client-runtime'
   }

--- a/x-pack/plugin/esql-datasource-parquet/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/build.gradle
@@ -34,15 +34,17 @@ dependencies {
   // Parquet format support - using parquet-hadoop-bundle to avoid jar hell from duplicate shaded classes
   implementation("org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}")
   
-  // Hadoop dependencies - required at both compile time and runtime for Parquet operations.
-  // 
-  // The Hadoop Configuration class is needed because:
-  // 1. ParquetFileReader has method overloads that reference Configuration in their signatures
-  // 2. ParquetReadOptions.Builder() constructor creates HadoopParquetConfiguration internally,
-  //    which requires the Configuration class to be present even when using non-Hadoop code paths
-  // 3. parquet-hadoop-bundle includes shaded Parquet classes but not Hadoop Configuration
+  // Hadoop API types — hadoop-client-api provides Configuration, Path, FileSystem,
+  // and CompressionCodec interfaces referenced by parquet-hadoop-bundle's public API.
+  // hadoop-client-runtime is NOT required: PlainParquetConfiguration replaces the
+  // HadoopParquetConfiguration that previously pulled in Configuration(true), and
+  // codec resolution works via hadoop-client-api classes alone.
   implementation("org.apache.hadoop:hadoop-client-api:${versions.hadoop}")
-  implementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}")
+
+  // hadoop-client-runtime is needed at test time because ParquetWriter.Builder.build()
+  // creates HadoopParquetConfiguration which requires shaded Woodstox classes.
+  // Not needed at runtime: the read path uses PlainParquetConfiguration.
+  testImplementation("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}")
 
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -57,7 +59,7 @@ tasks.named("dependencyLicenses").configure {
 tasks.named("thirdPartyAudit").configure {
   ignoreMissingClasses()
   ignoreViolations(
-    // Hadoop internal uses sun.misc.Unsafe
+    // Hadoop internal uses sun.misc.Unsafe (from hadoop-client-api)
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm',
     'org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm$Slot',
     'org.apache.hadoop.io.FastByteComparisons$LexicographicalComparerHolder$UnsafeComparer',
@@ -66,63 +68,6 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.hadoop.service.launcher.InterruptEscalator',
     'org.apache.hadoop.service.launcher.IrqHandler',
     'org.apache.hadoop.util.SignalLogger$Handler',
-    // Hadoop shaded Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    // Hadoop shaded Avro uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeBooleanField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeByteField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCachedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCharField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeCustomEncodedField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeDoubleField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeFloatField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeIntField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeLongField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeObjectField',
-    'org.apache.hadoop.shaded.org.apache.avro.reflect.FieldAccessUnsafe$UnsafeShortField',
-    // Hadoop shaded Curator Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.cache.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.hash.Striped64$Cell',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
-    'org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1',
-    'org.apache.hadoop.shaded.org.xbill.DNS.spi.DNSJavaNameServiceDescriptor',
-    // Hadoop thirdparty Protobuf uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.protobuf.MessageSchema',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$1',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android32MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$Android64MemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$JvmMemoryAccessor',
-    'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor',
-    // Hadoop thirdparty Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.thirdparty.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AbstractFutureState$UnsafeAtomicHelper',
     // Parquet shaded hashing uses sun.misc.Unsafe
     'shaded.parquet.net.openhft.hashing.HotSpotPrior7u6StringHash',
     'shaded.parquet.net.openhft.hashing.LongHashFunction',

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -15,6 +15,7 @@ import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -135,7 +136,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         // change to be async, we'll have to unwrap the breaker if it's a LocalBreaker.
         var breaker = blockFactory.breaker();
         var allocator = new CircuitBreakerByteBufferAllocator(new HeapByteBufferAllocator(), breaker);
-        return ParquetReadOptions.builder().withAllocator(allocator);
+        return ParquetReadOptions.builder(new PlainParquetConfiguration()).withAllocator(allocator);
     }
 
     /**

--- a/x-pack/plugin/esql/qa/server/build.gradle
+++ b/x-pack/plugin/esql/qa/server/build.gradle
@@ -7,9 +7,7 @@ versions << [
 description = 'Integration tests for ESQL'
 
 configurations {
-  // Separate classpath for OrcFixtureGenerator to avoid jar hell: hadoop-client-runtime
-  // bundles javax.xml.bind (multi-release) which conflicts with jakarta.xml.bind-api from
-  // repository-azure.
+  // Separate classpath for OrcFixtureGenerator to avoid jar hell with repository-azure.
   orcFixtureGenerator
   // Separate classpath for ParquetFixtureGenerator to avoid jar hell with repository-azure.
   parquetFixtureGenerator
@@ -52,6 +50,8 @@ dependencies {
   implementation "org.apache.commons:commons-compress:${versions.esql_commons_compress}"
 
   // OrcFixtureGenerator: ORC/Hadoop (separate from main to avoid jar hell)
+  // hadoop-client-runtime is needed here because OrcFile.createWriter() triggers
+  // Configuration class initialization which requires shaded Woodstox classes.
   orcFixtureGenerator("org.apache.orc:orc-core:${versions.orc}") { exclude group: 'org.slf4j', module: 'slf4j-api' }
   orcFixtureGenerator('org.apache.hive:hive-storage-api:2.8.1')
   orcFixtureGenerator('com.google.protobuf:protobuf-java:3.25.8')
@@ -62,6 +62,8 @@ dependencies {
   orcFixtureGenerator project(xpackModule('esql-datasource-csv'))
 
   // ParquetFixtureGenerator: Parquet/Hadoop (separate from main to avoid jar hell)
+  // hadoop-client-runtime is needed here because ParquetWriter.Builder.build() triggers
+  // HadoopParquetConfiguration which requires shaded Woodstox classes.
   parquetFixtureGenerator("org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}") {
     exclude group: 'org.apache.logging.log4j'
   }


### PR DESCRIPTION
Remove the `hadoop-client-runtime` jar (31MB, 18,464 classes, 67+ shaded libraries) from the runtime classpath of all three ESQL datasource plugins (Parquet, ORC, Iceberg). This removes ~93MB of dead code across the three plugins.

The Parquet read path now uses `PlainParquetConfiguration` (available since Parquet 1.17.0) instead of the default `HadoopParquetConfiguration` that required Hadoop's `Configuration` class initialization. The ORC read path only uses `Configuration(false)` with simple `set()`/`get()` calls which do not trigger loading of shaded runtime classes. `hadoop-client-api` is retained as it provides the types referenced in public APIs.

Developed with AI-assisted tooling

Fixes #146203