### PR TITLE
Simplify DiskBBQ empty query path

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
@@ -295,8 +295,15 @@ public abstract class IVFVectorsReader<E extends IVFVectorsReader.FieldEntry> ex
     @Override
     public final void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         final FieldInfo fieldInfo = state.fieldInfos.fieldInfo(field);
+        if (fieldInfo == null || fieldInfo.getVectorDimension() == 0) {
+            return;
+        }
         if (fieldInfo.getVectorEncoding().equals(VectorEncoding.FLOAT32) == false) {
             getReaderForField(field).search(field, target, knnCollector, acceptDocs);
+            return;
+        }
+        FieldEntry entry = fields.get(fieldInfo.number);
+        if (hasNoVectors(fieldInfo, entry)) {
             return;
         }
         if (fieldInfo.getVectorDimension() != target.length) {
@@ -331,7 +338,6 @@ public abstract class IVFVectorsReader<E extends IVFVectorsReader.FieldEntry> ex
             k = ivfSearchStrategy.getK();
         }
 
-        FieldEntry entry = fields.get(fieldInfo.number);
         if (visitRatio == dynamicVisitRatio) {
             visitRatio = Math.min(computeDynamicVisitRatio(numCands, k), computeSegmentSizeCap(numVectors));
         }
@@ -387,6 +393,12 @@ public abstract class IVFVectorsReader<E extends IVFVectorsReader.FieldEntry> ex
                 }
             }
         }
+    }
+
+    private static boolean hasNoVectors(FieldInfo fieldInfo, FieldEntry fieldEntry) {
+        return fieldInfo.getVectorDimension() == 0
+            || fieldEntry == null
+            || (fieldEntry.numCentroids() == 0 && fieldEntry.postingListLength == 0L && fieldEntry.centroidLength == 0L);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/IVFKnnFloatVectorQuery.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.vectors;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
@@ -129,14 +128,6 @@ public class IVFKnnFloatVectorQuery extends AbstractIVFKnnVectorQuery {
         float visitRatio
     ) throws IOException {
         LeafReader reader = context.reader();
-        FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
-        if (floatVectorValues == null) {
-            FloatVectorValues.checkField(reader, field);
-            return NO_RESULTS;
-        }
-        if (floatVectorValues.size() == 0) {
-            return NO_RESULTS;
-        }
         IVFKnnSearchStrategy strategy = new IVFKnnSearchStrategy(visitRatio, numCands, k, knnCollectorManager.longAccumulator);
         AbstractMaxScoreKnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, strategy, context);
         if (knnCollector == null) {
@@ -144,7 +135,6 @@ public class IVFKnnFloatVectorQuery extends AbstractIVFKnnVectorQuery {
         }
         strategy.setCollector(knnCollector);
         reader.searchNearestVectors(field, query, knnCollector, acceptDocs);
-        TopDocs results = knnCollector.topDocs();
-        return results != null ? results : NO_RESULTS;
+        return knnCollector.topDocs();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
@@ -11,14 +11,14 @@ package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborQueue;
 
+import static org.elasticsearch.search.vectors.AbstractIVFKnnVectorQuery.NO_RESULTS;
+
 class MaxScoreTopKnnCollector extends AbstractMaxScoreKnnCollector {
 
-    static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
     private long minCompetitiveDocScore;
     private float minCompetitiveSimilarity;
     protected final NeighborQueue queue;

--- a/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
@@ -11,12 +11,14 @@ package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborQueue;
 
 class MaxScoreTopKnnCollector extends AbstractMaxScoreKnnCollector {
 
+    static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
     private long minCompetitiveDocScore;
     private float minCompetitiveSimilarity;
     protected final NeighborQueue queue;
@@ -57,6 +59,9 @@ class MaxScoreTopKnnCollector extends AbstractMaxScoreKnnCollector {
 
     @Override
     public TopDocs topDocs() {
+        if (queue.size() == 0) {
+            return NO_RESULTS;
+        }
         assert queue.size() <= k() : "Tried to collect more results than the maximum number allowed";
         ScoreDoc[] scoreDocs = new ScoreDoc[queue.size()];
         for (int i = 1; i <= scoreDocs.length; i++) {

--- a/server/src/test/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollectorTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.search.vectors;
 
+import org.apache.lucene.search.TopDocsCollector;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborQueue;
 import org.elasticsearch.test.ESTestCase;
 
@@ -54,6 +55,14 @@ public class MaxScoreTopKnnCollectorTests extends ESTestCase {
 
         assertEquals(globalCompetitiveScore, collector.getMinCompetitiveDocScore());
         assertTrue(Float.NEGATIVE_INFINITY == collector.minCompetitiveSimilarity());
+    }
+
+    public void testEmptyTopDocsUsesStaticNoResults() {
+        LongAccumulator accumulator = new LongAccumulator(Long::max, AbstractMaxScoreKnnCollector.LEAST_COMPETITIVE);
+        MaxScoreTopKnnCollector collector = new MaxScoreTopKnnCollector(2, 1000, new IVFKnnSearchStrategy(0.5f, 100, 10, accumulator));
+
+        assertSame(MaxScoreTopKnnCollector.NO_RESULTS, collector.topDocs());
+        assertSame(TopDocsCollector.EMPTY_TOPDOCS, collector.topDocs());
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollectorTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.search.TopDocsCollector;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborQueue;
 import org.elasticsearch.test.ESTestCase;
 
@@ -55,14 +54,6 @@ public class MaxScoreTopKnnCollectorTests extends ESTestCase {
 
         assertEquals(globalCompetitiveScore, collector.getMinCompetitiveDocScore());
         assertTrue(Float.NEGATIVE_INFINITY == collector.minCompetitiveSimilarity());
-    }
-
-    public void testEmptyTopDocsUsesStaticNoResults() {
-        LongAccumulator accumulator = new LongAccumulator(Long::max, AbstractMaxScoreKnnCollector.LEAST_COMPETITIVE);
-        MaxScoreTopKnnCollector collector = new MaxScoreTopKnnCollector(2, 1000, new IVFKnnSearchStrategy(0.5f, 100, 10, accumulator));
-
-        assertSame(MaxScoreTopKnnCollector.NO_RESULTS, collector.topDocs());
-        assertSame(TopDocsCollector.EMPTY_TOPDOCS, collector.topDocs());
     }
 
 }


### PR DESCRIPTION
This simplifies the DiskBBQ empty query path, keeping from having to create a FloatVectorValues iterator. 

This prevents a very minor, but silly allocation of `float[]` on every single query.