### PR TITLE
[9.4] Update bundled JDK to 26 (#146167)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -184,6 +184,7 @@ steps:
             ES_RUNTIME_JAVA:
               - openjdk21
               - openjdk25
+              - openjdk26
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -209,6 +210,7 @@ steps:
             ES_RUNTIME_JAVA:
               - openjdk21
               - openjdk25
+              - openjdk26
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -710,6 +710,7 @@ steps:
             ES_RUNTIME_JAVA:
               - openjdk21
               - openjdk25
+              - openjdk26
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -735,6 +736,7 @@ steps:
             ES_RUNTIME_JAVA:
               - openjdk21
               - openjdk25
+              - openjdk26
             BWC_VERSION: ["8.19.15", "9.2.9", "9.3.4", "9.4.0"]
         agents:
           provider: gcp

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 9.4.0
 lucene            = 10.4.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 25.0.2+10@b1e0dfa218384cb9959bdcb897162d4e
+bundled_jdk = 26+35@c3cc523845074aa0af4f5e1e1ed4151d
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.20.0

--- a/distribution/tools/server-launcher/build.gradle
+++ b/distribution/tools/server-launcher/build.gradle
@@ -34,7 +34,7 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
 }
 
 // --- GraalVM native-image build (Linux only, Docker-based) ---
-def graalVmMajor = VersionProperties.getBundledJdkMajorVersion()
+def graalVmMajor = "25" // A relatively recent LTS version
 def nativeImageImage = "ghcr.io/graalvm/native-image-community:${graalVmMajor}-ol8"
 def launcherMainClass = 'org.elasticsearch.server.launcher.ServerLauncher'
 


### PR DESCRIPTION
Per ES-12784. Backport from #146167.