### PR TITLE
[DiskBBQ] Make ClusteringFloatVectorValuesSlice constructor more flexible

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/ClusteringFloatVectorValuesSlice.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/ClusteringFloatVectorValuesSlice.java
@@ -9,25 +9,29 @@
 
 package org.elasticsearch.index.codec.vectors.cluster;
 
+import org.apache.lucene.util.hnsw.IntToIntFunction;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
-final class ClusteringFloatVectorValuesSlice extends ClusteringFloatVectorValues {
+public final class ClusteringFloatVectorValuesSlice extends ClusteringFloatVectorValues {
 
     private final ClusteringFloatVectorValues allValues;
-    private final int[] slice;
+    private final IntToIntFunction ordTranslator;
+    private final int size;
 
-    ClusteringFloatVectorValuesSlice(ClusteringFloatVectorValues allValues, int[] slice) {
-        assert slice != null;
-        assert slice.length <= allValues.size();
+    public ClusteringFloatVectorValuesSlice(ClusteringFloatVectorValues allValues, IntToIntFunction ordTranslator, int size) {
+        assert ordTranslator != null;
+        assert allValues.size() >= size;
         this.allValues = allValues;
-        this.slice = slice;
+        this.ordTranslator = ordTranslator;
+        this.size = size;
     }
 
     @Override
     public float[] vectorValue(int ord) throws IOException {
-        return this.allValues.vectorValue(this.slice[ord]);
+        return this.allValues.vectorValue(ordTranslator.apply(ord));
     }
 
     @Override
@@ -37,17 +41,17 @@ final class ClusteringFloatVectorValuesSlice extends ClusteringFloatVectorValues
 
     @Override
     public int size() {
-        return slice.length;
+        return size;
     }
 
     @Override
     public int ordToDoc(int ord) {
-        return this.slice[ord];
+        return ordTranslator.apply(ord);
     }
 
     @Override
     public ClusteringFloatVectorValuesSlice copy() throws IOException {
-        return new ClusteringFloatVectorValuesSlice(this.allValues.copy(), this.slice);
+        return new ClusteringFloatVectorValuesSlice(this.allValues.copy(), this.ordTranslator, size);
     }
 
     static ClusteringFloatVectorValues createRandomSlice(ClusteringFloatVectorValues origin, int k, long seed) {
@@ -58,7 +62,7 @@ final class ClusteringFloatVectorValuesSlice extends ClusteringFloatVectorValues
         int[] samples = reservoirSample(origin.size(), k, seed);
         // sort to prevent random backwards access weirdness
         Arrays.sort(samples);
-        return new ClusteringFloatVectorValuesSlice(origin, samples);
+        return new ClusteringFloatVectorValuesSlice(origin, i -> samples[i], k);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
@@ -249,7 +249,7 @@ public class HierarchicalKMeans {
         }
         assert idx == clusterSize;
 
-        return new ClusteringFloatVectorValuesSlice(vectors, slice);
+        return new ClusteringFloatVectorValuesSlice(vectors, i -> slice[i], slice.length);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansFloatVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansFloatVectorValues.java
@@ -70,6 +70,11 @@ public final class KMeansFloatVectorValues extends ClusteringFloatVectorValues {
     }
 
     @Override
+    public DocIndexIterator iterator() {
+        return docs == null ? createDenseIterator() : createSparseIterator();
+    }
+
+    @Override
     public int dimension() {
         return vectors.dims();
     }
@@ -81,10 +86,7 @@ public final class KMeansFloatVectorValues extends ClusteringFloatVectorValues {
 
     @Override
     public int ordToDoc(int ord) {
-        if (docs == null) {
-            return ord;
-        }
-        return docs.ordToDoc(ord);
+        return docs == null ? ord : docs.ordToDoc(ord);
     }
 
     private sealed interface VectorSupplier permits OffHeapVectorSupplier, OnHeapVectorSupplier {


### PR DESCRIPTION
 It makes the constructor take an abstraction of the slice so we don't need to have an in-memory array to build an slice. In addition we are implementing the method #iterator()  in KMeansFloatVectorValues.