### PR TITLE
[8.19] Remove Security Manager usage from x-pack inference (#146268)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockInferenceClient.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockInferenceClient.java
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
@@ -35,8 +34,6 @@ import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockMod
 import org.reactivestreams.FlowAdapters;
 import org.slf4j.LoggerFactory;
 
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
@@ -140,28 +137,25 @@ public class AmazonBedrockInferenceClient extends AmazonBedrockBaseClient {
         var serviceSettings = model.getServiceSettings();
 
         try {
-            SpecialPermission.check();
-            return AccessController.doPrivileged((PrivilegedExceptionAction<BedrockRuntimeAsyncClient>) () -> {
-                var credentials = AwsBasicCredentials.create(secretSettings.accessKey().toString(), secretSettings.secretKey().toString());
-                var credentialsProvider = StaticCredentialsProvider.create(credentials);
-                var clientConfig = timeout == null
-                    ? NettyNioAsyncHttpClient.builder().connectionTimeout(DEFAULT_CLIENT_TIMEOUT_MS)
-                    : NettyNioAsyncHttpClient.builder().connectionTimeout(Duration.ofMillis(timeout.millis()));
-                var override = ClientOverrideConfiguration.builder()
-                    // disable profileFile, user credentials will always come from the configured Model Secrets
-                    .defaultProfileFileSupplier(ProfileFile.aggregator()::build)
-                    .defaultProfileFile(ProfileFile.aggregator().build())
-                    // each model request retries at most once, limit the impact a request can have on other request's availability
-                    .retryPolicy(retryPolicy -> retryPolicy.numRetries(1))
-                    .retryStrategy(retryStrategy -> retryStrategy.maxAttempts(1))
-                    .build();
-                return BedrockRuntimeAsyncClient.builder()
-                    .credentialsProvider(credentialsProvider)
-                    .region(Region.of(serviceSettings.region()))
-                    .httpClientBuilder(clientConfig)
-                    .overrideConfiguration(override)
-                    .build();
-            });
+            var credentials = AwsBasicCredentials.create(secretSettings.accessKey().toString(), secretSettings.secretKey().toString());
+            var credentialsProvider = StaticCredentialsProvider.create(credentials);
+            var clientConfig = timeout == null
+                ? NettyNioAsyncHttpClient.builder().connectionTimeout(DEFAULT_CLIENT_TIMEOUT_MS)
+                : NettyNioAsyncHttpClient.builder().connectionTimeout(Duration.ofMillis(timeout.millis()));
+            var override = ClientOverrideConfiguration.builder()
+                // disable profileFile, user credentials will always come from the configured Model Secrets
+                .defaultProfileFileSupplier(ProfileFile.aggregator()::build)
+                .defaultProfileFile(ProfileFile.aggregator().build())
+                // each model request retries at most once, limit the impact a request can have on other request's availability
+                .retryPolicy(retryPolicy -> retryPolicy.numRetries(1))
+                .retryStrategy(retryStrategy -> retryStrategy.maxAttempts(1))
+                .build();
+            return BedrockRuntimeAsyncClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(serviceSettings.region()))
+                .httpClientBuilder(clientConfig)
+                .overrideConfiguration(override)
+                .build();
         } catch (BedrockRuntimeException amazonBedrockRuntimeException) {
             throw new ElasticsearchException(
                 Strings.format("failed to create AmazonBedrockRuntime client: [%s]", amazonBedrockRuntimeException.getMessage()),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRequest.java
@@ -12,7 +12,6 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 
 import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.external.request.Request;
@@ -20,8 +19,6 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiS
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,17 +28,12 @@ public interface GoogleVertexAiRequest extends Request {
     List<String> AUTH_SCOPE = Collections.singletonList("https://www.googleapis.com/auth/cloud-platform");
 
     static void decorateWithBearerToken(HttpPost httpPost, GoogleVertexAiSecretSettings secretSettings) {
-        SpecialPermission.check();
         try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                GoogleCredentials credentials = ServiceAccountCredentials.fromStream(
-                    new ByteArrayInputStream(secretSettings.serviceAccountJson().toString().getBytes(StandardCharsets.UTF_8))
-                ).createScoped(AUTH_SCOPE);
-                credentials.refreshIfExpired();
-                httpPost.setHeader(createAuthBearerHeader(new SecureString(credentials.getAccessToken().getTokenValue().toCharArray())));
-
-                return null;
-            });
+            GoogleCredentials credentials = ServiceAccountCredentials.fromStream(
+                new ByteArrayInputStream(secretSettings.serviceAccountJson().toString().getBytes(StandardCharsets.UTF_8))
+            ).createScoped(AUTH_SCOPE);
+            credentials.refreshIfExpired();
+            httpPost.setHeader(createAuthBearerHeader(new SecureString(credentials.getAccessToken().getTokenValue().toCharArray())));
         } catch (Exception e) {
             throw new ElasticsearchStatusException(e.getMessage(), RestStatus.FORBIDDEN, e);
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClient.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClient.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.ListenerTimeouts;
@@ -42,8 +41,6 @@ import org.elasticsearch.xpack.inference.external.http.HttpSettings;
 import org.reactivestreams.FlowAdapters;
 
 import java.io.Closeable;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -189,29 +186,25 @@ public class SageMakerClient implements Closeable {
 
         @Override
         public SageMakerRuntimeAsyncClient load(RegionAndSecrets key) throws Exception {
-            SpecialPermission.check();
-            // TODO migrate to entitlements
-            return AccessController.doPrivileged((PrivilegedExceptionAction<SageMakerRuntimeAsyncClient>) () -> {
-                var credentials = AwsBasicCredentials.create(
-                    key.secretSettings().accessKey().toString(),
-                    key.secretSettings().secretKey().toString()
-                );
-                var credentialsProvider = StaticCredentialsProvider.create(credentials);
-                var clientConfig = NettyNioAsyncHttpClient.builder().connectionTimeout(httpSettings.connectionTimeoutDuration());
-                var override = ClientOverrideConfiguration.builder()
-                    // disable profileFile, user credentials will always come from the configured Model Secrets
-                    .defaultProfileFileSupplier(ProfileFile.aggregator()::build)
-                    .defaultProfileFile(ProfileFile.aggregator().build())
-                    .retryPolicy(retryPolicy -> retryPolicy.numRetries(3))
-                    .retryStrategy(retryStrategy -> retryStrategy.maxAttempts(3))
-                    .build();
-                return SageMakerRuntimeAsyncClient.builder()
-                    .credentialsProvider(credentialsProvider)
-                    .region(Region.of(key.region()))
-                    .httpClientBuilder(clientConfig)
-                    .overrideConfiguration(override)
-                    .build();
-            });
+            var credentials = AwsBasicCredentials.create(
+                key.secretSettings().accessKey().toString(),
+                key.secretSettings().secretKey().toString()
+            );
+            var credentialsProvider = StaticCredentialsProvider.create(credentials);
+            var clientConfig = NettyNioAsyncHttpClient.builder().connectionTimeout(httpSettings.connectionTimeoutDuration());
+            var override = ClientOverrideConfiguration.builder()
+                // disable profileFile, user credentials will always come from the configured Model Secrets
+                .defaultProfileFileSupplier(ProfileFile.aggregator()::build)
+                .defaultProfileFile(ProfileFile.aggregator().build())
+                .retryPolicy(retryPolicy -> retryPolicy.numRetries(3))
+                .retryStrategy(retryStrategy -> retryStrategy.maxAttempts(3))
+                .build();
+            return SageMakerRuntimeAsyncClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(key.region()))
+                .httpClientBuilder(clientConfig)
+                .overrideConfiguration(override)
+                .build();
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove Security Manager usage from x-pack inference (#146268)