### PR TITLE
[8.19] Remove Security Manager usage from x-pack ent-search (#146271)

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
@@ -15,14 +15,11 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -31,9 +28,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -85,20 +79,7 @@ public class TemplateParamValidator implements ToXContentObject, Writeable {
     }
 
     public void validate(Map<String, Object> templateParams) throws ValidationException {
-
-        JsonNode secondParam = null;
-        try {
-            SpecialPermission.check();
-            secondParam = AccessController.doPrivileged((PrivilegedExceptionAction<JsonNode>) () -> {
-                return OBJECT_MAPPER.valueToTree(templateParams);
-            });
-        } catch (PrivilegedActionException e) {
-            throw new ElasticsearchStatusException(
-                "failed to convert parameters while validating",
-                RestStatus.INTERNAL_SERVER_ERROR,
-                e.getCause()
-            );
-        }
+        JsonNode secondParam = OBJECT_MAPPER.valueToTree(templateParams);
         validateWithSchema(this.jsonSchema, secondParam);
     }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove Security Manager usage from x-pack ent-search (#146271)