### PR TITLE
[9.4] Restore initial thread context during reindex etc. (#146134)

### DIFF
--- a/docs/changelog/146134.yaml
+++ b/docs/changelog/146134.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 146134
+summary: Restore initial thread context during reindex etc
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -609,6 +609,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
         this.totalBatchSizeInSingleScrollResponse.addAndGet(batchSize);
 
         if (asyncResponse.hasRemainingHits()) {
+            // NB this means the next bulk task will be traced as a child of the current one, but it should really be a sibling
             onScrollResponse(asyncResponse);
             return;
         }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/PaginatedHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/PaginatedHitSource.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.PaginatedSearchFailure;
@@ -27,6 +28,7 @@ import org.elasticsearch.xcontent.XContentType;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A source of paginated search results. Pumps data out into the passed onResponse consumer. If a scrollable search is used, then the
@@ -45,6 +47,10 @@ public abstract class PaginatedHitSource {
     private final Consumer<AsyncResponse> onResponse;
     protected final Consumer<Exception> fail;
 
+    /// Each cycle must be executed in the root thread context and not in a descendant context of the previous task, so that the tracing
+    /// subsystem does not form a deeply-nested linked list of spans.
+    private final Supplier<ThreadContext.StoredContext> rootStoredContextSupplier;
+
     public PaginatedHitSource(
         Logger logger,
         BackoffPolicy backoffPolicy,
@@ -59,10 +65,11 @@ public abstract class PaginatedHitSource {
         this.countSearchRetry = countSearchRetry;
         this.onResponse = onResponse;
         this.fail = fail;
+        this.rootStoredContextSupplier = threadPool.getThreadContext().newRestorableContext(true);
     }
 
     public final void start() {
-        doFirstSearch(createRetryListener(this::doFirstSearch));
+        doFirstSearchInRootContext(createRetryListener(this::doFirstSearchInRootContext));
     }
 
     /**
@@ -95,7 +102,9 @@ public abstract class PaginatedHitSource {
             fail.accept(new IllegalStateException("No pagination cursor available for next batch"));
             return;
         }
-        doNextSearch(cursor, extraKeepAlive, searchListener);
+        try (var ignored = rootStoredContextSupplier.get()) {
+            doNextSearch(cursor, extraKeepAlive, searchListener);
+        }
     }
 
     private void onResponse(Response response) {
@@ -141,6 +150,12 @@ public abstract class PaginatedHitSource {
      * Whether there are more batches to fetch.
      */
     public abstract boolean hasMoreBatches();
+
+    private void doFirstSearchInRootContext(RejectAwareActionListener<Response> searchListener) {
+        try (var ignored = rootStoredContextSupplier.get()) {
+            doFirstSearch(searchListener);
+        }
+    }
 
     // following is the SPI to be implemented.
     protected abstract void doFirstSearch(RejectAwareActionListener<Response> searchListener);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientPitPaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientPitPaginatedHitSourceTests.java
@@ -315,20 +315,44 @@ public class ClientPitPaginatedHitSourceTests extends ESTestCase {
         AtomicInteger actualSearchRetries = new AtomicInteger();
         int expectedSearchRetries = 0;
 
-        ClientPitPaginatedHitSource paginatedHitSource = new ClientPitPaginatedHitSource(
-            logger,
-            BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
-            threadPool,
-            actualSearchRetries::incrementAndGet,
-            responses::add,
-            failureHandler,
-            new ParentTaskAssigningClient(client, parentTask),
-            createPitSearchRequest()
-        );
+        final var testHeaderName = randomIdentifier("header-");
+        final var threadContext = threadPool.getThreadContext();
+
+        final ClientPitPaginatedHitSource paginatedHitSource;
+        try (var ignored = threadContext.newStoredContext()) {
+            final var testHeaderInitialValue = randomIdentifier("initial-");
+            threadContext.putHeader(testHeaderName, testHeaderInitialValue);
+            paginatedHitSource = new ClientPitPaginatedHitSource(
+                logger,
+                BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
+                threadPool,
+                actualSearchRetries::incrementAndGet,
+                responses::add,
+                failureHandler,
+                new ParentTaskAssigningClient(client, parentTask) {
+                    @Override
+                    protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                        ActionType<Response> action,
+                        Request request,
+                        ActionListener<Response> listener
+                    ) {
+                        // Verify that the action is always invoked in the initial thread context, even though this header is set to
+                        // different random values in the rest of the test. This ensures we don't accumulate a deeply-nested tree of spans
+                        // when tracing these requests for APM.
+                        assertEquals(testHeaderInitialValue, threadContext.getHeader(testHeaderName));
+                        super.doExecute(action, request, listener);
+                    }
+                },
+                createPitSearchRequest()
+            );
+        }
 
         paginatedHitSource.start();
         for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-            client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            }
             if (retry >= retries) {
                 return;
             }
@@ -338,7 +362,10 @@ public class ClientPitPaginatedHitSourceTests extends ESTestCase {
         client.validateRequest(TransportSearchAction.TYPE, (SearchRequest r) -> assertSame(Boolean.FALSE, r.allowPartialSearchResults()));
         SearchResponse searchResponse = createPitSearchResponse();
         try {
-            client.respond(TransportSearchAction.TYPE, searchResponse);
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.respond(TransportSearchAction.TYPE, searchResponse);
+            }
 
             for (int i = 0; i < randomIntBetween(1, 10); ++i) {
                 PaginatedHitSource.AsyncResponse asyncResponse = responses.poll(10, TimeUnit.SECONDS);
@@ -348,14 +375,20 @@ public class ClientPitPaginatedHitSourceTests extends ESTestCase {
                 asyncResponse.done(TimeValue.ZERO);
 
                 for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-                    client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+                    try (var ignored = threadContext.newStoredContext()) {
+                        threadContext.putHeader(testHeaderName, randomIdentifier());
+                        client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+                    }
                     client.awaitOperation();
                     ++expectedSearchRetries;
                 }
 
                 searchResponse.decRef();
                 searchResponse = createPitSearchResponse();
-                client.respond(TransportSearchAction.TYPE, searchResponse);
+                try (var ignored = threadContext.newStoredContext()) {
+                    threadContext.putHeader(testHeaderName, randomIdentifier());
+                    client.respond(TransportSearchAction.TYPE, searchResponse);
+                }
             }
 
             assertEquals(actualSearchRetries.get(), expectedSearchRetries);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollablePaginatedHitSourceTests.java
@@ -97,20 +97,45 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
         TaskId parentTask = new TaskId("thenode", randomInt());
         AtomicInteger actualSearchRetries = new AtomicInteger();
         int expectedSearchRetries = 0;
-        ClientScrollablePaginatedHitSource paginatedHitSource = new ClientScrollablePaginatedHitSource(
-            logger,
-            BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
-            threadPool,
-            actualSearchRetries::incrementAndGet,
-            responses::add,
-            failureHandler,
-            new ParentTaskAssigningClient(client, parentTask),
-            new SearchRequest().scroll(TimeValue.timeValueMinutes(1))
-        );
 
+        final var testHeaderName = randomIdentifier("header-");
+        final var threadContext = threadPool.getThreadContext();
+
+        final ClientScrollablePaginatedHitSource paginatedHitSource;
+        try (var ignored = threadContext.newStoredContext()) {
+            final var testHeaderInitialValue = randomIdentifier("initial-");
+            threadContext.putHeader(testHeaderName, testHeaderInitialValue);
+            paginatedHitSource = new ClientScrollablePaginatedHitSource(
+                logger,
+                BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
+                threadPool,
+                actualSearchRetries::incrementAndGet,
+                responses::add,
+                failureHandler,
+                new ParentTaskAssigningClient(client, parentTask) {
+                    @Override
+                    protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                        ActionType<Response> action,
+                        Request request,
+                        ActionListener<Response> listener
+                    ) {
+                        // Verify that the action is always invoked in the initial thread context, even though this header is set to
+                        // different random values in the rest of the test. This ensures we don't accumulate a deeply-nested tree of spans
+                        // when tracing these requests for APM.
+                        assertEquals(testHeaderInitialValue, threadContext.getHeader(testHeaderName));
+                        super.doExecute(action, request, listener);
+                    }
+                },
+                new SearchRequest().scroll(TimeValue.timeValueMinutes(1))
+            );
+        }
         paginatedHitSource.start();
+
         for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-            client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            }
             if (retry >= retries) {
                 return;
             }
@@ -120,7 +145,10 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
         client.validateRequest(TransportSearchAction.TYPE, (SearchRequest r) -> assertTrue(r.allowPartialSearchResults() == Boolean.FALSE));
         SearchResponse searchResponse = createSearchResponse();
         try {
-            client.respond(TransportSearchAction.TYPE, searchResponse);
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.respond(TransportSearchAction.TYPE, searchResponse);
+            }
 
             for (int i = 0; i < randomIntBetween(1, 10); ++i) {
                 PaginatedHitSource.AsyncResponse asyncResponse = responses.poll(10, TimeUnit.SECONDS);
@@ -130,14 +158,20 @@ public class ClientScrollablePaginatedHitSourceTests extends ESTestCase {
                 asyncResponse.done(TimeValue.ZERO);
 
                 for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-                    client.fail(TransportSearchScrollAction.TYPE, new EsRejectedExecutionException());
+                    try (var ignored = threadContext.newStoredContext()) {
+                        threadContext.putHeader(testHeaderName, randomIdentifier());
+                        client.fail(TransportSearchScrollAction.TYPE, new EsRejectedExecutionException());
+                    }
                     client.awaitOperation();
                     ++expectedSearchRetries;
                 }
 
                 searchResponse.decRef();
                 searchResponse = createSearchResponse();
-                client.respond(TransportSearchScrollAction.TYPE, searchResponse);
+                try (var ignored = threadContext.newStoredContext()) {
+                    threadContext.putHeader(testHeaderName, randomIdentifier());
+                    client.respond(TransportSearchScrollAction.TYPE, searchResponse);
+                }
             }
 
             assertEquals(actualSearchRetries.get(), expectedSearchRetries);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Restore initial thread context during reindex etc. (#146134)