### PR TITLE
ESQL: Support configurable window function semantics #1

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
@@ -10,9 +10,6 @@ package org.elasticsearch.compute.aggregation;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-import java.time.Duration;
-import java.util.List;
-
 public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends GroupingAggregatorEvaluationContext {
     private IntVector allGroupIds;
 
@@ -21,11 +18,8 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
     }
 
     /**
-     * Returns the full set of group IDs when output filtering is active (i.e., the operator
-     * passes only output-aligned groups to aggregators). Window functions need the complete set
-     * to produce intermediate results for neighbor lookups during the merge step.
-     *
-     * @return all group IDs, or {@code null} when no output filtering is applied
+     * Returns the full set of group IDs when output filtering is active.
+     * Window aggregations use this to build intermediate states for non-output buckets.
      */
     public IntVector allGroupIds() {
         return allGroupIds;
@@ -37,36 +31,53 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
 
     /**
      * Returns the inclusive start of the time range, in milliseconds, for the specified group ID.
-     * Data points for this group are within the range [rangeStartInMillis, rangeEndInMillis).
-     *
-     * @param groupId the group id
-     * @return the start of the time range in milliseconds (inclusive)
      */
     public abstract long rangeStartInMillis(int groupId);
 
     /**
      * Returns the exclusive end of the time range, in milliseconds, for the specified group ID.
-     * Data points for this group are within the range [rangeStartInMillis, rangeEndInMillis).
      */
     public abstract long rangeEndInMillis(int groupId);
 
     /**
-     * Returns the group IDs of subsequent groups that belong to the window starting with the {@code startingGroupId}.
-     * The time ranges of returned group IDs are within the interval
-     * {@code [rangeStartInMillis(startingGroupId), rangeStartInMillis(startingGroupId) + window.toMillis())}.
-     *
-     * @param startingGroupId the starting group ID
-     * @param window          the window duration
-     * @return a list of group IDs within the window
+     * Calls {@code action} for each group ID in the window anchored at {@code startingGroupId}.
      */
-    public abstract List<Integer> groupIdsFromWindow(int startingGroupId, Duration window);
+    public abstract void forEachGroupInWindow(int startingGroupId, java.time.Duration window, java.util.function.IntConsumer action);
+
+    /**
+     * Calls {@code action} for each extra bucket timestamp that needs to be materialized
+     * so the window for {@code groupId} has all required neighbors.
+     */
+    public abstract void forEachBucketInWindow(
+        long groupId,
+        java.time.Duration window,
+        org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash tsBlockHash,
+        java.util.function.LongConsumer action
+    );
+
+    /**
+     * Invokes {@code action} for each group ID whose bucket falls within
+     * {@code [rangeStartMillis, rangeEndMillis)}. The starting group is always visited first.
+     */
+    public abstract void forEachGroupInRange(
+        int startingGroupId,
+        long rangeStartMillis,
+        long rangeEndMillis,
+        java.util.function.IntConsumer action
+    );
+
+    /**
+     * Invokes {@code action} for each bucket timestamp in {@code [rangeStartMillis, rangeEndMillis)}
+     * that does not already exist as a group. Used by expansion to create synthetic buckets.
+     */
+    public abstract void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action);
 
     public abstract int previousGroupId(int currentGroupId);
 
     public abstract int nextGroupId(int currentGroupId);
 
     /**
-     * Computes and caches the adjacent group IDs. They weill be used in #previousGroupId and #nextGroupId.
+     * Computes and caches the adjacent group IDs. They will be used in #previousGroupId and #nextGroupId.
      */
     public abstract void computeAdjacentGroupIds();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowAggregatorFunctionSupplier.java
@@ -7,15 +7,49 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
 import org.elasticsearch.compute.operator.DriverContext;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 /**
  * A {@link AggregatorFunctionSupplier} that wraps another, and apply a window function on the final aggregation.
  */
-public record WindowAggregatorFunctionSupplier(AggregatorFunctionSupplier supplier, Duration window) implements AggregatorFunctionSupplier {
+public record WindowAggregatorFunctionSupplier(
+    AggregatorFunctionSupplier supplier,
+    Duration window,
+    WindowEvaluationContext.Factory ctxFactory
+) implements AggregatorFunctionSupplier {
+
+    /**
+     * Builds a supplier whose window is {@code [rangeStart, rangeStart + window)}.
+     */
+    public static AggregatorFunctionSupplier forwardWindowFnSupplier(AggregatorFunctionSupplier supplier, Duration window) {
+        return new WindowAggregatorFunctionSupplier(supplier, window, ctx -> new WindowEvaluationContext() {
+            @Override
+            public void forEachGroupInWindow(int startingGroupId, IntConsumer action) {
+                ctx.forEachGroupInWindow(startingGroupId, window, action);
+            }
+
+            @Override
+            public void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action) {
+                ctx.forEachBucketInWindow(groupId, window, tsBlockHash, action);
+            }
+
+            @Override
+            public long rangeStartInMillis(int groupId) {
+                return ctx.rangeStartInMillis(groupId);
+            }
+
+            @Override
+            public long rangeEndInMillis(int groupId) {
+                return ctx.rangeStartInMillis(groupId) + window.toMillis();
+            }
+        });
+    }
 
     @Override
     public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
@@ -35,7 +69,7 @@ public record WindowAggregatorFunctionSupplier(AggregatorFunctionSupplier suppli
     @Override
     public GroupingAggregatorFunction groupingAggregator(DriverContext driverContext, List<Integer> channels) {
         GroupingAggregatorFunction fn = supplier.groupingAggregator(driverContext, channels);
-        return new WindowGroupingAggregatorFunction(fn, supplier, window);
+        return new WindowGroupingAggregatorFunction(fn, supplier, window, ctxFactory);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowEvaluationContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
+
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
+
+/**
+ * Direction-specific window evaluation behavior, created per window aggregator from the base
+ * time-series context. Forward and backward implementations provide different iteration order
+ * and range computation.
+ */
+public interface WindowEvaluationContext {
+
+    /**
+     * Calls {@code action} for each group ID in the window anchored at {@code startingGroupId}.
+     */
+    void forEachGroupInWindow(int startingGroupId, IntConsumer action);
+
+    /**
+     * Calls {@code action} for each extra bucket timestamp that needs to be materialized
+     * so the window for {@code groupId} has all required neighbors.
+     */
+    void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action);
+
+    /**
+     * Effective start of the window range for the given group (for downstream final aggregation).
+     */
+    long rangeStartInMillis(int groupId);
+
+    /**
+     * Effective end of the window range for the given group (for downstream final aggregation).
+     */
+    long rangeEndInMillis(int groupId);
+
+    /**
+     * Start of the original data range for post-expansion trimming.
+     * Return {@link Long#MAX_VALUE} to signal no trimming (the default).
+     */
+    default long trimRangeStart(long dataRangeStartMillis, long dataRangeEndMillis) {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * End of the original data range for post-expansion trimming.
+     * Return {@link Long#MIN_VALUE} to signal no trimming (the default).
+     */
+    default long trimRangeEnd(long dataRangeStartMillis, long dataRangeEndMillis) {
+        return Long.MIN_VALUE;
+    }
+
+    /**
+     * Creates a {@link WindowEvaluationContext} from a base time-series context.
+     */
+    @FunctionalInterface
+    interface Factory {
+        WindowEvaluationContext create(TimeSeriesGroupingAggregatorEvaluationContext aggCtx);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
@@ -17,15 +18,18 @@ import org.elasticsearch.core.Releasables;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.function.LongConsumer;
 import java.util.stream.IntStream;
 
 /**
  * A {@link GroupingAggregatorFunction} that wraps another, and apply a window function on the final aggregation.
  */
-public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, AggregatorFunctionSupplier supplier, Duration window)
-    implements
-        GroupingAggregatorFunction {
-
+public record WindowGroupingAggregatorFunction(
+    GroupingAggregatorFunction next,
+    AggregatorFunctionSupplier supplier,
+    Duration window,
+    WindowEvaluationContext.Factory ctxFactory
+) implements GroupingAggregatorFunction {
     @Override
     public AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds, Page page) {
         return next.prepareProcessRawInputPage(seenGroupIds, page);
@@ -74,6 +78,7 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
         IntVector selected,
         TimeSeriesGroupingAggregatorEvaluationContext ctx
     ) {
+        WindowEvaluationContext windowCtx = ctxFactory.create(ctx);
         if (selected.getPositionCount() > 0) {
             // TODO: rewrite to NO_WINDOW in the planner if the bucket and the window are the same
             int groupId = selected.getInt(0);
@@ -83,10 +88,6 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                 return next.prepareEvaluateFinal(selected, ctx);
             }
         }
-        // When output filtering is active, allGroupIds contains every group (including sub-bucket
-        // groups that won't appear in the final output). We need all of them for evaluateIntermediate
-        // so that neighbor data is available during the window merge. When null, selected already
-        // contains every group.
         IntVector allGroups = ctx.allGroupIds();
         if (allGroups == null) {
             allGroups = selected;
@@ -112,7 +113,7 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                 finalAgg.aggregatorFunction().addIntermediateInput(0, allGroups, page);
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int groupId = selected.getInt(i);
-                    mergeBucketsFromWindow(groupId, backwards, page, finalAgg.aggregatorFunction(), ctx);
+                    mergeBucketsFromWindow(groupId, backwards, page, finalAgg.aggregatorFunction(), windowCtx, ctx);
                 }
             } finally {
                 Releasables.close(intermediateBlocks);
@@ -120,20 +121,14 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
             PreparedForEvaluation delegate = finalAgg.prepareForEvaluate(
                 selected,
                 new TimeSeriesGroupingAggregatorEvaluationContext(ctx.driverContext()) {
-                    // expand the window to cover the new range
                     @Override
                     public long rangeStartInMillis(int groupId) {
-                        return ctx.rangeStartInMillis(groupId);
+                        return windowCtx.rangeStartInMillis(groupId);
                     }
 
                     @Override
                     public long rangeEndInMillis(int groupId) {
-                        return rangeStartInMillis(groupId) + window.toMillis();
-                    }
-
-                    @Override
-                    public List<Integer> groupIdsFromWindow(int startingGroupId, Duration window) {
-                        throw new UnsupportedOperationException();
+                        return windowCtx.rangeEndInMillis(groupId);
                     }
 
                     @Override
@@ -147,14 +142,45 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                     }
 
                     @Override
-                    public void computeAdjacentGroupIds() {
-                        // not used by #nextGroupId and #previousGroupId
+                    public void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void forEachGroupInRange(
+                        int startingGroupId,
+                        long rangeStartMillis,
+                        long rangeEndMillis,
+                        java.util.function.IntConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void computeAdjacentGroupIds() {}
+
+                    @Override
+                    public void forEachGroupInWindow(
+                        int startingGroupId,
+                        java.time.Duration window,
+                        java.util.function.IntConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void forEachBucketInWindow(
+                        long groupId,
+                        java.time.Duration window,
+                        TimeSeriesBlockHash tsBlockHash,
+                        LongConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
                     }
                 }
             );
             GroupingAggregator takeFinalAgg = finalAgg;
             finalAgg = null;
-            // Leave the final agg open until the prepared results are closed.
             return new PreparedForEvaluation() {
                 @Override
                 public void evaluate(Block[] blocks, int offset, IntVector selectedInPage) {
@@ -176,18 +202,16 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
         int[] groupIdToPositions,
         Page page,
         GroupingAggregatorFunction fn,
+        WindowEvaluationContext windowCtx,
         TimeSeriesGroupingAggregatorEvaluationContext context
     ) {
-        var groupIds = context.groupIdsFromWindow(startingGroupId, window);
-        if (groupIds.size() > 1) {
-            try (IntVector oneGroup = context.driverContext().blockFactory().newConstantIntVector(startingGroupId, 1)) {
-                for (int g : groupIds) {
-                    if (g != startingGroupId) {
-                        int position = groupIdToPositions[g];
-                        fn.addIntermediateInput(position, oneGroup, page);
-                    }
+        try (IntVector oneGroup = context.driverContext().blockFactory().newConstantIntVector(startingGroupId, 1)) {
+            windowCtx.forEachGroupInWindow(startingGroupId, g -> {
+                if (g != startingGroupId && g >= 0 && g < groupIdToPositions.length) {
+                    int position = groupIdToPositions[g];
+                    fn.addIntermediateInput(position, oneGroup, page);
                 }
-            }
+            });
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorEvaluationContext;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.TimeSeriesGroupingAggregatorEvaluationContext;
+import org.elasticsearch.compute.aggregation.WindowEvaluationContext;
 import org.elasticsearch.compute.aggregation.WindowGroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
@@ -33,12 +34,12 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.joining;
@@ -114,6 +115,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
     private final boolean collapsed;
     private ExpandingGroups expandingGroups = null;
     private int numGroupsBeforeExpanding = -1;
+    /** Snapshot of the query's timestamp bounds before backward expansion adds synthetic buckets. */
+    private long trimBeforeMillis = Long.MAX_VALUE;
+    private long trimAfterMillis = Long.MIN_VALUE;
 
     public TimeSeriesAggregationOperator(
         Rounding.Prepared timeBucket,
@@ -143,13 +147,23 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         if (rowsAddedInCurrentBatch == 0) {
             return;
         }
-        if (needsOutputFiltering() == false) {
+        if (blockHash instanceof TimeSeriesBlockHash == false) {
             super.emit();
             return;
         }
         TimeSeriesBlockHash tsBlockHash = (TimeSeriesBlockHash) blockHash;
-        int[] alignedPositions = computeOutputAlignedPositions(tsBlockHash);
-        if (alignedPositions == null) {
+        if (aggregatorMode.isOutputPartial()) {
+            super.emit();
+            return;
+        }
+        boolean needsTrim = needsExpandedGroupTrimming(tsBlockHash);
+        boolean filterOutputBucket = outputTimeBucket != null;
+        if (filterOutputBucket == false && needsTrim == false) {
+            super.emit();
+            return;
+        }
+        int[] outputPositions = computeOutputPositions(tsBlockHash);
+        if (outputPositions == null) {
             super.emit();
             return;
         }
@@ -166,7 +180,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             boolean keysFiltered = false;
             try {
                 for (int b = 0; b < fullKeys.length; b++) {
-                    outputKeys[b] = fullKeys[b].filter(false, alignedPositions);
+                    outputKeys[b] = fullKeys[b].filter(false, outputPositions);
                 }
                 keysFiltered = true;
             } finally {
@@ -176,9 +190,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                 }
             }
 
-            try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(alignedPositions.length)) {
-                for (int i = 0; i < alignedPositions.length; i++) {
-                    builder.appendInt(i, alignedPositions[i]);
+            try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
+                for (int i = 0; i < outputPositions.length; i++) {
+                    builder.appendInt(i, outputPositions[i]);
                 }
                 outputSelected = builder.build();
             }
@@ -215,26 +229,35 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         }
     }
 
-    private boolean needsOutputFiltering() {
-        return aggregatorMode.isOutputPartial() == false && outputTimeBucket != null && blockHash instanceof TimeSeriesBlockHash;
-    }
-
-    /**
-     * Computes the group IDs that are aligned to the output bucket boundary.
-     *
-     * @return aligned group IDs, or {@code null} when every group is already aligned (no filtering needed)
-     */
-    private int[] computeOutputAlignedPositions(TimeSeriesBlockHash tsBlockHash) {
-        Rounding.Prepared optimizedOutput = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp());
+    private int[] computeOutputPositions(TimeSeriesBlockHash tsBlockHash) {
+        final boolean trimExpandedGroups = needsExpandedGroupTrimming(tsBlockHash);
+        final boolean filterByOutputBucket = outputTimeBucket != null;
+        if (trimExpandedGroups == false && filterByOutputBucket == false) {
+            return null;
+        }
+        final long startTrimThreshold = trimExpandedGroups ? trimBeforeMillis + largestWindowMillis() : Long.MIN_VALUE;
+        Rounding.Prepared optimizedOutput = null;
+        if (filterByOutputBucket) {
+            long minTs = trimExpandedGroups ? trimBeforeMillis : timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+            long maxTs = trimExpandedGroups ? trimAfterMillis : timeResolution.roundDownToMillis(tsBlockHash.maxTimestamp());
+            optimizedOutput = optimizeOutputRoundingForTimeRange(minTs, maxTs);
+        }
         int totalGroups = Math.toIntExact(tsBlockHash.numGroups());
         int[] positions = new int[Math.min(totalGroups, 16)];
         int idx = 0;
         for (int p = 0; p < totalGroups; p++) {
             long millis = timeResolution.roundDownToMillis(tsBlockHash.timestampForGroup(p));
-            if (optimizedOutput.round(millis) == millis) {
-                positions = ArrayUtil.grow(positions, idx + 1);
-                positions[idx++] = p;
+            if (trimExpandedGroups && (millis < trimBeforeMillis || millis > trimAfterMillis)) {
+                continue;
             }
+            if (millis < startTrimThreshold) {
+                continue;
+            }
+            if (filterByOutputBucket && optimizedOutput.round(millis) != millis) {
+                continue;
+            }
+            positions = ArrayUtil.grow(positions, idx + 1);
+            positions[idx++] = p;
         }
         if (idx == totalGroups) {
             return null;
@@ -252,19 +275,23 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         }
     }
 
+    private boolean needsExpandedGroupTrimming(TimeSeriesBlockHash tsBlockHash) {
+        return numGroupsBeforeExpanding >= 0 && trimAfterMillis != Long.MIN_VALUE && tsBlockHash.numGroups() > numGroupsBeforeExpanding;
+    }
+
     @Override
     protected boolean shouldEmitPartialResultsPeriodically() {
         return false;
     }
 
     private long largestWindowMillis() {
-        long largestWindow = Long.MIN_VALUE;
+        long largest = 0L;
         for (GroupingAggregator aggregator : aggregators) {
-            if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction aggregatorFunction) {
-                largestWindow = Math.max(largestWindow, aggregatorFunction.window().toMillis());
+            if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction wf) {
+                largest = Math.max(largest, wf.window().toMillis());
             }
         }
-        return largestWindow;
+        return largest;
     }
 
     /*
@@ -330,36 +357,46 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         if (aggregatorMode.isOutputPartial()) {
             return;
         }
-        final long windowMillis = largestWindowMillis();
-        if (windowMillis <= 0) {
-            return;
-        }
         if (blockHash instanceof TimeSeriesBlockHash == false) {
             return;
         }
         TimeSeriesBlockHash tsBlockHash = (TimeSeriesBlockHash) blockHash;
-        final long numGroups = tsBlockHash.numGroups();
+        long numGroups = tsBlockHash.numGroups();
         if (numGroups == 0) {
             return;
         }
-        Rounding.Prepared optimizedTimeBucket = optimizeRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp());
-        long minBound = tsBlockHash.minTimestamp();
-        if (outputTimeBucket != null) {
-            minBound = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp()).round(minBound);
-        }
-        this.numGroupsBeforeExpanding = Math.toIntExact(numGroups);
+        boolean expanded = false;
         this.expandingGroups = new ExpandingGroups(driverContext.bigArrays());
-        for (long groupId = 0; groupId < numGroups; groupId++) {
-            int tsid = tsBlockHash.tsidForGroup(groupId);
-            long endTimestamp = tsBlockHash.timestampForGroup(groupId);
-            long bucket = optimizedTimeBucket.nextRoundingValue(endTimestamp - timeResolution.convert(largestWindowMillis()));
-            bucket = Math.max(bucket, minBound);
-            // Fill the missing buckets between (timestamp-window, timestamp)
-            while (bucket < endTimestamp) {
-                if (tsBlockHash.addExtraGroup(tsid, bucket) >= 0) {
-                    expandingGroups.addGroup(Math.toIntExact(groupId));
+        try (var baseCtx = evaluationContext(blockHash)) {
+            if (baseCtx instanceof TimeSeriesGroupingAggregatorEvaluationContext tsCtx) {
+                for (GroupingAggregator aggregator : aggregators) {
+                    if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction wf && wf.window().toMillis() > 0) {
+                        if (expanded == false) {
+                            this.numGroupsBeforeExpanding = Math.toIntExact(numGroups);
+                            expanded = true;
+                        }
+                        WindowEvaluationContext windowCtx = wf.ctxFactory().create(tsCtx);
+                        long dataStartMillis = timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+                        long dataEndMillis = timeResolution.roundDownToMillis(tsBlockHash.maxTimestamp());
+                        long trimStart = windowCtx.trimRangeStart(dataStartMillis, dataEndMillis);
+                        long trimEnd = windowCtx.trimRangeEnd(dataStartMillis, dataEndMillis);
+                        if (trimStart != Long.MAX_VALUE) {
+                            this.trimBeforeMillis = Math.min(this.trimBeforeMillis, trimStart);
+                        }
+                        if (trimEnd != Long.MIN_VALUE) {
+                            this.trimAfterMillis = Math.max(this.trimAfterMillis, trimEnd);
+                        }
+                        for (long groupId = 0; groupId < numGroups; groupId++) {
+                            final int originalGroupId = Math.toIntExact(groupId);
+                            int tsid = tsBlockHash.tsidForGroup(groupId);
+                            windowCtx.forEachBucketInWindow(groupId, tsBlockHash, candidateBucket -> {
+                                if (tsBlockHash.addExtraGroup(tsid, candidateBucket) >= 0) {
+                                    expandingGroups.addGroup(originalGroupId);
+                                }
+                            });
+                        }
+                    }
                 }
-                bucket = optimizedTimeBucket.nextRoundingValue(bucket);
             }
         }
     }
@@ -481,19 +518,67 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             }
 
             @Override
-            public List<Integer> groupIdsFromWindow(int startingGroupId, Duration window) {
+            public void forEachGroupInWindow(int startingGroupId, Duration window, IntConsumer action) {
                 int tsid = tsBlockHash.tsidForGroup(startingGroupId);
                 long bucket = tsBlockHash.timestampForGroup(startingGroupId);
-                List<Integer> results = new ArrayList<>();
-                results.add(startingGroupId);
-                long endTimestamp = bucket + timeResolution.convert(window.toMillis());
+                action.accept(startingGroupId);
+                long windowMillis = window.toMillis();
+                if (windowMillis == 0) {
+                    return;
+                }
+                long endTimestamp = bucket + timeResolution.convert(windowMillis);
                 while ((bucket = optimizedTimeBucket.nextRoundingValue(bucket)) < endTimestamp) {
-                    long nextGroupId = tsBlockHash.getGroupId(tsid, bucket);
-                    if (nextGroupId != -1) {
-                        results.add(Math.toIntExact(nextGroupId));
+                    long groupId = tsBlockHash.getGroupId(tsid, bucket);
+                    if (groupId != -1) {
+                        action.accept(Math.toIntExact(groupId));
                     }
                 }
-                return results;
+            }
+
+            @Override
+            public void forEachBucketInWindow(
+                long groupId,
+                Duration window,
+                TimeSeriesBlockHash windowBlockHash,
+                java.util.function.LongConsumer action
+            ) {
+                long bucket = windowBlockHash.timestampForGroup(groupId);
+                long earliestBucket = optimizedTimeBucket.nextRoundingValue(bucket - timeResolution.convert(window.toMillis()));
+                long minBound = windowBlockHash.minTimestamp();
+                if (outputTimeBucket != null) {
+                    minBound = optimizeOutputRoundingForTimeRange(windowBlockHash.minTimestamp(), windowBlockHash.maxTimestamp()).round(
+                        minBound
+                    );
+                }
+                earliestBucket = Math.max(earliestBucket, minBound);
+                while (earliestBucket < bucket) {
+                    action.accept(earliestBucket);
+                    earliestBucket = optimizedTimeBucket.nextRoundingValue(earliestBucket);
+                }
+            }
+
+            @Override
+            public void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action) {
+                long bucket = optimizedTimeBucket.nextRoundingValue(rangeStartMillis);
+                while (bucket < rangeEndMillis) {
+                    action.accept(bucket);
+                    bucket = optimizedTimeBucket.nextRoundingValue(bucket);
+                }
+            }
+
+            @Override
+            public void forEachGroupInRange(int startingGroupId, long rangeStartMillis, long rangeEndMillis, IntConsumer action) {
+                int tsid = tsBlockHash.tsidForGroup(startingGroupId);
+                action.accept(startingGroupId);
+                long minMillis = timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+                long bucket = optimizedTimeBucket.round(Math.max(rangeStartMillis, minMillis));
+                while (bucket < rangeEndMillis) {
+                    long groupId = tsBlockHash.getGroupId(tsid, bucket);
+                    if (groupId != -1 && groupId != startingGroupId) {
+                        action.accept(Math.toIntExact(groupId));
+                    }
+                    bucket = optimizedTimeBucket.nextRoundingValue(bucket);
+                }
             }
 
             @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunctionTests.java
@@ -149,7 +149,8 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
     }
 
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), Duration.ofMinutes(5));
+        Duration window = Duration.ofMinutes(5);
+        return WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), window);
     }
 
     protected String expectedToStringOfSimpleAggregator() {
@@ -215,10 +216,8 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                    AggregatorMode.SINGLE,
-                    List.of(HASH_CHANNEL_COUNT)
-                )
+                WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                    .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT))
             ),
             10_000,
             fiveMinBucket,
@@ -262,9 +261,9 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
         assertThat("expected 3 output rows at 5-minute boundaries", outputRows.size(), equalTo(3));
 
         // Verify the sums:
-        // bucket at baseTime+0: window covers [0,7m) → minutes 0..6 → 7 points → sum=7
-        // bucket at baseTime+5m: window covers [5m,12m) → minutes 5..11 → 7 points → sum=7
-        // bucket at baseTime+10m: window covers [10m,17m) → minutes 10..14 → 5 points → sum=5
+        // bucket at baseTime+0: window covers [0,7m) -> minutes 0..6 -> 7 points -> sum=7
+        // bucket at baseTime+5m: window covers [5m,12m) -> minutes 5..11 -> 7 points -> sum=7
+        // bucket at baseTime+10m: window covers [10m,17m) -> minutes 10..14 -> 5 points -> sum=5
         outputRows.sort(Comparator.comparingLong(OutputRow::bucket));
         assertThat("sum at baseTime+0m", outputRows.get(0).value(), equalTo(7L));
         assertThat("sum at baseTime+5m", outputRows.get(1).value(), equalTo(7L));
@@ -308,10 +307,8 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                    AggregatorMode.SINGLE,
-                    List.of(HASH_CHANNEL_COUNT)
-                )
+                WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                    .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT))
             ),
             10_000,
             fiveMinBucket,
@@ -355,17 +352,17 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
         outputRows.sort(Comparator.comparing(OutputRow::tsid).thenComparingLong(OutputRow::bucket));
 
         // TSID "a" (value=1, 10 minutes of data): output at 0, 5m
-        // bucket 0: [0,7m) → min(7,10)=7 points → sum=7
-        // bucket 5m: [5m,12m) → minutes 5..9 → 5 points → sum=5
+        // bucket 0: [0,7m) -> min(7,10)=7 points -> sum=7
+        // bucket 5m: [5m,12m) -> minutes 5..9 -> 5 points -> sum=5
         List<OutputRow> aRows = outputRows.stream().filter(r -> r.tsid().equals("a")).toList();
         assertThat(aRows.size(), equalTo(2));
         assertThat(aRows.get(0).value(), equalTo(7L));
         assertThat(aRows.get(1).value(), equalTo(5L));
 
         // TSID "b" (value=2, 15 minutes of data): output at 0, 5m, 10m
-        // bucket 0: [0,7m) → 7 points → sum=14
-        // bucket 5m: [5m,12m) → 7 points → sum=14
-        // bucket 10m: [10m,17m) → 5 points → sum=10
+        // bucket 0: [0,7m) -> 7 points -> sum=14
+        // bucket 5m: [5m,12m) -> 7 points -> sum=14
+        // bucket 10m: [10m,17m) -> 5 points -> sum=10
         List<OutputRow> bRows = outputRows.stream().filter(r -> r.tsid().equals("b")).toList();
         assertThat(bRows.size(), equalTo(3));
         assertThat(bRows.get(0).value(), equalTo(14L));
@@ -373,9 +370,9 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
         assertThat(bRows.get(2).value(), equalTo(10L));
 
         // TSID "c" (value=100, sparse at 0, 5, 10): output at 0, 5m, 10m
-        // bucket 0: [0,7m) → points at 0 and 5 → sum=200
-        // bucket 5m: [5m,12m) → points at 5 and 10 → sum=200
-        // bucket 10m: [10m,17m) → point at 10 → sum=100
+        // bucket 0: [0,7m) -> points at 0 and 5 -> sum=200
+        // bucket 5m: [5m,12m) -> points at 5 and 10 -> sum=200
+        // bucket 10m: [10m,17m) -> point at 10 -> sum=100
         List<OutputRow> cRows = outputRows.stream().filter(r -> r.tsid().equals("c")).toList();
         assertThat(cRows.size(), equalTo(3));
         assertThat(cRows.get(0).value(), equalTo(200L));
@@ -402,7 +399,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             rows.add(List.of("s", ts, 10));
         }
 
-        // No outputTimeBucket → needsOutputFiltering() returns false → super.emit() → allGroupIds stays null
+        // No outputTimeBucket -> needsOutputFiltering() returns false -> super.emit() -> allGroupIds stays null
         var operatorFactory = new TimeSeriesAggregationOperator.Factory(
             fiveMinBucket,
             false,
@@ -412,10 +409,9 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                    AggregatorMode.SINGLE,
-                    List.of(HASH_CHANNEL_COUNT)
-                )
+
+                WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                    .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT))
             ),
             10_000
         );
@@ -452,10 +448,10 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
 
         outputRows.sort(Comparator.comparingLong(OutputRow::bucket));
         // 10m window over 5m buckets: each bucket merges itself + the next bucket
-        // bucket 0: [0,10m) → points at 0 and 5m → sum=20
-        // bucket 5m: [5m,15m) → points at 5m and 10m → sum=20
-        // bucket 10m: [10m,20m) → points at 10m and 15m → sum=20
-        // bucket 15m: [15m,25m) → point at 15m → sum=10
+        // bucket 0: [0,10m) -> points at 0 and 5m -> sum=20
+        // bucket 5m: [5m,15m) -> points at 5m and 10m -> sum=20
+        // bucket 10m: [10m,20m) -> points at 10m and 15m -> sum=20
+        // bucket 15m: [15m,25m) -> point at 15m -> sum=10
         assertThat(outputRows.size(), equalTo(4));
         assertThat(outputRows.get(0).value(), equalTo(20L));
         assertThat(outputRows.get(1).value(), equalTo(20L));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -98,9 +98,9 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
 
         outputRows.sort(Comparator.comparing(OutputRow::tsid).thenComparingLong(OutputRow::bucket));
         // TSID "a": each point has value 1
-        assertThat(outputRows.get(0).value(), equalTo(7L));  // [0,7m) → 7 points
-        assertThat(outputRows.get(1).value(), equalTo(7L));  // [5m,12m) → 7 points
-        assertThat(outputRows.get(2).value(), equalTo(5L));  // [10m,17m) → 5 points
+        assertThat(outputRows.get(0).value(), equalTo(7L));  // [0,7m) -> 7 points
+        assertThat(outputRows.get(1).value(), equalTo(7L));  // [5m,12m) -> 7 points
+        assertThat(outputRows.get(2).value(), equalTo(5L));  // [10m,17m) -> 5 points
         // TSID "b": each point has value 10
         assertThat(outputRows.get(3).value(), equalTo(70L));
         assertThat(outputRows.get(4).value(), equalTo(70L));
@@ -124,7 +124,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             rows.add(List.of("x", ts, 3));
         }
 
-        // internal bucket == output bucket → no sub-bucketing, all groups aligned
+        // internal bucket == output bucket -> no sub-bucketing, all groups aligned
         List<Page> results = runPipeline(fiveMinBucket, fiveMinBucket, windowDuration, rows);
 
         List<OutputRow> outputRows = extractRows(results);
@@ -156,10 +156,8 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
 
         // Use both a window aggregator (sum) and a values aggregator (dimension values on tsid column)
         List<GroupingAggregator.Factory> aggregatorFactories = List.of(
-            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                AggregatorMode.SINGLE,
-                List.of(HASH_CHANNEL_COUNT)
-            ),
+            WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT)),
             new org.elasticsearch.compute.aggregation.ValuesBytesRefAggregatorFunctionSupplier().groupingAggregatorFactory(
                 AggregatorMode.SINGLE,
                 List.of(0)
@@ -221,8 +219,8 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
     /**
      * Sparse data where output-aligned sub-buckets have no direct data points.
      * With 7m window, 5m output bucket, 1m internal bucket, and data only at minutes 2 and 8:
-     * - Output group at 00:00 is an expanded group (no direct data) — VALUES must still resolve
-     * - Output group at 05:00 is an expanded group (no direct data) — VALUES must still resolve
+     * - Output group at 00:00 is an expanded group (no direct data) - VALUES must still resolve
+     * - Output group at 05:00 is an expanded group (no direct data) - VALUES must still resolve
      * This exercises the path where expandWindowBuckets creates groups that become output-aligned,
      * and selectedForValuesAggregator must remap them to the original group that has dimension data.
      */
@@ -240,10 +238,8 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         rows.add(List.of("s1", baseTime + TimeValue.timeValueMinutes(8).millis(), 10));
 
         List<GroupingAggregator.Factory> aggregatorFactories = List.of(
-            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                AggregatorMode.SINGLE,
-                List.of(HASH_CHANNEL_COUNT)
-            ),
+            WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT)),
             new org.elasticsearch.compute.aggregation.ValuesBytesRefAggregatorFunctionSupplier().groupingAggregatorFactory(
                 AggregatorMode.SINGLE,
                 List.of(0)
@@ -331,7 +327,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             rows.add(List.of("z", ts, 2));
         }
 
-        // 4m window, 3m output bucket, 1m internal bucket → GCD = 1m sub-buckets, output every 3m
+        // 4m window, 3m output bucket, 1m internal bucket -> GCD = 1m sub-buckets, output every 3m
         List<Page> results = runPipeline(oneMinBucket, threeMinBucket, windowDuration, rows);
 
         List<OutputRow> outputRows = extractRows(results);
@@ -340,11 +336,11 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             assertThat(threeMinBucket.round(row.bucket()), equalTo(row.bucket()));
         }
         outputRows.sort(Comparator.comparingLong(OutputRow::bucket));
-        // [0,4m) → minutes 0..3 → 4 points × 2 = 8
+        // [0,4m) -> minutes 0..3 -> 4 points × 2 = 8
         assertThat(outputRows.get(0).value(), equalTo(8L));
-        // [3m,7m) → minutes 3..6 → 4 points × 2 = 8
+        // [3m,7m) -> minutes 3..6 -> 4 points × 2 = 8
         assertThat(outputRows.get(1).value(), equalTo(8L));
-        // [6m,10m) → minutes 6..8 → 3 points × 2 = 6
+        // [6m,10m) -> minutes 6..8 -> 3 points × 2 = 6
         assertThat(outputRows.get(2).value(), equalTo(6L));
     }
 
@@ -365,10 +361,8 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
-                    AggregatorMode.SINGLE,
-                    List.of(HASH_CHANNEL_COUNT)
-                )
+                WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration)
+                    .groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(HASH_CHANNEL_COUNT))
             ),
             10_000,
             outputBucket,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -333,7 +333,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                     // apply the grouping window in the final phase
                     if (mode.isOutputPartial() == false && aggregateFunction.hasWindow()) {
                         Duration windowInterval = (Duration) aggregateFunction.window().fold(foldContext);
-                        aggSupplier = new WindowAggregatorFunctionSupplier(aggSupplier, windowInterval);
+                        aggSupplier = WindowAggregatorFunctionSupplier.forwardWindowFnSupplier(aggSupplier, windowInterval);
                     }
                     consumer.accept(new AggFunctionSupplierContext(aggSupplier, inputChannels, mode));
                 }


### PR DESCRIPTION
ESQL window functions are forward-looking only. For timeseries, that is usually the wrong default (Datadog, Prometheus, etc., use trailing windows). That mismatch will confuse anyone coming to Elasticsearch from those tools.

This diff stack extends ESQL TS window functions to support configurable window semantics. 

The window is passed to planner as `Expression` duration literal and doesn't carry orientation semantics. We have some options (1) introduce a dedicated window expression type, or (2) use the fact `java.time.Duration` is signed. The option (1) would require broader refactor and transport changes. Given we need only need window functions for TS aggregates the option (2) is sufficient to cover both `following` and `trailing` windows. 

In future we may decide to extend support to other non TS-bound windows so the contract ideally should not relay on the sign manipulation or duration type directly. New type non-expression type `Window<T>` we introduced solves this problem. 

Stack:

- https://github.com/elastic/elasticsearch/pull/146226 (this)
- https://github.com/elastic/elasticsearch/pull/146227