### PR TITLE
ESQL: remove muted test, relevant feature is not in snapshot anymore

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -181,9 +181,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
   method: testDisablePitWhenCrossProjectSearchIsEnabled
   issue: https://github.com/elastic/elasticsearch/issues/144822
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReorderLimitProjectAndOrderByGoldenTests
-  method: testLimitByAndProjectNotSwapped
-  issue: https://github.com/elastic/elasticsearch/issues/144978
 - class: org.elasticsearch.xpack.security.authc.ApiKeyIntegTests
   method: testDynamicDeletionInterval
   issue: https://github.com/elastic/elasticsearch/issues/145022


### PR DESCRIPTION
Cherry-picks #145974

This LIMIT BY test was failing with test-release in the PRs because the feature was snapshot so we were getting errors in the parser: no viable alternative at input 'BY'. The feature is already tech-preview