### PR TITLE
[9.4] Remove Security Manager usage from x-pack identity-provider (#146269)

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlInit.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlInit.java
@@ -9,15 +9,11 @@ package org.elasticsearch.xpack.idp.saml.support;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.xpack.core.security.support.RestorableContextClassLoader;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.xmlsec.signature.impl.X509CertificateBuilder;
 import org.slf4j.LoggerFactory;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class SamlInit {
@@ -30,27 +26,22 @@ public final class SamlInit {
     /**
      * This is needed in order to initialize the underlying OpenSAML library.
      * It must be called before doing anything that potentially interacts with OpenSAML (whether in server code, or in tests).
-     * The initialization happens within do privileged block as the underlying Apache XML security library has a permission check.
      * The initialization happens with a specific context classloader as OpenSAML loads resources from its jar file.
      */
     public static void initialize() {
         if (INITIALISED.compareAndSet(false, true)) {
             // We want to force these classes to be loaded _before_ we fiddle with the context classloader
             LoggerFactory.getLogger(InitializationService.class);
-            SpecialPermission.check();
             try {
-                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    LOGGER.debug("Initializing OpenSAML");
-                    try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(InitializationService.class)) {
-                        InitializationService.initialize();
-                        // Force load this now, because it has a static field that needs to run inside the doPrivileged block
-                        var ignore2 = new X509CertificateBuilder().buildObject();
-                    }
-                    LOGGER.debug("Initialized OpenSAML");
-                    return null;
-                });
-            } catch (PrivilegedActionException e) {
-                throw new ElasticsearchSecurityException("failed to set context classloader for SAML IdP", e);
+                LOGGER.debug("Initializing OpenSAML");
+                try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(InitializationService.class)) {
+                    InitializationService.initialize();
+                    // Force-load to initialize static fields while the context classloader is set
+                    var ignore2 = new X509CertificateBuilder().buildObject();
+                }
+                LOGGER.debug("Initialized OpenSAML");
+            } catch (Exception e) {
+                throw new ElasticsearchSecurityException("failed to initialize OpenSAML for SAML IdP", e);
             }
         }
     }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlObjectSigner.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlObjectSigner.java
@@ -17,10 +17,6 @@ import org.opensaml.xmlsec.signature.support.Signer;
 import org.opensaml.xmlsec.signature.support.SignerProvider;
 import org.w3c.dom.Element;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-
 /**
  * Signs OpenSAML {@link SignableXMLObject} instances using {@link SamlIdentityProvider#getSigningCredential()}.
  */
@@ -42,16 +38,9 @@ public class SamlObjectSigner {
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         object.setSignature(signature);
         Element element = SamlFactory.toDomElement(object);
-        try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(SignerProvider.class)) {
-                    Signer.signObject(signature);
-                } catch (SignatureException e) {
-                    throw new SecurityException("failed to sign SAML object " + object, e);
-                }
-                return null;
-            });
-        } catch (PrivilegedActionException e) {
+        try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(SignerProvider.class)) {
+            Signer.signObject(signature);
+        } catch (SignatureException e) {
             throw new SecurityException("failed to sign SAML object " + object, e);
         }
         return element;


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Remove Security Manager usage from x-pack identity-provider (#146269)