### PR TITLE
ESQL: Widens the HeapAttackLimitByIT timeout (#146001)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -228,9 +228,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/145519
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   issue: https://github.com/elastic/elasticsearch/issues/145461
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
-  method: testTopNByKeyEncoderTooMuchMemory
-  issue: https://github.com/elastic/elasticsearch/issues/145627
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/145654
@@ -303,12 +300,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexListRelocationIT
   method: testListReindexShowsOriginalIdentityAfterRelocation
   issue: https://github.com/elastic/elasticsearch/issues/145963
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
-  method: testTopNByManySortColumns
-  issue: https://github.com/elastic/elasticsearch/issues/145965
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLimitByIT
-  method: testTopNByManyGroupsSmallTopCount
-  issue: https://github.com/elastic/elasticsearch/issues/145970
 
 # Examples:
 #

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLimitByIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackLimitByIT.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.any;
  * and {@code SORT | LIMIT BY} ({@code GroupedTopNOperator}).
  * Each test exercises a distinct circuit-breaking path inside its respective operator.
  */
-@TimeoutSuite(millis = 5 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = 10 * TimeUnits.MINUTE)
 public class HeapAttackLimitByIT extends HeapAttackTestCase {
 
     /**


### PR DESCRIPTION
Cherry-pick of #146001

Closes https://github.com/elastic/elasticsearch/issues/146192