### PR TITLE
[9.4] Increase timeout for RerankIT (#146140)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
@@ -52,6 +51,9 @@ import static org.hamcrest.Matchers.equalTo;
 
 @TestLogging(value = "org.elasticsearch.xpack.esql.session:DEBUG", reason = "to better understand planning")
 public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
+
+    protected static final TimeValue DEFAULT_REQUEST_TIMEOUT = TimeValue.timeValueSeconds(30L);
+
     @After
     public void ensureExchangesAreReleased() throws Exception {
         for (String node : internalCluster().getNodeNames()) {
@@ -170,7 +172,11 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
     }
 
     protected final EsqlQueryResponse run(String esqlCommands) {
-        return run(syncEsqlQueryRequest(esqlCommands).pragmas(getPragmas()));
+        return run(esqlCommands, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    protected final EsqlQueryResponse run(String esqlCommands, TimeValue timeout) {
+        return run(syncEsqlQueryRequest(esqlCommands).pragmas(getPragmas()), timeout);
     }
 
     /** A hook for overriding. */
@@ -179,8 +185,12 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
     }
 
     public EsqlQueryResponse run(EsqlQueryRequest request) {
+        return run(request, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    public EsqlQueryResponse run(EsqlQueryRequest request, TimeValue timeout) {
         try {
-            return client().execute(EsqlQueryAction.INSTANCE, maybeWrapAsPrepared(request)).actionGet(30, TimeUnit.SECONDS);
+            return client().execute(EsqlQueryAction.INSTANCE, maybeWrapAsPrepared(request)).actionGet(timeout);
         } catch (ElasticsearchTimeoutException e) {
             throw new AssertionError("timeout", e);
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RerankIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RerankIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.esql.inference.InferenceSettings;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
@@ -147,7 +148,7 @@ public class RerankIT extends InferenceCommandIntegTestCase {
             | KEEP id, _score
             """, testIndexLarge, RERANK_MODEL_ID);
 
-        try (var resp = run(query)) {
+        try (var resp = run(query, TimeValue.timeValueSeconds(60L))) {
             List<List<Object>> values = getValuesList(resp);
             // Should be limited to exactly the default row limit (1000)
             assertThat(values, hasSize(1000));


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Increase timeout for RerankIT (#146140)