### PR TITLE
Rebalance checkPart tasks (round 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,13 +408,15 @@ allprojects {
         splitForCI(project, "Part5")
       } else if (project.path.contains("ql")) {
         splitForCI(project, "Part3")
+      } else if (project.path == ":x-pack:plugin") {
+        splitForCI(project, "Part1")
       } else {
         splitForCI(project, "Part2")
       }
     } else if (project.path.startsWith(":qa:") || project.path.startsWith(":test:")) {
       splitForCI(project, "Part6")
     } else if (project.path.startsWith(":libs:")) {
-      splitForCI(project, "Part3")
+      splitForCI(project, "Part6")
     } else {
       splitForCI(project, "Part1")
     }


### PR DESCRIPTION
## Summary

Follow-up to #145821. Post-merge data (4 days) showed Part 3 and Part 2 are still overloaded while Parts 1 and 6 have headroom:

| Part | Median | p90 |
|------|--------|-----|
| part-1 | 25.2 min | 36.1 min |
| part-2 | 36.7 min | 40.6 min |
| part-3 | 39.1 min | 49.5 min |
| part-4 | 35.7 min | 40.7 min |
| part-5 | 25.2 min | 27.1 min |
| part-6 | 19.6 min | 21.6 min |

### Changes

- **`:libs:` → Part 6** (was Part 3): Reduces resource contention in Part 3 where ~20 libs tasks compete with heavy ESQL tasks. Part 6 has ~10 min of headroom.
- **`:x-pack:plugin` (exact path) → Part 1** (was Part 2 default): Moves `x-pack:plugin:yamlRestTest` (p90 26.2 min), Part 2's single heaviest task, to Part 1 which has headroom.

### Expected result

| Part | Before median | After (est.) |
|------|---------------|-------------|
| Part 1 | 25 min | ~28-32 min |
| Part 2 | 37 min | ~32-34 min |
| Part 3 | 39 min | ~34-36 min |
| Part 4 | 36 min | ~36 min |
| Part 5 | 25 min | ~25 min |
| Part 6 | 20 min | ~25-28 min |

## Test plan

- [ ] Verify CI parts run with the new split
- [ ] Monitor wall-clock times for a few days post-merge to confirm balance improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)