### PR TITLE
Synthetic id NodeFeature in all builds

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
@@ -19,7 +19,7 @@ public class IndexFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of();
+        return Set.of(TIME_SERIES_SYNTHETIC_ID);
     }
 
     public static final NodeFeature LOGSDB_NO_HOST_NAME_FIELD = new NodeFeature("index.logsdb_no_host_name_field");
@@ -51,7 +51,6 @@ public class IndexFeatures implements FeatureSpecification {
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
             LOGSDB_NO_HOST_NAME_FIELD,
-            TIME_SERIES_SYNTHETIC_ID,
             TIME_SERIES_SYNTHETIC_ID_DEFAULT,
             TIME_SERIES_NO_SEQNO,
             SYNONYMS_SET_LENIENT_ON_NON_EXISTING,


### PR DESCRIPTION
Previously, they would only be registered as test features and would only be registered on nodes if
`System.getProperty("tests.testfeatures.enabled", "").equals("true")`. This is not correct.

As a result, yaml test files requirements doesn't behave correctly. E.g
```
- skip:
    cluster_features: "index.time_series_synthetic_id"
    reason: when cluster has synthetic_id feature use
    26_id_generation_synthetic_id_false instead
```
would not trigger for `MixedClusterClientYamlTestSuiteIT` because nodes in the mixed cluster doesn't get the system property, and thus it looks like the nodes doesn't have the synthetic id feature, which they do.

By always registering the synthetic id NodeFeature this is fixed.

This change will make `index.time_series_synthetic_id` visible in cluster state though `GET /_cluster/state?filter_path=nodes_features`. This is also the reason why `index.time_series_synthetic_id_default` is left under `getTestFeatures` (it is never used and was originally introduced as a safety measure).

Relates https://github.com/elastic/elasticsearch/issues/146177