### PR TITLE
[8.19] Update bundled JDK to 26 (#146167)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -185,6 +185,7 @@ steps:
               - openjdk21
               - openjdk22
               - openjdk25
+              - openjdk26
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -213,6 +214,7 @@ steps:
               - openjdk21
               - openjdk22
               - openjdk25
+              - openjdk26
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -984,6 +984,7 @@ steps:
               - openjdk21
               - openjdk22
               - openjdk25
+              - openjdk26
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -1012,6 +1013,7 @@ steps:
               - openjdk21
               - openjdk22
               - openjdk25
+              - openjdk26
             BWC_VERSION: ["8.19.15"]
         agents:
           provider: gcp

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.19.15
 lucene            = 9.12.2
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 25.0.2+10@b1e0dfa218384cb9959bdcb897162d4e
+bundled_jdk = 26+35@c3cc523845074aa0af4f5e1e1ed4151d
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0


### PR DESCRIPTION
Per ES-12784. Backport from #146167.