### PR TITLE
ESQL: Support configurable window function semantics #2

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
@@ -10,9 +10,6 @@ package org.elasticsearch.compute.aggregation;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-import java.time.Duration;
-import java.util.List;
-
 public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends GroupingAggregatorEvaluationContext {
     private IntVector allGroupIds;
 
@@ -21,11 +18,8 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
     }
 
     /**
-     * Returns the full set of group IDs when output filtering is active (i.e., the operator
-     * passes only output-aligned groups to aggregators). Window functions need the complete set
-     * to produce intermediate results for neighbor lookups during the merge step.
-     *
-     * @return all group IDs, or {@code null} when no output filtering is applied
+     * Returns the full set of group IDs when output filtering is active.
+     * Window aggregations use this to build intermediate states for non-output buckets.
      */
     public IntVector allGroupIds() {
         return allGroupIds;
@@ -37,36 +31,53 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
 
     /**
      * Returns the inclusive start of the time range, in milliseconds, for the specified group ID.
-     * Data points for this group are within the range [rangeStartInMillis, rangeEndInMillis).
-     *
-     * @param groupId the group id
-     * @return the start of the time range in milliseconds (inclusive)
      */
     public abstract long rangeStartInMillis(int groupId);
 
     /**
      * Returns the exclusive end of the time range, in milliseconds, for the specified group ID.
-     * Data points for this group are within the range [rangeStartInMillis, rangeEndInMillis).
      */
     public abstract long rangeEndInMillis(int groupId);
 
     /**
-     * Returns the group IDs of subsequent groups that belong to the window starting with the {@code startingGroupId}.
-     * The time ranges of returned group IDs are within the interval
-     * {@code [rangeStartInMillis(startingGroupId), rangeStartInMillis(startingGroupId) + window.toMillis())}.
-     *
-     * @param startingGroupId the starting group ID
-     * @param window          the window duration
-     * @return a list of group IDs within the window
+     * Calls {@code action} for each group ID in the window anchored at {@code startingGroupId}.
      */
-    public abstract List<Integer> groupIdsFromWindow(int startingGroupId, Duration window);
+    public abstract void forEachGroupInWindow(int startingGroupId, java.time.Duration window, java.util.function.IntConsumer action);
+
+    /**
+     * Calls {@code action} for each extra bucket timestamp that needs to be materialized
+     * so the window for {@code groupId} has all required neighbors.
+     */
+    public abstract void forEachBucketInWindow(
+        long groupId,
+        java.time.Duration window,
+        org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash tsBlockHash,
+        java.util.function.LongConsumer action
+    );
+
+    /**
+     * Invokes {@code action} for each group ID whose bucket falls within
+     * {@code [rangeStartMillis, rangeEndMillis)}. The starting group is always visited first.
+     */
+    public abstract void forEachGroupInRange(
+        int startingGroupId,
+        long rangeStartMillis,
+        long rangeEndMillis,
+        java.util.function.IntConsumer action
+    );
+
+    /**
+     * Invokes {@code action} for each bucket timestamp in {@code [rangeStartMillis, rangeEndMillis)}
+     * that does not already exist as a group. Used by expansion to create synthetic buckets.
+     */
+    public abstract void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action);
 
     public abstract int previousGroupId(int currentGroupId);
 
     public abstract int nextGroupId(int currentGroupId);
 
     /**
-     * Computes and caches the adjacent group IDs. They weill be used in #previousGroupId and #nextGroupId.
+     * Computes and caches the adjacent group IDs. They will be used in #previousGroupId and #nextGroupId.
      */
     public abstract void computeAdjacentGroupIds();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowAggregatorFunctionSupplier.java
@@ -15,7 +15,11 @@ import java.util.List;
 /**
  * A {@link AggregatorFunctionSupplier} that wraps another, and apply a window function on the final aggregation.
  */
-public record WindowAggregatorFunctionSupplier(AggregatorFunctionSupplier supplier, Duration window) implements AggregatorFunctionSupplier {
+public record WindowAggregatorFunctionSupplier(
+    AggregatorFunctionSupplier supplier,
+    Duration window,
+    WindowEvaluationContext.Factory windowContextFactory
+) implements AggregatorFunctionSupplier {
 
     @Override
     public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
@@ -35,7 +39,7 @@ public record WindowAggregatorFunctionSupplier(AggregatorFunctionSupplier suppli
     @Override
     public GroupingAggregatorFunction groupingAggregator(DriverContext driverContext, List<Integer> channels) {
         GroupingAggregatorFunction fn = supplier.groupingAggregator(driverContext, channels);
-        return new WindowGroupingAggregatorFunction(fn, supplier, window);
+        return new WindowGroupingAggregatorFunction(fn, supplier, window, windowContextFactory);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowEvaluationContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
+
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
+
+/**
+ * Direction-specific window evaluation behavior, created per window aggregator from the base
+ * time-series context. Forward and backward implementations provide different iteration order
+ * and range computation.
+ */
+public interface WindowEvaluationContext {
+
+    /**
+     * Calls {@code action} for each group ID in the window anchored at {@code startingGroupId}.
+     */
+    void forEachGroupInWindow(int startingGroupId, IntConsumer action);
+
+    /**
+     * Calls {@code action} for each extra bucket timestamp that needs to be materialized
+     * so the window for {@code groupId} has all required neighbors.
+     */
+    void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action);
+
+    /**
+     * Effective start of the window range for the given group (for downstream final aggregation).
+     */
+    long rangeStartInMillis(int groupId);
+
+    /**
+     * Effective end of the window range for the given group (for downstream final aggregation).
+     */
+    long rangeEndInMillis(int groupId);
+
+    /**
+     * Start of the original data range for post-expansion trimming.
+     * Return {@link Long#MAX_VALUE} to signal no trimming (the default).
+     */
+    default long trimRangeStart(long dataRangeStartMillis, long dataRangeEndMillis) {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * End of the original data range for post-expansion trimming.
+     * Return {@link Long#MIN_VALUE} to signal no trimming (the default).
+     */
+    default long trimRangeEnd(long dataRangeStartMillis, long dataRangeEndMillis) {
+        return Long.MIN_VALUE;
+    }
+
+    /**
+     * Creates a {@link WindowEvaluationContext} from a base time-series context.
+     */
+    @FunctionalInterface
+    interface Factory {
+        WindowEvaluationContext create(TimeSeriesGroupingAggregatorEvaluationContext aggCtx);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
@@ -17,14 +18,18 @@ import org.elasticsearch.core.Releasables;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.function.LongConsumer;
 import java.util.stream.IntStream;
 
 /**
  * A {@link GroupingAggregatorFunction} that wraps another, and apply a window function on the final aggregation.
  */
-public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, AggregatorFunctionSupplier supplier, Duration window)
-    implements
-        GroupingAggregatorFunction {
+public record WindowGroupingAggregatorFunction(
+    GroupingAggregatorFunction next,
+    AggregatorFunctionSupplier supplier,
+    Duration window,
+    WindowEvaluationContext.Factory windowContextFactory
+) implements GroupingAggregatorFunction {
 
     @Override
     public AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds, Page page) {
@@ -74,6 +79,7 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
         IntVector selected,
         TimeSeriesGroupingAggregatorEvaluationContext ctx
     ) {
+        WindowEvaluationContext windowCtx = windowContextFactory.create(ctx);
         if (selected.getPositionCount() > 0) {
             // TODO: rewrite to NO_WINDOW in the planner if the bucket and the window are the same
             int groupId = selected.getInt(0);
@@ -83,10 +89,6 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                 return next.prepareEvaluateFinal(selected, ctx);
             }
         }
-        // When output filtering is active, allGroupIds contains every group (including sub-bucket
-        // groups that won't appear in the final output). We need all of them for evaluateIntermediate
-        // so that neighbor data is available during the window merge. When null, selected already
-        // contains every group.
         IntVector allGroups = ctx.allGroupIds();
         if (allGroups == null) {
             allGroups = selected;
@@ -112,7 +114,7 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                 finalAgg.aggregatorFunction().addIntermediateInput(0, allGroups, page);
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int groupId = selected.getInt(i);
-                    mergeBucketsFromWindow(groupId, backwards, page, finalAgg.aggregatorFunction(), ctx);
+                    mergeBucketsFromWindow(groupId, backwards, page, finalAgg.aggregatorFunction(), windowCtx, ctx);
                 }
             } finally {
                 Releasables.close(intermediateBlocks);
@@ -120,20 +122,14 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
             PreparedForEvaluation delegate = finalAgg.prepareForEvaluate(
                 selected,
                 new TimeSeriesGroupingAggregatorEvaluationContext(ctx.driverContext()) {
-                    // expand the window to cover the new range
                     @Override
                     public long rangeStartInMillis(int groupId) {
-                        return ctx.rangeStartInMillis(groupId);
+                        return windowCtx.rangeStartInMillis(groupId);
                     }
 
                     @Override
                     public long rangeEndInMillis(int groupId) {
-                        return rangeStartInMillis(groupId) + window.toMillis();
-                    }
-
-                    @Override
-                    public List<Integer> groupIdsFromWindow(int startingGroupId, Duration window) {
-                        throw new UnsupportedOperationException();
+                        return windowCtx.rangeEndInMillis(groupId);
                     }
 
                     @Override
@@ -147,14 +143,45 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                     }
 
                     @Override
-                    public void computeAdjacentGroupIds() {
-                        // not used by #nextGroupId and #previousGroupId
+                    public void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void forEachGroupInRange(
+                        int startingGroupId,
+                        long rangeStartMillis,
+                        long rangeEndMillis,
+                        java.util.function.IntConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void computeAdjacentGroupIds() {}
+
+                    @Override
+                    public void forEachGroupInWindow(
+                        int startingGroupId,
+                        java.time.Duration window,
+                        java.util.function.IntConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void forEachBucketInWindow(
+                        long groupId,
+                        java.time.Duration window,
+                        TimeSeriesBlockHash tsBlockHash,
+                        LongConsumer action
+                    ) {
+                        throw new UnsupportedOperationException();
                     }
                 }
             );
             GroupingAggregator takeFinalAgg = finalAgg;
             finalAgg = null;
-            // Leave the final agg open until the prepared results are closed.
             return new PreparedForEvaluation() {
                 @Override
                 public void evaluate(Block[] blocks, int offset, IntVector selectedInPage) {
@@ -176,18 +203,16 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
         int[] groupIdToPositions,
         Page page,
         GroupingAggregatorFunction fn,
+        WindowEvaluationContext windowCtx,
         TimeSeriesGroupingAggregatorEvaluationContext context
     ) {
-        var groupIds = context.groupIdsFromWindow(startingGroupId, window);
-        if (groupIds.size() > 1) {
-            try (IntVector oneGroup = context.driverContext().blockFactory().newConstantIntVector(startingGroupId, 1)) {
-                for (int g : groupIds) {
-                    if (g != startingGroupId) {
-                        int position = groupIdToPositions[g];
-                        fn.addIntermediateInput(position, oneGroup, page);
-                    }
+        try (IntVector oneGroup = context.driverContext().blockFactory().newConstantIntVector(startingGroupId, 1)) {
+            windowCtx.forEachGroupInWindow(startingGroupId, g -> {
+                if (g != startingGroupId && g >= 0 && g < groupIdToPositions.length) {
+                    int position = groupIdToPositions[g];
+                    fn.addIntermediateInput(position, oneGroup, page);
                 }
-            }
+            });
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorEvaluationContext;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.TimeSeriesGroupingAggregatorEvaluationContext;
+import org.elasticsearch.compute.aggregation.WindowEvaluationContext;
 import org.elasticsearch.compute.aggregation.WindowGroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
@@ -33,12 +34,12 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.joining;
@@ -111,6 +112,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
     private final Rounding.Prepared outputTimeBucket;
     private ExpandingGroups expandingGroups = null;
     private int numGroupsBeforeExpanding = -1;
+    /** Snapshot of the query's timestamp bounds before backward expansion adds synthetic buckets. */
+    private long trimBeforeMillis = Long.MAX_VALUE;
+    private long trimAfterMillis = Long.MIN_VALUE;
 
     public TimeSeriesAggregationOperator(
         Rounding.Prepared timeBucket,
@@ -138,13 +142,23 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         if (rowsAddedInCurrentBatch == 0) {
             return;
         }
-        if (needsOutputFiltering() == false) {
+        if (blockHash instanceof TimeSeriesBlockHash == false) {
             super.emit();
             return;
         }
         TimeSeriesBlockHash tsBlockHash = (TimeSeriesBlockHash) blockHash;
-        int[] alignedPositions = computeOutputAlignedPositions(tsBlockHash);
-        if (alignedPositions == null) {
+        if (aggregatorMode.isOutputPartial()) {
+            super.emit();
+            return;
+        }
+        boolean needsTrim = needsExpandedGroupTrimming(tsBlockHash);
+        boolean filterOutputBucket = outputTimeBucket != null;
+        if (filterOutputBucket == false && needsTrim == false) {
+            super.emit();
+            return;
+        }
+        int[] outputPositions = computeOutputPositions(tsBlockHash);
+        if (outputPositions == null) {
             super.emit();
             return;
         }
@@ -161,7 +175,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             boolean keysFiltered = false;
             try {
                 for (int b = 0; b < fullKeys.length; b++) {
-                    outputKeys[b] = fullKeys[b].filter(false, alignedPositions);
+                    outputKeys[b] = fullKeys[b].filter(false, outputPositions);
                 }
                 keysFiltered = true;
             } finally {
@@ -171,9 +185,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                 }
             }
 
-            try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(alignedPositions.length)) {
-                for (int i = 0; i < alignedPositions.length; i++) {
-                    builder.appendInt(i, alignedPositions[i]);
+            try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
+                for (int i = 0; i < outputPositions.length; i++) {
+                    builder.appendInt(i, outputPositions[i]);
                 }
                 outputSelected = builder.build();
             }
@@ -210,26 +224,35 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         }
     }
 
-    private boolean needsOutputFiltering() {
-        return aggregatorMode.isOutputPartial() == false && outputTimeBucket != null && blockHash instanceof TimeSeriesBlockHash;
-    }
-
-    /**
-     * Computes the group IDs that are aligned to the output bucket boundary.
-     *
-     * @return aligned group IDs, or {@code null} when every group is already aligned (no filtering needed)
-     */
-    private int[] computeOutputAlignedPositions(TimeSeriesBlockHash tsBlockHash) {
-        Rounding.Prepared optimizedOutput = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp());
+    private int[] computeOutputPositions(TimeSeriesBlockHash tsBlockHash) {
+        final boolean trimExpandedGroups = needsExpandedGroupTrimming(tsBlockHash);
+        final boolean filterByOutputBucket = outputTimeBucket != null;
+        if (trimExpandedGroups == false && filterByOutputBucket == false) {
+            return null;
+        }
+        final long startTrimThreshold = trimExpandedGroups ? trimBeforeMillis + largestWindowMillis() : Long.MIN_VALUE;
+        Rounding.Prepared optimizedOutput = null;
+        if (filterByOutputBucket) {
+            long minTs = trimExpandedGroups ? trimBeforeMillis : timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+            long maxTs = trimExpandedGroups ? trimAfterMillis : timeResolution.roundDownToMillis(tsBlockHash.maxTimestamp());
+            optimizedOutput = optimizeOutputRoundingForTimeRange(minTs, maxTs);
+        }
         int totalGroups = Math.toIntExact(tsBlockHash.numGroups());
         int[] positions = new int[Math.min(totalGroups, 16)];
         int idx = 0;
         for (int p = 0; p < totalGroups; p++) {
             long millis = timeResolution.roundDownToMillis(tsBlockHash.timestampForGroup(p));
-            if (optimizedOutput.round(millis) == millis) {
-                positions = ArrayUtil.grow(positions, idx + 1);
-                positions[idx++] = p;
+            if (trimExpandedGroups && (millis < trimBeforeMillis || millis > trimAfterMillis)) {
+                continue;
             }
+            if (millis < startTrimThreshold) {
+                continue;
+            }
+            if (filterByOutputBucket && optimizedOutput.round(millis) != millis) {
+                continue;
+            }
+            positions = ArrayUtil.grow(positions, idx + 1);
+            positions[idx++] = p;
         }
         if (idx == totalGroups) {
             return null;
@@ -247,19 +270,23 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         }
     }
 
+    private boolean needsExpandedGroupTrimming(TimeSeriesBlockHash tsBlockHash) {
+        return numGroupsBeforeExpanding >= 0 && trimAfterMillis != Long.MIN_VALUE && tsBlockHash.numGroups() > numGroupsBeforeExpanding;
+    }
+
     @Override
     protected boolean shouldEmitPartialResultsPeriodically() {
         return false;
     }
 
     private long largestWindowMillis() {
-        long largestWindow = Long.MIN_VALUE;
+        long largest = 0L;
         for (GroupingAggregator aggregator : aggregators) {
-            if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction aggregatorFunction) {
-                largestWindow = Math.max(largestWindow, aggregatorFunction.window().toMillis());
+            if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction wf) {
+                largest = Math.max(largest, wf.window().toMillis());
             }
         }
-        return largestWindow;
+        return largest;
     }
 
     /*
@@ -325,36 +352,46 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         if (aggregatorMode.isOutputPartial()) {
             return;
         }
-        final long windowMillis = largestWindowMillis();
-        if (windowMillis <= 0) {
-            return;
-        }
         if (blockHash instanceof TimeSeriesBlockHash == false) {
             return;
         }
         TimeSeriesBlockHash tsBlockHash = (TimeSeriesBlockHash) blockHash;
-        final long numGroups = tsBlockHash.numGroups();
+        long numGroups = tsBlockHash.numGroups();
         if (numGroups == 0) {
             return;
         }
-        Rounding.Prepared optimizedTimeBucket = optimizeRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp());
-        long minBound = tsBlockHash.minTimestamp();
-        if (outputTimeBucket != null) {
-            minBound = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp()).round(minBound);
-        }
-        this.numGroupsBeforeExpanding = Math.toIntExact(numGroups);
+        boolean expanded = false;
         this.expandingGroups = new ExpandingGroups(driverContext.bigArrays());
-        for (long groupId = 0; groupId < numGroups; groupId++) {
-            int tsid = tsBlockHash.tsidForGroup(groupId);
-            long endTimestamp = tsBlockHash.timestampForGroup(groupId);
-            long bucket = optimizedTimeBucket.nextRoundingValue(endTimestamp - timeResolution.convert(largestWindowMillis()));
-            bucket = Math.max(bucket, minBound);
-            // Fill the missing buckets between (timestamp-window, timestamp)
-            while (bucket < endTimestamp) {
-                if (tsBlockHash.addExtraGroup(tsid, bucket) >= 0) {
-                    expandingGroups.addGroup(Math.toIntExact(groupId));
+        try (var baseCtx = evaluationContext(blockHash)) {
+            if (baseCtx instanceof TimeSeriesGroupingAggregatorEvaluationContext tsCtx) {
+                for (GroupingAggregator aggregator : aggregators) {
+                    if (aggregator.aggregatorFunction() instanceof WindowGroupingAggregatorFunction wf && wf.window().toMillis() > 0) {
+                        if (expanded == false) {
+                            this.numGroupsBeforeExpanding = Math.toIntExact(numGroups);
+                            expanded = true;
+                        }
+                        WindowEvaluationContext windowCtx = wf.windowContextFactory().create(tsCtx);
+                        long dataStartMillis = timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+                        long dataEndMillis = timeResolution.roundDownToMillis(tsBlockHash.maxTimestamp());
+                        long trimStart = windowCtx.trimRangeStart(dataStartMillis, dataEndMillis);
+                        long trimEnd = windowCtx.trimRangeEnd(dataStartMillis, dataEndMillis);
+                        if (trimStart != Long.MAX_VALUE) {
+                            this.trimBeforeMillis = Math.min(this.trimBeforeMillis, trimStart);
+                        }
+                        if (trimEnd != Long.MIN_VALUE) {
+                            this.trimAfterMillis = Math.max(this.trimAfterMillis, trimEnd);
+                        }
+                        for (long groupId = 0; groupId < numGroups; groupId++) {
+                            final int originalGroupId = Math.toIntExact(groupId);
+                            int tsid = tsBlockHash.tsidForGroup(groupId);
+                            windowCtx.forEachBucketInWindow(groupId, tsBlockHash, candidateBucket -> {
+                                if (tsBlockHash.addExtraGroup(tsid, candidateBucket) >= 0) {
+                                    expandingGroups.addGroup(originalGroupId);
+                                }
+                            });
+                        }
+                    }
                 }
-                bucket = optimizedTimeBucket.nextRoundingValue(bucket);
             }
         }
     }
@@ -476,19 +513,67 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             }
 
             @Override
-            public List<Integer> groupIdsFromWindow(int startingGroupId, Duration window) {
+            public void forEachGroupInWindow(int startingGroupId, Duration window, IntConsumer action) {
                 int tsid = tsBlockHash.tsidForGroup(startingGroupId);
                 long bucket = tsBlockHash.timestampForGroup(startingGroupId);
-                List<Integer> results = new ArrayList<>();
-                results.add(startingGroupId);
-                long endTimestamp = bucket + timeResolution.convert(window.toMillis());
+                action.accept(startingGroupId);
+                long windowMillis = window.toMillis();
+                if (windowMillis == 0) {
+                    return;
+                }
+                long endTimestamp = bucket + timeResolution.convert(windowMillis);
                 while ((bucket = optimizedTimeBucket.nextRoundingValue(bucket)) < endTimestamp) {
-                    long nextGroupId = tsBlockHash.getGroupId(tsid, bucket);
-                    if (nextGroupId != -1) {
-                        results.add(Math.toIntExact(nextGroupId));
+                    long groupId = tsBlockHash.getGroupId(tsid, bucket);
+                    if (groupId != -1) {
+                        action.accept(Math.toIntExact(groupId));
                     }
                 }
-                return results;
+            }
+
+            @Override
+            public void forEachBucketInWindow(
+                long groupId,
+                Duration window,
+                TimeSeriesBlockHash windowBlockHash,
+                java.util.function.LongConsumer action
+            ) {
+                long bucket = windowBlockHash.timestampForGroup(groupId);
+                long earliestBucket = optimizedTimeBucket.nextRoundingValue(bucket - timeResolution.convert(window.toMillis()));
+                long minBound = windowBlockHash.minTimestamp();
+                if (outputTimeBucket != null) {
+                    minBound = optimizeOutputRoundingForTimeRange(windowBlockHash.minTimestamp(), windowBlockHash.maxTimestamp()).round(
+                        minBound
+                    );
+                }
+                earliestBucket = Math.max(earliestBucket, minBound);
+                while (earliestBucket < bucket) {
+                    action.accept(earliestBucket);
+                    earliestBucket = optimizedTimeBucket.nextRoundingValue(earliestBucket);
+                }
+            }
+
+            @Override
+            public void forEachBucketInRange(long rangeStartMillis, long rangeEndMillis, java.util.function.LongConsumer action) {
+                long bucket = optimizedTimeBucket.nextRoundingValue(rangeStartMillis);
+                while (bucket < rangeEndMillis) {
+                    action.accept(bucket);
+                    bucket = optimizedTimeBucket.nextRoundingValue(bucket);
+                }
+            }
+
+            @Override
+            public void forEachGroupInRange(int startingGroupId, long rangeStartMillis, long rangeEndMillis, IntConsumer action) {
+                int tsid = tsBlockHash.tsidForGroup(startingGroupId);
+                action.accept(startingGroupId);
+                long minMillis = timeResolution.roundDownToMillis(tsBlockHash.minTimestamp());
+                long bucket = optimizedTimeBucket.round(Math.max(rangeStartMillis, minMillis));
+                while (bucket < rangeEndMillis) {
+                    long groupId = tsBlockHash.getGroupId(tsid, bucket);
+                    if (groupId != -1 && groupId != startingGroupId) {
+                        action.accept(Math.toIntExact(groupId));
+                    }
+                    bucket = optimizedTimeBucket.nextRoundingValue(bucket);
+                }
             }
 
             @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunctionTests.java
@@ -147,7 +147,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
     }
 
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), Duration.ofMinutes(5));
+        return forwardWindowAggregatorFunctionSupplier(Duration.ofMinutes(5));
     }
 
     protected String expectedToStringOfSimpleAggregator() {
@@ -213,7 +213,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+                forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                     AggregatorMode.SINGLE,
                     List.of(HASH_CHANNEL_COUNT)
                 )
@@ -305,7 +305,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+                forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                     AggregatorMode.SINGLE,
                     List.of(HASH_CHANNEL_COUNT)
                 )
@@ -398,7 +398,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             rows.add(List.of("s", ts, 10));
         }
 
-        // No outputTimeBucket → needsOutputFiltering() returns false → super.emit() → allGroupIds stays null
+        // No outputTimeBucket and only a forward window → custom emit is skipped → super.emit() → allGroupIds stays null
         var operatorFactory = new TimeSeriesAggregationOperator.Factory(
             fiveMinBucket,
             false,
@@ -408,7 +408,7 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+                forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                     AggregatorMode.SINGLE,
                     List.of(HASH_CHANNEL_COUNT)
                 )
@@ -457,5 +457,163 @@ public class WindowGroupingAggregatorFunctionTests extends ForkingOperatorTestCa
         assertThat(outputRows.get(1).value(), equalTo(20L));
         assertThat(outputRows.get(2).value(), equalTo(20L));
         assertThat(outputRows.get(3).value(), equalTo(10L));
+    }
+
+    /**
+     * Backward windows look backward in time while keeping a positive stored duration. With a coarser output bucket,
+     * emit filtering drops leading buckets that do not yet have a full lookback window of raw data.
+     */
+    public void testBackwardWindowOverCoarserOutputBuckets() {
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        Rounding.Prepared fiveMinBucket = Rounding.builder(TimeValue.timeValueMinutes(5)).build().prepareForUnknown();
+        Duration windowDuration = Duration.ofMinutes(10);
+
+        final long startTime = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2025-11-13");
+        long baseTime = oneMinBucket.round(startTime);
+        String tsid = "solo";
+
+        // Enough raw minutes that expanded buckets for the 15m output row stay within trimAfterMillis.
+        List<List<Object>> rows = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            long ts = baseTime + TimeValue.timeValueMinutes(i).millis();
+            rows.add(List.of(tsid, ts, 1));
+        }
+
+        var operatorFactory = new TimeSeriesAggregationOperator.Factory(
+            oneMinBucket,
+            false,
+            List.of(
+                new BlockHash.GroupSpec(0, ElementType.BYTES_REF, null, null),
+                new BlockHash.GroupSpec(1, ElementType.LONG, null, null)
+            ),
+            AggregatorMode.SINGLE,
+            List.of(
+                backwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
+                    AggregatorMode.SINGLE,
+                    List.of(HASH_CHANNEL_COUNT)
+                )
+            ),
+            10_000,
+            fiveMinBucket
+        );
+
+        var driverCtx = driverContext();
+        var source = new ListRowsBlockSourceOperator(
+            driverCtx.blockFactory(),
+            List.of(ElementType.BYTES_REF, ElementType.LONG, ElementType.INT),
+            rows
+        );
+        List<Page> results = new ArrayList<>();
+        try (
+            var driver = org.elasticsearch.compute.test.TestDriverFactory.create(
+                driverCtx,
+                source,
+                List.of(operatorFactory.get(driverCtx)),
+                new org.elasticsearch.compute.test.TestResultPageSinkOperator(results::add)
+            )
+        ) {
+            new org.elasticsearch.compute.test.TestDriverRunner().run(driver);
+        }
+
+        record OutputRow(long bucket, long value) {}
+        List<OutputRow> backwardRows = new ArrayList<>();
+        for (Page page : results) {
+            LongBlock buckets = page.getBlock(1);
+            LongBlock values = page.getBlock(2);
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                backwardRows.add(new OutputRow(buckets.getLong(p), values.getLong(p)));
+            }
+        }
+        backwardRows.sort(Comparator.comparingLong(OutputRow::bucket));
+        assertThat(backwardRows.size(), equalTo(3));
+        assertThat(backwardRows.get(0).bucket(), equalTo(baseTime + TimeValue.timeValueMinutes(10).millis()));
+        assertThat(backwardRows.get(1).bucket(), equalTo(baseTime + TimeValue.timeValueMinutes(15).millis()));
+        assertThat(backwardRows.get(2).bucket(), equalTo(baseTime + TimeValue.timeValueMinutes(20).millis()));
+        for (OutputRow row : backwardRows) {
+            assertThat(fiveMinBucket.round(row.bucket()), equalTo(row.bucket()));
+        }
+        assertThat(backwardRows.get(0).value(), equalTo(10L));
+        assertThat(backwardRows.get(1).value(), equalTo(10L));
+        assertThat(backwardRows.get(2).value(), equalTo(10L));
+    }
+
+    private static WindowAggregatorFunctionSupplier forwardWindowAggregatorFunctionSupplier(Duration windowDuration) {
+        return new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration, base -> {
+            long wMillis = windowDuration.toMillis();
+            return new WindowEvaluationContext() {
+                @Override
+                public void forEachGroupInWindow(int startingGroupId, java.util.function.IntConsumer action) {
+                    long start = base.rangeStartInMillis(startingGroupId);
+                    base.forEachGroupInRange(startingGroupId, start, start + wMillis, action);
+                }
+
+                @Override
+                public void forEachBucketInWindow(
+                    long groupId,
+                    org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash tsBlockHash,
+                    java.util.function.LongConsumer action
+                ) {
+                    base.forEachBucketInWindow(groupId, windowDuration, tsBlockHash, action);
+                }
+
+                @Override
+                public long rangeStartInMillis(int groupId) {
+                    return base.rangeStartInMillis(groupId);
+                }
+
+                @Override
+                public long rangeEndInMillis(int groupId) {
+                    return base.rangeStartInMillis(groupId) + wMillis;
+                }
+            };
+        });
+    }
+
+    private static WindowAggregatorFunctionSupplier backwardWindowAggregatorFunctionSupplier(Duration windowDuration) {
+        return new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration, base -> {
+            long wMillis = windowDuration.toMillis();
+            return new WindowEvaluationContext() {
+                @Override
+                public void forEachGroupInWindow(int startingGroupId, java.util.function.IntConsumer action) {
+                    long end = base.rangeEndInMillis(startingGroupId);
+                    base.forEachGroupInRange(startingGroupId, end - wMillis, end, action);
+                }
+
+                @Override
+                public void forEachBucketInWindow(
+                    long groupId,
+                    org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash tsBlockHash,
+                    java.util.function.LongConsumer action
+                ) {
+                    long bucket = tsBlockHash.timestampForGroup(groupId);
+                    long bucketMillis = base.rangeStartInMillis(Math.toIntExact(groupId));
+                    base.forEachBucketInRange(bucketMillis, bucketMillis + wMillis, ts -> {
+                        if (ts != bucket) {
+                            action.accept(ts);
+                        }
+                    });
+                }
+
+                @Override
+                public long rangeStartInMillis(int groupId) {
+                    return base.rangeEndInMillis(groupId) - wMillis;
+                }
+
+                @Override
+                public long rangeEndInMillis(int groupId) {
+                    return base.rangeEndInMillis(groupId);
+                }
+
+                @Override
+                public long trimRangeStart(long dataRangeStartMillis, long dataRangeEndMillis) {
+                    return dataRangeStartMillis;
+                }
+
+                @Override
+                public long trimRangeEnd(long dataRangeStartMillis, long dataRangeEndMillis) {
+                    return dataRangeEndMillis;
+                }
+            };
+        });
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.aggregation.ValuesBytesRefAggregatorFunctionSup
 import org.elasticsearch.compute.aggregation.ValuesIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesLongAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.WindowAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.WindowEvaluationContext;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -156,7 +157,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
 
         // Use both a window aggregator (sum) and a values aggregator (dimension values on tsid column)
         List<GroupingAggregator.Factory> aggregatorFactories = List.of(
-            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+            forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                 AggregatorMode.SINGLE,
                 List.of(HASH_CHANNEL_COUNT)
             ),
@@ -239,7 +240,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         rows.add(List.of("s1", baseTime + TimeValue.timeValueMinutes(8).millis(), 10));
 
         List<GroupingAggregator.Factory> aggregatorFactories = List.of(
-            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+            forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                 AggregatorMode.SINGLE,
                 List.of(HASH_CHANNEL_COUNT)
             ),
@@ -363,7 +364,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             ),
             AggregatorMode.SINGLE,
             List.of(
-                new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration).groupingAggregatorFactory(
+                forwardWindowAggregatorFunctionSupplier(windowDuration).groupingAggregatorFactory(
                     AggregatorMode.SINGLE,
                     List.of(HASH_CHANNEL_COUNT)
                 )
@@ -407,5 +408,41 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             }
         }
         return outputRows;
+    }
+
+    /**
+     * Windowed sum with forward-looking window iteration; ordinary {@link WindowAggregatorFunctionSupplier}
+     * usage applies the default backward-looking window.
+     */
+    private static WindowAggregatorFunctionSupplier forwardWindowAggregatorFunctionSupplier(Duration windowDuration) {
+        return new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), windowDuration, base -> {
+            long wMillis = windowDuration.toMillis();
+            return new WindowEvaluationContext() {
+                @Override
+                public void forEachGroupInWindow(int startingGroupId, java.util.function.IntConsumer action) {
+                    long start = base.rangeStartInMillis(startingGroupId);
+                    base.forEachGroupInRange(startingGroupId, start, start + wMillis, action);
+                }
+
+                @Override
+                public void forEachBucketInWindow(
+                    long groupId,
+                    org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash tsBlockHash,
+                    java.util.function.LongConsumer action
+                ) {
+                    base.forEachBucketInWindow(groupId, windowDuration, tsBlockHash, action);
+                }
+
+                @Override
+                public long rangeStartInMillis(int groupId) {
+                    return base.rangeStartInMillis(groupId);
+                }
+
+                @Override
+                public long rangeEndInMillis(int groupId) {
+                    return base.rangeStartInMillis(groupId) + wMillis;
+                }
+            };
+        });
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ts-window.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ts-window.csv-spec
@@ -273,6 +273,33 @@ s:long | dim:keyword | time_bucket:datetime
 ;
 
 ###############################################
+# Negative window duration = backward-looking window.
+# First output buckets before a full lookback exist are omitted; last row differs from +10m forward
+# when the forward case used a shorter tail window (see sum_over_time_exact_multiple_baseline).
+###############################################
+
+sum_over_time_backward_window_10m_5m_bucket
+required_capability: ts_command_v0
+required_capability: time_series_window_v1
+required_capability: time_series_window_trailing
+
+TS ts_window
+| STATS s = sum(sum_over_time(val, -10minute)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+s:long | dim:keyword | time_bucket:datetime
+105    | a           | 2024-01-01T00:10:00.000Z
+1050   | b           | 2024-01-01T00:10:00.000Z
+155    | a           | 2024-01-01T00:15:00.000Z
+1550   | b           | 2024-01-01T00:15:00.000Z
+205    | a           | 2024-01-01T00:20:00.000Z
+2050   | b           | 2024-01-01T00:20:00.000Z
+255    | a           | 2024-01-01T00:25:00.000Z
+2550   | b           | 2024-01-01T00:25:00.000Z
+;
+
+###############################################
 # Rate tests with non-multiple windows
 # rate() computes the per-second increase of a
 # counter metric, with interpolation at bucket

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1937,6 +1937,11 @@ public class EsqlCapabilities {
         TIME_SERIES_WINDOW_SMALLER_THAN_BUCKET,
 
         /**
+         * Trailing time-series window.
+         */
+        TIME_SERIES_WINDOW_TRAILING,
+
+        /**
          * Support like/rlike parameters https://github.com/elastic/elasticsearch/issues/131356
          */
         LIKE_PARAMETER_SUPPORT,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
 
@@ -129,6 +130,14 @@ public final class Expressions {
         return true;
     }
 
+    public static Object foldMap(Expression exp, FoldContext ctx, UnaryOperator<Object> mapper) {
+        Object value;
+        if ((value = exp.fold(ctx)) != null) {
+            return mapper.apply(value);
+        }
+        return null;
+    }
+
     public static List<Object> fold(FoldContext ctx, List<? extends Expression> exps) {
         List<Object> folded = new ArrayList<>(exps.size());
         for (Expression exp : exps) {
@@ -226,7 +235,7 @@ public final class Expressions {
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof SemanticExpression other && expression.semanticEquals(other.expression);
+            return obj instanceof SemanticExpression(Expression expression1) && expression.semanticEquals(expression1);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/WindowFilter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/WindowFilter.java
@@ -17,15 +17,16 @@ import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,16 +113,18 @@ public class WindowFilter extends EsqlScalarFunction implements TimestampAware, 
         if (window.foldable() == false) {
             throw new IllegalArgumentException("Window should be foldable");
         }
-        Duration foldedWindow = (Duration) window.fold(toEvaluator.foldCtx());
+        var w = (AggregateFunction.TSWindow) Expressions.foldMap(window, toEvaluator.foldCtx(), AggregateFunction.TSWindow.TYPE);
+
         Rounding.Prepared preparedRounding = bucketBucket.getDateRoundingOrNull(toEvaluator.foldCtx());
         var timestampFactory = toEvaluator.apply(timestamp);
         return new WindowFilterEvaluator.Factory(
             source(),
-            foldedWindow.toMillis(),
+            w.length().toMillis(),
             preparedRounding,
             driverContext -> new HashMap<>(),
             timestampFactory
         );
+
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -13,6 +13,8 @@ import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAwa
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -59,7 +62,28 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
  * </p>
  */
 public abstract class AggregateFunction extends Function implements PostAnalysisPlanVerificationAware {
-    public static final Literal NO_WINDOW = Literal.timeDuration(Source.EMPTY, Duration.ZERO);
+
+    public interface Window<T> {
+        T length();
+    }
+
+    public sealed interface TSWindow extends Window<Duration> permits TSFront, TSBack {
+        UnaryOperator<Object> TYPE = o -> {
+            if (o instanceof Duration d) {
+                if (d.isNegative()) {
+                    return new TSBack(d.negated());
+                }
+                return new TSFront(d);
+            }
+            return o;
+        };
+    }
+
+    public record TSBack(Duration length) implements TSWindow {}
+
+    public record TSFront(Duration length) implements TSWindow {}
+
+    public static final Expression NO_WINDOW = Literal.timeDuration(Source.EMPTY, Duration.ZERO);
     public static final TransportVersion WINDOW_INTERVAL = TransportVersion.fromName("aggregation_window");
 
     private final Expression field;
@@ -85,7 +109,7 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
         super(source, CollectionUtils.combine(asList(field, filter, window), parameters));
         this.field = field;
         this.filter = filter;
-        this.window = Objects.requireNonNull(window, "[window] must be specified; use NO_WINDOW instead");
+        this.window = window;
         this.parameters = parameters;
     }
 
@@ -113,7 +137,7 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
         out.writeNamedWriteable(field);
         out.writeNamedWriteable(filter);
         if (out.getTransportVersion().supports(WINDOW_INTERVAL)) {
-            out.writeNamedWriteable(window);
+            window.writeTo(out);
         }
         out.writeNamedWriteableCollection(parameters);
     }
@@ -160,7 +184,7 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
         if (parameters == this.parameters) {
             return this;
         }
-        return (AggregateFunction) replaceChildren(CollectionUtils.combine(asList(field, filter), parameters));
+        return (AggregateFunction) replaceChildren(CollectionUtils.combine(asList(field, filter, window), parameters));
     }
 
     /**
@@ -174,10 +198,14 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
      * Whether the aggregate function has a window different than NO_WINDOW.
      */
     public boolean hasWindow() {
-        if (window instanceof Literal lit && lit.value() instanceof Duration duration) {
-            return duration.isZero() == false;
+        if (window.foldable() == false) {
+            return true;
         }
-        return true;
+        var folded = Expressions.foldMap(window, FoldContext.small(), TSWindow.TYPE);
+        if (folded instanceof TSWindow w) {
+            return w.length().isZero() == false;
+        }
+        return false;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ApplyWindowFilter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ApplyWindowFilter.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.expression.function.WindowFilter;
@@ -35,12 +36,15 @@ public class ApplyWindowFilter extends OptimizerRules.ParameterizedOptimizerRule
         boolean modified = false;
         for (var agg : aggregate.aggregates()) {
             if (agg instanceof Alias alias && alias.child() instanceof AggregateFunction af && af.hasWindow()) {
-                if (af.window().foldable() && af.window().fold(FoldContext.small()) instanceof Duration windowDuration) {
+                // TODO(sidosera): Support trailing windows
+                var folded = Expressions.foldMap(af.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE);
+                if (folded instanceof AggregateFunction.TSFront tsf) {
+                    assert aggregate.timeBucket() != null;
                     Expression bucket = aggregate.timeBucket().buckets();
                     if (bucket != null
                         && bucket.foldable()
                         && bucket.fold(FoldContext.small()) instanceof Duration bucketDuration
-                        && bucketDuration.compareTo(windowDuration) > 0) {
+                        && bucketDuration.compareTo(tsf.length()) > 0) {
                         aggs.add(
                             new Alias(
                                 alias.source(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -473,18 +473,17 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
         List<String> windowSourceTexts = new ArrayList<>();
         for (NamedExpression ne : aggregates) {
             if (Alias.unwrap(ne) instanceof AggregateFunction af && af.hasWindow()) {
-                Expression window = af.window();
-                if (window.foldable() && window.fold(FoldContext.small()) instanceof Duration d) {
-                    long windowMillis = d.toMillis();
-                    if (windowMillis > 0) {
-                        windowSourceTexts.add(window.sourceText());
-                        if (windowMillis < bucketMillis) {
-                            hasSmallWindow = true;
-                        } else {
-                            gcdMillis = MathUtil.gcd(gcdMillis, windowMillis);
-                            if (windowMillis % bucketMillis != 0) {
-                                hasNonMultipleWindow = true;
-                            }
+                // TODO(sidosera): Support trailing windows
+                var folded = Expressions.foldMap(af.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE);
+                if (folded instanceof AggregateFunction.TSFront tsf) {
+                    windowSourceTexts.add(af.window().sourceText());
+                    long millis = tsf.length().toMillis();
+                    if (millis < bucketMillis) {
+                        hasSmallWindow = true;
+                    } else {
+                        gcdMillis = MathUtil.gcd(gcdMillis, millis);
+                        if (millis % bucketMillis != 0) {
+                            hasNonMultipleWindow = true;
                         }
                     }
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesAggregateExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesAggregateExec.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -19,12 +20,14 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An extension of {@link Aggregate} to perform time-series aggregation per time-series, such as rate or _over_time.
@@ -178,14 +181,27 @@ public class TimeSeriesAggregateExec extends AggregateExec {
     }
 
     public Rounding.Prepared timeBucketRounding(FoldContext foldContext) {
-        if (timeBucket == null) {
-            return null;
+        return timeBucket == null ? null : timeBucket.getDateRoundingOrNull(foldContext);
+    }
+
+    public DateFieldMapper.Resolution timeResolution() {
+        return timeBucket != null && timeBucket.dataType() == DataType.DATE_NANOS
+            ? DateFieldMapper.Resolution.NANOSECONDS
+            : DateFieldMapper.Resolution.MILLISECONDS;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), timeBucket, outputTimeBucket);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj) == false) {
+            return false;
         }
-        Rounding.Prepared rounding = timeBucket.getDateRoundingOrNull(foldContext);
-        if (rounding == null) {
-            throw new EsqlIllegalArgumentException("expected TBUCKET; got ", timeBucket);
-        }
-        return rounding;
+        TimeSeriesAggregateExec other = (TimeSeriesAggregateExec) obj;
+        return Objects.equals(timeBucket, other.timeBucket) && Objects.equals(outputTimeBucket, other.outputTimeBucket);
     }
 
     public Rounding.Prepared outputTimeBucketRounding(FoldContext foldContext) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -42,7 +42,6 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecution
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -336,32 +335,80 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                     }
                     // apply the grouping window in the final phase
                     if (mode.isOutputPartial() == false && aggregateFunction.hasWindow()) {
-                        Duration windowInterval = (Duration) aggregateFunction.window().fold(foldContext);
-                        aggSupplier = new WindowAggregatorFunctionSupplier(
-                            aggSupplier,
-                            windowInterval,
-                            aggCtx -> new WindowEvaluationContext() {
-                                @Override
-                                public void forEachGroupInWindow(int startingGroupId, IntConsumer action) {
-                                    aggCtx.forEachGroupInWindow(startingGroupId, windowInterval, action);
-                                }
-
-                                @Override
-                                public void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action) {
-                                    aggCtx.forEachBucketInWindow(groupId, windowInterval, tsBlockHash, action);
-                                }
-
-                                @Override
-                                public long rangeStartInMillis(int groupId) {
-                                    return aggCtx.rangeStartInMillis(groupId);
-                                }
-
-                                @Override
-                                public long rangeEndInMillis(int groupId) {
-                                    return aggCtx.rangeStartInMillis(groupId) + windowInterval.toMillis();
-                                }
-                            }
+                        var aggregateWindow = Expressions.foldMap(
+                            aggregateFunction.window(),
+                            FoldContext.small(),
+                            AggregateFunction.TSWindow.TYPE
                         );
+                        aggSupplier = switch (aggregateWindow) {
+                            case AggregateFunction.TSFront w -> new WindowAggregatorFunctionSupplier(
+                                aggSupplier,
+                                w.length(),
+                                aggCtx -> new WindowEvaluationContext() {
+                                    @Override
+                                    public void forEachGroupInWindow(int startingGroupId, IntConsumer action) {
+                                        aggCtx.forEachGroupInWindow(startingGroupId, w.length(), action);
+                                    }
+
+                                    @Override
+                                    public void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action) {
+                                        aggCtx.forEachBucketInWindow(groupId, w.length(), tsBlockHash, action);
+                                    }
+
+                                    @Override
+                                    public long rangeStartInMillis(int groupId) {
+                                        return aggCtx.rangeStartInMillis(groupId);
+                                    }
+
+                                    @Override
+                                    public long rangeEndInMillis(int groupId) {
+                                        return aggCtx.rangeStartInMillis(groupId) + w.length().toMillis();
+                                    }
+                                }
+                            );
+                            case AggregateFunction.TSBack w -> new WindowAggregatorFunctionSupplier(
+                                aggSupplier,
+                                w.length(),
+                                aggCtx -> new WindowEvaluationContext() {
+                                    @Override
+                                    public void forEachGroupInWindow(int startingGroupId, IntConsumer action) {
+                                        long end = aggCtx.rangeEndInMillis(startingGroupId);
+                                        aggCtx.forEachGroupInRange(startingGroupId, end - w.length().toMillis(), end, action);
+                                    }
+
+                                    @Override
+                                    public void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action) {
+                                        long bucketMillis = aggCtx.rangeStartInMillis(Math.toIntExact(groupId));
+                                        aggCtx.forEachBucketInRange(bucketMillis, bucketMillis + w.length().toMillis(), ts -> {
+                                            if (ts != tsBlockHash.timestampForGroup(groupId)) {
+                                                action.accept(ts);
+                                            }
+                                        });
+                                    }
+
+                                    @Override
+                                    public long rangeStartInMillis(int groupId) {
+                                        return aggCtx.rangeEndInMillis(groupId) - w.length().toMillis();
+                                    }
+
+                                    @Override
+                                    public long rangeEndInMillis(int groupId) {
+                                        return aggCtx.rangeEndInMillis(groupId);
+                                    }
+
+                                    @Override
+                                    public long trimRangeStart(long dataRangeStartMillis, long dataRangeEndMillis) {
+                                        return dataRangeStartMillis;
+                                    }
+
+                                    @Override
+                                    public long trimRangeEnd(long dataRangeStartMillis, long dataRangeEndMillis) {
+                                        return dataRangeEndMillis;
+                                    }
+                                }
+                            );
+                            default -> throw new EsqlIllegalArgumentException("unknown window: [{}]", aggregateFunction.window());
+                        };
                     }
                     consumer.accept(new AggFunctionSupplierContext(aggSupplier, inputChannels, mode));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -13,7 +13,9 @@ import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.aggregation.FilteredAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.WindowAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.WindowEvaluationContext;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.AggregationOperator;
@@ -48,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 import static java.util.Collections.emptyList;
 
@@ -333,7 +337,31 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                     // apply the grouping window in the final phase
                     if (mode.isOutputPartial() == false && aggregateFunction.hasWindow()) {
                         Duration windowInterval = (Duration) aggregateFunction.window().fold(foldContext);
-                        aggSupplier = new WindowAggregatorFunctionSupplier(aggSupplier, windowInterval);
+                        aggSupplier = new WindowAggregatorFunctionSupplier(
+                            aggSupplier,
+                            windowInterval,
+                            aggCtx -> new WindowEvaluationContext() {
+                                @Override
+                                public void forEachGroupInWindow(int startingGroupId, IntConsumer action) {
+                                    aggCtx.forEachGroupInWindow(startingGroupId, windowInterval, action);
+                                }
+
+                                @Override
+                                public void forEachBucketInWindow(long groupId, TimeSeriesBlockHash tsBlockHash, LongConsumer action) {
+                                    aggCtx.forEachBucketInWindow(groupId, windowInterval, tsBlockHash, action);
+                                }
+
+                                @Override
+                                public long rangeStartInMillis(int groupId) {
+                                    return aggCtx.rangeStartInMillis(groupId);
+                                }
+
+                                @Override
+                                public long rangeEndInMillis(int groupId) {
+                                    return aggCtx.rangeStartInMillis(groupId) + windowInterval.toMillis();
+                                }
+                            }
+                        );
                     }
                     consumer.accept(new AggFunctionSupplierContext(aggSupplier, inputChannels, mode));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -584,8 +585,8 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             && internalRounding != null
             && outputRounding.getUnprepared().equals(internalRounding.getUnprepared()) == false;
         return new TimeSeriesAggregationOperator.Factory(
-            internalRounding,
-            ts.timeBucket() != null && ts.timeBucket().dataType() == DataType.DATE_NANOS,
+            ts.timeBucketRounding(context.foldCtx()),
+            ts.timeResolution() == DateFieldMapper.Resolution.NANOSECONDS,
             groupSpecs,
             aggregatorMode,
             aggregatorFactories,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunctionWindowTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunctionWindowTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.time.Duration;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class AggregateFunctionWindowTests extends ESTestCase {
+
+    public void testNegativeDurationProducesTrailingWindow() {
+        var folded = Expressions.foldMap(
+            Literal.timeDuration(Source.EMPTY, Duration.ofMinutes(-10)),
+            FoldContext.small(),
+            AggregateFunction.TSWindow.TYPE
+        );
+
+        assertThat(folded, instanceOf(AggregateFunction.TSBack.class));
+        assertThat(((AggregateFunction.TSBack) folded).length(), equalTo(Duration.ofMinutes(10)));
+    }
+
+    public void testPositiveDurationProducesFollowingWindow() {
+        var folded = Expressions.foldMap(
+            Literal.timeDuration(Source.EMPTY, Duration.ofMinutes(10)),
+            FoldContext.small(),
+            AggregateFunction.TSWindow.TYPE
+        );
+
+        assertThat(folded, instanceOf(AggregateFunction.TSFront.class));
+        assertThat(((AggregateFunction.TSFront) folded).length(), equalTo(Duration.ofMinutes(10)));
+    }
+
+    public void testZeroDurationHasNoWindow() {
+        var folded = Expressions.foldMap(
+            Literal.timeDuration(Source.EMPTY, Duration.ZERO),
+            FoldContext.small(),
+            AggregateFunction.TSWindow.TYPE
+        );
+
+        assertThat(folded, instanceOf(AggregateFunction.TSFront.class));
+        assertThat(((AggregateFunction.TSFront) folded).length(), equalTo(Duration.ZERO));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -7907,7 +7907,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             plan.forEachExpressionDown(LastOverTime.class, holder::set);
             assertNotNull(holder.get());
             assertTrue(holder.get().hasWindow());
-            assertThat(holder.get().window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(window)));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    holder.get().window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length(),
+                equalTo(Duration.ofMinutes(window))
+            );
             Holder<WindowFilter> windowFilterHolder = new Holder<>();
             plan.forEachExpressionDown(WindowFilter.class, windowFilterHolder::set);
             assertNull(windowFilterHolder.get());
@@ -7925,7 +7932,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             plan.forEachExpressionDown(LastOverTime.class, holder::set);
             assertNotNull(holder.get());
             assertTrue(holder.get().hasWindow());
-            assertThat(holder.get().window().fold(FoldContext.small()), equalTo(Duration.ofHours(window)));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    holder.get().window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length(),
+                equalTo(Duration.ofHours(window))
+            );
             Holder<WindowFilter> windowFilterHolder = new Holder<>();
             plan.forEachExpressionDown(WindowFilter.class, windowFilterHolder::set);
             assertNull(windowFilterHolder.get());
@@ -7945,7 +7959,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             assertFalse(holder.get().hasWindow());
             assertTrue(holder.get().hasFilter());
             WindowFilter windowFilter = (WindowFilter) holder.get().filter();
-            assertThat(((Duration) windowFilter.window().fold(FoldContext.small())).toMinutes(), equalTo((long) window));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    windowFilter.window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length().toMinutes(),
+                equalTo((long) window)
+            );
         }
         // non-multiple window (>= bucket) - now supported via GCD sub-bucketing
         {
@@ -7960,7 +7981,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             plan.forEachExpressionDown(LastOverTime.class, holder::set);
             assertNotNull(holder.get());
             assertTrue(holder.get().hasWindow());
-            assertThat(holder.get().window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(window)));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    holder.get().window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length(),
+                equalTo(Duration.ofMinutes(window))
+            );
         }
         // no time bucket
         {
@@ -8025,7 +8053,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             Holder<WindowFilter> holder = new Holder<>();
             plan.forEachExpressionDown(WindowFilter.class, holder::set);
             assertNotNull(holder.get());
-            assertThat(((Duration) holder.get().window().fold(FoldContext.small())).toMinutes(), equalTo((long) window));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    holder.get().window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length().toMinutes(),
+                equalTo((long) window)
+            );
         }
         // nested aggregation
         {
@@ -8039,7 +8074,14 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             Holder<WindowFilter> holder = new Holder<>();
             plan.forEachExpressionDown(WindowFilter.class, holder::set);
             assertNotNull(holder.get());
-            assertThat(((Duration) holder.get().window().fold(FoldContext.small())).toMinutes(), equalTo((long) window));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    holder.get().window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length().toMinutes(),
+                equalTo((long) window)
+            );
         }
         // multiple aggregates with varying window sizes
         {
@@ -8063,8 +8105,22 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             assertTrue(rateHolder.get().hasFilter());
             WindowFilter lotWindowFilter = (WindowFilter) maxHolder.get().filter();
             WindowFilter rateWindowFilter = (WindowFilter) rateHolder.get().filter();
-            assertThat(((Duration) lotWindowFilter.window().fold(FoldContext.small())).toMinutes(), equalTo((long) window1));
-            assertThat(((Duration) rateWindowFilter.window().fold(FoldContext.small())).toMinutes(), equalTo((long) window2));
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    lotWindowFilter.window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length().toMinutes(),
+                equalTo((long) window1)
+            );
+            assertThat(
+                ((AggregateFunction.TSWindow) Expressions.foldMap(
+                    rateWindowFilter.window(),
+                    FoldContext.small(),
+                    AggregateFunction.TSWindow.TYPE
+                )).length().toMinutes(),
+                equalTo((long) window2)
+            );
         }
         // multiple aggregates with only one filter
         {
@@ -8088,21 +8144,49 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                 assertFalse(maxHolder.get().hasWindow());
                 assertTrue(maxHolder.get().hasFilter());
                 WindowFilter windowFilter = (WindowFilter) maxHolder.get().filter();
-                assertThat(((Duration) windowFilter.window().fold(FoldContext.small())).toMinutes(), equalTo((long) window1));
+                assertThat(
+                    ((AggregateFunction.TSWindow) Expressions.foldMap(
+                        windowFilter.window(),
+                        FoldContext.small(),
+                        AggregateFunction.TSWindow.TYPE
+                    )).length().toMinutes(),
+                    equalTo((long) window1)
+                );
 
                 assertTrue(rateHolder.get().hasWindow());
                 assertFalse(rateHolder.get().hasFilter());
-                assertThat(((Duration) rateHolder.get().window().fold(FoldContext.small())).toMinutes(), equalTo((long) window2));
+                assertThat(
+                    ((AggregateFunction.TSWindow) Expressions.foldMap(
+                        rateHolder.get().window(),
+                        FoldContext.small(),
+                        AggregateFunction.TSWindow.TYPE
+                    )).length().toMinutes(),
+                    equalTo((long) window2)
+                );
             } else {
                 // rate has window filter (window cleared); max_over_time no filter (still has window)
                 assertFalse(rateHolder.get().hasWindow());
                 assertTrue(rateHolder.get().hasFilter());
                 WindowFilter windowFilter = (WindowFilter) rateHolder.get().filter();
-                assertThat(((Duration) windowFilter.window().fold(FoldContext.small())).toMinutes(), equalTo((long) window2));
+                assertThat(
+                    ((AggregateFunction.TSWindow) Expressions.foldMap(
+                        windowFilter.window(),
+                        FoldContext.small(),
+                        AggregateFunction.TSWindow.TYPE
+                    )).length().toMinutes(),
+                    equalTo((long) window2)
+                );
 
                 assertTrue(maxHolder.get().hasWindow());
                 assertFalse(maxHolder.get().hasFilter());
-                assertThat(((Duration) maxHolder.get().window().fold(FoldContext.small())).toMinutes(), equalTo((long) window1));
+                assertThat(
+                    ((AggregateFunction.TSWindow) Expressions.foldMap(
+                        maxHolder.get().window(),
+                        FoldContext.small(),
+                        AggregateFunction.TSWindow.TYPE
+                    )).length().toMinutes(),
+                    equalTo((long) window1)
+                );
             }
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
@@ -156,7 +157,11 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
 
         TimeSeriesAggregate tsAggregate = plan.collect(TimeSeriesAggregate.class).getFirst();
         Rate rate = tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
-        assertThat(rate.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(5)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(rate.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE))
+                .length(),
+            equalTo(Duration.ofMinutes(5))
+        );
     }
 
     public void testImplicitRangeSelectorUsesScrapeIntervalWhenStepIsSmaller() {
@@ -166,7 +171,11 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
 
         TimeSeriesAggregate tsAggregate = plan.collect(TimeSeriesAggregate.class).getFirst();
         Rate rate = tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
-        assertThat(rate.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(1)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(rate.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE))
+                .length(),
+            equalTo(Duration.ofMinutes(1))
+        );
     }
 
     public void testImplicitRangeSelectorRoundsWindowToStepMultiple() {
@@ -176,7 +185,11 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
 
         TimeSeriesAggregate tsAggregate = plan.collect(TimeSeriesAggregate.class).getFirst();
         Rate rate = tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
-        assertThat(rate.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(1)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(rate.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE))
+                .length(),
+            equalTo(Duration.ofMinutes(1))
+        );
     }
 
     public void testImplicitRangeSelectorUsesInferredStepFromDefaultBuckets() {
@@ -188,7 +201,11 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
         assertThat(tsAggregate.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(1)));
 
         Rate rate = tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
-        assertThat(rate.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(1)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(rate.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE))
+                .length(),
+            equalTo(Duration.ofMinutes(1))
+        );
     }
 
     public void testImplicitRangeSelectorUsesInferredStepFromBuckets() {
@@ -200,7 +217,11 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
         assertThat(tsAggregate.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(10)));
 
         Rate rate = tsAggregate.aggregates().getFirst().collect(Rate.class).getFirst();
-        assertThat(rate.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(10)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(rate.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE))
+                .length(),
+            equalTo(Duration.ofMinutes(10))
+        );
     }
 
     public void testStartEndStep() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
@@ -9,10 +9,12 @@ package org.elasticsearch.xpack.esql.optimizer.promql;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
@@ -40,7 +42,10 @@ public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
     public void testRangeSelector() {
         var plan = planPromql("PROMQL index=k8s step=1h ( max by (pod) (last_over_time(network.bytes_in[1h])) )");
         var lot = collectInnerLastOverTimes(plan).getFirst();
-        assertThat(lot.window().fold(FoldContext.small()), equalTo(Duration.ofHours(1)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(lot.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE)).length(),
+            equalTo(Duration.ofHours(1))
+        );
     }
 
     public void testRangeSelectorWithDifferentStep() {
@@ -48,7 +53,10 @@ public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
         var tsAggregate = plan.collect(TimeSeriesAggregate.class).getFirst();
         assertThat(tsAggregate.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(5)));
         var sum = tsAggregate.aggregates().getFirst().collect(Sum.class).getFirst();
-        assertThat(sum.window().fold(FoldContext.small()), equalTo(Duration.ofMinutes(10)));
+        assertThat(
+            ((AggregateFunction.TSWindow) Expressions.foldMap(sum.window(), FoldContext.small(), AggregateFunction.TSWindow.TYPE)).length(),
+            equalTo(Duration.ofMinutes(10))
+        );
     }
 
     public void testLabelSelector() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -1,0 +1,833 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.LazyInitializable;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.aggregation.GroupingAggregator;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.SourceOperator.SourceOperatorFactory;
+import org.elasticsearch.compute.operator.TimeSeriesAggregationOperator;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.SpatialEnvelopeVisitor;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
+import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.lucene.spatial.CentroidCalculator;
+import org.elasticsearch.lucene.spatial.CoordinateEncoder;
+import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
+import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.MultiTypeEsField;
+import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
+import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
+import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
+import static org.elasticsearch.compute.aggregation.spatial.SpatialAggregationUtils.encodeLongitude;
+import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
+import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS;
+import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS_AND_CENTROID;
+import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.EXTRACT_SPATIAL_CENTROID;
+
+public class TestPhysicalOperationProviders extends AbstractPhysicalOperationProviders {
+
+    public static final LazyInitializable<Environment, RuntimeException> TEST_ENV = new LazyInitializable<>(
+        () -> TestEnvironment.newEnvironment(
+            Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
+        )
+    );
+
+    private final List<IndexPage> indexPages;
+    private final UnmappedResolution unmappedResolution;
+
+    private TestPhysicalOperationProviders(
+        FoldContext foldContext,
+        List<IndexPage> indexPages,
+        UnmappedResolution unmappedResolution,
+        AnalysisRegistry analysisRegistry
+    ) {
+        super(foldContext, analysisRegistry);
+        this.indexPages = indexPages;
+        this.unmappedResolution = unmappedResolution;
+    }
+
+    public static TestPhysicalOperationProviders create(
+        FoldContext foldContext,
+        List<IndexPage> indexPages,
+        UnmappedResolution unmappedResolution
+    ) throws IOException {
+        return new TestPhysicalOperationProviders(foldContext, indexPages, unmappedResolution, createAnalysisRegistry());
+    }
+
+    public record IndexPage(String index, Page page, List<String> columnNames, Set<String> mappedFields) {
+        Optional<Integer> columnIndex(String columnName) {
+            var result = IntStream.range(0, columnNames.size()).filter(i -> columnNames.get(i).equals(columnName)).findFirst();
+            return result.isPresent() ? Optional.of(result.getAsInt()) : Optional.empty();
+        }
+    }
+
+    private static AnalysisRegistry createAnalysisRegistry() throws IOException {
+        return new AnalysisModule(
+            TEST_ENV.getOrCompute(),
+            List.of(new MachineLearning(Settings.EMPTY), new CommonAnalysisPlugin()),
+            new StablePluginsRegistry()
+        ).getAnalysisRegistry();
+    }
+
+    @Override
+    public PhysicalOperation fieldExtractPhysicalOperation(
+        FieldExtractExec fieldExtractExec,
+        PhysicalOperation source,
+        LocalExecutionPlannerContext context
+    ) {
+        Layout.Builder layout = source.layout.builder();
+        PhysicalOperation op = source;
+        for (Attribute attr : fieldExtractExec.attributesToExtract()) {
+            layout.append(attr);
+            op = op.with(new TestFieldExtractOperatorFactory(attr, fieldExtractExec.fieldExtractPreference(attr)), layout.build());
+        }
+        return op;
+    }
+
+    @Override
+    public PhysicalOperation sourcePhysicalOperation(EsQueryExec esQueryExec, LocalExecutionPlannerContext context) {
+        Layout.Builder layout = new Layout.Builder();
+        layout.append(esQueryExec.output());
+        return PhysicalOperation.fromSource(new TestSourceOperatorFactory(), layout.build());
+    }
+
+    @Override
+    public Operator.OperatorFactory timeSeriesAggregatorOperatorFactory(
+        TimeSeriesAggregateExec ts,
+        AggregatorMode aggregatorMode,
+        List<GroupingAggregator.Factory> aggregatorFactories,
+        List<BlockHash.GroupSpec> groupSpecs,
+        LocalExecutionPlannerContext context,
+        int maxPageSize
+    ) {
+        return new TimeSeriesAggregationOperator.Factory(
+            ts.timeBucketRounding(context.foldCtx()),
+            ts.timeResolution() == DateFieldMapper.Resolution.NANOSECONDS,
+            groupSpecs,
+            aggregatorMode,
+            aggregatorFactories,
+            maxPageSize
+        );
+    }
+
+    private class TestSourceOperator extends SourceOperator {
+        private int index = 0;
+        private final DriverContext driverContext;
+
+        TestSourceOperator(DriverContext driverContext) {
+            this.driverContext = driverContext;
+        }
+
+        @Override
+        public Page getOutput() {
+            var pageIndex = indexPages.get(index);
+            var page = pageIndex.page;
+            BlockFactory blockFactory = driverContext.blockFactory();
+            DocVector docVector = new DocVector(
+                ConstantShardContextIndexedByShardId.INSTANCE,
+                // The shard ID is used to encode the index ID.
+                blockFactory.newConstantIntVector(index, page.getPositionCount()),
+                blockFactory.newConstantIntVector(0, page.getPositionCount()),
+                blockFactory.newIntArrayVector(IntStream.range(0, page.getPositionCount()).toArray(), page.getPositionCount()),
+                DocVector.config().singleSegmentNonDecreasing(true)
+            );
+            var block = docVector.asBlock();
+            index++;
+            return new Page(block);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return index == indexPages.size();
+        }
+
+        @Override
+        public void finish() {
+            index = indexPages.size();
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+
+    private class TestSourceOperatorFactory implements SourceOperatorFactory {
+
+        @Override
+        public SourceOperator get(DriverContext driverContext) {
+            return new TestSourceOperator(driverContext);
+        }
+
+        @Override
+        public String describe() {
+            return "TestSourceOperator";
+        }
+    }
+
+    private class TestFieldExtractOperator implements Operator {
+        private final DriverContext context;
+        private final Attribute attribute;
+        private Page lastPage;
+        boolean finished;
+        private final FieldExtractPreference extractPreference;
+
+        TestFieldExtractOperator(DriverContext context, Attribute attr, FieldExtractPreference extractPreference) {
+            this.context = context;
+            this.attribute = attr;
+            this.extractPreference = extractPreference;
+        }
+
+        @Override
+        public void addInput(Page page) {
+            lastPage = page.appendBlock(getBlock(context, page.getBlock(0), attribute, extractPreference));
+        }
+
+        @Override
+        public Page getOutput() {
+            Page l = lastPage;
+            lastPage = null;
+            return l;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return finished && lastPage == null;
+        }
+
+        @Override
+        public void finish() {
+            finished = true;
+        }
+
+        @Override
+        public boolean needsInput() {
+            return lastPage == null;
+        }
+
+        @Override
+        public boolean canProduceMoreDataWithoutExtraInput() {
+            return lastPage != null;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+
+    private class TestFieldExtractOperatorFactory implements Operator.OperatorFactory {
+        private final Attribute attribute;
+        private final FieldExtractPreference extractPreference;
+
+        private TestFieldExtractOperatorFactory(Attribute attribute, FieldExtractPreference extractPreference) {
+            this.attribute = attribute;
+            this.extractPreference = extractPreference;
+        }
+
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new TestFieldExtractOperator(driverContext, attribute, extractPreference);
+        }
+
+        @Override
+        public String describe() {
+            return "TestFieldExtractOperator(" + attribute.name() + ")";
+        }
+    }
+
+    private Block getBlock(DriverContext context, DocBlock docBlock, Attribute attribute, FieldExtractPreference extractPreference) {
+        if (attribute instanceof UnsupportedAttribute) {
+            return getNullsBlock(docBlock);
+        }
+        BiFunction<DocBlock, TestBlockCopier, Block> blockExtraction = getBlockExtraction(context, attribute);
+        return extractBlockForColumn(docBlock, attribute.dataType(), extractPreference, blockExtraction);
+    }
+
+    private BiFunction<DocBlock, TestBlockCopier, Block> getBlockExtraction(DriverContext context, Attribute attribute) {
+        if (attribute instanceof FieldAttribute fa) {
+            if (fa.field() instanceof MultiTypeEsField m) {
+                return (doc, copier) -> getBlockForMultiType(context, doc, m, copier);
+
+            }
+            if (fa.field() instanceof PotentiallyUnmappedKeywordEsField k) {
+                return (doc, copier) -> switch (extractBlockForSingleDoc(doc, k.getName(), copier)) {
+                    case BlockResultMissing unused -> getNullsBlock(doc);
+                    case BlockResultSuccess success -> success.block;
+                };
+            }
+            // For NULL-typed fields (unmapped fields with NULLIFY mode), return nulls
+            if (fa.dataType() == DataType.NULL) {
+                return (doc, copier) -> getNullsBlock(doc);
+            }
+        }
+        return (indexDoc, blockCopier) -> switch (extractBlockForSingleDoc(indexDoc, attribute.name(), blockCopier)) {
+            case BlockResultMissing missing -> {
+                if (unmappedResolution == UnmappedResolution.NULLIFY) {
+                    yield getNullsBlock(indexDoc);
+                }
+                throw new EsqlIllegalArgumentException("Cannot find column named [{}] in {}", missing.columnName, missing.columnNames);
+            }
+            case BlockResultSuccess success -> success.block;
+        };
+    }
+
+    private Block getBlockForMultiType(
+        DriverContext context,
+        DocBlock indexDoc,
+        MultiTypeEsField multiTypeEsField,
+        TestBlockCopier blockCopier
+    ) {
+        var conversion = getConversion(multiTypeEsField, getIndexPage(indexDoc));
+        if (conversion == null) {
+            return getNullsBlock(indexDoc);
+        }
+        return switch (extractBlockForSingleDoc(indexDoc, ((FieldAttribute) conversion.field()).fieldName().string(), blockCopier)) {
+            case BlockResultMissing unused -> getNullsBlock(indexDoc);
+            case BlockResultSuccess success -> {
+                if (success.block.elementType() != PlannerUtils.toElementType(conversion.field().dataType().widenSmallNumeric())
+                    && success.block.elementType() == PlannerUtils.toElementType(conversion.dataType().widenSmallNumeric())) {
+                    // Block is already in the correct type, we can skip the conversion.
+                    yield success.block;
+                }
+                try (var converter = new TypeConverter(conversion).build(context)) {
+                    yield converter.convert(success.block);
+                }
+            }
+        };
+    }
+
+    @Nullable
+    private static AbstractConvertFunction getConversion(MultiTypeEsField multiTypeEsField, IndexPage indexPage) {
+        var conversion = (AbstractConvertFunction) multiTypeEsField.getConversionExpressionForIndex(indexPage.index);
+        boolean isPotentiallyUnmapped = conversion == null
+            && multiTypeEsField.getPotentiallyUnmappedExpression() != null
+            && indexPage.mappedFields().contains(multiTypeEsField.getName()) == false;
+        return isPotentiallyUnmapped ? (AbstractConvertFunction) multiTypeEsField.getPotentiallyUnmappedExpression() : conversion;
+    }
+
+    private IndexPage getIndexPage(DocBlock indexDoc) {
+        return indexPages.get(indexDoc.asVector().shards().getInt(0));
+    }
+
+    private static Block getNullsBlock(DocBlock indexDoc) {
+        return indexDoc.blockFactory().newConstantNullBlock(indexDoc.getPositionCount());
+    }
+
+    private sealed interface BlockResult {}
+
+    private record BlockResultSuccess(Block block) implements BlockResult {}
+
+    private record BlockResultMissing(String columnName, List<String> columnNames) implements BlockResult {}
+
+    private BlockResult extractBlockForSingleDoc(DocBlock docBlock, String columnName, TestBlockCopier blockCopier) {
+        var indexId = docBlock.asVector().shards().getInt(0);
+        var indexPage = indexPages.get(indexId);
+        return switch (columnName) {
+            case MetadataAttribute.INDEX -> new BlockResultSuccess(
+                docBlock.blockFactory()
+                    .newConstantBytesRefBlockWith(new BytesRef(indexPage.index), blockCopier.docIndices.getPositionCount())
+            );
+            case DataTierFieldMapper.NAME -> new BlockResultSuccess(
+                docBlock.blockFactory()
+                    .newConstantBytesRefBlockWith(new BytesRef("data_content"), blockCopier.docIndices.getPositionCount())
+            );
+            default -> indexPage.columnIndex(columnName)
+                .<BlockResult>map(columnIndex -> new BlockResultSuccess(blockCopier.copyBlock(indexPage.page.getBlock(columnIndex))))
+                .orElseGet(() -> new BlockResultMissing(columnName, indexPage.columnNames()));
+        };
+    }
+
+    private static void foreachIndexDoc(DocBlock docBlock, Consumer<DocBlock> indexDocConsumer) {
+        var currentIndex = -1;
+        List<Integer> currentList = null;
+        DocVector vector = docBlock.asVector();
+        for (int i = 0; i < docBlock.getPositionCount(); i++) {
+            int indexId = vector.shards().getInt(i);
+            if (indexId != currentIndex) {
+                consumeIndexDoc(indexDocConsumer, vector, currentList);
+                currentList = new ArrayList<>();
+                currentIndex = indexId;
+            }
+            currentList.add(i);
+        }
+        consumeIndexDoc(indexDocConsumer, vector, currentList);
+    }
+
+    private static void consumeIndexDoc(Consumer<DocBlock> indexDocConsumer, DocVector vector, @Nullable List<Integer> currentList) {
+        if (currentList != null) {
+            try (DocVector indexDocVector = vector.filter(false, currentList.stream().mapToInt(Integer::intValue).toArray())) {
+                indexDocConsumer.accept(indexDocVector.asBlock());
+            }
+        }
+    }
+
+    private Block extractBlockForColumn(
+        DocBlock docBlock,
+        DataType dataType,
+        FieldExtractPreference extractPreference,
+        BiFunction<DocBlock, TestBlockCopier, Block> extractBlock
+    ) {
+        try (
+            Block.Builder blockBuilder = blockBuilder(
+                dataType,
+                extractPreference,
+                docBlock.getPositionCount(),
+                TestBlockFactory.getNonBreakingInstance()
+            )
+        ) {
+            foreachIndexDoc(docBlock, indexDoc -> {
+                TestBlockCopier blockCopier = blockCopier(dataType, extractPreference, indexDoc.asVector().docs());
+                try (Block blockForIndex = extractBlock.apply(indexDoc, blockCopier)) {
+                    blockBuilder.copyFrom(blockForIndex, 0, blockForIndex.getPositionCount());
+                }
+            });
+            var result = blockBuilder.build();
+            assert result.getPositionCount() == docBlock.getPositionCount()
+                : "Expected " + docBlock.getPositionCount() + " rows, got " + result.getPositionCount();
+            return result;
+        }
+    }
+
+    private static class TestBlockCopier {
+
+        protected final IntVector docIndices;
+
+        private TestBlockCopier(IntVector docIndices) {
+            this.docIndices = docIndices;
+        }
+
+        protected Block copyBlock(Block originalData) {
+            try (
+                Block.Builder builder = originalData.elementType()
+                    .newBlockBuilder(docIndices.getPositionCount(), TestBlockFactory.getNonBreakingInstance())
+            ) {
+                for (int c = 0; c < docIndices.getPositionCount(); c++) {
+                    int doc = docIndices.getInt(c);
+                    builder.copyFrom(originalData, doc, doc + 1);
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    /**
+     * geo_point and cartesian_point are normally loaded as WKT from source, but for aggregations we can load them as doc-values
+     * which are encoded Long values. This class is used to convert the test loaded WKB into encoded longs for the aggregators.
+     */
+    private abstract static class TestSpatialPointStatsBlockCopier extends TestBlockCopier {
+
+        private TestSpatialPointStatsBlockCopier(IntVector docIndices) {
+            super(docIndices);
+        }
+
+        protected abstract long encode(BytesRef wkb);
+
+        @Override
+        protected Block copyBlock(Block originalData) {
+            BytesRef scratch = new BytesRef(100);
+            BytesRefBlock bytesRefBlock = (BytesRefBlock) originalData;
+            try (LongBlock.Builder builder = bytesRefBlock.blockFactory().newLongBlockBuilder(docIndices.getPositionCount())) {
+                for (int c = 0; c < docIndices.getPositionCount(); c++) {
+                    int doc = docIndices.getInt(c);
+                    int count = bytesRefBlock.getValueCount(doc);
+                    if (count == 0) {
+                        builder.appendNull();
+                    } else {
+                        if (count > 1) {
+                            builder.beginPositionEntry();
+                        }
+                        int firstValueIndex = bytesRefBlock.getFirstValueIndex(doc);
+                        for (int i = firstValueIndex; i < firstValueIndex + count; i++) {
+                            builder.appendLong(encode(bytesRefBlock.getBytesRef(i, scratch)));
+                        }
+                        if (count > 1) {
+                            builder.endPositionEntry();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private static TestSpatialPointStatsBlockCopier create(IntVector docIndices, DataType dataType) {
+            Function<BytesRef, Long> encoder = switch (dataType) {
+                case GEO_POINT -> SpatialCoordinateTypes.GEO::wkbAsLong;
+                case CARTESIAN_POINT -> SpatialCoordinateTypes.CARTESIAN::wkbAsLong;
+                default -> throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
+            };
+            return new TestSpatialPointStatsBlockCopier(docIndices) {
+                @Override
+                protected long encode(BytesRef wkb) {
+                    return encoder.apply(wkb);
+                }
+            };
+        }
+    }
+
+    /**
+     * geo_shape and cartesian_shape are normally loaded as WKT from source, but for ST_EXTENT_AGG we can load them from doc-values
+     * extracting the spatial Extent information. This class is used to convert the test loaded WKB into the int[6] used in the aggregators.
+     */
+    private abstract static class TestSpatialShapeAbstractBlockCopier<T extends Block.Builder> extends TestBlockCopier {
+
+        private TestSpatialShapeAbstractBlockCopier(IntVector docIndices) {
+            super(docIndices);
+        }
+
+        protected abstract T blockBuilder(BytesRefBlock bytesRefBlock);
+
+        protected abstract void initData();
+
+        protected abstract void visitGeometry(Geometry geometry);
+
+        protected abstract void encodeData(T builder);
+
+        @Override
+        protected Block copyBlock(Block originalData) {
+            BytesRef scratch = new BytesRef(100);
+            BytesRefBlock bytesRefBlock = (BytesRefBlock) originalData;
+            try (T builder = blockBuilder(bytesRefBlock)) {
+                for (int c = 0; c < docIndices.getPositionCount(); c++) {
+                    int doc = docIndices.getInt(c);
+                    int count = bytesRefBlock.getValueCount(doc);
+                    if (count == 0) {
+                        builder.appendNull();
+                    } else {
+                        initData();
+                        int firstValueIndex = bytesRefBlock.getFirstValueIndex(doc);
+                        for (int i = firstValueIndex; i < firstValueIndex + count; i++) {
+                            BytesRef wkb = bytesRefBlock.getBytesRef(i, scratch);
+                            Geometry geometry = WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, wkb.bytes, wkb.offset, wkb.length);
+                            visitGeometry(geometry);
+                        }
+                        encodeData(builder);
+                    }
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    private abstract static class TestSpatialShapeExtentBlockCopier extends TestSpatialShapeAbstractBlockCopier<IntBlock.Builder> {
+        protected final SpatialEnvelopeVisitor.PointVisitor pointVisitor;
+        private final SpatialEnvelopeVisitor visitor;
+
+        private TestSpatialShapeExtentBlockCopier(IntVector docIndices, SpatialEnvelopeVisitor.PointVisitor pointVisitor) {
+            super(docIndices);
+            this.pointVisitor = pointVisitor;
+            this.visitor = new SpatialEnvelopeVisitor(pointVisitor);
+        }
+
+        @Override
+        protected IntBlock.Builder blockBuilder(BytesRefBlock bytesRefBlock) {
+            return bytesRefBlock.blockFactory().newIntBlockBuilder(docIndices.getPositionCount());
+        }
+
+        @Override
+        protected void initData() {
+            pointVisitor.reset();
+        }
+
+        @Override
+        protected void visitGeometry(Geometry geometry) {
+            geometry.visit(visitor);
+        }
+
+        private static TestSpatialShapeExtentBlockCopier create(IntVector docIndices, DataType dataType) {
+            return switch (dataType) {
+                case GEO_SHAPE -> new TestGeoCopier(docIndices);
+                case CARTESIAN_SHAPE -> new TestCartesianCopier(docIndices);
+                default -> throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
+            };
+        }
+
+        private static class TestGeoCopier extends TestSpatialShapeExtentBlockCopier {
+            private TestGeoCopier(IntVector docIndices) {
+                super(docIndices, new SpatialEnvelopeVisitor.GeoPointVisitor(SpatialEnvelopeVisitor.WrapLongitude.WRAP));
+            }
+
+            @Override
+            protected void encodeData(IntBlock.Builder builder) {
+                // We store the 6 values as a single multi-valued field, in the same order as the fields in the Extent class
+                // This requires that consumers also know the meaning of the values, which they can learn from the Extent class
+                SpatialEnvelopeVisitor.GeoPointVisitor visitor = (SpatialEnvelopeVisitor.GeoPointVisitor) pointVisitor;
+                builder.beginPositionEntry();
+                builder.appendInt(CoordinateEncoder.GEO.encodeY(visitor.getTop()));
+                builder.appendInt(CoordinateEncoder.GEO.encodeY(visitor.getBottom()));
+                builder.appendInt(encodeLongitude(visitor.getNegLeft()));
+                builder.appendInt(encodeLongitude(visitor.getNegRight()));
+                builder.appendInt(encodeLongitude(visitor.getPosLeft()));
+                builder.appendInt(encodeLongitude(visitor.getPosRight()));
+                builder.endPositionEntry();
+            }
+        }
+
+        private static class TestCartesianCopier extends TestSpatialShapeExtentBlockCopier {
+            private TestCartesianCopier(IntVector docIndices) {
+                super(docIndices, new SpatialEnvelopeVisitor.CartesianPointVisitor());
+            }
+
+            @Override
+            protected void encodeData(IntBlock.Builder builder) {
+                // We store the 4 values as a single multi-valued field, in the same order as the fields in the Rectangle class
+                // This requires that consumers also know the meaning of the values, which they can learn from the Rectangle class
+                SpatialEnvelopeVisitor.CartesianPointVisitor visitor = (SpatialEnvelopeVisitor.CartesianPointVisitor) pointVisitor;
+                builder.beginPositionEntry();
+                builder.appendInt(CoordinateEncoder.CARTESIAN.encodeX(visitor.getMinX()));
+                builder.appendInt(CoordinateEncoder.CARTESIAN.encodeX(visitor.getMaxX()));
+                builder.appendInt(CoordinateEncoder.CARTESIAN.encodeY(visitor.getMaxY()));
+                builder.appendInt(CoordinateEncoder.CARTESIAN.encodeY(visitor.getMinY()));
+                builder.endPositionEntry();
+            }
+        }
+    }
+
+    /**
+     * geo_shape and cartesian_shape are normally loaded as WKT from source, but for ST_CENTROID_AGG we can load them from doc-values
+     * extracting the centroid information. This class converts the test loaded WKB into the double[4] used in the aggregators.
+     */
+    private static class TestSpatialShapeCentroidBlockCopier extends TestSpatialShapeAbstractBlockCopier<DoubleBlock.Builder> {
+        private final CoordinateEncoder encoder;
+        private CentroidCalculator calculator;
+
+        private TestSpatialShapeCentroidBlockCopier(IntVector docIndices, CoordinateEncoder encoder) {
+            super(docIndices);
+            this.encoder = encoder;
+        }
+
+        @Override
+        protected DoubleBlock.Builder blockBuilder(BytesRefBlock bytesRefBlock) {
+            return bytesRefBlock.blockFactory().newDoubleBlockBuilder(docIndices.getPositionCount());
+        }
+
+        @Override
+        protected void initData() {
+            calculator = new CentroidCalculator();
+        }
+
+        @Override
+        protected void visitGeometry(Geometry geometry) {
+            calculator.add(geometry);
+        }
+
+        @Override
+        protected void encodeData(DoubleBlock.Builder builder) {
+            builder.beginPositionEntry();
+            builder.appendDouble(encoder.decodeX(encoder.encodeX(encoder.normalizeX(calculator.getX()))));
+            builder.appendDouble(encoder.decodeY(encoder.encodeY(encoder.normalizeY(calculator.getY()))));
+            builder.appendDouble(calculator.sumWeight());
+            builder.appendDouble(calculator.getDimensionalShapeType().ordinal());
+            builder.endPositionEntry();
+        }
+
+        private static TestSpatialShapeCentroidBlockCopier create(IntVector docIndices, DataType dataType) {
+            return switch (dataType) {
+                case GEO_SHAPE -> new TestSpatialShapeCentroidBlockCopier(docIndices, CoordinateEncoder.GEO);
+                case CARTESIAN_SHAPE -> new TestSpatialShapeCentroidBlockCopier(docIndices, CoordinateEncoder.CARTESIAN);
+                default -> throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
+            };
+        }
+    }
+
+    /**
+     * geo_shape and cartesian_shape are normally loaded as WKT from source, but when both ST_EXTENT_AGG and ST_CENTROID_AGG are used
+     * on the same field, we load combined bounds and centroid data from doc-values. This class converts the test loaded WKB into the
+     * double[10] (geo) or double[8] (cartesian) used in the aggregators.
+     */
+    private abstract static class TestSpatialShapeBoundsAndCentroidBlockCopier extends TestSpatialShapeAbstractBlockCopier<
+        DoubleBlock.Builder> {
+        protected final SpatialEnvelopeVisitor.PointVisitor pointVisitor;
+        private final SpatialEnvelopeVisitor visitor;
+        private final CoordinateEncoder encoder;
+        private CentroidCalculator calculator;
+
+        private TestSpatialShapeBoundsAndCentroidBlockCopier(
+            IntVector docIndices,
+            SpatialEnvelopeVisitor.PointVisitor pointVisitor,
+            CoordinateEncoder encoder
+        ) {
+            super(docIndices);
+            this.pointVisitor = pointVisitor;
+            this.visitor = new SpatialEnvelopeVisitor(pointVisitor);
+            this.encoder = encoder;
+        }
+
+        @Override
+        protected DoubleBlock.Builder blockBuilder(BytesRefBlock bytesRefBlock) {
+            return bytesRefBlock.blockFactory().newDoubleBlockBuilder(docIndices.getPositionCount());
+        }
+
+        @Override
+        protected void initData() {
+            pointVisitor.reset();
+            calculator = new CentroidCalculator();
+        }
+
+        @Override
+        protected void visitGeometry(Geometry geometry) {
+            geometry.visit(visitor);
+            calculator.add(geometry);
+        }
+
+        @Override
+        protected void encodeData(DoubleBlock.Builder builder) {
+            builder.beginPositionEntry();
+            encodeBounds(builder);
+            encodeCentroid(builder, calculator);
+            builder.endPositionEntry();
+        }
+
+        protected abstract void encodeBounds(DoubleBlock.Builder builder);
+
+        private void encodeCentroid(DoubleBlock.Builder builder, CentroidCalculator calculator) {
+            builder.appendDouble(encoder.decodeX(encoder.encodeX(encoder.normalizeX(calculator.getX()))));
+            builder.appendDouble(encoder.decodeY(encoder.encodeY(encoder.normalizeY(calculator.getY()))));
+            builder.appendDouble(calculator.sumWeight());
+            builder.appendDouble(calculator.getDimensionalShapeType().ordinal());
+        }
+
+        private static TestSpatialShapeBoundsAndCentroidBlockCopier create(IntVector docIndices, DataType dataType) {
+            return switch (dataType) {
+                case GEO_SHAPE -> new TestGeoCopier(docIndices);
+                case CARTESIAN_SHAPE -> new TestCartesianCopier(docIndices);
+                default -> throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
+            };
+        }
+
+        private static class TestGeoCopier extends TestSpatialShapeBoundsAndCentroidBlockCopier {
+            private TestGeoCopier(IntVector docIndices) {
+                super(
+                    docIndices,
+                    new SpatialEnvelopeVisitor.GeoPointVisitor(SpatialEnvelopeVisitor.WrapLongitude.WRAP),
+                    CoordinateEncoder.GEO
+                );
+            }
+
+            @Override
+            protected void encodeBounds(DoubleBlock.Builder builder) {
+                SpatialEnvelopeVisitor.GeoPointVisitor visitor = (SpatialEnvelopeVisitor.GeoPointVisitor) pointVisitor;
+                builder.appendDouble(CoordinateEncoder.GEO.encodeY(visitor.getTop()));
+                builder.appendDouble(CoordinateEncoder.GEO.encodeY(visitor.getBottom()));
+                builder.appendDouble(encodeLongitude(visitor.getNegLeft()));
+                builder.appendDouble(encodeLongitude(visitor.getNegRight()));
+                builder.appendDouble(encodeLongitude(visitor.getPosLeft()));
+                builder.appendDouble(encodeLongitude(visitor.getPosRight()));
+            }
+        }
+
+        private static class TestCartesianCopier extends TestSpatialShapeBoundsAndCentroidBlockCopier {
+            private TestCartesianCopier(IntVector docIndices) {
+                super(docIndices, new SpatialEnvelopeVisitor.CartesianPointVisitor(), CoordinateEncoder.CARTESIAN);
+            }
+
+            @Override
+            protected void encodeBounds(DoubleBlock.Builder builder) {
+                SpatialEnvelopeVisitor.CartesianPointVisitor visitor = (SpatialEnvelopeVisitor.CartesianPointVisitor) pointVisitor;
+                builder.appendDouble(CoordinateEncoder.CARTESIAN.encodeX(visitor.getMinX()));
+                builder.appendDouble(CoordinateEncoder.CARTESIAN.encodeX(visitor.getMaxX()));
+                builder.appendDouble(CoordinateEncoder.CARTESIAN.encodeY(visitor.getMaxY()));
+                builder.appendDouble(CoordinateEncoder.CARTESIAN.encodeY(visitor.getMinY()));
+            }
+        }
+    }
+
+    private static Block.Builder blockBuilder(
+        DataType dataType,
+        FieldExtractPreference extractPreference,
+        int estimatedSize,
+        BlockFactory blockFactory
+    ) {
+        ElementType elementType = switch (dataType) {
+            case SHORT -> ElementType.INT;
+            case FLOAT, HALF_FLOAT, SCALED_FLOAT -> ElementType.DOUBLE;
+            default -> PlannerUtils.toElementType(dataType);
+        };
+        if (extractPreference == DOC_VALUES && DataType.isSpatialPoint(dataType)) {
+            return blockFactory.newLongBlockBuilder(estimatedSize);
+        } else if (extractPreference == EXTRACT_SPATIAL_BOUNDS && DataType.isSpatial(dataType)) {
+            return blockFactory.newIntBlockBuilder(estimatedSize);
+        } else if ((extractPreference == EXTRACT_SPATIAL_CENTROID || extractPreference == EXTRACT_SPATIAL_BOUNDS_AND_CENTROID)
+            && isShapeType(dataType)) {
+                return blockFactory.newDoubleBlockBuilder(estimatedSize);
+            } else {
+                return elementType.newBlockBuilder(estimatedSize, blockFactory);
+            }
+    }
+
+    private static TestBlockCopier blockCopier(DataType dataType, FieldExtractPreference extractPreference, IntVector docIndices) {
+        if (extractPreference == DOC_VALUES && DataType.isSpatialPoint(dataType)) {
+            return TestSpatialPointStatsBlockCopier.create(docIndices, dataType);
+        } else if (extractPreference == EXTRACT_SPATIAL_BOUNDS && DataType.isSpatial(dataType)) {
+            return TestSpatialShapeExtentBlockCopier.create(docIndices, dataType);
+        } else if (extractPreference == EXTRACT_SPATIAL_CENTROID && isShapeType(dataType)) {
+            return TestSpatialShapeCentroidBlockCopier.create(docIndices, dataType);
+        } else if (extractPreference == EXTRACT_SPATIAL_BOUNDS_AND_CENTROID && isShapeType(dataType)) {
+            return TestSpatialShapeBoundsAndCentroidBlockCopier.create(docIndices, dataType);
+        } else {
+            return new TestBlockCopier(docIndices);
+        }
+    }
+
+    private static boolean isShapeType(DataType dataType) {
+        return dataType == DataType.GEO_SHAPE || dataType == DataType.CARTESIAN_SHAPE;
+    }
+}


### PR DESCRIPTION
ESQL window functions are forward-looking only. For timeseries, that is usually the wrong default (Datadog, Prometheus, etc., use trailing windows). That mismatch will confuse anyone coming to Elasticsearch from those tools.

This diff stack extends ESQL aggregate functions to support configurable window semantics. 

Stack:

- https://github.com/elastic/elasticsearch/pull/146226
- https://github.com/elastic/elasticsearch/pull/146227 (this)