### PR TITLE
[9.4] Fix false circular view reference with shared wildcards (#146144)

### DIFF
--- a/docs/changelog/146144.yaml
+++ b/docs/changelog/146144.yaml
@@ -1,0 +1,7 @@
+area: ES|QL
+issues:
+ - 146097
+ - 146118
+pr: 146144
+summary: Fix false circular view reference with shared wildcards
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -36,12 +36,15 @@ import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -155,8 +158,18 @@ public class ViewResolver {
         LinkedHashSet<String> seenInner = new LinkedHashSet<>(seenViews);
         // Tracks wildcard patterns already resolved within this transformDown traversal to prevent duplicate processing
         HashSet<String> seenWildcards = new HashSet<>();
+        // Tracks plans already resolved by view handlers (Fork, UR) to prevent double-processing.
+        // Without this, transformDown recurses into the children of resolved plans, causing wildcards
+        // in view subqueries to be re-resolved against sibling view names, producing false circular
+        // reference errors and deeply nested duplicate resolution.
+        Set<LogicalPlan> resolvedPlans = Collections.newSetFromMap(new IdentityHashMap<>());
 
         plan.transformDown((p, planListener) -> {
+            if (resolvedPlans.contains(p)) {
+                // This plan was already resolved by a handler — skip it to prevent double-processing.
+                planListener.onResponse(p);
+                return;
+            }
             switch (p) {
                 case ViewUnionAll viewUnion -> {
                     // ViewUnionAll is the result of view resolution, so we skip it.
@@ -166,11 +179,25 @@ public class ViewResolver {
                     return;
                 }
                 case Fork fork -> {
-                    replaceViewsFork(fork, parser, seenInner, viewQueries, depth, planListener);
+                    replaceViewsFork(fork, parser, seenInner, viewQueries, depth, planListener.delegateFailureAndWrap((l, result) -> {
+                        plan.forEachDown(resolvedPlans::add);
+                        l.onResponse(result);
+                    }));
                     return;
                 }
                 case UnresolvedRelation ur -> {
-                    replaceViewsUnresolvedRelation(ur, parser, seenInner, seenWildcards, viewQueries, depth, planListener);
+                    replaceViewsUnresolvedRelation(
+                        ur,
+                        parser,
+                        seenInner,
+                        seenWildcards,
+                        viewQueries,
+                        depth,
+                        planListener.delegateFailureAndWrap((l, result) -> {
+                            plan.forEachDown(resolvedPlans::add);
+                            l.onResponse(result);
+                        })
+                    );
                     return;
                 }
                 default -> {
@@ -259,7 +286,6 @@ public class ViewResolver {
             SubscribableListener<Void> chain = SubscribableListener.newForked(l2 -> l2.onResponse(null));
             for (var view : response.views()) {
                 chain = chain.andThen(l2 -> {
-                    seenViews.add(view.name());
                     // Make sure we don't block sibling branches from containing the same views
                     LinkedHashSet<String> branchSeenViews = new LinkedHashSet<>(ancestorViews);
                     validateViewReferenceAndMarkSeen(view.name(), branchSeenViews);
@@ -608,20 +634,22 @@ public class ViewResolver {
         // Trial pass: collect all entries from full flattening and check for conflicts.
         // Inner ViewUnionAlls that only contain UnresolvedRelations are lifted into the parent,
         // eliminating nesting that the runtime doesn't yet support.
+        // Inner Forks/UnionAlls (from user-written subqueries inside views) are also lifted,
+        // with each child becoming a separate named entry suffixed from the parent view name.
         LinkedHashMap<String, LogicalPlan> flat = new LinkedHashMap<>();
-        boolean hasInnerVua = false;
+        boolean hasInnerFork = false;
 
-        // Process non-VUA entries first so that all outer keys are in `flat` before we attempt
-        // to flatten inner ViewUnionAlls. This makes the conflict check order-independent —
-        // without it, an inner VUA processed before a later outer entry with the same key would
+        // Process non-fork entries first so that all outer keys are in `flat` before we attempt
+        // to flatten inner forks. This makes the conflict check order-independent —
+        // without it, an inner fork processed before a later outer entry with the same key would
         // miss the conflict, producing extra branches that can exceed the Fork limit.
-        List<Map.Entry<String, LogicalPlan>> vuaEntries = new ArrayList<>();
+        List<Map.Entry<String, LogicalPlan>> forkEntries = new ArrayList<>();
         for (Map.Entry<String, LogicalPlan> entry : vua.namedSubqueries().entrySet()) {
             String key = entry.getKey();
             LogicalPlan value = entry.getValue();
             LogicalPlan inner = (value instanceof NamedSubquery ns) ? ns.child() : value;
-            if (inner instanceof ViewUnionAll) {
-                vuaEntries.add(entry);
+            if (inner instanceof Fork) {
+                forkEntries.add(entry);
             } else if (value instanceof UnresolvedRelation) {
                 flat.put(makeUniqueKey(flat, key), value);
             } else {
@@ -632,17 +660,29 @@ public class ViewResolver {
             }
         }
 
-        for (Map.Entry<String, LogicalPlan> entry : vuaEntries) {
+        for (Map.Entry<String, LogicalPlan> entry : forkEntries) {
+            String parentKey = entry.getKey();
             LogicalPlan value = entry.getValue();
             LogicalPlan inner = (value instanceof NamedSubquery ns) ? ns.child() : value;
-            ViewUnionAll innerVua = (ViewUnionAll) inner;
-            hasInnerVua = true;
-            for (Map.Entry<String, LogicalPlan> innerEntry : innerVua.namedSubqueries().entrySet()) {
-                flat.put(makeUniqueKey(flat, innerEntry.getKey()), innerEntry.getValue());
+            hasInnerFork = true;
+            if (inner instanceof ViewUnionAll innerVua) {
+                // Named branches from inner ViewUnionAll: lift with their own names
+                for (Map.Entry<String, LogicalPlan> innerEntry : innerVua.namedSubqueries().entrySet()) {
+                    flat.put(makeUniqueKey(flat, innerEntry.getKey()), innerEntry.getValue());
+                }
+            } else {
+                // Plain Fork/UnionAll from user-written subqueries: lift children with suffixed parent name
+                Fork fork = (Fork) inner;
+                int childIndex = 1;
+                for (LogicalPlan child : fork.children()) {
+                    LogicalPlan unwrapped = (child instanceof Subquery sq) ? sq.child() : child;
+                    String childKey = parentKey + "#" + childIndex++;
+                    flat.put(makeUniqueKey(flat, childKey), unwrapped);
+                }
             }
         }
 
-        if (hasInnerVua == false) {
+        if (hasInnerFork == false) {
             return vua;
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -801,6 +801,128 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM idx_otel_linux),(FROM idx_otel,idx_otel_linux)")));
     }
 
+    /**
+     * Reproduces the bug where composing two views that share an underlying index pattern
+     * inside a parent view incorrectly triggers a "circular view reference" error.
+     * The error_triage view uses inline subqueries (FROM (subquery), ...) and one of those
+     * subqueries references svc-auth-* which is also the target of the suspicious_ips view.
+     * Neither view references the other, so there is no circular reference.
+     */
+    public void testFalseCircularReferenceWithSharedWildcardInSubqueries() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        // Set up concrete indices matching the wildcard patterns
+        addIndex("svc-gateway-logs");
+        addIndex("svc-payments-logs");
+        addIndex("svc-auth-logs");
+
+        // error_triage uses inline subqueries, one of which references svc-auth-*
+        addView(
+            "error_triage",
+            "FROM (FROM svc-gateway-* | WHERE http_status >= 500 | KEEP @timestamp, http_status),"
+                + "(FROM svc-payments-* | WHERE http_status >= 500 | KEEP @timestamp, http_status),"
+                + "(FROM svc-auth-* | WHERE http_status >= 500 | KEEP @timestamp, http_status)"
+        );
+
+        // suspicious_ips also references svc-auth-* but is a completely separate view
+        addView("suspicious_ips", "FROM svc-auth-* | STATS attempts = COUNT(*) BY source_ip");
+
+        // incident_dashboard composes both views — no circular reference exists
+        addView("incident_dashboard", "FROM error_triage, suspicious_ips");
+
+        // This should NOT throw a circular view reference error
+        LogicalPlan result = replaceViews(query("FROM incident_dashboard"));
+        assertNotNull("incident_dashboard should resolve without circular reference errors", result);
+        assertNoPlanConsistencyFailures(result, "incident_dashboard");
+    }
+
+    /**
+     * Tests that composing two views in a parent view does not produce a false circular reference
+     * when a wildcard in one view's subquery happens to match the sibling view's name, provided
+     * the sibling view uses self-exclusion to avoid genuine self-reference.
+     * <p>
+     * Before the fix, the {@code seenViews} set was polluted by sibling view names from the outer
+     * scope, causing the wildcard resolution inside {@code error_view} to see {@code svc-auth-failures}
+     * as already visited even though it was only a sibling, not an ancestor.
+     */
+    public void testFalseCircularReferenceWhenWildcardMatchesSiblingViewName() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        addIndex("svc-gateway-logs");
+        addIndex("svc-auth-logs");
+
+        // error_view uses inline subqueries, one references svc-auth-*
+        addView(
+            "error_view",
+            "FROM (FROM svc-gateway-* | WHERE http_status >= 500 | KEEP @timestamp, http_status),"
+                + "(FROM svc-auth-* | WHERE http_status >= 500 | KEEP @timestamp, http_status)"
+        );
+
+        // svc-auth-failures is a view whose NAME matches the svc-auth-* pattern.
+        // It self-excludes to avoid genuine self-reference via wildcard.
+        addView("svc-auth-failures", "FROM svc-auth-*,-svc-auth-failures | STATS attempts = COUNT(*) BY source_ip");
+
+        // dashboard composes both views — no circular reference exists
+        addView("dashboard", "FROM error_view, svc-auth-failures");
+
+        // This should NOT throw a circular view reference error
+        LogicalPlan result = replaceViews(query("FROM dashboard"));
+        assertNotNull("dashboard should resolve without circular reference errors", result);
+
+        // The wildcard svc-auth-* inside error_view's subquery matches the view svc-auth-failures,
+        // creating a nested ViewUnionAll inside the pipeline chain. This produces a "nested subqueries"
+        // error — which is the correct behavior (not a false circular reference).
+        Failures failures = new Failures();
+        Failures depFailures = new Failures();
+        LogicalVerifier.INSTANCE.checkPlanConsistency(result, failures, depFailures);
+        assertTrue("Expected nested subquery failure", failures.hasFailures());
+        for (Failure failure : failures.failures()) {
+            assertThat(failure.failMessage(), containsString("Nested subqueries are not supported"));
+        }
+    }
+
+    /**
+     * Tests that a view whose name matches its own wildcard pattern IS correctly detected as
+     * a circular self-reference when it does NOT use self-exclusion.
+     */
+    public void testGenuineSelfReferenceViaWildcardInComposedView() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        addIndex("svc-auth-logs");
+
+        // svc-auth-failures queries FROM svc-auth-* which matches itself — genuine self-reference
+        addView("svc-auth-failures", "FROM svc-auth-* | STATS attempts = COUNT(*) BY source_ip");
+
+        Exception e = expectThrows(VerificationException.class, () -> replaceViews(query("FROM svc-auth-failures")));
+        assertThat(e.getMessage(), containsString("circular view reference 'svc-auth-failures'"));
+    }
+
+    /**
+     * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/146097">#146097</a>:
+     * a subquery-based view composed with a simple view that shares a wildcard index pattern
+     * incorrectly triggers a "circular view reference" error.
+     * <p>
+     * view_x uses subqueries touching two wildcard patterns. view_y is a simple view on one of
+     * the same patterns. Neither references the other, so composing them in view_xy should not
+     * produce a circular reference error.
+     */
+    public void testFalseCircularReferenceFromSharedWildcardPattern_Issue146097() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        addIndex("app-events-001");
+        addIndex("auth-events-001");
+
+        // view_x: subqueries touching both patterns
+        addView("view_x", "FROM (FROM app-events-* | KEEP msg, level), (FROM auth-events-* | KEEP msg, level)");
+
+        // view_y: simple view on one of the same patterns
+        addView("view_y", "FROM auth-events-* | KEEP msg, level");
+
+        // Compose both views
+        addView("view_xy", "FROM view_x, view_y");
+
+        // Before the fix this threw: "circular view reference 'view_y': view_xy -> view_x -> view_y"
+        LogicalPlan result = replaceViews(query("FROM view_xy"));
+        assertNotNull("view_xy should resolve without circular reference errors", result);
+        assertNoPlanConsistencyFailures(result, "view_xy");
+    }
+
     public void testModifiedViewDepth() {
         try (
             InMemoryViewService customViewService = viewService.withSettings(
@@ -1646,6 +1768,13 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
      */
     private InMemoryViewService matrixViewService() {
         return viewService.withSettings(Settings.builder().put(ViewService.MAX_VIEWS_COUNT_SETTING.getKey(), 200).build());
+    }
+
+    private static void assertNoPlanConsistencyFailures(LogicalPlan plan, String context) {
+        Failures failures = new Failures();
+        Failures depFailures = new Failures();
+        LogicalVerifier.INSTANCE.checkPlanConsistency(plan, failures, depFailures);
+        assertFalse("Plan consistency failures for " + context + ": " + failures, failures.hasFailures());
     }
 
     private LogicalPlan replaceViews(LogicalPlan plan) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix false circular view reference with shared wildcards (#146144)