### PR TITLE
Restore initial thread context during reindex etc.

### DIFF
--- a/docs/changelog/146134.yaml
+++ b/docs/changelog/146134.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 146134
+summary: Restore initial thread context during reindex etc
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -542,6 +542,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
             int totalBatchSize = totalBatchSizeInSingleScrollResponse.getAndSet(0);
             asyncResponse.done(worker.throttleWaitTime(thisBatchStartTimeNS, System.nanoTime(), totalBatchSize));
         } else {
+            // NB this means the next bulk task will be traced as a child of the current one, but it should really be a sibling
             onScrollResponse(asyncResponse);
         }
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -91,20 +91,44 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
         TaskId parentTask = new TaskId("thenode", randomInt());
         AtomicInteger actualSearchRetries = new AtomicInteger();
         int expectedSearchRetries = 0;
-        ClientScrollableHitSource hitSource = new ClientScrollableHitSource(
-            logger,
-            BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
-            threadPool,
-            actualSearchRetries::incrementAndGet,
-            responses::add,
-            failureHandler,
-            new ParentTaskAssigningClient(client, parentTask),
-            new SearchRequest().scroll(TimeValue.timeValueMinutes(1))
-        );
+
+        final var testHeaderName = randomIdentifier("header-");
+        final var threadContext = threadPool.getThreadContext();
+        final ClientScrollableHitSource hitSource;
+        try (var ignored = threadContext.newStoredContext()) {
+            final var testHeaderInitialValue = randomIdentifier("initial-");
+            threadContext.putHeader(testHeaderName, testHeaderInitialValue);
+            hitSource = new ClientScrollableHitSource(
+                logger,
+                BackoffPolicy.constantBackoff(TimeValue.ZERO, retries),
+                threadPool,
+                actualSearchRetries::incrementAndGet,
+                responses::add,
+                failureHandler,
+                new ParentTaskAssigningClient(client, parentTask) {
+                    @Override
+                    protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                        ActionType<Response> action,
+                        Request request,
+                        ActionListener<Response> listener
+                    ) {
+                        // Verify that the action is always invoked in the initial thread context, even though this header is set to
+                        // different random values in the rest of the test. This ensures we don't accumulate a deeply-nested tree of spans
+                        // when tracing these requests for APM.
+                        assertEquals(testHeaderInitialValue, threadContext.getHeader(testHeaderName));
+                        super.doExecute(action, request, listener);
+                    }
+                },
+                new SearchRequest().scroll(TimeValue.timeValueMinutes(1))
+            );
+        }
 
         hitSource.start();
         for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-            client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.fail(TransportSearchAction.TYPE, new EsRejectedExecutionException());
+            }
             if (retry >= retries) {
                 return;
             }
@@ -114,7 +138,10 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
         client.validateRequest(TransportSearchAction.TYPE, (SearchRequest r) -> assertTrue(r.allowPartialSearchResults() == Boolean.FALSE));
         SearchResponse searchResponse = createSearchResponse();
         try {
-            client.respond(TransportSearchAction.TYPE, searchResponse);
+            try (var ignored = threadContext.newStoredContext()) {
+                threadContext.putHeader(testHeaderName, randomIdentifier());
+                client.respond(TransportSearchAction.TYPE, searchResponse);
+            }
 
             for (int i = 0; i < randomIntBetween(1, 10); ++i) {
                 ScrollableHitSource.AsyncResponse asyncResponse = responses.poll(10, TimeUnit.SECONDS);
@@ -124,14 +151,20 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
                 asyncResponse.done(TimeValue.ZERO);
 
                 for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {
-                    client.fail(TransportSearchScrollAction.TYPE, new EsRejectedExecutionException());
+                    try (var ignored = threadContext.newStoredContext()) {
+                        threadContext.putHeader(testHeaderName, randomIdentifier());
+                        client.fail(TransportSearchScrollAction.TYPE, new EsRejectedExecutionException());
+                    }
                     client.awaitOperation();
                     ++expectedSearchRetries;
                 }
 
                 searchResponse.decRef();
                 searchResponse = createSearchResponse();
-                client.respond(TransportSearchScrollAction.TYPE, searchResponse);
+                try (var ignored = threadContext.newStoredContext()) {
+                    threadContext.putHeader(testHeaderName, randomIdentifier());
+                    client.respond(TransportSearchScrollAction.TYPE, searchResponse);
+                }
             }
 
             assertEquals(actualSearchRetries.get(), expectedSearchRetries);

--- a/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.seqno.SequenceNumbers;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,6 +56,10 @@ public abstract class ScrollableHitSource {
     private final Consumer<AsyncResponse> onResponse;
     protected final Consumer<Exception> fail;
 
+    /// Each cycle must be executed in the root thread context and not in a descendant context of the previous task, so that the tracing
+    /// subsystem does not form a deeply-nested linked list of spans.
+    private final Supplier<ThreadContext.StoredContext> rootStoredContextSupplier;
+
     public ScrollableHitSource(
         Logger logger,
         BackoffPolicy backoffPolicy,
@@ -68,10 +74,11 @@ public abstract class ScrollableHitSource {
         this.countSearchRetry = countSearchRetry;
         this.onResponse = onResponse;
         this.fail = fail;
+        this.rootStoredContextSupplier = threadPool.getThreadContext().newRestorableContext(true);
     }
 
     public final void start() {
-        doStart(createRetryListener(this::doStart));
+        doStartInRootContext(createRetryListener(this::doStartInRootContext));
     }
 
     private RetryListener createRetryListener(Consumer<RejectAwareActionListener<Response>> retryHandler) {
@@ -88,7 +95,9 @@ public abstract class ScrollableHitSource {
     }
 
     private void startNextScroll(TimeValue extraKeepAlive, RejectAwareActionListener<Response> searchListener) {
-        doStartNextScroll(scrollId.get(), extraKeepAlive, searchListener);
+        try (var ignored = rootStoredContextSupplier.get()) {
+            doStartNextScroll(scrollId.get(), extraKeepAlive, searchListener);
+        }
     }
 
     private void onResponse(Response response) {
@@ -116,6 +125,12 @@ public abstract class ScrollableHitSource {
             clearScroll(scrollId, () -> cleanup(onCompletion));
         } else {
             cleanup(onCompletion);
+        }
+    }
+
+    private void doStartInRootContext(RejectAwareActionListener<Response> searchListener) {
+        try (var ignored = rootStoredContextSupplier.get()) {
+            doStart(searchListener);
         }
     }
 


### PR DESCRIPTION
The tracing subsystem tracks each index/search task during a reindex as
a child span of the previous search/index task respectively. With this
commit we restore the initial thread context for each search, so that
the search-related spans are direct children of the root span instead.

Closes ES-13060
Backport of #146134 to 9.2