### PR TITLE
ESQL: Optimized Parquet reader with batch decode and async I/O

### DIFF
--- a/docs/changelog/146308.yaml
+++ b/docs/changelog/146308.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146308
+summary: Optimized Parquet reader with batch decode and async I/O
+type: enhancement

--- a/x-pack/plugin/esql-datasource-azure/build.gradle
+++ b/x-pack/plugin/esql-datasource-azure/build.gradle
@@ -19,6 +19,11 @@ base {
   archivesName = 'esql-datasource-azure'
 }
 
+// Aligned with modules/repository-azure
+versions << [
+  'azureReactorNetty': '1.0.45',
+]
+
 dependencies {
   // SPI interfaces from ESQL core
   compileOnly project(path: xpackModule('esql'))
@@ -32,8 +37,8 @@ dependencies {
   implementation 'com.azure:azure-core:1.51.0'
   implementation 'com.azure:azure-identity:1.13.2'
   implementation 'com.azure:azure-core-http-netty:1.15.3'
-  implementation "io.projectreactor.netty:reactor-netty-core:1.0.45"
-  implementation "io.projectreactor.netty:reactor-netty-http:1.0.45"
+  implementation "io.projectreactor.netty:reactor-netty-core:${versions.azureReactorNetty}"
+  implementation "io.projectreactor.netty:reactor-netty-http:${versions.azureReactorNetty}"
   implementation "io.projectreactor:reactor-core:3.4.38"
   // Netty - must be bundled as plugin classloader is isolated from server
   implementation "io.netty:netty-buffer:${versions.netty}"

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.esql.datasource.azure;
 
+import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.utils.ContentRangeParser;
@@ -19,7 +21,9 @@ import org.elasticsearch.xpack.esql.datasources.utils.ContentRangeParser;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.concurrent.Executor;
 
 /**
  * StorageObject implementation for Azure Blob Storage.
@@ -27,6 +31,7 @@ import java.time.Instant;
  */
 public final class AzureStorageObject implements StorageObject {
     private final BlobClient blobClient;
+    private final BlobAsyncClient blobAsyncClient;
     private final String container;
     private final String blobName;
     private final StoragePath path;
@@ -36,6 +41,10 @@ public final class AzureStorageObject implements StorageObject {
     private volatile Boolean cachedExists;
 
     public AzureStorageObject(BlobClient blobClient, String container, String blobName, StoragePath path) {
+        this(blobClient, null, container, blobName, path);
+    }
+
+    public AzureStorageObject(BlobClient blobClient, BlobAsyncClient blobAsyncClient, String container, String blobName, StoragePath path) {
         if (blobClient == null) {
             throw new IllegalArgumentException("blobClient cannot be null");
         }
@@ -49,13 +58,25 @@ public final class AzureStorageObject implements StorageObject {
             throw new IllegalArgumentException("path cannot be null");
         }
         this.blobClient = blobClient;
+        this.blobAsyncClient = blobAsyncClient;
         this.container = container;
         this.blobName = blobName;
         this.path = path;
     }
 
     public AzureStorageObject(BlobClient blobClient, String container, String blobName, StoragePath path, long length) {
-        this(blobClient, container, blobName, path);
+        this(blobClient, null, container, blobName, path, length);
+    }
+
+    public AzureStorageObject(
+        BlobClient blobClient,
+        BlobAsyncClient blobAsyncClient,
+        String container,
+        String blobName,
+        StoragePath path,
+        long length
+    ) {
+        this(blobClient, blobAsyncClient, container, blobName, path);
         this.cachedLength = length;
     }
 
@@ -67,7 +88,19 @@ public final class AzureStorageObject implements StorageObject {
         long length,
         Instant lastModified
     ) {
-        this(blobClient, container, blobName, path, length);
+        this(blobClient, null, container, blobName, path, length, lastModified);
+    }
+
+    public AzureStorageObject(
+        BlobClient blobClient,
+        BlobAsyncClient blobAsyncClient,
+        String container,
+        String blobName,
+        StoragePath path,
+        long length,
+        Instant lastModified
+    ) {
+        this(blobClient, blobAsyncClient, container, blobName, path, length);
         this.cachedLastModified = lastModified;
     }
 
@@ -175,6 +208,52 @@ public final class AzureStorageObject implements StorageObject {
         cachedExists = false;
         cachedLength = 0L;
         cachedLastModified = null;
+    }
+
+    @Override
+    public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+        if (blobAsyncClient == null) {
+            StorageObject.super.readBytesAsync(position, length, executor, listener);
+            return;
+        }
+
+        if (position < 0) {
+            listener.onFailure(new IllegalArgumentException("position must be non-negative, got: " + position));
+            return;
+        }
+        if (length < 0) {
+            listener.onFailure(new IllegalArgumentException("length must be non-negative, got: " + length));
+            return;
+        }
+
+        BlobRange range = new BlobRange(position, length);
+        blobAsyncClient.downloadWithResponse(range, null, null, false)
+            .flatMapMany(response -> response.getValue())
+            .reduce(ByteBuffer.allocate(Math.toIntExact(length)), (acc, buf) -> {
+                if (buf.remaining() > acc.remaining()) {
+                    throw new IllegalStateException("Server returned more bytes than requested (" + length + ")");
+                }
+                acc.put(buf);
+                return acc;
+            })
+            .map(buffer -> {
+                buffer.flip();
+                return buffer;
+            })
+            .toFuture()
+            .whenComplete((buffer, error) -> {
+                if (error != null) {
+                    Throwable cause = error.getCause() != null ? error.getCause() : error;
+                    listener.onFailure(cause instanceof Exception e ? e : new RuntimeException(cause));
+                } else {
+                    listener.onResponse(buffer);
+                }
+            });
+    }
+
+    @Override
+    public boolean supportsNativeAsync() {
+        return blobAsyncClient != null;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.esql.datasource.azure;
 
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobItem;
@@ -41,17 +43,36 @@ import java.util.NoSuchElementException;
  *   <li>path: /container/path/to/blob (first segment = container, remainder = blob name)</li>
  * </ul>
  * <p>
+ * Maintains both a sync {@link BlobServiceClient} and an async {@link BlobServiceAsyncClient},
+ * built from the same {@link BlobServiceClientBuilder} (same pattern as {@code repository-azure}'s
+ * {@code AzureClientProvider}). Both clients share credentials, endpoint, and HTTP pipeline config.
+ * <ul>
+ *   <li><b>Sync client</b> — used for streaming reads ({@code openInputStream} returns a live
+ *       {@code InputStream}), metadata ({@code getProperties}), existence checks, and listing.
+ *       These are inherently blocking or return streaming results.</li>
+ *   <li><b>Async client</b> — used for {@code readBytesAsync} range reads in
+ *       {@link AzureStorageObject} via {@code BlobAsyncClient.downloadWithResponse}. Reactor
+ *       Netty handles concurrent range reads without blocking a thread per request.</li>
+ * </ul>
+ * <p>
+ * The async dependencies ({@code azure-core-http-netty}, Reactor Netty, Netty) are already
+ * bundled in this plugin's classloader. Versions are aligned with {@code repository-azure}.
+ * <p>
  * Authentication can be provided via connection string, account+key, SAS token,
  * or DefaultAzureCredential when no explicit credentials are configured.
  */
 public final class AzureStorageProvider implements StorageProvider {
-    private volatile BlobServiceClient blobServiceClient;
+
+    private record Clients(BlobServiceClient sync, BlobServiceAsyncClient async) {}
+
+    private volatile Clients clients;
     private final AzureConfiguration config;
 
     public AzureStorageProvider(AzureConfiguration config) {
         this.config = config;
         if (config != null && (config.hasCredentials() || config.isAnonymous())) {
-            this.blobServiceClient = buildBlobServiceClient(config);
+            BlobServiceClientBuilder builder = configureBlobServiceClientBuilder(config, null);
+            this.clients = new Clients(builder.buildClient(), builder.buildAsyncClient());
         }
     }
 
@@ -60,26 +81,24 @@ public final class AzureStorageProvider implements StorageProvider {
      */
     public AzureStorageProvider(BlobServiceClient blobServiceClient) {
         this.config = null;
-        this.blobServiceClient = blobServiceClient;
+        this.clients = new Clients(blobServiceClient, null);
     }
 
-    private BlobServiceClient client(String accountFromPath) {
-        if (blobServiceClient != null) {
-            return blobServiceClient;
+    private Clients clients(String accountFromPath) {
+        Clients c = clients;
+        if (c != null) {
+            return c;
         }
         synchronized (this) {
-            if (blobServiceClient == null) {
-                blobServiceClient = buildBlobServiceClient(config, accountFromPath);
+            if (clients == null) {
+                BlobServiceClientBuilder builder = configureBlobServiceClientBuilder(config, accountFromPath);
+                clients = new Clients(builder.buildClient(), builder.buildAsyncClient());
             }
         }
-        return blobServiceClient;
+        return clients;
     }
 
-    private static BlobServiceClient buildBlobServiceClient(AzureConfiguration config) {
-        return buildBlobServiceClient(config, null);
-    }
-
-    private static BlobServiceClient buildBlobServiceClient(AzureConfiguration config, String accountFromPath) {
+    private static BlobServiceClientBuilder configureBlobServiceClientBuilder(AzureConfiguration config, String accountFromPath) {
         BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
 
         if (config != null && config.isAnonymous()) {
@@ -97,8 +116,6 @@ public final class AzureStorageProvider implements StorageProvider {
                         + "(wasbs://account.blob.core.windows.net/...) or WITH (endpoint = '...')"
                 );
             }
-            // No credential — Azure SDK sends unauthenticated requests for public containers
-            return builder.buildClient();
         } else if (config != null && config.hasCredentials()) {
             if (config.connectionString() != null && config.connectionString().isEmpty() == false) {
                 builder.connectionString(config.connectionString());
@@ -137,7 +154,7 @@ public final class AzureStorageProvider implements StorageProvider {
             builder.endpoint(endpoint).credential(new DefaultAzureCredentialBuilder().build());
         }
 
-        return builder.buildClient();
+        return builder;
     }
 
     @Override
@@ -145,8 +162,10 @@ public final class AzureStorageProvider implements StorageProvider {
         validateAzureScheme(path);
         ParsedPath parsed = parsePath(path);
         String account = extractAccountFromHost(parsed.host);
-        BlobClient blobClient = client(account).getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
-        return new AzureStorageObject(blobClient, parsed.container, parsed.blobName, path);
+        Clients c = clients(account);
+        BlobClient blobClient = c.sync().getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
+        BlobAsyncClient blobAsyncClient = resolveAsyncClient(c, parsed);
+        return new AzureStorageObject(blobClient, blobAsyncClient, parsed.container, parsed.blobName, path);
     }
 
     @Override
@@ -154,8 +173,10 @@ public final class AzureStorageProvider implements StorageProvider {
         validateAzureScheme(path);
         ParsedPath parsed = parsePath(path);
         String account = extractAccountFromHost(parsed.host);
-        BlobClient blobClient = client(account).getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
-        return new AzureStorageObject(blobClient, parsed.container, parsed.blobName, path, length);
+        Clients c = clients(account);
+        BlobClient blobClient = c.sync().getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
+        BlobAsyncClient blobAsyncClient = resolveAsyncClient(c, parsed);
+        return new AzureStorageObject(blobClient, blobAsyncClient, parsed.container, parsed.blobName, path, length);
     }
 
     @Override
@@ -163,8 +184,18 @@ public final class AzureStorageProvider implements StorageProvider {
         validateAzureScheme(path);
         ParsedPath parsed = parsePath(path);
         String account = extractAccountFromHost(parsed.host);
-        BlobClient blobClient = client(account).getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
-        return new AzureStorageObject(blobClient, parsed.container, parsed.blobName, path, length, lastModified);
+        Clients c = clients(account);
+        BlobClient blobClient = c.sync().getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
+        BlobAsyncClient blobAsyncClient = resolveAsyncClient(c, parsed);
+        return new AzureStorageObject(blobClient, blobAsyncClient, parsed.container, parsed.blobName, path, length, lastModified);
+    }
+
+    private static BlobAsyncClient resolveAsyncClient(Clients c, ParsedPath parsed) {
+        BlobServiceAsyncClient async = c.async();
+        if (async == null) {
+            return null;
+        }
+        return async.getBlobContainerAsyncClient(parsed.container).getBlobAsyncClient(parsed.blobName);
     }
 
     @Override
@@ -172,7 +203,7 @@ public final class AzureStorageProvider implements StorageProvider {
         validateAzureScheme(prefix);
         ParsedPath parsed = parsePathForListing(prefix);
         String account = extractAccountFromHost(parsed.host);
-        BlobContainerClient containerClient = client(account).getBlobContainerClient(parsed.container);
+        BlobContainerClient containerClient = clients(account).sync().getBlobContainerClient(parsed.container);
         ListBlobsOptions options = new ListBlobsOptions().setPrefix(parsed.blobName);
         Iterable<BlobItem> blobItems = recursive
             ? containerClient.listBlobs(options, null)
@@ -185,7 +216,7 @@ public final class AzureStorageProvider implements StorageProvider {
         validateAzureScheme(path);
         ParsedPath parsed = parsePath(path);
         String account = extractAccountFromHost(parsed.host);
-        BlobClient blobClient = client(account).getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
+        BlobClient blobClient = clients(account).sync().getBlobContainerClient(parsed.container).getBlobClient(parsed.blobName);
         try {
             return blobClient.exists();
         } catch (Exception e) {
@@ -222,13 +253,21 @@ public final class AzureStorageProvider implements StorageProvider {
 
     @Override
     public void close() throws IOException {
-        BlobServiceClient client = blobServiceClient;
-        blobServiceClient = null;
-        if (client != null) {
+        Clients c = clients;
+        clients = null;
+        if (c != null) {
             try {
-                closeHttpClient(client.getHttpPipeline().getHttpClient());
+                closeHttpClient(c.sync().getHttpPipeline().getHttpClient());
             } catch (Exception e) {
                 throw new IOException("Failed to close Azure BlobServiceClient", e);
+            } finally {
+                if (c.async() != null) {
+                    try {
+                        closeHttpClient(c.async().getHttpPipeline().getHttpClient());
+                    } catch (Exception e) {
+                        throw new IOException("Failed to close Azure BlobServiceAsyncClient", e);
+                    }
+                }
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectAsyncTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectAsyncTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.azure;
+
+import com.azure.storage.blob.BlobAsyncClient;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Tests for AzureStorageObject async wiring and AzureStorageProvider lifecycle.
+ * <p>
+ * Uses real Azure SDK clients built against a dummy Azurite-style connection string.
+ * Final Azure SDK classes cannot be mocked with standard Mockito, so we follow
+ * the same pattern as {@code repository-azure}: build real clients, test wiring
+ * and validation without hitting the network.
+ * <p>
+ * Only the sync client is built here (no Reactor Netty threads). Tests that need
+ * the async client use the provider which manages its own lifecycle.
+ */
+public class AzureStorageObjectAsyncTests extends ESTestCase {
+
+    private static final String CONNECTION_STRING = "DefaultEndpointsProtocol=http;"
+        + "AccountName=devstoreaccount1;"
+        + "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        + "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1";
+
+    private static final StoragePath PATH = StoragePath.of("wasbs://devstoreaccount1.blob.core.windows.net/container/blob.parquet");
+
+    private BlobClient blobClient() {
+        return new BlobServiceClientBuilder().connectionString(CONNECTION_STRING)
+            .buildClient()
+            .getBlobContainerClient("container")
+            .getBlobClient("blob.parquet");
+    }
+
+    private BlobAsyncClient blobAsyncClient() {
+        return new BlobServiceClientBuilder().connectionString(CONNECTION_STRING)
+            .buildAsyncClient()
+            .getBlobContainerAsyncClient("container")
+            .getBlobAsyncClient("blob.parquet");
+    }
+
+    public void testSupportsNativeAsyncWithAsyncClient() {
+        AzureStorageObject obj = new AzureStorageObject(blobClient(), blobAsyncClient(), "container", "blob.parquet", PATH);
+        assertTrue(obj.supportsNativeAsync());
+    }
+
+    public void testSupportsNativeAsyncWithoutAsyncClient() {
+        AzureStorageObject obj = new AzureStorageObject(blobClient(), "container", "blob.parquet", PATH);
+        assertFalse(obj.supportsNativeAsync());
+    }
+
+    public void testReadBytesAsyncNegativePositionFails() throws Exception {
+        AzureStorageObject obj = new AzureStorageObject(blobClient(), blobAsyncClient(), "container", "blob.parquet", PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(-1, 10, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer buffer) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(IllegalArgumentException.class));
+        assertThat(error.get().getMessage(), containsString("position must be non-negative"));
+    }
+
+    public void testReadBytesAsyncNegativeLengthFails() throws Exception {
+        AzureStorageObject obj = new AzureStorageObject(blobClient(), blobAsyncClient(), "container", "blob.parquet", PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(0, -1, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer buffer) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(IllegalArgumentException.class));
+        assertThat(error.get().getMessage(), containsString("length must be non-negative"));
+    }
+
+    public void testProviderCloseDoesNotThrow() throws IOException {
+        AzureConfiguration azureConfig = AzureConfiguration.fromFields(
+            null,
+            "devstoreaccount1",
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+            null,
+            "http://127.0.0.1:10000/devstoreaccount1"
+        );
+        AzureStorageProvider provider = new AzureStorageProvider(azureConfig);
+        provider.close();
+    }
+
+    public void testProviderCreatedObjectsAreAsyncCapable() throws IOException {
+        AzureConfiguration azureConfig = AzureConfiguration.fromFields(
+            null,
+            "devstoreaccount1",
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+            null,
+            "http://127.0.0.1:10000/devstoreaccount1"
+        );
+        try (AzureStorageProvider provider = new AzureStorageProvider(azureConfig)) {
+            var obj = provider.newObject(PATH);
+            assertTrue("Provider-created objects should support native async", obj.supportsNativeAsync());
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Data source plugin providing Google Cloud Storage support for ESQL.
@@ -36,7 +37,7 @@ public class GcsDataSourcePlugin extends Plugin implements DataSourcePlugin {
     }
 
     @Override
-    public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+    public Map<String, StorageProviderFactory> storageProviders(Settings settings, ExecutorService executor) {
         StorageProviderFactory gcsFactory = new StorageProviderFactory() {
             @Override
             public StorageProvider create(Settings settings) {

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePluginTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.gcs;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
@@ -21,7 +22,7 @@ public class GcsDataSourcePluginTests extends ESTestCase {
 
     public void testStorageProvidersRegistersGsScheme() {
         GcsDataSourcePlugin plugin = new GcsDataSourcePlugin();
-        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY, EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         assertTrue("Should register gs scheme", providers.containsKey("gs"));
         assertEquals("Should register exactly 1 scheme", 1, providers.size());
@@ -29,7 +30,7 @@ public class GcsDataSourcePluginTests extends ESTestCase {
 
     public void testStorageProviderFactoryCreateWithNullConfigDelegatesToDefault() {
         GcsDataSourcePlugin plugin = new GcsDataSourcePlugin();
-        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY, EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         StorageProviderFactory factory = providers.get("gs");
         assertNotNull("gs factory should not be null", factory);
@@ -42,7 +43,7 @@ public class GcsDataSourcePluginTests extends ESTestCase {
 
     public void testStorageProviderFactoryCreateWithEmptyConfigDelegatesToDefault() {
         GcsDataSourcePlugin plugin = new GcsDataSourcePlugin();
-        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY, EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         StorageProviderFactory factory = providers.get("gs");
         assertNotNull("gs factory should not be null", factory);
@@ -55,7 +56,7 @@ public class GcsDataSourcePluginTests extends ESTestCase {
 
     public void testStorageProviderFactoryCreateWithConfigParsesFields() {
         GcsDataSourcePlugin plugin = new GcsDataSourcePlugin();
-        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY, EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         StorageProviderFactory factory = providers.get("gs");
         assertNotNull("gs factory should not be null", factory);
@@ -84,7 +85,7 @@ public class GcsDataSourcePluginTests extends ESTestCase {
 
     public void testGsSchemeSameFactory() {
         GcsDataSourcePlugin plugin = new GcsDataSourcePlugin();
-        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY);
+        Map<String, StorageProviderFactory> providers = plugin.storageProviders(Settings.EMPTY, EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         // Only gs:// is supported (unlike S3 which has s3, s3a, s3n)
         assertNotNull(providers.get("gs"));

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/BatchColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/BatchColumnReader.java
@@ -83,7 +83,8 @@ final class BatchColumnReader {
                 values[i] = cr.getBoolean();
                 cr.consume();
             }
-            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantBoolean(values, rows, blockFactory);
+            return constant != null ? constant : blockFactory.newBooleanArrayVector(values, rows).asBlock();
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -96,10 +97,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return blockFactory.newBooleanArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
         }
-        return blockFactory.newBooleanArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
+        Block constant = ConstantBlockDetection.tryConstantBoolean(values, rows, blockFactory);
+        return constant != null ? constant : blockFactory.newBooleanArrayVector(values, rows).asBlock();
     }
 
     // --- Int ---
@@ -111,7 +117,8 @@ final class BatchColumnReader {
                 values[i] = cr.getInteger();
                 cr.consume();
             }
-            return blockFactory.newIntArrayVector(values, rows).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantInt(values, rows, blockFactory);
+            return constant != null ? constant : blockFactory.newIntArrayVector(values, rows).asBlock();
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -124,10 +131,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return blockFactory.newIntArrayVector(values, rows).asBlock();
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return blockFactory.newIntArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
         }
-        return blockFactory.newIntArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
+        Block constant = ConstantBlockDetection.tryConstantInt(values, rows, blockFactory);
+        return constant != null ? constant : blockFactory.newIntArrayVector(values, rows).asBlock();
     }
 
     // --- Long ---
@@ -139,7 +151,8 @@ final class BatchColumnReader {
                 values[i] = cr.getLong();
                 cr.consume();
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -152,10 +165,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static Block readInt32AsLongBatch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
@@ -165,7 +183,8 @@ final class BatchColumnReader {
                 values[i] = cr.getInteger();
                 cr.consume();
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -178,10 +197,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
     }
 
     // --- Double ---
@@ -209,7 +233,8 @@ final class BatchColumnReader {
                     cr.consume();
                 }
             }
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -222,10 +247,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static Block readDecimalAsDoubleBatch(ColumnReader cr, ColumnInfo info, int scale, int rows, BlockFactory blockFactory) {
@@ -236,7 +266,8 @@ final class BatchColumnReader {
                 values[i] = decimalToDouble(cr, info.parquetType(), scale);
                 cr.consume();
             }
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -249,10 +280,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static double decimalToDouble(ColumnReader cr, PrimitiveType.PrimitiveTypeName parquetType, int scale) {
@@ -272,7 +308,8 @@ final class BatchColumnReader {
                 values[i] = decodeFloat16(cr.getBinary().getBytes());
                 cr.consume();
             }
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -285,10 +322,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantDouble(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static double decodeFloat16(byte[] bytes) {
@@ -301,38 +343,56 @@ final class BatchColumnReader {
     private static Block readBytesBatch(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
         boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
         int maxDef = info.maxDefLevel();
-        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
-            if (maxDef == 0) {
-                if (isUuid) {
-                    for (int i = 0; i < rows; i++) {
-                        builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes())));
-                        cr.consume();
-                    }
-                } else {
-                    for (int i = 0; i < rows; i++) {
-                        builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                        cr.consume();
-                    }
+        if (maxDef == 0) {
+            BytesRef[] values = new BytesRef[rows];
+            if (isUuid) {
+                for (int i = 0; i < rows; i++) {
+                    values[i] = new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes()));
+                    cr.consume();
                 }
             } else {
-                if (isUuid) {
-                    for (int i = 0; i < rows; i++) {
-                        if (cr.getCurrentDefinitionLevel() < maxDef) {
-                            builder.appendNull();
-                        } else {
-                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes())));
-                        }
-                        cr.consume();
-                    }
+                for (int i = 0; i < rows; i++) {
+                    values[i] = new BytesRef(cr.getBinary().getBytes());
+                    cr.consume();
+                }
+            }
+            Block constant = ConstantBlockDetection.tryConstantBytesRef(values, rows, blockFactory);
+            if (constant != null) {
+                return constant;
+            }
+            try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+                for (int i = 0; i < rows; i++) {
+                    builder.appendBytesRef(values[i]);
+                }
+                return builder.build();
+            }
+        }
+        BitSet nulls = new BitSet(rows);
+        BytesRef[] values = new BytesRef[rows];
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else if (isUuid) {
+                values[i] = new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes()));
+            } else {
+                values[i] = new BytesRef(cr.getBinary().getBytes());
+            }
+            cr.consume();
+        }
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+        }
+        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            for (int i = 0; i < rows; i++) {
+                if (nulls.get(i)) {
+                    builder.appendNull();
                 } else {
-                    for (int i = 0; i < rows; i++) {
-                        if (cr.getCurrentDefinitionLevel() < maxDef) {
-                            builder.appendNull();
-                        } else {
-                            builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                        }
-                        cr.consume();
-                    }
+                    builder.appendBytesRef(values[i]);
                 }
             }
             return builder.build();
@@ -361,7 +421,8 @@ final class BatchColumnReader {
                     cr.consume();
                 }
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -377,10 +438,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
@@ -401,7 +467,8 @@ final class BatchColumnReader {
                 values[i] = decodeInt96Timestamp(cr.getBinary());
                 cr.consume();
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
         }
         BitSet nulls = new BitSet(rows);
         boolean hasNulls = false;
@@ -414,10 +481,15 @@ final class BatchColumnReader {
             }
             cr.consume();
         }
-        if (hasNulls == false) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        if (hasNulls) {
+            Block allNull = ConstantBlockDetection.tryAllNull(nulls, rows, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
         }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+        Block constant = ConstantBlockDetection.tryConstantLong(values, rows, blockFactory);
+        return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
     }
 
     private static long decodeInt96Timestamp(Binary bin) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/BatchColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/BatchColumnReader.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.BitSet;
+
+/**
+ * Batch-oriented column reader that produces ESQL {@link Block}s from a Parquet {@link ColumnReader}.
+ *
+ * <p>Replaces the row-at-a-time decode pattern (check def level → read value → consume → repeat)
+ * with tight loops that separate the non-nullable fast path from the nullable path:
+ * <ul>
+ *   <li><b>Non-nullable (maxDef == 0)</b>: no def-level check per row; tight loop reads values
+ *       directly into the output array. JIT can auto-vectorize these loops for PLAIN encoding.</li>
+ *   <li><b>Nullable (maxDef &gt; 0)</b>: builds a {@link BitSet} of null positions directly
+ *       (no intermediate {@code boolean[]} + conversion), reads only non-null values.</li>
+ * </ul>
+ *
+ * <p>List columns (maxRepLevel &gt; 0) and unsupported types return {@code null} from
+ * {@link #readBatch}, signaling the caller to fall back to the per-row path in
+ * {@link OptimizedParquetColumnIterator}. All flat column types including DECIMAL,
+ * FLOAT16, UUID, and INT96 are handled here.
+ */
+final class BatchColumnReader {
+
+    private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+
+    private BatchColumnReader() {}
+
+    /**
+     * Reads a batch of rows from the column reader into an ESQL Block.
+     * Returns null if this column/type combination is not supported by batch reading,
+     * signaling the caller to fall back to the row-at-a-time path.
+     */
+    static Block readBatch(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        if (info.maxRepLevel() > 0) {
+            return null;
+        }
+        return switch (info.esqlType()) {
+            case BOOLEAN -> readBooleanBatch(cr, info.maxDefLevel(), rows, blockFactory);
+            case INTEGER -> readIntBatch(cr, info.maxDefLevel(), rows, blockFactory);
+            case LONG -> {
+                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                    yield readInt32AsLongBatch(cr, info.maxDefLevel(), rows, blockFactory);
+                }
+                yield readLongBatch(cr, info.maxDefLevel(), rows, blockFactory);
+            }
+            case DOUBLE -> readDoubleBatch(cr, info, rows, blockFactory);
+            case KEYWORD, TEXT -> readBytesBatch(cr, info, rows, blockFactory);
+            case DATETIME -> readDatetimeBatch(cr, info, rows, blockFactory);
+            default -> null;
+        };
+    }
+
+    // --- Boolean ---
+
+    private static Block readBooleanBatch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        boolean[] values = new boolean[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = cr.getBoolean();
+                cr.consume();
+            }
+            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = cr.getBoolean();
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    // --- Int ---
+
+    private static Block readIntBatch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        int[] values = new int[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = cr.getInteger();
+                cr.consume();
+            }
+            return blockFactory.newIntArrayVector(values, rows).asBlock();
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = cr.getInteger();
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return blockFactory.newIntArrayVector(values, rows).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(values, rows, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    // --- Long ---
+
+    private static Block readLongBatch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        long[] values = new long[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = cr.getLong();
+                cr.consume();
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = cr.getLong();
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static Block readInt32AsLongBatch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        long[] values = new long[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = cr.getInteger();
+                cr.consume();
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = cr.getInteger();
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    // --- Double ---
+
+    private static Block readDoubleBatch(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        LogicalTypeAnnotation logical = info.logicalType();
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
+            return readDecimalAsDoubleBatch(cr, info, decimal.getScale(), rows, blockFactory);
+        }
+        if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+            return readFloat16Batch(cr, info.maxDefLevel(), rows, blockFactory);
+        }
+        int maxDef = info.maxDefLevel();
+        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
+        double[] values = new double[rows];
+        if (maxDef == 0) {
+            if (isFloat) {
+                for (int i = 0; i < rows; i++) {
+                    values[i] = cr.getFloat();
+                    cr.consume();
+                }
+            } else {
+                for (int i = 0; i < rows; i++) {
+                    values[i] = cr.getDouble();
+                    cr.consume();
+                }
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = isFloat ? cr.getFloat() : cr.getDouble();
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static Block readDecimalAsDoubleBatch(ColumnReader cr, ColumnInfo info, int scale, int rows, BlockFactory blockFactory) {
+        int maxDef = info.maxDefLevel();
+        double[] values = new double[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = decimalToDouble(cr, info.parquetType(), scale);
+                cr.consume();
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = decimalToDouble(cr, info.parquetType(), scale);
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static double decimalToDouble(ColumnReader cr, PrimitiveType.PrimitiveTypeName parquetType, int scale) {
+        BigInteger unscaled = switch (parquetType) {
+            case INT32 -> BigInteger.valueOf(cr.getInteger());
+            case INT64 -> BigInteger.valueOf(cr.getLong());
+            case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
+            default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + parquetType);
+        };
+        return new BigDecimal(unscaled, scale).doubleValue();
+    }
+
+    private static Block readFloat16Batch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        double[] values = new double[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = decodeFloat16(cr.getBinary().getBytes());
+                cr.consume();
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = decodeFloat16(cr.getBinary().getBytes());
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static double decodeFloat16(byte[] bytes) {
+        short float16Bits = (short) ((bytes[1] & 0xFF) << 8 | (bytes[0] & 0xFF));
+        return Float.float16ToFloat(float16Bits);
+    }
+
+    // --- BytesRef (KEYWORD/TEXT) ---
+
+    private static Block readBytesBatch(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        int maxDef = info.maxDefLevel();
+        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            if (maxDef == 0) {
+                if (isUuid) {
+                    for (int i = 0; i < rows; i++) {
+                        builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes())));
+                        cr.consume();
+                    }
+                } else {
+                    for (int i = 0; i < rows; i++) {
+                        builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                        cr.consume();
+                    }
+                }
+            } else {
+                if (isUuid) {
+                    for (int i = 0; i < rows; i++) {
+                        if (cr.getCurrentDefinitionLevel() < maxDef) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(cr.getBinary().getBytes())));
+                        }
+                        cr.consume();
+                    }
+                } else {
+                    for (int i = 0; i < rows; i++) {
+                        if (cr.getCurrentDefinitionLevel() < maxDef) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                        }
+                        cr.consume();
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    // --- Datetime ---
+
+    private static Block readDatetimeBatch(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return readInt96Batch(cr, info.maxDefLevel(), rows, blockFactory);
+        }
+        int maxDef = info.maxDefLevel();
+        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
+        long[] values = new long[rows];
+        if (maxDef == 0) {
+            if (isDate) {
+                for (int i = 0; i < rows; i++) {
+                    values[i] = cr.getInteger() * MILLIS_PER_DAY;
+                    cr.consume();
+                }
+            } else {
+                LogicalTypeAnnotation logicalType = info.logicalType();
+                for (int i = 0; i < rows; i++) {
+                    values[i] = convertTimestampToMillis(cr.getLong(), logicalType);
+                    cr.consume();
+                }
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        LogicalTypeAnnotation logicalType = info.logicalType();
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else if (isDate) {
+                values[i] = cr.getInteger() * MILLIS_PER_DAY;
+            } else {
+                values[i] = convertTimestampToMillis(cr.getLong(), logicalType);
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case MILLIS -> raw;
+                case MICROS -> raw / 1_000;
+                case NANOS -> raw / 1_000_000;
+            };
+        }
+        return raw;
+    }
+
+    private static Block readInt96Batch(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        long[] values = new long[rows];
+        if (maxDef == 0) {
+            for (int i = 0; i < rows; i++) {
+                values[i] = decodeInt96Timestamp(cr.getBinary());
+                cr.consume();
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        BitSet nulls = new BitSet(rows);
+        boolean hasNulls = false;
+        for (int i = 0; i < rows; i++) {
+            if (cr.getCurrentDefinitionLevel() < maxDef) {
+                nulls.set(i);
+                hasNulls = true;
+            } else {
+                values[i] = decodeInt96Timestamp(cr.getBinary());
+            }
+            cr.consume();
+        }
+        if (hasNulls == false) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, false, false, toBooleanArray(nulls, rows));
+    }
+
+    private static long decodeInt96Timestamp(Binary bin) {
+        ByteBuffer buf = ByteBuffer.wrap(bin.getBytes()).order(ByteOrder.LITTLE_ENDIAN);
+        long nanosOfDay = buf.getLong();
+        int julianDay = buf.getInt();
+        long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
+        return epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
+    }
+
+    // --- Utilities ---
+
+    /**
+     * Converts a BitSet of null positions to a boolean[] as required by ColumnBlockConversions.
+     */
+    private static boolean[] toBooleanArray(BitSet nulls, int length) {
+        boolean[] result = new boolean[length];
+        for (int i = nulls.nextSetBit(0); i >= 0; i = nulls.nextSetBit(i + 1)) {
+            result[i] = true;
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Merges adjacent byte ranges and fetches them in parallel via {@link StorageObject#readBytesAsync}.
+ * After all merged ranges complete, individual sub-ranges are sliced from the coalesced buffers.
+ *
+ * <p>This is the I/O coalescing layer for the optimized Parquet reader. It reduces the number of
+ * remote requests (e.g., S3 GETs) by merging nearby byte ranges and issuing them concurrently.
+ */
+final class CoalescedRangeReader {
+
+    static final long DEFAULT_MAX_COALESCE_GAP = 512 * 1024;
+
+    /**
+     * A byte range within a file: {@code [offset, offset + length)}.
+     */
+    record ByteRange(long offset, long length) implements Comparable<ByteRange> {
+        @Override
+        public int compareTo(ByteRange other) {
+            return Long.compare(this.offset, other.offset);
+        }
+
+        long end() {
+            return offset + length;
+        }
+    }
+
+    private CoalescedRangeReader() {}
+
+    /**
+     * Merges adjacent/overlapping ranges whose gap is below {@code maxCoalesceGap}, then fetches
+     * each merged range in parallel via {@link StorageObject#readBytesAsync}. On completion, slices
+     * individual requested ranges from the coalesced buffers and delivers them to the listener.
+     *
+     * @param storageObject the storage object to read from
+     * @param ranges the byte ranges to fetch (need not be sorted)
+     * @param maxCoalesceGap maximum gap in bytes between two ranges to merge them
+     * @param executor executor for async dispatch
+     * @param listener receives a map from each original range to its data
+     */
+    static void readCoalesced(
+        StorageObject storageObject,
+        List<ByteRange> ranges,
+        long maxCoalesceGap,
+        Executor executor,
+        ActionListener<Map<ByteRange, ByteBuffer>> listener
+    ) {
+        if (ranges.isEmpty()) {
+            listener.onResponse(Map.of());
+            return;
+        }
+
+        List<MergedRange> merged = mergeRanges(ranges, maxCoalesceGap);
+
+        Map<ByteRange, ByteBuffer> results = new HashMap<>(ranges.size());
+        AtomicInteger remaining = new AtomicInteger(merged.size());
+        AtomicReference<Exception> firstFailure = new AtomicReference<>();
+
+        for (MergedRange mr : merged) {
+            storageObject.readBytesAsync(mr.offset, mr.length, executor, new ActionListener<>() {
+                @Override
+                public void onResponse(ByteBuffer buffer) {
+                    synchronized (results) {
+                        for (ByteRange original : mr.constituents) {
+                            int relativeOffset = (int) (original.offset - mr.offset);
+                            ByteBuffer slice = buffer.duplicate();
+                            slice.position(relativeOffset);
+                            slice.limit(relativeOffset + (int) original.length);
+                            results.put(original, slice.slice());
+                        }
+                    }
+                    complete();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (firstFailure.compareAndSet(null, e) == false) {
+                        firstFailure.get().addSuppressed(e);
+                    }
+                    complete();
+                }
+
+                private void complete() {
+                    if (remaining.decrementAndGet() == 0) {
+                        Exception failure = firstFailure.get();
+                        if (failure != null) {
+                            listener.onFailure(failure);
+                        } else {
+                            listener.onResponse(results);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Sorts ranges by offset and merges adjacent/overlapping ranges whose gap is within threshold.
+     */
+    static List<MergedRange> mergeRanges(List<ByteRange> ranges, long maxCoalesceGap) {
+        if (ranges.size() == 1) {
+            return List.of(new MergedRange(ranges.getFirst().offset, ranges.getFirst().length, List.of(ranges.getFirst())));
+        }
+
+        List<ByteRange> sorted = new ArrayList<>(ranges);
+        sorted.sort(Comparator.comparingLong(ByteRange::offset));
+
+        List<MergedRange> result = new ArrayList<>();
+        long groupStart = sorted.getFirst().offset;
+        long groupEnd = sorted.getFirst().end();
+        List<ByteRange> constituents = new ArrayList<>();
+        constituents.add(sorted.getFirst());
+
+        for (int i = 1; i < sorted.size(); i++) {
+            ByteRange current = sorted.get(i);
+            if (current.offset - groupEnd <= maxCoalesceGap) {
+                groupEnd = Math.max(groupEnd, current.end());
+                constituents.add(current);
+            } else {
+                result.add(new MergedRange(groupStart, groupEnd - groupStart, List.copyOf(constituents)));
+                groupStart = current.offset;
+                groupEnd = current.end();
+                constituents.clear();
+                constituents.add(current);
+            }
+        }
+        result.add(new MergedRange(groupStart, groupEnd - groupStart, List.copyOf(constituents)));
+        return result;
+    }
+
+    /**
+     * A merged range that covers one or more original {@link ByteRange}s.
+     */
+    record MergedRange(long offset, long length, List<ByteRange> constituents) {}
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Fetches column chunk data for a Parquet row group in parallel via {@link CoalescedRangeReader}.
+ *
+ * <p>Column chunks within a row group are typically stored sequentially but may be spread across
+ * a wide byte range. For remote storage (S3, HTTP), issuing a single large GET is wasteful when
+ * only a subset of columns is projected. Instead, this class computes the byte ranges for the
+ * needed column chunks, merges nearby ranges (via {@link CoalescedRangeReader#mergeRanges}),
+ * and fetches them concurrently using {@link StorageObject#readBytesAsync}.
+ *
+ * <p>The prefetched data is stored in a position-indexed map that
+ * {@link ParquetStorageObjectAdapter} can consult before issuing its own I/O.
+ *
+ * <p><b>Threading model:</b> {@link #prefetch} is called from the {@code esql_worker} thread.
+ * For native async storage (S3), I/O runs on the SDK's event loop. For local/default storage,
+ * the default {@link StorageObject#readBytesAsync} runs inline via {@code Runnable::run}.
+ */
+final class ColumnChunkPrefetcher {
+
+    private static final Logger logger = LogManager.getLogger(ColumnChunkPrefetcher.class);
+
+    private ColumnChunkPrefetcher() {}
+
+    /**
+     * Computes byte ranges for all column chunks in the given row group and fetches them
+     * in parallel. Returns a future that completes with a position-indexed map of the
+     * prefetched data.
+     *
+     * @param storageObject the storage backend
+     * @param block metadata for the row group to prefetch
+     * @param projectedColumns column paths to include (null = all columns)
+     * @return a future that, on completion, holds a navigable map from file position to buffer
+     */
+    static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetch(
+        StorageObject storageObject,
+        BlockMetaData block,
+        java.util.Set<String> projectedColumns
+    ) {
+        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        if (ranges.isEmpty()) {
+            return CompletableFuture.completedFuture(new TreeMap<>());
+        }
+
+        logger.debug(
+            "Prefetching [{}] column chunk ranges for row group at [{}] ({} bytes)",
+            ranges.size(),
+            block.getStartingPos(),
+            block.getTotalByteSize()
+        );
+
+        CompletableFuture<NavigableMap<Long, PrefetchedChunk>> result = new CompletableFuture<>();
+
+        PlainActionFuture<Map<CoalescedRangeReader.ByteRange, ByteBuffer>> ioFuture = new PlainActionFuture<>();
+        CoalescedRangeReader.readCoalesced(storageObject, ranges, CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP, Runnable::run, ioFuture);
+
+        try {
+            Map<CoalescedRangeReader.ByteRange, ByteBuffer> fetched = ioFuture.actionGet();
+            NavigableMap<Long, PrefetchedChunk> prefetched = new TreeMap<>();
+            for (var entry : fetched.entrySet()) {
+                CoalescedRangeReader.ByteRange range = entry.getKey();
+                prefetched.put(range.offset(), new PrefetchedChunk(range.offset(), range.length(), entry.getValue()));
+            }
+            result.complete(prefetched);
+        } catch (Exception e) {
+            result.completeExceptionally(e);
+        }
+
+        return result;
+    }
+
+    /**
+     * Asynchronous variant that dispatches the coalesced read and returns immediately.
+     * The future completes on whatever thread the storage I/O completes on.
+     */
+    static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        java.util.Set<String> projectedColumns
+    ) {
+        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        if (ranges.isEmpty()) {
+            return CompletableFuture.completedFuture(new TreeMap<>());
+        }
+
+        logger.debug(
+            "Async prefetching [{}] column chunk ranges for row group at [{}] ({} bytes)",
+            ranges.size(),
+            block.getStartingPos(),
+            block.getTotalByteSize()
+        );
+
+        CompletableFuture<NavigableMap<Long, PrefetchedChunk>> result = new CompletableFuture<>();
+
+        CoalescedRangeReader.readCoalesced(
+            storageObject,
+            ranges,
+            CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
+            Runnable::run,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Map<CoalescedRangeReader.ByteRange, ByteBuffer> fetched) {
+                    NavigableMap<Long, PrefetchedChunk> prefetched = new TreeMap<>();
+                    for (var entry : fetched.entrySet()) {
+                        CoalescedRangeReader.ByteRange range = entry.getKey();
+                        prefetched.put(range.offset(), new PrefetchedChunk(range.offset(), range.length(), entry.getValue()));
+                    }
+                    result.complete(prefetched);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    result.completeExceptionally(e);
+                }
+            }
+        );
+
+        return result;
+    }
+
+    /**
+     * Computes the byte ranges for column chunks in a row group. Each column chunk has a
+     * starting position and total size in the file metadata.
+     */
+    static List<CoalescedRangeReader.ByteRange> computeColumnChunkRanges(BlockMetaData block, java.util.Set<String> projectedColumns) {
+        List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            if (projectedColumns != null && projectedColumns.contains(col.getPath().toDotString()) == false) {
+                continue;
+            }
+            long startPos = col.getStartingPos();
+            long totalSize = col.getTotalSize();
+            if (totalSize > 0) {
+                ranges.add(new CoalescedRangeReader.ByteRange(startPos, totalSize));
+            }
+        }
+        return ranges;
+    }
+
+    /**
+     * A prefetched chunk of column data at a specific file position.
+     */
+    record PrefetchedChunk(long offset, long length, ByteBuffer data) {
+        boolean covers(long position, int requestedLength) {
+            return position >= offset && position + requestedLength <= offset + length;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.logging.LogManager;
@@ -20,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 
@@ -158,6 +160,185 @@ final class ColumnChunkPrefetcher {
             }
         }
         return ranges;
+    }
+
+    /**
+     * Computes byte ranges for only the surviving data pages within each column chunk.
+     * Pages whose row span does not overlap with {@code rowRanges} are excluded, reducing
+     * the number of bytes fetched from remote storage.
+     *
+     * <p>Dictionary pages (which sit before data pages) are always included since they are
+     * needed to decode any surviving page. Adjacent page ranges are merged by the caller
+     * via {@link CoalescedRangeReader#mergeRanges}.
+     *
+     * @param block metadata for the row group
+     * @param rowRanges selected row ranges (null = fall back to whole chunks)
+     * @param metadata preloaded row group metadata with offset indexes
+     * @param rowGroupOrdinal ordinal of the row group in the file
+     * @param projectedColumns column paths to include (null = all columns)
+     * @param rowGroupRowCount total rows in the row group
+     * @return merged byte ranges covering only surviving pages
+     */
+    static List<CoalescedRangeReader.ByteRange> computeFilteredPageRanges(
+        BlockMetaData block,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        Set<String> projectedColumns,
+        long rowGroupRowCount
+    ) {
+        if (rowRanges == null || rowRanges.isAll()) {
+            return computeColumnChunkRanges(block, projectedColumns);
+        }
+
+        List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            String path = col.getPath().toDotString();
+            if (projectedColumns != null && projectedColumns.contains(path) == false) {
+                continue;
+            }
+
+            OffsetIndex oi = metadata.getOffsetIndex(rowGroupOrdinal, path);
+            if (oi == null) {
+                long totalSize = col.getTotalSize();
+                if (totalSize > 0) {
+                    ranges.add(new CoalescedRangeReader.ByteRange(col.getStartingPos(), totalSize));
+                }
+                continue;
+            }
+
+            long dictOffset = col.getDictionaryPageOffset();
+            long firstDataPageOffset = oi.getOffset(0);
+            if (dictOffset > 0 && dictOffset < firstDataPageOffset) {
+                ranges.add(new CoalescedRangeReader.ByteRange(dictOffset, firstDataPageOffset - dictOffset));
+            }
+
+            int pageCount = oi.getPageCount();
+            for (int p = 0; p < pageCount; p++) {
+                long pageStart = oi.getFirstRowIndex(p);
+                long pageEnd = (p + 1 < pageCount) ? oi.getFirstRowIndex(p + 1) : rowGroupRowCount;
+                if (rowRanges.overlaps(pageStart, pageEnd)) {
+                    ranges.add(new CoalescedRangeReader.ByteRange(oi.getOffset(p), oi.getCompressedPageSize(p)));
+                }
+            }
+        }
+
+        if (ranges.isEmpty()) {
+            return ranges;
+        }
+        List<CoalescedRangeReader.MergedRange> merged = CoalescedRangeReader.mergeRanges(
+            ranges,
+            CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP
+        );
+        List<CoalescedRangeReader.ByteRange> result = new ArrayList<>(merged.size());
+        for (CoalescedRangeReader.MergedRange mr : merged) {
+            result.add(new CoalescedRangeReader.ByteRange(mr.offset(), mr.length()));
+        }
+        return result;
+    }
+
+    static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetch(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        long rowGroupRowCount
+    ) {
+        if (rowRanges == null || rowRanges.isAll()) {
+            return prefetch(storageObject, block, projectedColumns);
+        }
+
+        List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
+            block,
+            rowRanges,
+            metadata,
+            rowGroupOrdinal,
+            projectedColumns,
+            rowGroupRowCount
+        );
+        if (ranges.isEmpty()) {
+            return CompletableFuture.completedFuture(new TreeMap<>());
+        }
+
+        logger.debug(
+            "Prefetching [{}] filtered page ranges for row group at [{}] (row ranges: {} selected of {})",
+            ranges.size(),
+            block.getStartingPos(),
+            rowRanges != null ? rowRanges.selectedRowCount() : rowGroupRowCount,
+            rowGroupRowCount
+        );
+
+        CompletableFuture<NavigableMap<Long, PrefetchedChunk>> result = new CompletableFuture<>();
+        PlainActionFuture<Map<CoalescedRangeReader.ByteRange, ByteBuffer>> ioFuture = new PlainActionFuture<>();
+        CoalescedRangeReader.readCoalesced(storageObject, ranges, CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP, Runnable::run, ioFuture);
+
+        try {
+            Map<CoalescedRangeReader.ByteRange, ByteBuffer> fetched = ioFuture.actionGet();
+            NavigableMap<Long, PrefetchedChunk> prefetched = new TreeMap<>();
+            for (var entry : fetched.entrySet()) {
+                CoalescedRangeReader.ByteRange range = entry.getKey();
+                prefetched.put(range.offset(), new PrefetchedChunk(range.offset(), range.length(), entry.getValue()));
+            }
+            result.complete(prefetched);
+        } catch (Exception e) {
+            result.completeExceptionally(e);
+        }
+        return result;
+    }
+
+    static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        long rowGroupRowCount
+    ) {
+        if (rowRanges == null || rowRanges.isAll()) {
+            return prefetchAsync(storageObject, block, projectedColumns);
+        }
+
+        List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
+            block,
+            rowRanges,
+            metadata,
+            rowGroupOrdinal,
+            projectedColumns,
+            rowGroupRowCount
+        );
+        if (ranges.isEmpty()) {
+            return CompletableFuture.completedFuture(new TreeMap<>());
+        }
+
+        logger.debug("Async prefetching [{}] filtered page ranges for row group at [{}]", ranges.size(), block.getStartingPos());
+
+        CompletableFuture<NavigableMap<Long, PrefetchedChunk>> result = new CompletableFuture<>();
+        CoalescedRangeReader.readCoalesced(
+            storageObject,
+            ranges,
+            CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
+            Runnable::run,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Map<CoalescedRangeReader.ByteRange, ByteBuffer> fetched) {
+                    NavigableMap<Long, PrefetchedChunk> prefetched = new TreeMap<>();
+                    for (var entry : fetched.entrySet()) {
+                        CoalescedRangeReader.ByteRange range = entry.getKey();
+                        prefetched.put(range.offset(), new PrefetchedChunk(range.offset(), range.length(), entry.getValue()));
+                    }
+                    result.complete(prefetched);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    result.completeExceptionally(e);
+                }
+            }
+        );
+        return result;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+/**
+ * Per-column metadata used by both the baseline and optimized Parquet column iterators.
+ * Holds the Parquet column descriptor alongside the ESQL type mapping and definition/repetition levels.
+ */
+record ColumnInfo(
+    ColumnDescriptor descriptor,
+    PrimitiveType.PrimitiveTypeName parquetType,
+    DataType esqlType,
+    int maxDefLevel,
+    int maxRepLevel,
+    LogicalTypeAnnotation logicalType
+) {}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+
+import java.util.BitSet;
+
+/**
+ * Post-decode constant detection for Parquet column batches. After values are decoded into arrays,
+ * these methods check whether all non-null values are identical and, if so, return a constant
+ * {@link Block} instead of an array-backed block. This turns O(n) downstream consumers into O(1)
+ * for partition columns and other repeated-value scenarios common in Parquet files.
+ *
+ * <p>Returns {@code null} when the values are not constant, signaling the caller to fall through
+ * to the normal array-block path.
+ */
+final class ConstantBlockDetection {
+
+    private ConstantBlockDetection() {}
+
+    /**
+     * Returns a constant boolean block if all values are identical, or null otherwise.
+     * Only called for the non-nullable (no nulls) path.
+     */
+    static Block tryConstantBoolean(boolean[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantBooleanBlockWith(rows == 0 ? false : values[0], rows);
+        }
+        boolean first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantBooleanBlockWith(first, rows);
+    }
+
+    /**
+     * Returns a constant int block if all values are identical, or null otherwise.
+     * Only called for the non-nullable (no nulls) path.
+     */
+    static Block tryConstantInt(int[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantIntBlockWith(rows == 0 ? 0 : values[0], rows);
+        }
+        int first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantIntBlockWith(first, rows);
+    }
+
+    /**
+     * Returns a constant long block if all values are identical, or null otherwise.
+     * Only called for the non-nullable (no nulls) path.
+     */
+    static Block tryConstantLong(long[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantLongBlockWith(rows == 0 ? 0L : values[0], rows);
+        }
+        long first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantLongBlockWith(first, rows);
+    }
+
+    /**
+     * Returns a constant double block if all values are identical, or null otherwise.
+     * Only called for the non-nullable (no nulls) path.
+     * Uses {@code Double.doubleToRawLongBits} for bitwise comparison to handle NaN correctly
+     * (all NaN bit patterns are treated as distinct unless bitwise identical).
+     */
+    static Block tryConstantDouble(double[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantDoubleBlockWith(rows == 0 ? 0.0 : values[0], rows);
+        }
+        long firstBits = Double.doubleToRawLongBits(values[0]);
+        for (int i = 1; i < rows; i++) {
+            if (Double.doubleToRawLongBits(values[i]) != firstBits) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantDoubleBlockWith(values[0], rows);
+    }
+
+    /**
+     * Returns a constant BytesRef block if all values in the builder are identical, or null.
+     * This is checked by examining the first and subsequent BytesRef values for equality.
+     * Only called for the non-nullable (no nulls) path; the values array must be fully populated.
+     */
+    static Block tryConstantBytesRef(BytesRef[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantBytesRefBlockWith(rows == 0 ? new BytesRef() : values[0], rows);
+        }
+        BytesRef first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (first.bytesEquals(values[i]) == false) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantBytesRefBlockWith(new BytesRef(first.bytes, first.offset, first.length), rows);
+    }
+
+    /**
+     * Checks if all rows in a nullable batch are null. When {@code nullCount == rows},
+     * returns a constant null block; otherwise returns null to signal fall-through.
+     */
+    static Block tryAllNull(BitSet nulls, int rows, BlockFactory blockFactory) {
+        if (nulls.cardinality() == rows) {
+            return blockFactory.newConstantNullBlock(rows);
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -82,6 +82,43 @@ final class DefinitionLevelDecoder {
     }
 
     /**
+     * Decodes {@code count} definition levels but only populates null positions for selected rows.
+     * Returns the number of non-null values among selected rows (needed to size the value output array).
+     * The RLE stream is advanced for all {@code count} rows regardless of selection.
+     *
+     * <p>Null bit positions in {@code nulls} are set relative to output position (starting at
+     * {@code outOffset}), not input position — matching the compacted output array layout.
+     */
+    int readBatchSelective(int count, BitSet nulls, int outOffset, RowSelection selection) {
+        if (nonNullable) {
+            return selection.selectedCount();
+        }
+        if (count == 0) {
+            return 0;
+        }
+        int nonNullSelected = 0;
+        int outPos = outOffset;
+        int selIdx = selection.nextSelected(0);
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (i == selIdx) {
+                    if (def < maxDefLevel) {
+                        nulls.set(outPos);
+                    } else {
+                        nonNullSelected++;
+                    }
+                    outPos++;
+                    selIdx = selection.nextSelected(selIdx + 1);
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read definition levels selectively: " + e.getMessage(), e);
+        }
+        return nonNullSelected;
+    }
+
+    /**
      * Skips {@code count} definition levels without materializing values.
      * Returns the number of non-null values that were skipped.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -119,6 +119,65 @@ final class DefinitionLevelDecoder {
     }
 
     /**
+     * Combined def-level decode, null tracking, and value-stream position mapping for selective reads.
+     * Decodes all {@code count} def levels (advancing the RLE stream), but only populates output
+     * null positions for selected rows. Also builds a {@link BitSet} of which non-null value-stream
+     * positions correspond to selected non-null rows.
+     *
+     * @param count total rows in the page chunk
+     * @param outputNulls null bitmap for the output (set at output positions)
+     * @param outOffset starting output position
+     * @param selection which rows are selected
+     * @param valueSel output BitSet marking selected non-null positions in the value stream
+     * @return int array of [totalNonNull, selectedNonNull]
+     */
+    int[] readBatchSelectiveWithValueTracking(int count, BitSet outputNulls, int outOffset, RowSelection selection, BitSet valueSel) {
+        if (nonNullable) {
+            int selectedCount = selection.selectedCount();
+            int selIdx = selection.nextSelected(0);
+            for (int i = 0; i < count; i++) {
+                if (i == selIdx) {
+                    valueSel.set(i);
+                    selIdx = selection.nextSelected(selIdx + 1);
+                }
+            }
+            return new int[] { count, selectedCount };
+        }
+        if (count == 0) {
+            return new int[] { 0, 0 };
+        }
+        int totalNonNull = 0;
+        int selectedNonNull = 0;
+        int outPos = outOffset;
+        int valuePos = 0;
+        int selIdx = selection.nextSelected(0);
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                boolean isNull = def < maxDefLevel;
+                boolean isSelected = (i == selIdx);
+                if (isSelected) {
+                    if (isNull) {
+                        outputNulls.set(outPos);
+                    } else {
+                        valueSel.set(valuePos);
+                        selectedNonNull++;
+                    }
+                    outPos++;
+                    selIdx = selection.nextSelected(selIdx + 1);
+                }
+                if (isNull == false) {
+                    totalNonNull++;
+                    valuePos++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read definition levels with value tracking: " + e.getMessage(), e);
+        }
+        return new int[] { totalNonNull, selectedNonNull };
+    }
+
+    /**
      * Skips {@code count} definition levels without materializing values.
      * Returns the number of non-null values that were skipped.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.BitSet;
+
+/**
+ * Bulk decoder for Parquet definition levels, producing a {@link BitSet} of null positions
+ * for nullable flat columns. Delegates to parquet-java's {@link RunLengthBitPackingHybridDecoder}
+ * for the actual RLE hybrid stream decoding.
+ *
+ * <p>For non-nullable columns ({@code maxDefLevel == 0}), no def-level section exists in the
+ * page and all operations are no-ops.
+ */
+final class DefinitionLevelDecoder {
+
+    private boolean nonNullable;
+    private int maxDefLevel;
+    private RunLengthBitPackingHybridDecoder rleDecoder;
+
+    DefinitionLevelDecoder() {}
+
+    void init(ByteBuffer defLevelBytes, int valueCount, int maxDefLevel, boolean hasLengthPrefix) {
+        this.maxDefLevel = maxDefLevel;
+        if (maxDefLevel <= 0) {
+            this.nonNullable = true;
+            this.rleDecoder = null;
+            return;
+        }
+        this.nonNullable = false;
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        ByteBuffer source = defLevelBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        if (hasLengthPrefix) {
+            int payloadLen = source.getInt();
+            byte[] payload = new byte[payloadLen];
+            source.get(payload);
+            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(payload));
+        } else {
+            byte[] data = new byte[source.remaining()];
+            source.get(data);
+            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(data));
+        }
+    }
+
+    /**
+     * Decodes the next {@code count} definition levels, setting null positions in {@code nulls}
+     * starting at {@code offset}. Returns the number of non-null values.
+     */
+    int readBatch(int count, BitSet nulls, int offset) {
+        if (nonNullable) {
+            return count;
+        }
+        if (count == 0) {
+            return 0;
+        }
+        int nonNull = 0;
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (def < maxDefLevel) {
+                    nulls.set(offset + i);
+                } else {
+                    nonNull++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read definition levels: " + e.getMessage(), e);
+        }
+        return nonNull;
+    }
+
+    /**
+     * Skips {@code count} definition levels without materializing values.
+     * Returns the number of non-null values that were skipped.
+     */
+    int skip(int count) {
+        if (nonNullable || count == 0) {
+            return count;
+        }
+        int nonNull = 0;
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (def >= maxDefLevel) {
+                    nonNull++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to skip definition levels: " + e.getMessage(), e);
+        }
+        return nonNull;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -327,20 +327,59 @@ final class DictionaryValueDecoder {
     }
 
     private static void unpack8Values(byte[] packed, int byteOffset, int[] out, int outOffset, int bitWidth) {
-        for (int i = 0; i < 8; i++) {
-            out[outOffset + i] = readBitsLE(packed, byteOffset * 8 + i * bitWidth, bitWidth);
+        switch (bitWidth) {
+            case 0 -> {
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = 0;
+                }
+            }
+            case 1 -> {
+                int b = packed[byteOffset] & 0xFF;
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (b >>> i) & 1;
+                }
+            }
+            case 2 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8);
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (word >>> (i * 2)) & 0x3;
+                }
+            }
+            case 4 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8) | ((packed[byteOffset + 2] & 0xFF) << 16)
+                    | ((packed[byteOffset + 3] & 0xFF) << 24);
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (word >>> (i * 4)) & 0xF;
+                }
+            }
+            case 8 -> {
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = packed[byteOffset + i] & 0xFF;
+                }
+            }
+            case 16 -> {
+                for (int i = 0; i < 8; i++) {
+                    int base = byteOffset + i * 2;
+                    out[outOffset + i] = (packed[base] & 0xFF) | ((packed[base + 1] & 0xFF) << 8);
+                }
+            }
+            default -> {
+                int bitBase = byteOffset * 8;
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = readBitsLE(packed, bitBase + i * bitWidth, bitWidth);
+                }
+            }
         }
     }
 
     private static int readBitsLE(byte[] data, int bitOffset, int width) {
-        int result = 0;
-        for (int b = 0; b < width; b++) {
-            int abs = bitOffset + b;
-            int byteIdx = abs / 8;
-            int bitInByte = abs % 8;
-            int bit = (data[byteIdx] >>> bitInByte) & 1;
-            result |= (bit << b);
+        int byteIdx = bitOffset >>> 3;
+        int bitInByte = bitOffset & 7;
+        long word = 0;
+        int bytesNeeded = ((bitInByte + width) + 7) >>> 3;
+        for (int i = 0; i < bytesNeeded && (byteIdx + i) < data.length; i++) {
+            word |= (long) (data[byteIdx + i] & 0xFF) << (i * 8);
         }
-        return result;
+        return (int) ((word >>> bitInByte) & (width == 32 ? 0xFFFFFFFFL : ((1L << width) - 1)));
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -110,6 +110,82 @@ final class DictionaryValueDecoder {
         }
     }
 
+    // --- Selective read methods: consume totalCount indices but only store selected positions ---
+
+    void readIntsSelective(int[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                output[outIdx++] = dict.decodeToInt(idx);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
+    void readLongsSelective(long[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                output[outIdx++] = dict.decodeToLong(idx);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
+    void readFloatsSelective(double[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                output[outIdx++] = dict.decodeToFloat(idx);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
+    void readDoublesSelective(double[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                output[outIdx++] = dict.decodeToDouble(idx);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
+    void readBooleansSelective(boolean[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                output[outIdx++] = dict.decodeToBoolean(idx);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
+    void readBinariesSelective(BytesRef[] output, int outOffset, RowSelection selection, int totalCount, Dictionary dict) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int idx = nextIndex();
+            if (i == selIdx) {
+                Binary bin = dict.decodeToBinary(idx);
+                byte[] bytes = bin.getBytes();
+                output[outIdx++] = new BytesRef(bytes, 0, bytes.length);
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+    }
+
     private int skipPackedValues(int remaining) {
         int skipped = 0;
         while (skipped < remaining) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.api.Binary;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * Bulk decoder for RLE_DICTIONARY-encoded Parquet values. Reads a 1-byte bit width header,
+ * then decodes RLE hybrid–encoded dictionary indices and gathers typed values from the
+ * {@link Dictionary}.
+ */
+final class DictionaryValueDecoder {
+
+    private ByteBuffer in;
+    private int bitWidth;
+
+    private boolean rleMode;
+    private int rleLeft;
+    private int rleValue;
+
+    private byte[] packedBytes;
+    private int packedByteOffset;
+    private int packedRemaining;
+    private final int[] groupValues = new int[8];
+    private int groupNext = 8;
+
+    private int[] indexScratch;
+
+    void init(ByteBuffer valueBytes) {
+        ByteBuffer dup = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        bitWidth = dup.get() & 0xFF;
+        if (bitWidth > 32) {
+            throw new IllegalArgumentException("Dictionary index bit width must be <= 32, got " + bitWidth);
+        }
+        in = dup.slice().order(ByteOrder.LITTLE_ENDIAN);
+        rleMode = true;
+        rleLeft = 0;
+        rleValue = 0;
+        packedByteOffset = 0;
+        packedRemaining = 0;
+        groupNext = 8;
+    }
+
+    void readInts(int[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToInt(indexScratch[i]);
+        }
+    }
+
+    void readLongs(long[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToLong(indexScratch[i]);
+        }
+    }
+
+    void readFloats(double[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToFloat(indexScratch[i]);
+        }
+    }
+
+    void readDoubles(double[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToDouble(indexScratch[i]);
+        }
+    }
+
+    void readBooleans(boolean[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToBoolean(indexScratch[i]);
+        }
+    }
+
+    void readBinaries(BytesRef[] values, int offset, int count, Dictionary dict) {
+        readIndicesBulk(count);
+        for (int i = 0; i < count; i++) {
+            Binary bin = dict.decodeToBinary(indexScratch[i]);
+            byte[] bytes = bin.getBytes();
+            values[offset + i] = new BytesRef(bytes, 0, bytes.length);
+        }
+    }
+
+    void skip(int count) {
+        int remaining = count;
+        while (remaining > 0) {
+            ensureRunLoaded();
+            if (rleMode) {
+                int take = Math.min(remaining, rleLeft);
+                rleLeft -= take;
+                remaining -= take;
+            } else {
+                remaining -= skipPackedValues(remaining);
+            }
+        }
+    }
+
+    private int skipPackedValues(int remaining) {
+        int skipped = 0;
+        while (skipped < remaining) {
+            if (packedRemaining == 0) {
+                return skipped;
+            }
+            if (groupNext >= 8) {
+                if (packedRemaining == 0) {
+                    return skipped;
+                }
+                loadPackedGroup();
+            }
+            int inGroupAvail = 8 - groupNext;
+            int take = Math.min(inGroupAvail, remaining - skipped);
+            groupNext += take;
+            packedRemaining -= take;
+            skipped += take;
+        }
+        return skipped;
+    }
+
+    private void readIndicesBulk(int count) {
+        ensureScratch(count);
+        for (int i = 0; i < count; i++) {
+            indexScratch[i] = nextIndex();
+        }
+    }
+
+    private void ensureScratch(int count) {
+        if (indexScratch == null || indexScratch.length < count) {
+            indexScratch = new int[count];
+        }
+    }
+
+    private int nextIndex() {
+        while (true) {
+            ensureRunLoaded();
+            if (rleMode) {
+                if (rleLeft > 0) {
+                    rleLeft--;
+                    return rleValue;
+                }
+                startNextRun();
+                continue;
+            }
+            if (packedRemaining > 0) {
+                if (groupNext >= 8) {
+                    loadPackedGroup();
+                }
+                int v = groupValues[groupNext++];
+                packedRemaining--;
+                return v;
+            }
+            startNextRun();
+        }
+    }
+
+    private void ensureRunLoaded() {
+        if (rleMode && rleLeft > 0) {
+            return;
+        }
+        if (rleMode == false && packedRemaining > 0) {
+            return;
+        }
+        startNextRun();
+    }
+
+    private void startNextRun() {
+        if (in.hasRemaining() == false) {
+            throw new IllegalStateException("Truncated dictionary index stream");
+        }
+        int header = readUnsignedVarInt();
+        if ((header & 1) == 0) {
+            rleMode = true;
+            rleLeft = header >>> 1;
+            rleValue = readIntLittleEndianPadded();
+            packedRemaining = 0;
+            groupNext = 8;
+        } else {
+            rleMode = false;
+            int numGroups = header >>> 1;
+            packedRemaining = numGroups * 8;
+            int byteLen = numGroups * bitWidth;
+            if (in.remaining() < byteLen) {
+                throw new IllegalStateException("Truncated bit-packed dictionary index data");
+            }
+            if (packedBytes == null || packedBytes.length < byteLen) {
+                packedBytes = new byte[byteLen];
+            }
+            in.get(packedBytes, 0, byteLen);
+            packedByteOffset = 0;
+            groupNext = 8;
+            rleLeft = 0;
+        }
+    }
+
+    private void loadPackedGroup() {
+        if (bitWidth == 0) {
+            Arrays.fill(groupValues, 0);
+        } else {
+            unpack8Values(packedBytes, packedByteOffset, groupValues, 0, bitWidth);
+            packedByteOffset += bitWidth;
+        }
+        groupNext = 0;
+    }
+
+    private int readUnsignedVarInt() {
+        int shift = 0;
+        int result = 0;
+        while (true) {
+            if (in.hasRemaining() == false) {
+                throw new IllegalStateException("Truncated varint in dictionary index stream");
+            }
+            int b = in.get() & 0xFF;
+            result |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+            if (shift > 35) {
+                throw new IllegalStateException("Varint overflow in dictionary index stream");
+            }
+        }
+    }
+
+    private int readIntLittleEndianPadded() {
+        int n = (bitWidth + 7) >>> 3;
+        if (n == 0) {
+            return 0;
+        }
+        if (in.remaining() < n) {
+            throw new IllegalStateException("Truncated padded dictionary index value");
+        }
+        int v = 0;
+        for (int i = 0; i < n; i++) {
+            v |= (in.get() & 0xFF) << (8 * i);
+        }
+        return v;
+    }
+
+    private static void unpack8Values(byte[] packed, int byteOffset, int[] out, int outOffset, int bitWidth) {
+        for (int i = 0; i < 8; i++) {
+            out[outOffset + i] = readBitsLE(packed, byteOffset * 8 + i * bitWidth, bitWidth);
+        }
+    }
+
+    private static int readBitsLE(byte[] data, int bitOffset, int width) {
+        int result = 0;
+        for (int b = 0; b < width; b++) {
+            int abs = bitOffset + b;
+            int byteIdx = abs / 8;
+            int bitInByte = abs % 8;
+            int bit = (data[byteIdx] >>> bitInByte) & 1;
+            result |= (bit << b);
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -39,14 +39,18 @@ import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
@@ -75,6 +79,13 @@ import java.util.Set;
  * projection-only columns for surviving rows only. Columns in both predicate and projection sets
  * are decoded once in Phase 1 and their Blocks compacted in Phase 2.
  *
+ * <p>Stage 5: parallel column chunk fetch and async row group prefetch. When a
+ * {@link StorageObject} is available, column chunks for the current row group are fetched in
+ * parallel via {@link CoalescedRangeReader} and installed into the
+ * {@link ParquetStorageObjectAdapter} before parquet-java reads them. While the current row
+ * group is being decoded, the next row group's column chunks are prefetched asynchronously.
+ * This overlaps I/O with decode for significant throughput improvement on remote storage.
+ *
  * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
  * stable fallback when {@code optimized_reader=false}.
  */
@@ -97,6 +108,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final boolean pageLevelReader;
     private final boolean lateMaterialization;
     private final boolean[] isPredicateColumn;
+    private final StorageObject storageObject;
+    private final ParquetStorageObjectAdapter adapter;
+    private final Set<String> projectedColumnPaths;
     private int rowBudget;
 
     private PageReadStore rowGroup;
@@ -110,6 +124,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private long pagesSkippedByColumnIndex = 0;
     private long pagesEvaluatedByColumnIndex = 0;
     private long rowsEliminatedByLateMaterialization = 0;
+    private CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> pendingPrefetch;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -124,7 +139,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         PreloadedRowGroupMetadata preloadedMetadata,
         ParquetPushedExpressions pushedExpressions,
         boolean pageLevelReader,
-        boolean lateMaterialization
+        boolean lateMaterialization,
+        StorageObject storageObject,
+        ParquetStorageObjectAdapter adapter
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -139,10 +156,23 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.pushedExpressions = pushedExpressions;
         this.pageLevelReader = pageLevelReader;
         this.lateMaterialization = lateMaterialization && pageLevelReader && pushedExpressions != null;
+        this.storageObject = storageObject;
+        this.adapter = adapter;
 
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
+        this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
 
         reader.setRequestedSchema(projectedSchema);
+    }
+
+    private static Set<String> buildProjectedColumnPaths(ColumnInfo[] columnInfos) {
+        Set<String> paths = new HashSet<>();
+        for (ColumnInfo info : columnInfos) {
+            if (info != null) {
+                paths.add(String.join(".", info.descriptor().getPath()));
+            }
+        }
+        return paths;
     }
 
     /**
@@ -196,9 +226,16 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 rowGroup.close();
                 rowGroup = null;
             }
+
+            installPendingPrefetch();
+
             rowGroup = reader.readNextFilteredRowGroup();
+
+            adapter.clearPrefetchedData();
+
             if (rowGroup == null) {
                 exhausted = true;
+                cancelPendingPrefetch();
                 if (rowGroupsSkippedByDictionary > 0) {
                     logger.debug("Dictionary pruning skipped [{}] row groups in [{}]", rowGroupsSkippedByDictionary, fileLocation);
                 }
@@ -229,6 +266,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 logger.trace("Page-level skipping: all pages pruned for row group [{}] in [{}]", rowGroupOrdinal, fileLocation);
                 continue;
             }
+
+            triggerNextRowGroupPrefetch();
 
             if (pageLevelReader) {
                 pageColumnReaders = new PageColumnReader[columnInfos.length];
@@ -278,6 +317,71 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 }
             }
             return rowsRemainingInGroup > 0;
+        }
+    }
+
+    /**
+     * Installs any previously prefetched row group data into the adapter so that
+     * the next {@code readNextFilteredRowGroup()} can read from memory instead of
+     * issuing network I/O. Falls back gracefully on failure.
+     */
+    private void installPendingPrefetch() {
+        if (pendingPrefetch == null) {
+            return;
+        }
+        try {
+            NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> data = pendingPrefetch.join();
+            if (data != null && data.isEmpty() == false) {
+                adapter.installPrefetchedData(data);
+                logger.trace(
+                    "Installed [{}] prefetched column chunks for row group [{}] in [{}]",
+                    data.size(),
+                    rowGroupOrdinal + 1,
+                    fileLocation
+                );
+            }
+        } catch (Exception e) {
+            logger.debug(
+                "Prefetch for row group [{}] failed in [{}], falling back to synchronous I/O: {}",
+                rowGroupOrdinal + 1,
+                fileLocation,
+                e.getMessage()
+            );
+        } finally {
+            pendingPrefetch = null;
+        }
+    }
+
+    /**
+     * Triggers an async prefetch of column chunk data for the next row group.
+     * The prefetch runs in the background; the data is consumed in the next
+     * {@link #advanceRowGroup()} call via {@link #installPendingPrefetch()}.
+     */
+    private void triggerNextRowGroupPrefetch() {
+        if (storageObject == null) {
+            return;
+        }
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        int nextRgOrdinal = rowGroupOrdinal + 1;
+        if (nextRgOrdinal >= rowGroups.size()) {
+            return;
+        }
+        BlockMetaData nextBlock = rowGroups.get(nextRgOrdinal);
+        try {
+            pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+        } catch (Exception e) {
+            logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextRgOrdinal, fileLocation, e.getMessage());
+            pendingPrefetch = null;
+        }
+    }
+
+    /**
+     * Cancels any pending prefetch to avoid resource leaks when iteration ends early.
+     */
+    private void cancelPendingPrefetch() {
+        if (pendingPrefetch != null) {
+            pendingPrefetch.cancel(false);
+            pendingPrefetch = null;
         }
     }
 
@@ -791,6 +895,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
     @Override
     public void close() throws IOException {
+        cancelPendingPrefetch();
+        adapter.clearPrefetchedData();
         try {
             if (rowGroup != null) {
                 rowGroup.close();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.Dictionary;
@@ -15,11 +16,13 @@ import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
@@ -125,6 +128,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private long pagesEvaluatedByColumnIndex = 0;
     private long rowsEliminatedByLateMaterialization = 0;
     private CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> pendingPrefetch;
+    private CompressionCodecFactory codecFactory;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -221,6 +225,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     private boolean advanceRowGroup() throws IOException {
+        return pageLevelReader ? advanceRowGroupWithPageSkip() : advanceRowGroupDefault();
+    }
+
+    /**
+     * Default row-group advancement: delegates to Parquet's {@code readNextFilteredRowGroup()}
+     * which applies the pushed RecordFilter (row-group stats + page-level ColumnIndex filtering).
+     */
+    private boolean advanceRowGroupDefault() throws IOException {
         while (true) {
             if (rowGroup != null) {
                 rowGroup.close();
@@ -236,20 +248,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             if (rowGroup == null) {
                 exhausted = true;
                 cancelPendingPrefetch();
-                if (rowGroupsSkippedByDictionary > 0) {
-                    logger.debug("Dictionary pruning skipped [{}] row groups in [{}]", rowGroupsSkippedByDictionary, fileLocation);
-                }
-                if (pagesEvaluatedByColumnIndex > 0) {
-                    logger.debug(
-                        "Page-level skipping: evaluated [{}] pages, skipped [{}] in [{}]",
-                        pagesEvaluatedByColumnIndex,
-                        pagesSkippedByColumnIndex,
-                        fileLocation
-                    );
-                }
-                if (rowsEliminatedByLateMaterialization > 0) {
-                    logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
-                }
+                logSkipStats();
                 return false;
             }
             rowGroupOrdinal++;
@@ -261,48 +260,189 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 continue;
             }
 
-            RowRanges pageRanges = computePageRowRanges();
-            if (pageRanges != null && pageRanges.isEmpty()) {
-                logger.trace("Page-level skipping: all pages pruned for row group [{}] in [{}]", rowGroupOrdinal, fileLocation);
+            triggerNextRowGroupPrefetch();
+            initColumnReaders(null);
+            return rowsRemainingInGroup > 0;
+        }
+    }
+
+    /**
+     * Page-level row-group advancement: iterates through all row groups by ordinal so that
+     * {@code rowGroupOrdinal} stays aligned with {@code reader.getRowGroups()} indices.
+     * The Parquet RecordFilter is NOT set on the reader in this mode, so row-group-level
+     * and page-level pruning are handled entirely by our code.
+     */
+    private boolean advanceRowGroupWithPageSkip() throws IOException {
+        List<BlockMetaData> allRowGroups = reader.getRowGroups();
+        while (true) {
+            if (rowGroup != null) {
+                rowGroup.close();
+                rowGroup = null;
+            }
+            closeSelectivePageReaders();
+
+            rowGroupOrdinal++;
+            if (rowGroupOrdinal >= allRowGroups.size()) {
+                exhausted = true;
+                cancelPendingPrefetch();
+                logSkipStats();
+                return false;
+            }
+            pageBatchIndexInRowGroup = 0;
+            rowsRemainingInGroup = allRowGroups.get(rowGroupOrdinal).getRowCount();
+
+            if (shouldSkipByDictionary()) {
+                rowGroupsSkippedByDictionary++;
+                reader.skipNextRowGroup();
                 continue;
             }
 
-            triggerNextRowGroupPrefetch();
+            RowRanges pageRanges = computePageRowRanges();
+            if (pageRanges != null && pageRanges.isEmpty()) {
+                logger.trace("Page-level skipping: all pages pruned for row group [{}] in [{}]", rowGroupOrdinal, fileLocation);
+                reader.skipNextRowGroup();
+                continue;
+            }
 
-            if (pageLevelReader) {
-                pageColumnReaders = new PageColumnReader[columnInfos.length];
-                columnReaders = null;
-                for (int i = 0; i < columnInfos.length; i++) {
-                    if (columnInfos[i] != null && columnInfos[i].maxRepLevel() == 0) {
-                        ColumnDescriptor desc = columnInfos[i].descriptor();
-                        PageReader pr = rowGroup.getPageReader(desc);
-                        pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], pageRanges);
-                    }
-                }
-                // List columns still need ColumnReadStoreImpl
-                boolean hasListColumns = false;
-                for (int i = 0; i < columnInfos.length; i++) {
-                    if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
-                        hasListColumns = true;
-                        break;
-                    }
-                }
-                if (hasListColumns) {
-                    ColumnReadStoreImpl store = new ColumnReadStoreImpl(
-                        rowGroup,
-                        new NoOpGroupConverter(projectedSchema),
-                        projectedSchema,
-                        createdBy
-                    );
-                    columnReaders = new ColumnReader[columnInfos.length];
-                    for (int i = 0; i < columnInfos.length; i++) {
-                        if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
-                            columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
-                        }
-                    }
-                }
+            boolean useSelectivePageReader = pageRanges != null && pageRanges.isAll() == false && hasNoListColumns();
+
+            installPendingPrefetch();
+
+            if (useSelectivePageReader) {
+                reader.skipNextRowGroup();
+                adapter.clearPrefetchedData();
+                triggerNextRowGroupPrefetch();
+                initSelectiveColumnReaders(pageRanges, allRowGroups.get(rowGroupOrdinal));
             } else {
-                pageColumnReaders = null;
+                rowGroup = reader.readNextRowGroup();
+                adapter.clearPrefetchedData();
+                if (rowGroup == null) {
+                    exhausted = true;
+                    cancelPendingPrefetch();
+                    return false;
+                }
+                triggerNextRowGroupPrefetch();
+                initColumnReaders(pageRanges);
+            }
+            return rowsRemainingInGroup > 0;
+        }
+    }
+
+    private void logSkipStats() {
+        if (rowGroupsSkippedByDictionary > 0) {
+            logger.debug("Dictionary pruning skipped [{}] row groups in [{}]", rowGroupsSkippedByDictionary, fileLocation);
+        }
+        if (pagesEvaluatedByColumnIndex > 0) {
+            logger.debug(
+                "Page-level skipping: evaluated [{}] pages, skipped [{}] in [{}]",
+                pagesEvaluatedByColumnIndex,
+                pagesSkippedByColumnIndex,
+                fileLocation
+            );
+        }
+        if (rowsEliminatedByLateMaterialization > 0) {
+            logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
+        }
+    }
+
+    private boolean hasNoListColumns() {
+        for (ColumnInfo info : columnInfos) {
+            if (info != null && info.maxRepLevel() > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private CompressionCodecFactory getCodecFactory() {
+        if (codecFactory == null) {
+            codecFactory = ParquetReadOptions.builder().build().getCodecFactory();
+        }
+        return codecFactory;
+    }
+
+    /**
+     * Creates {@link PageColumnReader}s backed by {@link SelectivePageReader} instances that
+     * read directly from the adapter's stream, seeking only to surviving pages. This avoids
+     * parquet-java's eager page loading in {@code readNextRowGroup()}.
+     */
+    private void initSelectiveColumnReaders(RowRanges pageRanges, BlockMetaData block) {
+        pageColumnReaders = new PageColumnReader[columnInfos.length];
+        columnReaders = null;
+
+        Map<String, ColumnChunkMetaData> chunkMap = new HashMap<>();
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            chunkMap.put(col.getPath().toDotString(), col);
+        }
+
+        CompressionCodecFactory factory = getCodecFactory();
+        long rgRowCount = block.getRowCount();
+
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] == null || columnInfos[i].maxRepLevel() > 0) {
+                continue;
+            }
+            ColumnDescriptor desc = columnInfos[i].descriptor();
+            String colPath = String.join(".", desc.getPath());
+            ColumnChunkMetaData colMeta = chunkMap.get(colPath);
+            OffsetIndex oi = preloadedMetadata.getOffsetIndex(rowGroupOrdinal, colPath);
+
+            if (colMeta != null && oi != null) {
+                try {
+                    SeekableInputStream stream = adapter.newStream();
+                    CompressionCodecFactory.BytesInputDecompressor decompressor = factory.getDecompressor(colMeta.getCodec());
+                    PageReader pr = new SelectivePageReader(stream, oi, pageRanges, decompressor, colMeta, rgRowCount);
+                    pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], pageRanges);
+                } catch (IOException e) {
+                    throw new ElasticsearchException(
+                        "Failed to create selective page reader for column ["
+                            + colPath
+                            + "] in row group ["
+                            + rowGroupOrdinal
+                            + "] of ["
+                            + fileLocation
+                            + "]",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    private void closeSelectivePageReaders() {
+        if (pageColumnReaders == null) {
+            return;
+        }
+        for (PageColumnReader pcr : pageColumnReaders) {
+            if (pcr != null && pcr.getPageReader() instanceof SelectivePageReader spr) {
+                try {
+                    spr.close();
+                } catch (IOException e) {
+                    logger.debug("Failed to close selective page reader: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void initColumnReaders(RowRanges pageRanges) {
+        if (pageLevelReader) {
+            pageColumnReaders = new PageColumnReader[columnInfos.length];
+            columnReaders = null;
+            for (int i = 0; i < columnInfos.length; i++) {
+                if (columnInfos[i] != null && columnInfos[i].maxRepLevel() == 0) {
+                    ColumnDescriptor desc = columnInfos[i].descriptor();
+                    PageReader pr = rowGroup.getPageReader(desc);
+                    pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], pageRanges);
+                }
+            }
+            boolean hasListColumns = false;
+            for (int i = 0; i < columnInfos.length; i++) {
+                if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
+                    hasListColumns = true;
+                    break;
+                }
+            }
+            if (hasListColumns) {
                 ColumnReadStoreImpl store = new ColumnReadStoreImpl(
                     rowGroup,
                     new NoOpGroupConverter(projectedSchema),
@@ -311,12 +451,25 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 );
                 columnReaders = new ColumnReader[columnInfos.length];
                 for (int i = 0; i < columnInfos.length; i++) {
-                    if (columnInfos[i] != null) {
+                    if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
                         columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
                     }
                 }
             }
-            return rowsRemainingInGroup > 0;
+        } else {
+            pageColumnReaders = null;
+            ColumnReadStoreImpl store = new ColumnReadStoreImpl(
+                rowGroup,
+                new NoOpGroupConverter(projectedSchema),
+                projectedSchema,
+                createdBy
+            );
+            columnReaders = new ColumnReader[columnInfos.length];
+            for (int i = 0; i < columnInfos.length; i++) {
+                if (columnInfos[i] != null) {
+                    columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+                }
+            }
         }
     }
 
@@ -368,7 +521,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         BlockMetaData nextBlock = rowGroups.get(nextRgOrdinal);
         try {
-            pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+            RowRanges nextRanges = computePageRowRangesForBlock(nextBlock, nextRgOrdinal, false);
+            if (nextRanges != null && nextRanges.isEmpty()) {
+                pendingPrefetch = null;
+                return;
+            }
+            pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(
+                storageObject,
+                nextBlock,
+                projectedColumnPaths,
+                nextRanges,
+                preloadedMetadata,
+                nextRgOrdinal,
+                nextBlock.getRowCount()
+            );
         } catch (Exception e) {
             logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextRgOrdinal, fileLocation, e.getMessage());
             pendingPrefetch = null;
@@ -471,17 +637,34 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      * (a row must satisfy ALL predicates).
      */
     private RowRanges computePageRowRanges() {
-        if (pushedExpressions == null || preloadedMetadata.hasColumnIndexes() == false || preloadedMetadata.hasOffsetIndexes() == false) {
-            return null;
-        }
-
         List<BlockMetaData> rowGroups = reader.getRowGroups();
         if (rowGroupOrdinal >= rowGroups.size()) {
             return null;
         }
         BlockMetaData block = rowGroups.get(rowGroupOrdinal);
-        long rowGroupRowCount = block.getRowCount();
+        RowRanges result = computePageRowRangesForBlock(block, rowGroupOrdinal, true);
+        if (result != null && result.shouldDiscard()) {
+            logger.trace(
+                "Page-level skipping: anti-fragmentation triggered for row group [{}] in [{}] "
+                    + "(density={}, transitions={}, selected={}/{})",
+                rowGroupOrdinal,
+                fileLocation,
+                result.density(),
+                result.transitionCount(),
+                result.selectedRowCount(),
+                block.getRowCount()
+            );
+            return null;
+        }
+        return result;
+    }
 
+    private RowRanges computePageRowRangesForBlock(BlockMetaData block, int rgOrdinal, boolean recordColumnIndexStats) {
+        if (pushedExpressions == null || preloadedMetadata.hasColumnIndexes() == false || preloadedMetadata.hasOffsetIndexes() == false) {
+            return null;
+        }
+
+        long rowGroupRowCount = block.getRowCount();
         RowRanges combined = null;
 
         for (ColumnChunkMetaData col : block.getColumns()) {
@@ -490,8 +673,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 continue;
             }
 
-            ColumnIndex columnIndex = preloadedMetadata.getColumnIndex(rowGroupOrdinal, columnPath);
-            OffsetIndex offsetIndex = preloadedMetadata.getOffsetIndex(rowGroupOrdinal, columnPath);
+            ColumnIndex columnIndex = preloadedMetadata.getColumnIndex(rgOrdinal, columnPath);
+            OffsetIndex offsetIndex = preloadedMetadata.getOffsetIndex(rgOrdinal, columnPath);
             if (columnIndex == null || offsetIndex == null) {
                 continue;
             }
@@ -503,13 +686,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
             List<long[]> matchingRanges = new ArrayList<>();
             for (int pageIdx = 0; pageIdx < pageCount; pageIdx++) {
-                pagesEvaluatedByColumnIndex++;
+                if (recordColumnIndexStats) {
+                    pagesEvaluatedByColumnIndex++;
+                }
                 boolean canMatch = pushedExpressions.pageCanMatch(columnPath, columnIndex, pageIdx, col.getPrimitiveType());
                 if (canMatch) {
                     long pageStart = offsetIndex.getFirstRowIndex(pageIdx);
                     long pageEnd = (pageIdx + 1 < pageCount) ? offsetIndex.getFirstRowIndex(pageIdx + 1) : rowGroupRowCount;
                     matchingRanges.add(new long[] { pageStart, pageEnd });
-                } else {
+                } else if (recordColumnIndexStats) {
                     pagesSkippedByColumnIndex++;
                 }
             }
@@ -530,24 +715,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             }
         }
 
-        if (combined == null) {
-            return null;
-        }
-
-        if (combined.shouldDiscard()) {
-            logger.trace(
-                "Page-level skipping: anti-fragmentation triggered for row group [{}] in [{}] "
-                    + "(density={}, transitions={}, selected={}/{})",
-                rowGroupOrdinal,
-                fileLocation,
-                combined.density(),
-                combined.transitionCount(),
-                combined.selectedRowCount(),
-                rowGroupRowCount
-            );
-            return null;
-        }
-
         return combined;
     }
 
@@ -565,23 +732,46 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         Page result = lateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
 
         pageBatchIndexInRowGroup++;
-        rowsRemainingInGroup -= rowsToRead;
+        long logicalConsumed = computeLogicalRowsConsumed(rowsToRead);
+        rowsRemainingInGroup -= logicalConsumed;
         if (rowBudget != FormatReader.NO_LIMIT) {
             rowBudget -= result.getPositionCount();
         }
         return result;
     }
 
+    /**
+     * Determines how many logical row-group rows were consumed by the last batch.
+     * With page-level skipping, skipped pages advance the row position beyond the
+     * requested batch size. Falls back to {@code rowsToRead} when page-level readers
+     * are not active.
+     */
+    private long computeLogicalRowsConsumed(int rowsToRead) {
+        if (pageColumnReaders == null) {
+            return rowsToRead;
+        }
+        for (PageColumnReader pcr : pageColumnReaders) {
+            if (pcr != null) {
+                return pcr.logicalRowsConsumed();
+            }
+        }
+        return rowsToRead;
+    }
+
     private Page nextStandard(int rowsToRead) {
         Block[] blocks = new Block[attributes.size()];
+        int producedRows = -1;
         try {
             for (int col = 0; col < columnInfos.length; col++) {
                 ColumnInfo info = columnInfos[col];
                 if (info == null) {
-                    blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                    continue;
                 } else {
                     try {
                         blocks[col] = readColumnBlock(col, info, rowsToRead);
+                        if (producedRows < 0) {
+                            producedRows = blocks[col].getPositionCount();
+                        }
                     } catch (Exception e) {
                         Releasables.closeExpectNoException(blocks);
                         Attribute attr = attributes.get(col);
@@ -601,6 +791,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                             e
                         );
                     }
+                }
+            }
+            if (producedRows < 0) {
+                producedRows = rowsToRead;
+            }
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (blocks[col] == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(producedRows);
                 }
             }
         } catch (ElasticsearchException e) {
@@ -623,53 +821,63 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     /**
-     * Three-phase late materialization pipeline:
+     * Two-phase late materialization pipeline using filter-during-decode:
      * <ol>
-     *   <li>Phase 1: Decode predicate columns (referenced in pushed filter)</li>
-     *   <li>Phase 2: Evaluate filter against predicate Blocks → survivor mask; compact predicate Blocks</li>
-     *   <li>Phase 3: Decode projection-only columns for surviving rows only</li>
+     *   <li>Phase 1: Decode predicate columns fully, evaluate filter → {@link RowSelection}</li>
+     *   <li>Phase 2: Use the selection vector to decode only surviving rows from projection
+     *       columns at the byte level (no full-batch allocation for non-surviving rows)</li>
      * </ol>
+     *
+     * <p>Predicate column Blocks are compacted to contain only surviving rows. Projection-only
+     * columns use {@link PageColumnReader#readBatchWithSelection} to skip non-surviving values
+     * during decode, avoiding the double-allocation pattern of the old filter-after-decode path.
      */
     private Page nextWithLateMaterialization(int rowsToRead) {
         Block[] blocks = new Block[attributes.size()];
         try {
-            // Phase 1: decode predicate columns
+            // === Phase 1: Decode predicate columns, build selection ===
             Map<String, Block> predicateBlockMap = new HashMap<>();
+            int actualProduced = rowsToRead;
             for (int col = 0; col < columnInfos.length; col++) {
                 if (isPredicateColumn[col]) {
                     ColumnInfo info = columnInfos[col];
-                    if (info == null) {
-                        blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
-                    } else {
+                    if (info != null) {
                         blocks[col] = readColumnBlock(col, info, rowsToRead);
+                        actualProduced = blocks[col].getPositionCount();
                         predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
                     }
                 }
             }
-
-            // Phase 2: evaluate filter
-            boolean[] survivorMask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead);
-            int survivorCount = rowsToRead;
-            if (survivorMask != null) {
-                survivorCount = 0;
-                for (boolean b : survivorMask) {
-                    if (b) survivorCount++;
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col] && blocks[col] == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(actualProduced);
+                    predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
                 }
-                rowsEliminatedByLateMaterialization += (rowsToRead - survivorCount);
             }
 
-            if (survivorMask != null && survivorCount < rowsToRead) {
-                // Compact predicate Blocks to contain only surviving rows
+            boolean[] survivorMask = pushedExpressions.evaluateFilter(predicateBlockMap, actualProduced);
+            RowSelection selection;
+            if (survivorMask == null) {
+                selection = RowSelection.all(actualProduced);
+            } else {
+                selection = RowSelection.fromMask(survivorMask, actualProduced);
+                rowsEliminatedByLateMaterialization += (actualProduced - selection.selectedCount());
+            }
+
+            int survivorCount = selection.selectedCount();
+
+            if (selection.isAllSelected() == false) {
+                boolean[] mask = selection.toBooleanArray();
                 for (int col = 0; col < columnInfos.length; col++) {
                     if (isPredicateColumn[col] && blocks[col] != null) {
-                        Block filtered = PageColumnReader.filterBlock(blocks[col], survivorMask, survivorCount, blockFactory);
+                        Block filtered = PageColumnReader.filterBlock(blocks[col], mask, survivorCount, blockFactory);
                         blocks[col].close();
                         blocks[col] = filtered;
                     }
                 }
             }
 
-            // Phase 3: decode projection-only columns
+            // === Phase 2: Decode projection-only columns using selection vector ===
             for (int col = 0; col < columnInfos.length; col++) {
                 if (isPredicateColumn[col]) {
                     continue;
@@ -677,23 +885,23 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 ColumnInfo info = columnInfos[col];
                 if (info == null) {
                     blocks[col] = blockFactory.newConstantNullBlock(survivorCount);
-                } else if (survivorMask != null && survivorCount == 0) {
-                    // No survivors: skip decode entirely for projection columns
+                } else if (selection.isNoneSelected()) {
                     if (pageColumnReaders != null && pageColumnReaders[col] != null) {
-                        pageColumnReaders[col].skipRows(rowsToRead);
+                        pageColumnReaders[col].skipRows(actualProduced);
                     } else {
                         ColumnReader cr = columnReaders != null ? columnReaders[col] : null;
                         if (cr != null) {
-                            skipValues(cr, rowsToRead);
+                            skipValues(cr, actualProduced);
                         }
                     }
                     blocks[col] = blockFactory.newConstantNullBlock(0);
-                } else if (survivorMask != null && pageColumnReaders != null && pageColumnReaders[col] != null) {
-                    blocks[col] = pageColumnReaders[col].readBatchFiltered(rowsToRead, blockFactory, survivorMask, survivorCount);
+                } else if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                    blocks[col] = pageColumnReaders[col].readBatchWithSelection(actualProduced, blockFactory, selection);
                 } else {
-                    Block fullBlock = readColumnBlock(col, info, rowsToRead);
-                    if (survivorMask != null && survivorCount < rowsToRead) {
-                        Block filtered = PageColumnReader.filterBlock(fullBlock, survivorMask, survivorCount, blockFactory);
+                    Block fullBlock = readColumnBlock(col, info, actualProduced);
+                    if (selection.isAllSelected() == false) {
+                        boolean[] mask = selection.toBooleanArray();
+                        Block filtered = PageColumnReader.filterBlock(fullBlock, mask, survivorCount, blockFactory);
                         fullBlock.close();
                         blocks[col] = filtered;
                     } else {
@@ -701,7 +909,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     }
                 }
             }
-            return new Page(blocks);
+            return new Page(survivorCount, blocks);
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
             throw new ElasticsearchException(
@@ -897,11 +1105,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     public void close() throws IOException {
         cancelPendingPrefetch();
         adapter.clearPrefetchedData();
+        closeSelectivePageReaders();
         try {
             if (rowGroup != null) {
                 rowGroup.close();
             }
         } finally {
+            if (codecFactory != null) {
+                codecFactory.release();
+            }
             reader.close();
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -42,8 +42,11 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
@@ -66,6 +69,12 @@ import java.util.NoSuchElementException;
  * builds null {@link java.util.BitSet}s directly instead of going through a {@code boolean[]}
  * intermediary. List columns remain row-at-a-time since they require stateful multi-value handling.
  *
+ * <p>Stage 4: late materialization pipeline. When {@code late_materialization=true}, the
+ * {@link #next()} method is restructured into three phases: (1) decode predicate columns first,
+ * (2) evaluate pushed filter against decoded Blocks to produce a survivor mask, (3) decode
+ * projection-only columns for surviving rows only. Columns in both predicate and projection sets
+ * are decoded once in Phase 1 and their Blocks compacted in Phase 2.
+ *
  * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
  * stable fallback when {@code optimized_reader=false}.
  */
@@ -86,6 +95,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final PreloadedRowGroupMetadata preloadedMetadata;
     private final ParquetPushedExpressions pushedExpressions;
     private final boolean pageLevelReader;
+    private final boolean lateMaterialization;
+    private final boolean[] isPredicateColumn;
     private int rowBudget;
 
     private PageReadStore rowGroup;
@@ -98,6 +109,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private long rowGroupsSkippedByDictionary = 0;
     private long pagesSkippedByColumnIndex = 0;
     private long pagesEvaluatedByColumnIndex = 0;
+    private long rowsEliminatedByLateMaterialization = 0;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -111,7 +123,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         ColumnInfo[] columnInfos,
         PreloadedRowGroupMetadata preloadedMetadata,
         ParquetPushedExpressions pushedExpressions,
-        boolean pageLevelReader
+        boolean pageLevelReader,
+        boolean lateMaterialization
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -125,8 +138,34 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.preloadedMetadata = preloadedMetadata;
         this.pushedExpressions = pushedExpressions;
         this.pageLevelReader = pageLevelReader;
+        this.lateMaterialization = lateMaterialization && pageLevelReader && pushedExpressions != null;
+
+        this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
 
         reader.setRequestedSchema(projectedSchema);
+    }
+
+    /**
+     * Classifies each projected column as predicate (referenced in pushed filter) or projection-only.
+     * A column that appears in both the filter and the projection is marked as predicate — it will
+     * be decoded in Phase 1 and its Block reused in Phase 3 (no duplicate decode).
+     */
+    private static boolean[] classifyPredicateColumns(
+        List<Attribute> attributes,
+        ColumnInfo[] columnInfos,
+        ParquetPushedExpressions pushed
+    ) {
+        boolean[] predicate = new boolean[columnInfos.length];
+        if (pushed == null) {
+            return predicate;
+        }
+        Set<String> predicateNames = pushed.predicateColumnNames();
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && predicateNames.contains(attributes.get(i).name())) {
+                predicate[i] = true;
+            }
+        }
+        return predicate;
     }
 
     @Override
@@ -170,6 +209,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                         pagesSkippedByColumnIndex,
                         fileLocation
                     );
+                }
+                if (rowsEliminatedByLateMaterialization > 0) {
+                    logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
                 }
                 return false;
             }
@@ -416,6 +458,17 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
 
+        Page result = lateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
+
+        pageBatchIndexInRowGroup++;
+        rowsRemainingInGroup -= rowsToRead;
+        if (rowBudget != FormatReader.NO_LIMIT) {
+            rowBudget -= result.getPositionCount();
+        }
+        return result;
+    }
+
+    private Page nextStandard(int rowsToRead) {
         Block[] blocks = new Block[attributes.size()];
         try {
             for (int col = 0; col < columnInfos.length; col++) {
@@ -462,13 +515,103 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 e
             );
         }
-
-        pageBatchIndexInRowGroup++;
-        rowsRemainingInGroup -= rowsToRead;
-        if (rowBudget != FormatReader.NO_LIMIT) {
-            rowBudget -= rowsToRead;
-        }
         return new Page(blocks);
+    }
+
+    /**
+     * Three-phase late materialization pipeline:
+     * <ol>
+     *   <li>Phase 1: Decode predicate columns (referenced in pushed filter)</li>
+     *   <li>Phase 2: Evaluate filter against predicate Blocks → survivor mask; compact predicate Blocks</li>
+     *   <li>Phase 3: Decode projection-only columns for surviving rows only</li>
+     * </ol>
+     */
+    private Page nextWithLateMaterialization(int rowsToRead) {
+        Block[] blocks = new Block[attributes.size()];
+        try {
+            // Phase 1: decode predicate columns
+            Map<String, Block> predicateBlockMap = new HashMap<>();
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    ColumnInfo info = columnInfos[col];
+                    if (info == null) {
+                        blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                    } else {
+                        blocks[col] = readColumnBlock(col, info, rowsToRead);
+                        predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
+                    }
+                }
+            }
+
+            // Phase 2: evaluate filter
+            boolean[] survivorMask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead);
+            int survivorCount = rowsToRead;
+            if (survivorMask != null) {
+                survivorCount = 0;
+                for (boolean b : survivorMask) {
+                    if (b) survivorCount++;
+                }
+                rowsEliminatedByLateMaterialization += (rowsToRead - survivorCount);
+            }
+
+            if (survivorMask != null && survivorCount < rowsToRead) {
+                // Compact predicate Blocks to contain only surviving rows
+                for (int col = 0; col < columnInfos.length; col++) {
+                    if (isPredicateColumn[col] && blocks[col] != null) {
+                        Block filtered = PageColumnReader.filterBlock(blocks[col], survivorMask, survivorCount, blockFactory);
+                        blocks[col].close();
+                        blocks[col] = filtered;
+                    }
+                }
+            }
+
+            // Phase 3: decode projection-only columns
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    continue;
+                }
+                ColumnInfo info = columnInfos[col];
+                if (info == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(survivorCount);
+                } else if (survivorMask != null && survivorCount == 0) {
+                    // No survivors: skip decode entirely for projection columns
+                    if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                        pageColumnReaders[col].skipRows(rowsToRead);
+                    } else {
+                        ColumnReader cr = columnReaders != null ? columnReaders[col] : null;
+                        if (cr != null) {
+                            skipValues(cr, rowsToRead);
+                        }
+                    }
+                    blocks[col] = blockFactory.newConstantNullBlock(0);
+                } else if (survivorMask != null && pageColumnReaders != null && pageColumnReaders[col] != null) {
+                    blocks[col] = pageColumnReaders[col].readBatchFiltered(rowsToRead, blockFactory, survivorMask, survivorCount);
+                } else {
+                    Block fullBlock = readColumnBlock(col, info, rowsToRead);
+                    if (survivorMask != null && survivorCount < rowsToRead) {
+                        Block filtered = PageColumnReader.filterBlock(fullBlock, survivorMask, survivorCount, blockFactory);
+                        fullBlock.close();
+                        blocks[col] = filtered;
+                    } else {
+                        blocks[col] = fullBlock;
+                    }
+                }
+            }
+            return new Page(blocks);
+        } catch (Exception e) {
+            Releasables.closeExpectNoException(blocks);
+            throw new ElasticsearchException(
+                "Failed to create late-materialized Page batch at row group ["
+                    + (rowGroupOrdinal + 1)
+                    + "] page batch ["
+                    + pageBatchIndexInRowGroup
+                    + "] in file ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
     }
 
     private Block readColumnBlock(int colIndex, ColumnInfo info, int rowsToRead) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -8,18 +8,24 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
+import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.compute.data.Block;
@@ -27,17 +33,15 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -45,17 +49,30 @@ import java.util.NoSuchElementException;
  * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
  *
  * <p>Stage 0: functionally identical to the baseline {@code ParquetColumnIterator} but structured
- * for progressive enhancement. Accepts {@link PreloadedRowGroupMetadata} for future use by
- * dictionary pruning (Stage 1), page-level skipping (Stage 2), and batch decode (Stage 3).
+ * for progressive enhancement. Uses {@link PreloadedRowGroupMetadata} for preloaded column/offset
+ * indexes and dictionary pages.
+ *
+ * <p>Stage 1: dictionary-aware row group pruning. When a row group has dictionary-encoded predicate
+ * columns, evaluates the pushed predicate against dictionary values. Row groups where no dictionary
+ * value matches are skipped entirely.
+ *
+ * <p>Stage 2: page-level skipping via ColumnIndex. Uses preloaded ColumnIndex min/max per data page
+ * to evaluate pushed predicates and skip pages that cannot contain matching rows. Produces
+ * {@link RowRanges} that represent selected row ranges within a row group. Anti-fragmentation
+ * discards the ranges when the selection is too dense or fragmented to benefit from skipping.
+ *
+ * <p>Stage 3: batch column reader. Flat (non-list) columns are decoded via {@link BatchColumnReader}
+ * which uses tight loops with a non-nullable fast path (no def-level check when maxDef == 0) and
+ * builds null {@link java.util.BitSet}s directly instead of going through a {@code boolean[]}
+ * intermediary. List columns remain row-at-a-time since they require stateful multi-value handling.
  *
  * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
  * stable fallback when {@code optimized_reader=false}.
  */
 final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
-    private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
-    private static final long NANOS_PER_MILLI = 1_000_000L;
-    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+    private static final Logger logger = LogManager.getLogger(OptimizedParquetColumnIterator.class);
+
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     private final ParquetFileReader reader;
@@ -67,14 +84,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final String fileLocation;
     private final ColumnInfo[] columnInfos;
     private final PreloadedRowGroupMetadata preloadedMetadata;
+    private final ParquetPushedExpressions pushedExpressions;
+    private final boolean pageLevelReader;
     private int rowBudget;
 
     private PageReadStore rowGroup;
     private ColumnReader[] columnReaders;
+    private PageColumnReader[] pageColumnReaders;
     private long rowsRemainingInGroup;
     private boolean exhausted = false;
     private int rowGroupOrdinal = -1;
     private int pageBatchIndexInRowGroup = 0;
+    private long rowGroupsSkippedByDictionary = 0;
+    private long pagesSkippedByColumnIndex = 0;
+    private long pagesEvaluatedByColumnIndex = 0;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -86,7 +109,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         String createdBy,
         String fileLocation,
         ColumnInfo[] columnInfos,
-        PreloadedRowGroupMetadata preloadedMetadata
+        PreloadedRowGroupMetadata preloadedMetadata,
+        ParquetPushedExpressions pushedExpressions,
+        boolean pageLevelReader
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -98,6 +123,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.fileLocation = fileLocation;
         this.columnInfos = columnInfos;
         this.preloadedMetadata = preloadedMetadata;
+        this.pushedExpressions = pushedExpressions;
+        this.pageLevelReader = pageLevelReader;
 
         reader.setRequestedSchema(projectedSchema);
     }
@@ -125,26 +152,257 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     private boolean advanceRowGroup() throws IOException {
-        if (rowGroup != null) {
-            rowGroup.close();
-            rowGroup = null;
+        while (true) {
+            if (rowGroup != null) {
+                rowGroup.close();
+                rowGroup = null;
+            }
+            rowGroup = reader.readNextFilteredRowGroup();
+            if (rowGroup == null) {
+                exhausted = true;
+                if (rowGroupsSkippedByDictionary > 0) {
+                    logger.debug("Dictionary pruning skipped [{}] row groups in [{}]", rowGroupsSkippedByDictionary, fileLocation);
+                }
+                if (pagesEvaluatedByColumnIndex > 0) {
+                    logger.debug(
+                        "Page-level skipping: evaluated [{}] pages, skipped [{}] in [{}]",
+                        pagesEvaluatedByColumnIndex,
+                        pagesSkippedByColumnIndex,
+                        fileLocation
+                    );
+                }
+                return false;
+            }
+            rowGroupOrdinal++;
+            pageBatchIndexInRowGroup = 0;
+            rowsRemainingInGroup = rowGroup.getRowCount();
+
+            if (shouldSkipByDictionary()) {
+                rowGroupsSkippedByDictionary++;
+                continue;
+            }
+
+            RowRanges pageRanges = computePageRowRanges();
+            if (pageRanges != null && pageRanges.isEmpty()) {
+                logger.trace("Page-level skipping: all pages pruned for row group [{}] in [{}]", rowGroupOrdinal, fileLocation);
+                continue;
+            }
+
+            if (pageLevelReader) {
+                pageColumnReaders = new PageColumnReader[columnInfos.length];
+                columnReaders = null;
+                for (int i = 0; i < columnInfos.length; i++) {
+                    if (columnInfos[i] != null && columnInfos[i].maxRepLevel() == 0) {
+                        ColumnDescriptor desc = columnInfos[i].descriptor();
+                        PageReader pr = rowGroup.getPageReader(desc);
+                        pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], pageRanges);
+                    }
+                }
+                // List columns still need ColumnReadStoreImpl
+                boolean hasListColumns = false;
+                for (int i = 0; i < columnInfos.length; i++) {
+                    if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
+                        hasListColumns = true;
+                        break;
+                    }
+                }
+                if (hasListColumns) {
+                    ColumnReadStoreImpl store = new ColumnReadStoreImpl(
+                        rowGroup,
+                        new NoOpGroupConverter(projectedSchema),
+                        projectedSchema,
+                        createdBy
+                    );
+                    columnReaders = new ColumnReader[columnInfos.length];
+                    for (int i = 0; i < columnInfos.length; i++) {
+                        if (columnInfos[i] != null && columnInfos[i].maxRepLevel() > 0) {
+                            columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+                        }
+                    }
+                }
+            } else {
+                pageColumnReaders = null;
+                ColumnReadStoreImpl store = new ColumnReadStoreImpl(
+                    rowGroup,
+                    new NoOpGroupConverter(projectedSchema),
+                    projectedSchema,
+                    createdBy
+                );
+                columnReaders = new ColumnReader[columnInfos.length];
+                for (int i = 0; i < columnInfos.length; i++) {
+                    if (columnInfos[i] != null) {
+                        columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+                    }
+                }
+            }
+            return rowsRemainingInGroup > 0;
         }
-        rowGroup = reader.readNextFilteredRowGroup();
-        if (rowGroup == null) {
-            exhausted = true;
+    }
+
+    /**
+     * Evaluates pushed predicates against dictionary values for the current row group.
+     * If any predicate column is dictionary-encoded and no dictionary value matches,
+     * the entire row group can be skipped.
+     *
+     * @return true if the row group should be skipped (no dictionary values match any predicate)
+     */
+    private boolean shouldSkipByDictionary() {
+        if (pushedExpressions == null) {
             return false;
         }
-        rowGroupOrdinal++;
-        pageBatchIndexInRowGroup = 0;
-        rowsRemainingInGroup = rowGroup.getRowCount();
-        ColumnReadStoreImpl store = new ColumnReadStoreImpl(rowGroup, new NoOpGroupConverter(projectedSchema), projectedSchema, createdBy);
-        columnReaders = new ColumnReader[columnInfos.length];
-        for (int i = 0; i < columnInfos.length; i++) {
-            if (columnInfos[i] != null) {
-                columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        if (rowGroupOrdinal >= rowGroups.size()) {
+            return false;
+        }
+        BlockMetaData block = rowGroups.get(rowGroupOrdinal);
+
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            if (col.hasDictionaryPage() == false) {
+                continue;
+            }
+            String columnPath = col.getPath().toDotString();
+            if (pushedExpressions.referencesColumn(columnPath) == false) {
+                continue;
+            }
+
+            DictionaryPage dictPage = readDictionaryPage(col);
+            if (dictPage == null) {
+                continue;
+            }
+
+            try {
+                Dictionary dictionary = dictPage.decode(projectedSchema.getColumnDescription(col.getPath().toArray()));
+                if (dictionary == null || dictionary.getMaxId() < 0) {
+                    continue;
+                }
+
+                if (pushedExpressions.allDictionaryValuesRejected(columnPath, dictionary, col.getPrimitiveType())) {
+                    logger.trace(
+                        "Dictionary pruning: skipping row group [{}] — no dictionary values match for column [{}] in [{}]",
+                        rowGroupOrdinal,
+                        columnPath,
+                        fileLocation
+                    );
+                    return true;
+                }
+            } catch (Exception e) {
+                logger.debug(
+                    "Dictionary evaluation failed for column [{}] in row group [{}] of [{}]: {}",
+                    columnPath,
+                    rowGroupOrdinal,
+                    fileLocation,
+                    e.getMessage()
+                );
             }
         }
-        return rowsRemainingInGroup > 0;
+        return false;
+    }
+
+    /**
+     * Reads the dictionary page for a column chunk from the current row group's page store.
+     */
+    private DictionaryPage readDictionaryPage(ColumnChunkMetaData col) {
+        try {
+            PageReader pageReader = rowGroup.getPageReader(projectedSchema.getColumnDescription(col.getPath().toArray()));
+            if (pageReader != null) {
+                return pageReader.readDictionaryPage();
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to read dictionary page for [{}] in row group [{}]: {}", col.getPath(), rowGroupOrdinal, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Computes page-level row ranges by evaluating pushed predicates against ColumnIndex min/max
+     * for each data page. Returns null if page-level skipping is not applicable (no predicates,
+     * no column indexes, or anti-fragmentation triggered). Returns an empty RowRanges if all
+     * pages are pruned (row group can be skipped entirely).
+     *
+     * <p>For each predicate column with a ColumnIndex and OffsetIndex, evaluates each page's
+     * min/max against the pushed expressions. Matching pages are converted to row ranges using
+     * the OffsetIndex's firstRowIndex. Ranges from different predicate columns are intersected
+     * (a row must satisfy ALL predicates).
+     */
+    private RowRanges computePageRowRanges() {
+        if (pushedExpressions == null || preloadedMetadata.hasColumnIndexes() == false || preloadedMetadata.hasOffsetIndexes() == false) {
+            return null;
+        }
+
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        if (rowGroupOrdinal >= rowGroups.size()) {
+            return null;
+        }
+        BlockMetaData block = rowGroups.get(rowGroupOrdinal);
+        long rowGroupRowCount = block.getRowCount();
+
+        RowRanges combined = null;
+
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            String columnPath = col.getPath().toDotString();
+            if (pushedExpressions.referencesColumn(columnPath) == false) {
+                continue;
+            }
+
+            ColumnIndex columnIndex = preloadedMetadata.getColumnIndex(rowGroupOrdinal, columnPath);
+            OffsetIndex offsetIndex = preloadedMetadata.getOffsetIndex(rowGroupOrdinal, columnPath);
+            if (columnIndex == null || offsetIndex == null) {
+                continue;
+            }
+
+            int pageCount = offsetIndex.getPageCount();
+            if (pageCount == 0) {
+                continue;
+            }
+
+            List<long[]> matchingRanges = new ArrayList<>();
+            for (int pageIdx = 0; pageIdx < pageCount; pageIdx++) {
+                pagesEvaluatedByColumnIndex++;
+                boolean canMatch = pushedExpressions.pageCanMatch(columnPath, columnIndex, pageIdx, col.getPrimitiveType());
+                if (canMatch) {
+                    long pageStart = offsetIndex.getFirstRowIndex(pageIdx);
+                    long pageEnd = (pageIdx + 1 < pageCount) ? offsetIndex.getFirstRowIndex(pageIdx + 1) : rowGroupRowCount;
+                    matchingRanges.add(new long[] { pageStart, pageEnd });
+                } else {
+                    pagesSkippedByColumnIndex++;
+                }
+            }
+
+            RowRanges columnRanges;
+            if (matchingRanges.isEmpty()) {
+                columnRanges = RowRanges.of(0, 0, rowGroupRowCount);
+            } else if (matchingRanges.size() == pageCount) {
+                columnRanges = RowRanges.all(rowGroupRowCount);
+            } else {
+                columnRanges = RowRanges.fromUnsorted(matchingRanges, rowGroupRowCount);
+            }
+
+            combined = (combined == null) ? columnRanges : combined.intersect(columnRanges);
+
+            if (combined.isEmpty()) {
+                return combined;
+            }
+        }
+
+        if (combined == null) {
+            return null;
+        }
+
+        if (combined.shouldDiscard()) {
+            logger.trace(
+                "Page-level skipping: anti-fragmentation triggered for row group [{}] in [{}] "
+                    + "(density={}, transitions={}, selected={}/{})",
+                rowGroupOrdinal,
+                fileLocation,
+                combined.density(),
+                combined.transitionCount(),
+                combined.selectedRowCount(),
+                rowGroupRowCount
+            );
+            return null;
+        }
+
+        return combined;
     }
 
     @Override
@@ -166,7 +424,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
                 } else {
                     try {
-                        blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead);
+                        blocks[col] = readColumnBlock(col, info, rowsToRead);
                     } catch (Exception e) {
                         Releasables.closeExpectNoException(blocks);
                         Attribute attr = attributes.get(col);
@@ -213,238 +471,26 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return new Page(blocks);
     }
 
-    private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead) {
+    private Block readColumnBlock(int colIndex, ColumnInfo info, int rowsToRead) {
+        if (pageColumnReaders != null && pageColumnReaders[colIndex] != null) {
+            return pageColumnReaders[colIndex].readBatch(rowsToRead, blockFactory);
+        }
+        ColumnReader cr = columnReaders != null ? columnReaders[colIndex] : null;
+        if (cr == null) {
+            return blockFactory.newConstantNullBlock(rowsToRead);
+        }
+        Block batch = BatchColumnReader.readBatch(cr, info, rowsToRead, blockFactory);
+        if (batch != null) {
+            return batch;
+        }
         if (info.maxRepLevel() > 0) {
             return readListColumn(cr, info, rowsToRead);
         }
-        return switch (info.esqlType()) {
-            case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel(), rowsToRead);
-            case INTEGER -> readIntColumn(cr, info.maxDefLevel(), rowsToRead);
-            case LONG -> {
-                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
-                    yield readInt32WidenedToLongColumn(cr, info.maxDefLevel(), rowsToRead);
-                }
-                yield readLongColumn(cr, info.maxDefLevel(), rowsToRead);
-            }
-            case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
-            case KEYWORD, TEXT -> readBytesRefColumn(cr, info, rowsToRead);
-            case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
-            default -> {
-                skipValues(cr, rowsToRead);
-                yield blockFactory.newConstantNullBlock(rowsToRead);
-            }
-        };
+        skipValues(cr, rowsToRead);
+        return blockFactory.newConstantNullBlock(rowsToRead);
     }
 
-    // --- Primitive column readers (same logic as baseline) ---
-
-    private Block readBooleanColumn(ColumnReader cr, int maxDef, int rows) {
-        boolean[] values = new boolean[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                values[i] = cr.getBoolean();
-            }
-            cr.consume();
-        }
-        if (noNulls) {
-            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
-        }
-        return blockFactory.newBooleanArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
-    }
-
-    private Block readIntColumn(ColumnReader cr, int maxDef, int rows) {
-        int[] values = new int[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                values[i] = cr.getInteger();
-            }
-            cr.consume();
-        }
-        if (noNulls) {
-            return blockFactory.newIntArrayVector(values, rows).asBlock();
-        }
-        return blockFactory.newIntArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
-    }
-
-    private Block readInt32WidenedToLongColumn(ColumnReader cr, int maxDef, int rows) {
-        long[] values = new long[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                values[i] = cr.getInteger();
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private Block readLongColumn(ColumnReader cr, int maxDef, int rows) {
-        long[] values = new long[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                values[i] = cr.getLong();
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private Block readDoubleColumn(ColumnReader cr, ColumnInfo info, int rows) {
-        LogicalTypeAnnotation logical = info.logicalType();
-        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
-            return readDecimalAsDoubleColumn(cr, info, decimal.getScale(), rows);
-        }
-        if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
-            return readFloat16Column(cr, info.maxDefLevel(), rows);
-        }
-        double[] values = new double[rows];
-        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
-        for (int i = 0; i < rows; i++) {
-            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                values[i] = isFloat ? cr.getFloat() : cr.getDouble();
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private Block readDecimalAsDoubleColumn(ColumnReader cr, ColumnInfo info, int scale, int rows) {
-        double[] values = new double[rows];
-        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                BigInteger unscaled = switch (info.parquetType()) {
-                    case INT32 -> BigInteger.valueOf(cr.getInteger());
-                    case INT64 -> BigInteger.valueOf(cr.getLong());
-                    case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
-                    default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
-                };
-                values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private Block readFloat16Column(ColumnReader cr, int maxDef, int rows) {
-        double[] values = new double[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                byte[] bytes = cr.getBinary().getBytes();
-                short float16Bits = (short) ((bytes[1] & 0xFF) << 8 | (bytes[0] & 0xFF));
-                values[i] = Float.float16ToFloat(float16Bits);
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows) {
-        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
-        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
-            for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
-                    builder.appendNull();
-                } else if (isUuid) {
-                    builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
-                } else {
-                    builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                }
-                cr.consume();
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
-        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
-            return readInt96TimestampColumn(cr, info.maxDefLevel(), rows);
-        }
-        long[] values = new long[rows];
-        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
-        for (int i = 0; i < rows; i++) {
-            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
-                isNull[i] = true;
-                noNulls = false;
-            } else if (isDate) {
-                values[i] = cr.getInteger() * MILLIS_PER_DAY;
-            } else {
-                long raw = cr.getLong();
-                values[i] = convertTimestampToMillis(raw, info.logicalType());
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
-        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
-            return switch (ts.getUnit()) {
-                case MILLIS -> raw;
-                case MICROS -> raw / 1_000;
-                case NANOS -> raw / 1_000_000;
-            };
-        }
-        return raw;
-    }
-
-    private Block readInt96TimestampColumn(ColumnReader cr, int maxDef, int rows) {
-        long[] values = new long[rows];
-        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
-        boolean noNulls = true;
-        for (int i = 0; i < rows; i++) {
-            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
-                isNull[i] = true;
-                noNulls = false;
-            } else {
-                Binary bin = cr.getBinary();
-                ByteBuffer buf = ByteBuffer.wrap(bin.getBytes()).order(ByteOrder.LITTLE_ENDIAN);
-                long nanosOfDay = buf.getLong();
-                int julianDay = buf.getInt();
-                long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
-                values[i] = epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
-            }
-            cr.consume();
-        }
-        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
-    }
-
-    // --- List column readers ---
+    // --- List column readers (not batch-optimized: require stateful multi-value handling) ---
 
     private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
         DataType elementType = info.esqlType();
@@ -568,20 +614,21 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
     // --- Utilities ---
 
+    private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case MILLIS -> raw;
+                case MICROS -> raw / 1_000;
+                case NANOS -> raw / 1_000_000;
+            };
+        }
+        return raw;
+    }
+
     private static void skipValues(ColumnReader cr, int rows) {
         for (int i = 0; i < rows; i++) {
             cr.consume();
         }
-    }
-
-    private static java.util.BitSet toBitSet(boolean[] isNull, int length) {
-        java.util.BitSet bits = new java.util.BitSet(length);
-        for (int i = 0; i < length; i++) {
-            if (isNull[i]) {
-                bits.set(i);
-            }
-        }
-        return bits;
     }
 
     static String formatUuid(byte[] bytes) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1,0 +1,637 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.column.impl.ColumnReadStoreImpl;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
+ *
+ * <p>Stage 0: functionally identical to the baseline {@code ParquetColumnIterator} but structured
+ * for progressive enhancement. Accepts {@link PreloadedRowGroupMetadata} for future use by
+ * dictionary pruning (Stage 1), page-level skipping (Stage 2), and batch decode (Stage 3).
+ *
+ * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
+ * stable fallback when {@code optimized_reader=false}.
+ */
+final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
+
+    private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private final ParquetFileReader reader;
+    private final MessageType projectedSchema;
+    private final List<Attribute> attributes;
+    private final int batchSize;
+    private final BlockFactory blockFactory;
+    private final String createdBy;
+    private final String fileLocation;
+    private final ColumnInfo[] columnInfos;
+    private final PreloadedRowGroupMetadata preloadedMetadata;
+    private int rowBudget;
+
+    private PageReadStore rowGroup;
+    private ColumnReader[] columnReaders;
+    private long rowsRemainingInGroup;
+    private boolean exhausted = false;
+    private int rowGroupOrdinal = -1;
+    private int pageBatchIndexInRowGroup = 0;
+
+    OptimizedParquetColumnIterator(
+        ParquetFileReader reader,
+        MessageType projectedSchema,
+        List<Attribute> attributes,
+        int batchSize,
+        BlockFactory blockFactory,
+        int rowLimit,
+        String createdBy,
+        String fileLocation,
+        ColumnInfo[] columnInfos,
+        PreloadedRowGroupMetadata preloadedMetadata
+    ) {
+        this.reader = reader;
+        this.projectedSchema = projectedSchema;
+        this.attributes = attributes;
+        this.batchSize = batchSize;
+        this.blockFactory = blockFactory;
+        this.rowBudget = rowLimit;
+        this.createdBy = createdBy != null ? createdBy : "";
+        this.fileLocation = fileLocation;
+        this.columnInfos = columnInfos;
+        this.preloadedMetadata = preloadedMetadata;
+
+        reader.setRequestedSchema(projectedSchema);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (exhausted) {
+            return false;
+        }
+        if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+            exhausted = true;
+            return false;
+        }
+        if (rowsRemainingInGroup > 0) {
+            return true;
+        }
+        try {
+            return advanceRowGroup();
+        } catch (IOException e) {
+            throw new ElasticsearchException(
+                "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]: " + e.getMessage(),
+                e
+            );
+        }
+    }
+
+    private boolean advanceRowGroup() throws IOException {
+        if (rowGroup != null) {
+            rowGroup.close();
+            rowGroup = null;
+        }
+        rowGroup = reader.readNextFilteredRowGroup();
+        if (rowGroup == null) {
+            exhausted = true;
+            return false;
+        }
+        rowGroupOrdinal++;
+        pageBatchIndexInRowGroup = 0;
+        rowsRemainingInGroup = rowGroup.getRowCount();
+        ColumnReadStoreImpl store = new ColumnReadStoreImpl(rowGroup, new NoOpGroupConverter(projectedSchema), projectedSchema, createdBy);
+        columnReaders = new ColumnReader[columnInfos.length];
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null) {
+                columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+            }
+        }
+        return rowsRemainingInGroup > 0;
+    }
+
+    @Override
+    public Page next() {
+        if (hasNext() == false) {
+            throw new NoSuchElementException();
+        }
+        int effectiveBatch = batchSize;
+        if (rowBudget != FormatReader.NO_LIMIT) {
+            effectiveBatch = Math.min(effectiveBatch, rowBudget);
+        }
+        int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
+
+        Block[] blocks = new Block[attributes.size()];
+        try {
+            for (int col = 0; col < columnInfos.length; col++) {
+                ColumnInfo info = columnInfos[col];
+                if (info == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                } else {
+                    try {
+                        blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead);
+                    } catch (Exception e) {
+                        Releasables.closeExpectNoException(blocks);
+                        Attribute attr = attributes.get(col);
+                        throw new ElasticsearchException(
+                            "Failed to read Parquet column ["
+                                + attr.name()
+                                + "] (type "
+                                + attr.dataType()
+                                + ") at row group ["
+                                + (rowGroupOrdinal + 1)
+                                + "] page batch ["
+                                + pageBatchIndexInRowGroup
+                                + "] in file ["
+                                + fileLocation
+                                + "]: "
+                                + e.getMessage(),
+                            e
+                        );
+                    }
+                }
+            }
+        } catch (ElasticsearchException e) {
+            throw e;
+        } catch (Exception e) {
+            Releasables.closeExpectNoException(blocks);
+            throw new ElasticsearchException(
+                "Failed to create Page batch at row group ["
+                    + (rowGroupOrdinal + 1)
+                    + "] page batch ["
+                    + pageBatchIndexInRowGroup
+                    + "] in file ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
+
+        pageBatchIndexInRowGroup++;
+        rowsRemainingInGroup -= rowsToRead;
+        if (rowBudget != FormatReader.NO_LIMIT) {
+            rowBudget -= rowsToRead;
+        }
+        return new Page(blocks);
+    }
+
+    private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead) {
+        if (info.maxRepLevel() > 0) {
+            return readListColumn(cr, info, rowsToRead);
+        }
+        return switch (info.esqlType()) {
+            case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel(), rowsToRead);
+            case INTEGER -> readIntColumn(cr, info.maxDefLevel(), rowsToRead);
+            case LONG -> {
+                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                    yield readInt32WidenedToLongColumn(cr, info.maxDefLevel(), rowsToRead);
+                }
+                yield readLongColumn(cr, info.maxDefLevel(), rowsToRead);
+            }
+            case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
+            case KEYWORD, TEXT -> readBytesRefColumn(cr, info, rowsToRead);
+            case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
+            default -> {
+                skipValues(cr, rowsToRead);
+                yield blockFactory.newConstantNullBlock(rowsToRead);
+            }
+        };
+    }
+
+    // --- Primitive column readers (same logic as baseline) ---
+
+    private Block readBooleanColumn(ColumnReader cr, int maxDef, int rows) {
+        boolean[] values = new boolean[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                values[i] = cr.getBoolean();
+            }
+            cr.consume();
+        }
+        if (noNulls) {
+            return blockFactory.newBooleanArrayVector(values, rows).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
+    }
+
+    private Block readIntColumn(ColumnReader cr, int maxDef, int rows) {
+        int[] values = new int[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                values[i] = cr.getInteger();
+            }
+            cr.consume();
+        }
+        if (noNulls) {
+            return blockFactory.newIntArrayVector(values, rows).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
+    }
+
+    private Block readInt32WidenedToLongColumn(ColumnReader cr, int maxDef, int rows) {
+        long[] values = new long[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                values[i] = cr.getInteger();
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private Block readLongColumn(ColumnReader cr, int maxDef, int rows) {
+        long[] values = new long[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                values[i] = cr.getLong();
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private Block readDoubleColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        LogicalTypeAnnotation logical = info.logicalType();
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
+            return readDecimalAsDoubleColumn(cr, info, decimal.getScale(), rows);
+        }
+        if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+            return readFloat16Column(cr, info.maxDefLevel(), rows);
+        }
+        double[] values = new double[rows];
+        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
+        for (int i = 0; i < rows; i++) {
+            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                values[i] = isFloat ? cr.getFloat() : cr.getDouble();
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private Block readDecimalAsDoubleColumn(ColumnReader cr, ColumnInfo info, int scale, int rows) {
+        double[] values = new double[rows];
+        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                BigInteger unscaled = switch (info.parquetType()) {
+                    case INT32 -> BigInteger.valueOf(cr.getInteger());
+                    case INT64 -> BigInteger.valueOf(cr.getLong());
+                    case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
+                    default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
+                };
+                values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private Block readFloat16Column(ColumnReader cr, int maxDef, int rows) {
+        double[] values = new double[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                byte[] bytes = cr.getBinary().getBytes();
+                short float16Bits = (short) ((bytes[1] & 0xFF) << 8 | (bytes[0] & 0xFF));
+                values[i] = Float.float16ToFloat(float16Bits);
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            for (int i = 0; i < rows; i++) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
+                    builder.appendNull();
+                } else if (isUuid) {
+                    builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
+                } else {
+                    builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                }
+                cr.consume();
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return readInt96TimestampColumn(cr, info.maxDefLevel(), rows);
+        }
+        long[] values = new long[rows];
+        boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
+        for (int i = 0; i < rows; i++) {
+            if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
+                isNull[i] = true;
+                noNulls = false;
+            } else if (isDate) {
+                values[i] = cr.getInteger() * MILLIS_PER_DAY;
+            } else {
+                long raw = cr.getLong();
+                values[i] = convertTimestampToMillis(raw, info.logicalType());
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case MILLIS -> raw;
+                case MICROS -> raw / 1_000;
+                case NANOS -> raw / 1_000_000;
+            };
+        }
+        return raw;
+    }
+
+    private Block readInt96TimestampColumn(ColumnReader cr, int maxDef, int rows) {
+        long[] values = new long[rows];
+        boolean[] isNull = maxDef > 0 ? new boolean[rows] : null;
+        boolean noNulls = true;
+        for (int i = 0; i < rows; i++) {
+            if (maxDef > 0 && cr.getCurrentDefinitionLevel() < maxDef) {
+                isNull[i] = true;
+                noNulls = false;
+            } else {
+                Binary bin = cr.getBinary();
+                ByteBuffer buf = ByteBuffer.wrap(bin.getBytes()).order(ByteOrder.LITTLE_ENDIAN);
+                long nanosOfDay = buf.getLong();
+                int julianDay = buf.getInt();
+                long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
+                values[i] = epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
+            }
+            cr.consume();
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
+    }
+
+    // --- List column readers ---
+
+    private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        DataType elementType = info.esqlType();
+        int maxDef = info.maxDefLevel();
+        return switch (elementType) {
+            case INTEGER -> readListIntColumn(cr, maxDef, rows);
+            case LONG -> readListLongColumn(cr, maxDef, rows);
+            case DOUBLE -> readListDoubleColumn(cr, maxDef, rows);
+            case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows);
+            case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows);
+            case DATETIME -> readListDatetimeColumn(cr, info, rows);
+            default -> {
+                skipListValues(cr, maxDef, rows);
+                yield blockFactory.newConstantNullBlock(rows);
+            }
+        };
+    }
+
+    private static void skipListValues(ColumnReader cr, int maxDef, int rows) {
+        for (int row = 0; row < rows; row++) {
+            cr.consume();
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                cr.consume();
+            }
+        }
+    }
+
+    private Block readListIntColumn(ColumnReader cr, int maxDef, int rows) {
+        try (var builder = blockFactory.newIntBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendInt(cr.getInteger()));
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readListLongColumn(ColumnReader cr, int maxDef, int rows) {
+        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendLong(cr.getLong()));
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows) {
+        try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendDouble(cr.getDouble()));
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows) {
+        try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendBoolean(cr.getBoolean()));
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows) {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes())));
+            }
+            return builder.build();
+        }
+    }
+
+    private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+            int maxDef = info.maxDefLevel();
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, () -> builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType())));
+            }
+            return builder.build();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ValueAppender {
+        void append();
+    }
+
+    private static void readListRow(ColumnReader cr, int maxDef, Block.Builder builder, ValueAppender appender) {
+        int def = cr.getCurrentDefinitionLevel();
+        if (def >= maxDef) {
+            builder.beginPositionEntry();
+            appender.append();
+            cr.consume();
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                    appender.append();
+                }
+                cr.consume();
+            }
+            builder.endPositionEntry();
+        } else {
+            cr.consume();
+            boolean hasValues = false;
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                    if (hasValues == false) {
+                        builder.beginPositionEntry();
+                        hasValues = true;
+                    }
+                    appender.append();
+                }
+                cr.consume();
+            }
+            if (hasValues) {
+                builder.endPositionEntry();
+            } else {
+                builder.appendNull();
+            }
+        }
+    }
+
+    // --- Utilities ---
+
+    private static void skipValues(ColumnReader cr, int rows) {
+        for (int i = 0; i < rows; i++) {
+            cr.consume();
+        }
+    }
+
+    private static java.util.BitSet toBitSet(boolean[] isNull, int length) {
+        java.util.BitSet bits = new java.util.BitSet(length);
+        for (int i = 0; i < length; i++) {
+            if (isNull[i]) {
+                bits.set(i);
+            }
+        }
+        return bits;
+    }
+
+    static String formatUuid(byte[] bytes) {
+        if (bytes == null || bytes.length < 16) {
+            throw new QlIllegalArgumentException("UUID requires 16 bytes, got " + (bytes == null ? "null" : bytes.length));
+        }
+        StringBuilder sb = new StringBuilder(36);
+        for (int i = 0; i < 16; i++) {
+            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
+            sb.append(HEX[bytes[i] & 0xF]);
+            if (i == 3 || i == 5 || i == 7 || i == 9) {
+                sb.append('-');
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (rowGroup != null) {
+                rowGroup.close();
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Minimal GroupConverter that satisfies {@link ColumnReadStoreImpl}'s constructor.
+     */
+    private static class NoOpGroupConverter extends GroupConverter {
+        private final GroupType schema;
+
+        NoOpGroupConverter(GroupType schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex) {
+            Type field = schema.getType(fieldIndex);
+            return field.isPrimitive() ? new NoOpPrimitiveConverter() : new NoOpGroupConverter(field.asGroupType());
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void end() {}
+    }
+
+    private static class NoOpPrimitiveConverter extends PrimitiveConverter {}
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -73,10 +73,12 @@ final class PageColumnReader {
     private ByteBuffer currentValueBytes;
     private Encoding currentEncoding;
     private int currentPageValueCount;
+    private int physicalPageValueCount;
     private int currentPageConsumed;
     private boolean currentPageIsV1;
     private long rowPositionInRowGroup;
     private boolean columnExhausted;
+    private long batchStartRowPosition;
 
     PageColumnReader(PageReader pageReader, ColumnDescriptor descriptor, ColumnInfo info, RowRanges rowRanges) {
         this.pageReader = pageReader;
@@ -88,9 +90,24 @@ final class PageColumnReader {
         this.rowPositionInRowGroup = 0;
         this.currentPageConsumed = 0;
         this.currentPageValueCount = 0;
+        this.physicalPageValueCount = 0;
+    }
+
+    PageReader getPageReader() {
+        return pageReader;
+    }
+
+    /**
+     * Returns the number of logical row-group rows consumed by the last batch operation,
+     * including rows in pages that were skipped by RowRanges. This allows the iterator to
+     * correctly update {@code rowsRemainingInGroup} when page-level skipping is active.
+     */
+    long logicalRowsConsumed() {
+        return rowPositionInRowGroup - batchStartRowPosition;
     }
 
     Block readBatch(int maxRows, BlockFactory blockFactory) {
+        batchStartRowPosition = rowPositionInRowGroup;
         loadDictionaryIfNeeded();
         return switch (info.esqlType()) {
             case BOOLEAN -> readBooleanBatch(maxRows, blockFactory);
@@ -124,6 +141,7 @@ final class PageColumnReader {
      * @return a Block containing only the surviving rows
      */
     Block readBatchFiltered(int maxRows, BlockFactory blockFactory, boolean[] survivorMask, int survivorCount) {
+        batchStartRowPosition = rowPositionInRowGroup;
         if (survivorCount == maxRows) {
             return readBatch(maxRows, blockFactory);
         }
@@ -137,6 +155,44 @@ final class PageColumnReader {
         } finally {
             fullBlock.close();
         }
+    }
+
+    /**
+     * Reads a batch where only rows in {@code selection} are materialized.
+     * Non-selected values are consumed from the page stream but never stored.
+     * The returned Block has exactly {@code selection.selectedCount()} positions.
+     *
+     * <p>This avoids the double-allocation pattern of {@link #readBatchFiltered} (which decodes
+     * all rows into a full-sized array, then copies survivors into a smaller array). Instead,
+     * a single right-sized array is allocated and populated directly.
+     */
+    Block readBatchWithSelection(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        batchStartRowPosition = rowPositionInRowGroup;
+        if (selection.isAllSelected()) {
+            return readBatch(totalRows, blockFactory);
+        }
+        if (selection.isNoneSelected()) {
+            skipRows(totalRows);
+            return blockFactory.newConstantNullBlock(0);
+        }
+        loadDictionaryIfNeeded();
+        return switch (info.esqlType()) {
+            case BOOLEAN -> readBooleanBatchSelective(totalRows, blockFactory, selection);
+            case INTEGER -> readIntBatchSelective(totalRows, blockFactory, selection);
+            case LONG -> {
+                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                    yield readInt32AsLongBatchSelective(totalRows, blockFactory, selection);
+                }
+                yield readLongBatchSelective(totalRows, blockFactory, selection);
+            }
+            case DOUBLE -> readDoubleBatchSelective(totalRows, blockFactory, selection);
+            case KEYWORD, TEXT -> readBytesBatchSelective(totalRows, blockFactory, selection);
+            case DATETIME -> readDatetimeBatchSelective(totalRows, blockFactory, selection);
+            default -> {
+                skipRows(totalRows);
+                yield blockFactory.newConstantNullBlock(selection.selectedCount());
+            }
+        };
     }
 
     static Block filterBlock(Block source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
@@ -276,28 +332,55 @@ final class PageColumnReader {
     }
 
     private boolean loadNextPage() {
-        DataPage page = pageReader.readPage();
-        if (page == null) {
-            columnExhausted = true;
-            return false;
+        if (physicalPageValueCount > 0 && currentPageConsumed < physicalPageValueCount) {
+            int remainder = physicalPageValueCount - currentPageConsumed;
+            if (remainder > 0) {
+                int nonNullSkipped = defDecoder.skip(remainder);
+                skipValues(nonNullSkipped);
+                rowPositionInRowGroup += remainder;
+                currentPageConsumed = physicalPageValueCount;
+            }
         }
-        currentPageValueCount = page.getValueCount();
-        currentPageConsumed = 0;
+        while (true) {
+            DataPage page = pageReader.readPage();
+            if (page == null) {
+                columnExhausted = true;
+                physicalPageValueCount = 0;
+                return false;
+            }
 
-        if (page instanceof DataPageV1 v1) {
-            currentPageIsV1 = true;
-            currentEncoding = v1.getValueEncoding();
-            splitV1Page(v1);
-        } else if (page instanceof DataPageV2 v2) {
-            currentPageIsV1 = false;
-            currentEncoding = v2.getDataEncoding();
-            splitV2Page(v2);
-        } else {
-            throw new QlIllegalArgumentException("Unexpected page type: " + page.getClass().getName());
+            page.getFirstRowIndex().ifPresent(firstRow -> {
+                if (firstRow > rowPositionInRowGroup) {
+                    rowPositionInRowGroup = firstRow;
+                }
+            });
+
+            int pageRowCount = page.getValueCount();
+
+            if (rowRanges != null && rowRanges.overlaps(rowPositionInRowGroup, rowPositionInRowGroup + pageRowCount) == false) {
+                rowPositionInRowGroup += pageRowCount;
+                continue;
+            }
+
+            currentPageValueCount = pageRowCount;
+            physicalPageValueCount = pageRowCount;
+            currentPageConsumed = 0;
+
+            if (page instanceof DataPageV1 v1) {
+                currentPageIsV1 = true;
+                currentEncoding = v1.getValueEncoding();
+                splitV1Page(v1);
+            } else if (page instanceof DataPageV2 v2) {
+                currentPageIsV1 = false;
+                currentEncoding = v2.getDataEncoding();
+                splitV2Page(v2);
+            } else {
+                throw new QlIllegalArgumentException("Unexpected page type: " + page.getClass().getName());
+            }
+
+            initDecoders();
+            return true;
         }
-
-        initDecoders();
-        return true;
     }
 
     private void splitV1Page(DataPageV1 v1) {
@@ -352,6 +435,33 @@ final class PageColumnReader {
         }
     }
 
+    private void applyIntraPageSkip() {
+        if (rowRanges == null) {
+            return;
+        }
+        long originalPageStart = rowPositionInRowGroup;
+        long originalPageEnd = originalPageStart + currentPageValueCount;
+
+        long firstSelected = rowRanges.firstSelectedInRange(originalPageStart, originalPageEnd);
+        if (firstSelected < 0) {
+            return;
+        }
+
+        int leadingSkip = (int) (firstSelected - originalPageStart);
+        if (leadingSkip > 0) {
+            int nonNullSkipped = defDecoder.skip(leadingSkip);
+            skipValues(nonNullSkipped);
+            currentPageConsumed += leadingSkip;
+            rowPositionInRowGroup += leadingSkip;
+        }
+
+        long lastSelected = rowRanges.lastSelectedInRange(originalPageStart, originalPageEnd);
+        if (lastSelected >= 0 && lastSelected < originalPageEnd - 1) {
+            int trailingRows = (int) (originalPageEnd - 1 - lastSelected);
+            currentPageValueCount -= trailingRows;
+        }
+    }
+
     private int availableInPage() {
         return currentPageValueCount - currentPageConsumed;
     }
@@ -362,6 +472,7 @@ final class PageColumnReader {
     }
 
     void skipRows(int count) {
+        batchStartRowPosition = rowPositionInRowGroup;
         int remaining = count;
         while (remaining > 0) {
             if (ensurePage() == false) {
@@ -1155,7 +1266,627 @@ final class PageColumnReader {
         }
     }
 
+    // --- Selective batch readers (filter-during-decode) ---
+
+    private Block readBooleanBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        int selectedCount = selection.selectedCount();
+        boolean[] values = new boolean[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                if (currentEncoding.usesDictionary()) {
+                    dictDecoder.readBooleansSelective(values, outOff, pageSel, fromPage, dictionary);
+                } else {
+                    plainDecoder.readBooleansSelective(values, outOff, pageSel, fromPage);
+                }
+                return pageSel.selectedCount();
+            });
+            return blockFactory.newBooleanArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        readNullableValuesSelective(
+            totalRows,
+            selection,
+            nulls,
+            values,
+            (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterBooleans(
+                (boolean[]) vals,
+                outOff,
+                outNulls,
+                pageSC,
+                nonNullSel,
+                totalNonNull
+            )
+        );
+        if (nulls.isEmpty()) {
+            return blockFactory.newBooleanArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private void readAndScatterBooleans(boolean[] output, int outOff, BitSet nulls, int pageSelCount, RowSelection valSel, int totalNN) {
+        boolean[] packed = new boolean[valSel.selectedCount()];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBooleansSelective(packed, 0, valSel, totalNN, dictionary);
+        } else {
+            plainDecoder.readBooleansSelective(packed, 0, valSel, totalNN);
+        }
+        scatterPacked(packed, output, outOff, nulls, pageSelCount);
+    }
+
+    private Block readIntBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        int selectedCount = selection.selectedCount();
+        int[] values = new int[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                if (currentEncoding.usesDictionary()) {
+                    dictDecoder.readIntsSelective(values, outOff, pageSel, fromPage, dictionary);
+                } else {
+                    plainDecoder.readIntsSelective(values, outOff, pageSel, fromPage);
+                }
+                return pageSel.selectedCount();
+            });
+            return blockFactory.newIntArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        readNullableValuesSelective(
+            totalRows,
+            selection,
+            nulls,
+            values,
+            (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterInts(
+                (int[]) vals,
+                outOff,
+                outNulls,
+                pageSC,
+                nonNullSel,
+                totalNonNull
+            )
+        );
+        if (nulls.isEmpty()) {
+            return blockFactory.newIntArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private void readAndScatterInts(int[] output, int outOff, BitSet nulls, int pageSelCount, RowSelection valSel, int totalNN) {
+        int[] packed = new int[valSel.selectedCount()];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readIntsSelective(packed, 0, valSel, totalNN, dictionary);
+        } else {
+            plainDecoder.readIntsSelective(packed, 0, valSel, totalNN);
+        }
+        scatterPacked(packed, output, outOff, nulls, pageSelCount);
+    }
+
+    private Block readLongBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        int selectedCount = selection.selectedCount();
+        long[] values = new long[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                if (currentEncoding.usesDictionary()) {
+                    dictDecoder.readLongsSelective(values, outOff, pageSel, fromPage, dictionary);
+                } else {
+                    plainDecoder.readLongsSelective(values, outOff, pageSel, fromPage);
+                }
+                return pageSel.selectedCount();
+            });
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        readNullableValuesSelective(
+            totalRows,
+            selection,
+            nulls,
+            values,
+            (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterLongs(
+                (long[]) vals,
+                outOff,
+                outNulls,
+                pageSC,
+                nonNullSel,
+                totalNonNull
+            )
+        );
+        if (nulls.isEmpty()) {
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newLongArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private void readAndScatterLongs(long[] output, int outOff, BitSet nulls, int pageSelCount, RowSelection valSel, int totalNN) {
+        long[] packed = new long[valSel.selectedCount()];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readLongsSelective(packed, 0, valSel, totalNN, dictionary);
+        } else {
+            plainDecoder.readLongsSelective(packed, 0, valSel, totalNN);
+        }
+        scatterPacked(packed, output, outOff, nulls, pageSelCount);
+    }
+
+    private Block readInt32AsLongBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        int selectedCount = selection.selectedCount();
+        long[] values = new long[selectedCount];
+        int[] intBuf = new int[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                int pageSelected = pageSel.selectedCount();
+                if (currentEncoding.usesDictionary()) {
+                    dictDecoder.readIntsSelective(intBuf, outOff, pageSel, fromPage, dictionary);
+                } else {
+                    plainDecoder.readIntsSelective(intBuf, outOff, pageSel, fromPage);
+                }
+                for (int i = 0; i < pageSelected; i++) {
+                    values[outOff + i] = intBuf[outOff + i];
+                }
+                return pageSelected;
+            });
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        readNullableValuesSelective(
+            totalRows,
+            selection,
+            nulls,
+            intBuf,
+            (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterInts(
+                (int[]) vals,
+                outOff,
+                outNulls,
+                pageSC,
+                nonNullSel,
+                totalNonNull
+            )
+        );
+        for (int i = 0; i < selectedCount; i++) {
+            if (nulls.get(i) == false) {
+                values[i] = intBuf[i];
+            }
+        }
+        if (nulls.isEmpty()) {
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newLongArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private Block readDoubleBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        LogicalTypeAnnotation logical = info.logicalType();
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation
+            || logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+            return readBatchFiltered(totalRows, blockFactory, selection.toBooleanArray(), selection.selectedCount());
+        }
+        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
+        int selectedCount = selection.selectedCount();
+        double[] values = new double[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                if (currentEncoding.usesDictionary()) {
+                    if (isFloat) {
+                        dictDecoder.readFloatsSelective(values, outOff, pageSel, fromPage, dictionary);
+                    } else {
+                        dictDecoder.readDoublesSelective(values, outOff, pageSel, fromPage, dictionary);
+                    }
+                } else {
+                    if (isFloat) {
+                        plainDecoder.readFloatsSelective(values, outOff, pageSel, fromPage);
+                    } else {
+                        plainDecoder.readDoublesSelective(values, outOff, pageSel, fromPage);
+                    }
+                }
+                return pageSel.selectedCount();
+            });
+            return blockFactory.newDoubleArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        readNullableValuesSelective(
+            totalRows,
+            selection,
+            nulls,
+            values,
+            (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterDoubles(
+                (double[]) vals,
+                outOff,
+                outNulls,
+                pageSC,
+                nonNullSel,
+                totalNonNull,
+                isFloat
+            )
+        );
+        if (nulls.isEmpty()) {
+            return blockFactory.newDoubleArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newDoubleArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private void readAndScatterDoubles(
+        double[] output,
+        int outOff,
+        BitSet nulls,
+        int pageSelCount,
+        RowSelection valSel,
+        int totalNN,
+        boolean isFloat
+    ) {
+        double[] packed = new double[valSel.selectedCount()];
+        if (currentEncoding.usesDictionary()) {
+            if (isFloat) {
+                dictDecoder.readFloatsSelective(packed, 0, valSel, totalNN, dictionary);
+            } else {
+                dictDecoder.readDoublesSelective(packed, 0, valSel, totalNN, dictionary);
+            }
+        } else {
+            if (isFloat) {
+                plainDecoder.readFloatsSelective(packed, 0, valSel, totalNN);
+            } else {
+                plainDecoder.readDoublesSelective(packed, 0, valSel, totalNN);
+            }
+        }
+        scatterPacked(packed, output, outOff, nulls, pageSelCount);
+    }
+
+    private Block readBytesBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        int selectedCount = selection.selectedCount();
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        boolean isFixedLen = info.parquetType() == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+        BytesRef[] values = new BytesRef[selectedCount];
+        if (maxDefLevel == 0) {
+            readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                int pageSelected = pageSel.selectedCount();
+                if (currentEncoding.usesDictionary()) {
+                    dictDecoder.readBinariesSelective(values, outOff, pageSel, fromPage, dictionary);
+                } else if (isFixedLen) {
+                    plainDecoder.readFixedBinariesSelective(
+                        values,
+                        outOff,
+                        pageSel,
+                        fromPage,
+                        descriptor.getPrimitiveType().getTypeLength()
+                    );
+                } else {
+                    plainDecoder.readBinariesSelective(values, outOff, pageSel, fromPage);
+                }
+                if (isUuid) {
+                    for (int i = 0; i < pageSelected; i++) {
+                        values[outOff + i] = new BytesRef(OptimizedParquetColumnIterator.formatUuid(values[outOff + i].bytes));
+                    }
+                }
+                return pageSelected;
+            });
+        } else {
+            BitSet nulls = new BitSet(selectedCount);
+            readNullableValuesSelective(
+                totalRows,
+                selection,
+                nulls,
+                values,
+                (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterBytes(
+                    (BytesRef[]) vals,
+                    outOff,
+                    outNulls,
+                    pageSC,
+                    nonNullSel,
+                    totalNonNull,
+                    isUuid,
+                    isFixedLen
+                )
+            );
+            if (nulls.isEmpty() == false) {
+                try (var builder = blockFactory.newBytesRefBlockBuilder(selectedCount)) {
+                    for (int i = 0; i < selectedCount; i++) {
+                        if (nulls.get(i)) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBytesRef(values[i]);
+                        }
+                    }
+                    return builder.build();
+                }
+            }
+        }
+        try (var builder = blockFactory.newBytesRefBlockBuilder(selectedCount)) {
+            for (int i = 0; i < selectedCount; i++) {
+                builder.appendBytesRef(values[i]);
+            }
+            return builder.build();
+        }
+    }
+
+    private void readAndScatterBytes(
+        BytesRef[] output,
+        int outOff,
+        BitSet nulls,
+        int pageSelCount,
+        RowSelection valSel,
+        int totalNN,
+        boolean isUuid,
+        boolean isFixedLen
+    ) {
+        BytesRef[] packed = new BytesRef[valSel.selectedCount()];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinariesSelective(packed, 0, valSel, totalNN, dictionary);
+        } else if (isFixedLen) {
+            plainDecoder.readFixedBinariesSelective(packed, 0, valSel, totalNN, descriptor.getPrimitiveType().getTypeLength());
+        } else {
+            plainDecoder.readBinariesSelective(packed, 0, valSel, totalNN);
+        }
+        if (isUuid) {
+            for (int i = 0; i < packed.length; i++) {
+                packed[i] = new BytesRef(OptimizedParquetColumnIterator.formatUuid(packed[i].bytes));
+            }
+        }
+        scatterPacked(packed, output, outOff, nulls, pageSelCount);
+    }
+
+    private Block readDatetimeBatchSelective(int totalRows, BlockFactory blockFactory, RowSelection selection) {
+        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return readBatchFiltered(totalRows, blockFactory, selection.toBooleanArray(), selection.selectedCount());
+        }
+        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
+        int selectedCount = selection.selectedCount();
+        long[] values = new long[selectedCount];
+        if (maxDefLevel == 0) {
+            if (isDate) {
+                int[] intBuf = new int[selectedCount];
+                readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                    int pageSelected = pageSel.selectedCount();
+                    if (currentEncoding.usesDictionary()) {
+                        dictDecoder.readIntsSelective(intBuf, outOff, pageSel, fromPage, dictionary);
+                    } else {
+                        plainDecoder.readIntsSelective(intBuf, outOff, pageSel, fromPage);
+                    }
+                    return pageSelected;
+                });
+                for (int i = 0; i < selectedCount; i++) {
+                    values[i] = intBuf[i] * MILLIS_PER_DAY;
+                }
+            } else {
+                readNonNullValuesSelective(totalRows, selection, (pageSel, fromPage, outOff) -> {
+                    if (currentEncoding.usesDictionary()) {
+                        dictDecoder.readLongsSelective(values, outOff, pageSel, fromPage, dictionary);
+                    } else {
+                        plainDecoder.readLongsSelective(values, outOff, pageSel, fromPage);
+                    }
+                    return pageSel.selectedCount();
+                });
+                applyTimestampConversion(values, selectedCount);
+            }
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        BitSet nulls = new BitSet(selectedCount);
+        if (isDate) {
+            int[] intBuf = new int[selectedCount];
+            readNullableValuesSelective(
+                totalRows,
+                selection,
+                nulls,
+                intBuf,
+                (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterInts(
+                    (int[]) vals,
+                    outOff,
+                    outNulls,
+                    pageSC,
+                    nonNullSel,
+                    totalNonNull
+                )
+            );
+            for (int i = 0; i < selectedCount; i++) {
+                if (nulls.get(i) == false) {
+                    values[i] = intBuf[i] * MILLIS_PER_DAY;
+                }
+            }
+        } else {
+            readNullableValuesSelective(
+                totalRows,
+                selection,
+                nulls,
+                values,
+                (vals, nonNullSel, totalNonNull, outOff, outNulls, pageSC) -> readAndScatterLongs(
+                    (long[]) vals,
+                    outOff,
+                    outNulls,
+                    pageSC,
+                    nonNullSel,
+                    totalNonNull
+                )
+            );
+            applyTimestampConversion(values, selectedCount);
+        }
+        if (nulls.isEmpty()) {
+            return blockFactory.newLongArrayVector(values, selectedCount).asBlock();
+        }
+        return blockFactory.newLongArrayBlock(values, selectedCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private void applyTimestampConversion(long[] values, int count) {
+        LogicalTypeAnnotation logicalType = info.logicalType();
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            switch (ts.getUnit()) {
+                case MILLIS -> {
+                }
+                case MICROS -> {
+                    for (int i = 0; i < count; i++) {
+                        values[i] = values[i] / 1_000;
+                    }
+                }
+                case NANOS -> {
+                    for (int i = 0; i < count; i++) {
+                        values[i] = values[i] / 1_000_000;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Drives the page loop for non-nullable selective reads. The callback is invoked once
+     * per page with the page-local selection and output offset.
+     */
+    private void readNonNullValuesSelective(int totalRows, RowSelection selection, SelectivePageReader pageReader) {
+        int remaining = totalRows;
+        int consumed = 0;
+        int outOffset = 0;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            RowSelection pageSel = selection.slice(consumed, fromPage);
+            if (pageSel.isNoneSelected()) {
+                skipValues(fromPage); // non-nullable: value count == row count
+            } else {
+                int produced = pageReader.read(pageSel, fromPage, outOffset);
+                outOffset += produced;
+            }
+            advancePosition(fromPage);
+            consumed += fromPage;
+            remaining -= fromPage;
+        }
+    }
+
+    @FunctionalInterface
+    private interface SelectivePageReader {
+        int read(RowSelection pageSel, int fromPage, int outOffset);
+    }
+
+    /**
+     * Drives the page loop for nullable selective reads. Handles def levels, null tracking,
+     * and value reading for selected rows only.
+     *
+     * <p>For nullable columns, def levels are decoded for ALL rows (to advance the RLE stream).
+     * A value-level selection vector maps selected-and-non-null row positions to positions
+     * in the non-null value stream, enabling the value decoder to skip non-selected values.
+     * Selected non-null values are read packed, then scattered into the output array at the
+     * correct non-null positions.
+     */
+    private void readNullableValuesSelective(
+        int totalRows,
+        RowSelection selection,
+        BitSet nulls,
+        Object values,
+        NullableSelectivePageReader pageReader
+    ) {
+        int remaining = totalRows;
+        int consumed = 0;
+        int outOffset = 0;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            RowSelection pageSel = selection.slice(consumed, fromPage);
+            int pageSelectedCount = pageSel.selectedCount();
+            if (pageSel.isNoneSelected()) {
+                int nonNullSkipped = defDecoder.skip(fromPage);
+                skipValues(nonNullSkipped);
+            } else {
+                BitSet pageNulls = new BitSet(fromPage);
+                int totalNonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+
+                // Track nulls for selected rows in the output BitSet
+                int outPos = outOffset;
+                int selIdx = pageSel.nextSelected(0);
+                while (selIdx >= 0 && selIdx < fromPage) {
+                    if (pageNulls.get(selIdx)) {
+                        nulls.set(outPos);
+                    }
+                    outPos++;
+                    selIdx = pageSel.nextSelected(selIdx + 1);
+                }
+
+                if (totalNonNull == 0) {
+                    // No values to read from the value stream
+                } else {
+                    // Build value-level selection: among totalNonNull value positions,
+                    // which correspond to selected non-null rows?
+                    BitSet valueSel = new BitSet(totalNonNull);
+                    int valuePos = 0;
+                    int selectedNonNull = 0;
+                    selIdx = pageSel.nextSelected(0);
+                    for (int i = 0; i < fromPage; i++) {
+                        boolean isNull = pageNulls.get(i);
+                        boolean isSelected = (i == selIdx);
+                        if (isSelected && isNull == false) {
+                            valueSel.set(valuePos);
+                            selectedNonNull++;
+                        }
+                        if (isSelected) {
+                            selIdx = pageSel.nextSelected(selIdx + 1);
+                        }
+                        if (isNull == false) {
+                            valuePos++;
+                        }
+                    }
+
+                    if (selectedNonNull > 0) {
+                        RowSelection nonNullValueSelection = new RowSelection(valueSel, totalNonNull, selectedNonNull);
+                        pageReader.read(values, nonNullValueSelection, totalNonNull, outOffset, nulls, pageSelectedCount);
+                    } else {
+                        skipValues(totalNonNull);
+                    }
+                }
+                outOffset += pageSelectedCount;
+            }
+            advancePosition(fromPage);
+            consumed += fromPage;
+            remaining -= fromPage;
+        }
+    }
+
+    @FunctionalInterface
+    private interface NullableSelectivePageReader {
+        /**
+         * Read values selectively and scatter into output positions, skipping null positions.
+         *
+         * @param values output array (typed — caller casts)
+         * @param nonNullSelection selection over the non-null value stream
+         * @param totalNonNull total non-null values in this page chunk
+         * @param outOffset starting output offset for this page's selected rows
+         * @param nulls null bitmap for the output
+         * @param pageSelectedCount number of selected rows in this page chunk
+         */
+        void read(Object values, RowSelection nonNullSelection, int totalNonNull, int outOffset, BitSet nulls, int pageSelectedCount);
+    }
+
     // --- Scatter utilities ---
+
+    private static void scatterPacked(boolean[] packed, boolean[] output, int outOff, BitSet nulls, int pageSelCount) {
+        int pi = 0;
+        for (int i = 0; i < pageSelCount; i++) {
+            if (nulls.get(outOff + i) == false) {
+                output[outOff + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatterPacked(int[] packed, int[] output, int outOff, BitSet nulls, int pageSelCount) {
+        int pi = 0;
+        for (int i = 0; i < pageSelCount; i++) {
+            if (nulls.get(outOff + i) == false) {
+                output[outOff + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatterPacked(long[] packed, long[] output, int outOff, BitSet nulls, int pageSelCount) {
+        int pi = 0;
+        for (int i = 0; i < pageSelCount; i++) {
+            if (nulls.get(outOff + i) == false) {
+                output[outOff + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatterPacked(double[] packed, double[] output, int outOff, BitSet nulls, int pageSelCount) {
+        int pi = 0;
+        for (int i = 0; i < pageSelCount; i++) {
+            if (nulls.get(outOff + i) == false) {
+                output[outOff + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatterPacked(BytesRef[] packed, BytesRef[] output, int outOff, BitSet nulls, int pageSelCount) {
+        int pi = 0;
+        for (int i = 0; i < pageSelCount; i++) {
+            if (nulls.get(outOff + i) == false) {
+                output[outOff + i] = packed[pi++];
+            }
+        }
+    }
 
     private static void scatter(boolean[] packed, boolean[] output, BitSet nulls, int offset, int totalRows) {
         int pi = 0;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -406,7 +406,8 @@ final class PageColumnReader {
         boolean[] values = new boolean[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullBooleans(values, 0, maxRows);
-            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
+            return constant != null ? constant : blockFactory.newBooleanArrayVector(values, produced).asBlock();
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -420,7 +421,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
+            return constant != null ? constant : blockFactory.newBooleanArrayVector(values, produced).asBlock();
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return blockFactory.newBooleanArrayBlock(values, produced, null, nulls, Block.MvOrdering.UNORDERED);
     }
@@ -469,7 +475,8 @@ final class PageColumnReader {
         int[] values = new int[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullInts(values, 0, maxRows);
-            return blockFactory.newIntArrayVector(values, produced).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
+            return constant != null ? constant : blockFactory.newIntArrayVector(values, produced).asBlock();
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -483,7 +490,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return blockFactory.newIntArrayVector(values, produced).asBlock();
+            Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
+            return constant != null ? constant : blockFactory.newIntArrayVector(values, produced).asBlock();
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return blockFactory.newIntArrayBlock(values, produced, null, nulls, Block.MvOrdering.UNORDERED);
     }
@@ -532,7 +544,8 @@ final class PageColumnReader {
         long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullLongs(values, 0, maxRows);
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -546,7 +559,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -595,7 +613,8 @@ final class PageColumnReader {
         long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullInt32AsLong(values, 0, maxRows);
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -609,7 +628,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -670,7 +694,8 @@ final class PageColumnReader {
         double[] values = new double[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullDoubles(values, 0, maxRows, isFloat);
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -684,7 +709,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -763,7 +793,8 @@ final class PageColumnReader {
                 produced += fromPage;
                 remaining -= fromPage;
             }
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -785,7 +816,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -840,7 +876,8 @@ final class PageColumnReader {
                 produced += fromPage;
                 remaining -= fromPage;
             }
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -862,7 +899,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -886,38 +928,67 @@ final class PageColumnReader {
 
     private Block readBytesBatch(int maxRows, BlockFactory blockFactory) {
         boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
-        try (var builder = blockFactory.newBytesRefBlockBuilder(maxRows)) {
+        if (maxDefLevel == 0) {
+            BytesRef[] allValues = new BytesRef[maxRows];
             int produced = 0;
             int remaining = maxRows;
             while (remaining > 0 && ensurePage()) {
                 int fromPage = Math.min(remaining, availableInPage());
-                if (maxDefLevel == 0) {
-                    BytesRef[] vals = readBinaryValues(fromPage);
-                    for (int i = 0; i < fromPage; i++) {
-                        if (isUuid) {
-                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[i].bytes)));
-                        } else {
-                            builder.appendBytesRef(vals[i]);
-                        }
-                    }
-                } else {
-                    BitSet nulls = new BitSet(fromPage);
-                    int nonNull = defDecoder.readBatch(fromPage, nulls, 0);
-                    BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
-                    int valIdx = 0;
-                    for (int i = 0; i < fromPage; i++) {
-                        if (nulls.get(i)) {
-                            builder.appendNull();
-                        } else if (isUuid) {
-                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[valIdx++].bytes)));
-                        } else {
-                            builder.appendBytesRef(vals[valIdx++]);
-                        }
-                    }
+                BytesRef[] vals = readBinaryValues(fromPage);
+                for (int i = 0; i < fromPage; i++) {
+                    allValues[produced + i] = isUuid ? new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[i].bytes)) : vals[i];
                 }
                 advancePosition(fromPage);
                 produced += fromPage;
                 remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantBytesRef(allValues, produced, blockFactory);
+            if (constant != null) {
+                return constant;
+            }
+            try (var builder = blockFactory.newBytesRefBlockBuilder(produced)) {
+                for (int i = 0; i < produced; i++) {
+                    builder.appendBytesRef(allValues[i]);
+                }
+                return builder.build();
+            }
+        }
+        BytesRef[] allValues = new BytesRef[maxRows];
+        BitSet allNulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            BitSet pageNulls = new BitSet(fromPage);
+            int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+            BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+            int valIdx = 0;
+            for (int i = 0; i < fromPage; i++) {
+                if (pageNulls.get(i)) {
+                    allNulls.set(produced + i);
+                } else if (isUuid) {
+                    allValues[produced + i] = new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[valIdx++].bytes));
+                } else {
+                    allValues[produced + i] = vals[valIdx++];
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (allNulls.isEmpty() == false) {
+            Block allNull = ConstantBlockDetection.tryAllNull(allNulls, produced, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+        }
+        try (var builder = blockFactory.newBytesRefBlockBuilder(produced)) {
+            for (int i = 0; i < produced; i++) {
+                if (allNulls.get(i)) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(allValues[i]);
+                }
             }
             return builder.build();
         }
@@ -953,7 +1024,8 @@ final class PageColumnReader {
                 produced += fromPage;
                 remaining -= fromPage;
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -975,7 +1047,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }
@@ -1029,7 +1106,8 @@ final class PageColumnReader {
                 produced += fromPage;
                 remaining -= fromPage;
             }
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
         }
         BitSet nulls = new BitSet(maxRows);
         int produced = 0;
@@ -1051,7 +1129,12 @@ final class PageColumnReader {
             remaining -= fromPage;
         }
         if (nulls.isEmpty()) {
-            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            return constant != null ? constant : ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls, produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
         }
         return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -1773,50 +1773,18 @@ final class PageColumnReader {
                 int nonNullSkipped = defDecoder.skip(fromPage);
                 skipValues(nonNullSkipped);
             } else {
-                BitSet pageNulls = new BitSet(fromPage);
-                int totalNonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
-
-                // Track nulls for selected rows in the output BitSet
-                int outPos = outOffset;
-                int selIdx = pageSel.nextSelected(0);
-                while (selIdx >= 0 && selIdx < fromPage) {
-                    if (pageNulls.get(selIdx)) {
-                        nulls.set(outPos);
-                    }
-                    outPos++;
-                    selIdx = pageSel.nextSelected(selIdx + 1);
-                }
+                BitSet valueSel = new BitSet(fromPage);
+                int[] metrics = defDecoder.readBatchSelectiveWithValueTracking(fromPage, nulls, outOffset, pageSel, valueSel);
+                int totalNonNull = metrics[0];
+                int selectedNonNull = metrics[1];
 
                 if (totalNonNull == 0) {
                     // No values to read from the value stream
+                } else if (selectedNonNull > 0) {
+                    RowSelection nonNullValueSelection = new RowSelection(valueSel, totalNonNull, selectedNonNull);
+                    pageReader.read(values, nonNullValueSelection, totalNonNull, outOffset, nulls, pageSelectedCount);
                 } else {
-                    // Build value-level selection: among totalNonNull value positions,
-                    // which correspond to selected non-null rows?
-                    BitSet valueSel = new BitSet(totalNonNull);
-                    int valuePos = 0;
-                    int selectedNonNull = 0;
-                    selIdx = pageSel.nextSelected(0);
-                    for (int i = 0; i < fromPage; i++) {
-                        boolean isNull = pageNulls.get(i);
-                        boolean isSelected = (i == selIdx);
-                        if (isSelected && isNull == false) {
-                            valueSel.set(valuePos);
-                            selectedNonNull++;
-                        }
-                        if (isSelected) {
-                            selIdx = pageSel.nextSelected(selIdx + 1);
-                        }
-                        if (isNull == false) {
-                            valuePos++;
-                        }
-                    }
-
-                    if (selectedNonNull > 0) {
-                        RowSelection nonNullValueSelection = new RowSelection(valueSel, totalNonNull, selectedNonNull);
-                        pageReader.read(values, nonNullValueSelection, totalNonNull, outOffset, nulls, pageSelectedCount);
-                    } else {
-                        skipValues(totalNonNull);
-                    }
+                    skipValues(totalNonNull);
                 }
                 outOffset += pageSelectedCount;
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -21,6 +21,11 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 
@@ -104,6 +109,149 @@ final class PageColumnReader {
                 yield blockFactory.newConstantNullBlock(maxRows);
             }
         };
+    }
+
+    /**
+     * Reads a batch and filters it using the survivor mask from late materialization. When no rows
+     * survive, the column values are skipped without decode. When all rows survive, this is
+     * equivalent to {@link #readBatch}. For partial survival, the full batch is decoded and then
+     * compacted to contain only surviving rows.
+     *
+     * @param maxRows total rows in this batch (including eliminated rows)
+     * @param blockFactory factory for building output Blocks
+     * @param survivorMask boolean array where true = row survives; length must equal maxRows
+     * @param survivorCount number of true entries in survivorMask (pre-computed for efficiency)
+     * @return a Block containing only the surviving rows
+     */
+    Block readBatchFiltered(int maxRows, BlockFactory blockFactory, boolean[] survivorMask, int survivorCount) {
+        if (survivorCount == maxRows) {
+            return readBatch(maxRows, blockFactory);
+        }
+        if (survivorCount == 0) {
+            skipRows(maxRows);
+            return blockFactory.newConstantNullBlock(0);
+        }
+        Block fullBlock = readBatch(maxRows, blockFactory);
+        try {
+            return filterBlock(fullBlock, survivorMask, survivorCount, blockFactory);
+        } finally {
+            fullBlock.close();
+        }
+    }
+
+    static Block filterBlock(Block source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        if (source instanceof LongBlock lb) {
+            return filterLongBlock(lb, mask, survivorCount, blockFactory);
+        } else if (source instanceof IntBlock ib) {
+            return filterIntBlock(ib, mask, survivorCount, blockFactory);
+        } else if (source instanceof DoubleBlock db) {
+            return filterDoubleBlock(db, mask, survivorCount, blockFactory);
+        } else if (source instanceof BytesRefBlock bb) {
+            return filterBytesRefBlock(bb, mask, survivorCount, blockFactory);
+        } else if (source instanceof BooleanBlock boolBlock) {
+            return filterBooleanBlock(boolBlock, mask, survivorCount, blockFactory);
+        }
+        return blockFactory.newConstantNullBlock(survivorCount);
+    }
+
+    private static Block filterLongBlock(LongBlock source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        long[] values = new long[survivorCount];
+        BitSet nulls = null;
+        int out = 0;
+        for (int i = 0; i < mask.length; i++) {
+            if (mask[i]) {
+                if (source.isNull(i)) {
+                    if (nulls == null) nulls = new BitSet(survivorCount);
+                    nulls.set(out);
+                } else {
+                    values[out] = source.getLong(source.getFirstValueIndex(i));
+                }
+                out++;
+            }
+        }
+        if (nulls == null) {
+            return blockFactory.newLongArrayVector(values, survivorCount).asBlock();
+        }
+        return blockFactory.newLongArrayBlock(values, survivorCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private static Block filterIntBlock(IntBlock source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        int[] values = new int[survivorCount];
+        BitSet nulls = null;
+        int out = 0;
+        for (int i = 0; i < mask.length; i++) {
+            if (mask[i]) {
+                if (source.isNull(i)) {
+                    if (nulls == null) nulls = new BitSet(survivorCount);
+                    nulls.set(out);
+                } else {
+                    values[out] = source.getInt(source.getFirstValueIndex(i));
+                }
+                out++;
+            }
+        }
+        if (nulls == null) {
+            return blockFactory.newIntArrayVector(values, survivorCount).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(values, survivorCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private static Block filterDoubleBlock(DoubleBlock source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        double[] values = new double[survivorCount];
+        BitSet nulls = null;
+        int out = 0;
+        for (int i = 0; i < mask.length; i++) {
+            if (mask[i]) {
+                if (source.isNull(i)) {
+                    if (nulls == null) nulls = new BitSet(survivorCount);
+                    nulls.set(out);
+                } else {
+                    values[out] = source.getDouble(source.getFirstValueIndex(i));
+                }
+                out++;
+            }
+        }
+        if (nulls == null) {
+            return blockFactory.newDoubleArrayVector(values, survivorCount).asBlock();
+        }
+        return blockFactory.newDoubleArrayBlock(values, survivorCount, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private static Block filterBytesRefBlock(BytesRefBlock source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(survivorCount)) {
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < mask.length; i++) {
+                if (mask[i]) {
+                    if (source.isNull(i)) {
+                        builder.appendNull();
+                    } else {
+                        builder.appendBytesRef(source.getBytesRef(source.getFirstValueIndex(i), scratch));
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block filterBooleanBlock(BooleanBlock source, boolean[] mask, int survivorCount, BlockFactory blockFactory) {
+        boolean[] values = new boolean[survivorCount];
+        BitSet nulls = null;
+        int out = 0;
+        for (int i = 0; i < mask.length; i++) {
+            if (mask[i]) {
+                if (source.isNull(i)) {
+                    if (nulls == null) nulls = new BitSet(survivorCount);
+                    nulls.set(out);
+                } else {
+                    values[out] = source.getBoolean(source.getFirstValueIndex(i));
+                }
+                out++;
+            }
+        }
+        if (nulls == null) {
+            return blockFactory.newBooleanArrayVector(values, survivorCount).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(values, survivorCount, null, nulls, Block.MvOrdering.UNORDERED);
     }
 
     private void loadDictionaryIfNeeded() {
@@ -213,7 +361,7 @@ final class PageColumnReader {
         rowPositionInRowGroup += count;
     }
 
-    private void skipRows(int count) {
+    void skipRows(int count) {
         int remaining = count;
         while (remaining > 0) {
             if (ensurePage() == false) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -1,0 +1,972 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.BitSet;
+
+/**
+ * Page-level batch column reader that bypasses {@code ColumnReadStoreImpl} and works directly
+ * with {@link PageReader} and {@link DataPage} objects. For each batch request, it:
+ * <ol>
+ *   <li>Reads data pages from the {@link PageReader}</li>
+ *   <li>Splits V1/V2 pages into def-level and value streams</li>
+ *   <li>Bulk-decodes def levels via {@link DefinitionLevelDecoder} → null {@link BitSet}</li>
+ *   <li>Bulk-decodes values via {@link PlainValueDecoder} or {@link DictionaryValueDecoder}</li>
+ *   <li>Assembles into ESQL {@link Block}s</li>
+ * </ol>
+ *
+ * <p>Only handles flat columns (maxRepLevel == 0). List columns must use the row-at-a-time path.
+ */
+final class PageColumnReader {
+
+    private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+
+    private final PageReader pageReader;
+    private final ColumnDescriptor descriptor;
+    private final ColumnInfo info;
+    private final RowRanges rowRanges;
+    private final int maxDefLevel;
+
+    private Dictionary dictionary;
+    private boolean dictionaryLoaded;
+
+    private final DefinitionLevelDecoder defDecoder = new DefinitionLevelDecoder();
+    private final PlainValueDecoder plainDecoder = new PlainValueDecoder();
+    private final DictionaryValueDecoder dictDecoder = new DictionaryValueDecoder();
+
+    private ByteBuffer currentDefLevelBytes;
+    private ByteBuffer currentValueBytes;
+    private Encoding currentEncoding;
+    private int currentPageValueCount;
+    private int currentPageConsumed;
+    private boolean currentPageIsV1;
+    private long rowPositionInRowGroup;
+    private boolean columnExhausted;
+
+    PageColumnReader(PageReader pageReader, ColumnDescriptor descriptor, ColumnInfo info, RowRanges rowRanges) {
+        this.pageReader = pageReader;
+        this.descriptor = descriptor;
+        this.info = info;
+        this.rowRanges = rowRanges;
+        this.maxDefLevel = descriptor.getMaxDefinitionLevel();
+        this.columnExhausted = false;
+        this.rowPositionInRowGroup = 0;
+        this.currentPageConsumed = 0;
+        this.currentPageValueCount = 0;
+    }
+
+    Block readBatch(int maxRows, BlockFactory blockFactory) {
+        loadDictionaryIfNeeded();
+        return switch (info.esqlType()) {
+            case BOOLEAN -> readBooleanBatch(maxRows, blockFactory);
+            case INTEGER -> readIntBatch(maxRows, blockFactory);
+            case LONG -> {
+                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                    yield readInt32AsLongBatch(maxRows, blockFactory);
+                }
+                yield readLongBatch(maxRows, blockFactory);
+            }
+            case DOUBLE -> readDoubleBatch(maxRows, blockFactory);
+            case KEYWORD, TEXT -> readBytesBatch(maxRows, blockFactory);
+            case DATETIME -> readDatetimeBatch(maxRows, blockFactory);
+            default -> {
+                skipRows(maxRows);
+                yield blockFactory.newConstantNullBlock(maxRows);
+            }
+        };
+    }
+
+    private void loadDictionaryIfNeeded() {
+        if (dictionaryLoaded) {
+            return;
+        }
+        dictionaryLoaded = true;
+        DictionaryPage dictPage = pageReader.readDictionaryPage();
+        if (dictPage != null) {
+            dictionary = dictPage.decode(descriptor);
+        }
+    }
+
+    private boolean ensurePage() {
+        if (columnExhausted) {
+            return false;
+        }
+        if (currentPageConsumed < currentPageValueCount) {
+            return true;
+        }
+        return loadNextPage();
+    }
+
+    private boolean loadNextPage() {
+        DataPage page = pageReader.readPage();
+        if (page == null) {
+            columnExhausted = true;
+            return false;
+        }
+        currentPageValueCount = page.getValueCount();
+        currentPageConsumed = 0;
+
+        if (page instanceof DataPageV1 v1) {
+            currentPageIsV1 = true;
+            currentEncoding = v1.getValueEncoding();
+            splitV1Page(v1);
+        } else if (page instanceof DataPageV2 v2) {
+            currentPageIsV1 = false;
+            currentEncoding = v2.getDataEncoding();
+            splitV2Page(v2);
+        } else {
+            throw new QlIllegalArgumentException("Unexpected page type: " + page.getClass().getName());
+        }
+
+        initDecoders();
+        return true;
+    }
+
+    private void splitV1Page(DataPageV1 v1) {
+        try {
+            byte[] pageData = v1.getBytes().toByteArray();
+            ByteBuffer pageBytes = ByteBuffer.wrap(pageData).order(ByteOrder.LITTLE_ENDIAN);
+
+            if (maxDefLevel > 0) {
+                int dlLength = pageBytes.getInt();
+                byte[] dlData = new byte[Integer.BYTES + dlLength];
+                pageBytes.position(pageBytes.position() - Integer.BYTES);
+                pageBytes.get(dlData);
+                currentDefLevelBytes = ByteBuffer.wrap(dlData).order(ByteOrder.LITTLE_ENDIAN);
+
+                byte[] valueData = new byte[pageBytes.remaining()];
+                pageBytes.get(valueData);
+                currentValueBytes = ByteBuffer.wrap(valueData).order(ByteOrder.LITTLE_ENDIAN);
+            } else {
+                currentDefLevelBytes = null;
+                currentValueBytes = pageBytes;
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read V1 page bytes: " + e.getMessage(), e);
+        }
+    }
+
+    private void splitV2Page(DataPageV2 v2) {
+        try {
+            if (maxDefLevel > 0) {
+                BytesInput dlInput = v2.getDefinitionLevels();
+                currentDefLevelBytes = dlInput.toByteBuffer();
+            } else {
+                currentDefLevelBytes = null;
+            }
+            currentValueBytes = v2.getData().toByteBuffer();
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read V2 page bytes: " + e.getMessage(), e);
+        }
+    }
+
+    private void initDecoders() {
+        if (maxDefLevel > 0 && currentDefLevelBytes != null) {
+            defDecoder.init(currentDefLevelBytes, currentPageValueCount, maxDefLevel, currentPageIsV1);
+        } else {
+            defDecoder.init(ByteBuffer.allocate(0), currentPageValueCount, 0, false);
+        }
+
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.init(currentValueBytes);
+        } else {
+            plainDecoder.init(currentValueBytes);
+        }
+    }
+
+    private int availableInPage() {
+        return currentPageValueCount - currentPageConsumed;
+    }
+
+    private void advancePosition(int count) {
+        currentPageConsumed += count;
+        rowPositionInRowGroup += count;
+    }
+
+    private void skipRows(int count) {
+        int remaining = count;
+        while (remaining > 0) {
+            if (ensurePage() == false) {
+                break;
+            }
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNullSkipped = defDecoder.skip(fromPage);
+            skipValues(nonNullSkipped);
+            advancePosition(fromPage);
+            remaining -= fromPage;
+        }
+    }
+
+    private void skipValues(int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.skip(nonNullCount);
+        } else {
+            skipPlainValues(nonNullCount);
+        }
+    }
+
+    private void skipPlainValues(int count) {
+        switch (info.parquetType()) {
+            case INT32 -> plainDecoder.skipInts(count);
+            case INT64 -> plainDecoder.skipLongs(count);
+            case FLOAT -> plainDecoder.skipFloats(count);
+            case DOUBLE -> plainDecoder.skipDoubles(count);
+            case BOOLEAN -> plainDecoder.skipBooleans(count);
+            case BINARY -> plainDecoder.skipBinaries(count);
+            case FIXED_LEN_BYTE_ARRAY -> plainDecoder.skipFixedBinaries(count, descriptor.getPrimitiveType().getTypeLength());
+            case INT96 -> plainDecoder.skipFixedBinaries(count, 12);
+            default -> throw new QlIllegalArgumentException("Unsupported Parquet type for skip: " + info.parquetType());
+        }
+    }
+
+    // --- Boolean ---
+
+    private Block readBooleanBatch(int maxRows, BlockFactory blockFactory) {
+        boolean[] values = new boolean[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = readNonNullBooleans(values, 0, maxRows);
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readBooleanValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(values, produced, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private int readNonNullBooleans(boolean[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readBooleans(values, offset + produced, fromPage, dictionary);
+            } else {
+                plainDecoder.readBooleans(values, offset + produced, fromPage);
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readBooleanValues(boolean[] values, BitSet nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readBooleans(values, offset, nonNullCount, dictionary);
+            } else {
+                plainDecoder.readBooleans(values, offset, nonNullCount);
+            }
+            return;
+        }
+        boolean[] packed = new boolean[nonNullCount];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBooleans(packed, 0, nonNullCount, dictionary);
+        } else {
+            plainDecoder.readBooleans(packed, 0, nonNullCount);
+        }
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Int ---
+
+    private Block readIntBatch(int maxRows, BlockFactory blockFactory) {
+        int[] values = new int[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = readNonNullInts(values, 0, maxRows);
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readIntValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(values, produced, null, nulls, Block.MvOrdering.UNORDERED);
+    }
+
+    private int readNonNullInts(int[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readInts(values, offset + produced, fromPage, dictionary);
+            } else {
+                plainDecoder.readInts(values, offset + produced, fromPage);
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readIntValues(int[] values, BitSet nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readInts(values, offset, nonNullCount, dictionary);
+            } else {
+                plainDecoder.readInts(values, offset, nonNullCount);
+            }
+            return;
+        }
+        int[] packed = new int[nonNullCount];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readInts(packed, 0, nonNullCount, dictionary);
+        } else {
+            plainDecoder.readInts(packed, 0, nonNullCount);
+        }
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Long ---
+
+    private Block readLongBatch(int maxRows, BlockFactory blockFactory) {
+        long[] values = new long[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = readNonNullLongs(values, 0, maxRows);
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readLongValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private int readNonNullLongs(long[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readLongs(values, offset + produced, fromPage, dictionary);
+            } else {
+                plainDecoder.readLongs(values, offset + produced, fromPage);
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readLongValues(long[] values, BitSet nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readLongs(values, offset, nonNullCount, dictionary);
+            } else {
+                plainDecoder.readLongs(values, offset, nonNullCount);
+            }
+            return;
+        }
+        long[] packed = new long[nonNullCount];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readLongs(packed, 0, nonNullCount, dictionary);
+        } else {
+            plainDecoder.readLongs(packed, 0, nonNullCount);
+        }
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Int32 widened to Long ---
+
+    private Block readInt32AsLongBatch(int maxRows, BlockFactory blockFactory) {
+        long[] values = new long[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = readNonNullInt32AsLong(values, 0, maxRows);
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readInt32AsLongValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private int readNonNullInt32AsLong(long[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int[] intValues = new int[fromPage];
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readInts(intValues, 0, fromPage, dictionary);
+            } else {
+                plainDecoder.readInts(intValues, 0, fromPage);
+            }
+            for (int i = 0; i < fromPage; i++) {
+                values[offset + produced + i] = intValues[i];
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readInt32AsLongValues(long[] values, BitSet nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        int[] intPacked = new int[nonNullCount];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readInts(intPacked, 0, nonNullCount, dictionary);
+        } else {
+            plainDecoder.readInts(intPacked, 0, nonNullCount);
+        }
+        long[] longPacked = new long[nonNullCount];
+        for (int i = 0; i < nonNullCount; i++) {
+            longPacked[i] = intPacked[i];
+        }
+        if (nonNullCount == totalRows) {
+            System.arraycopy(longPacked, 0, values, offset, nonNullCount);
+        } else {
+            scatter(longPacked, values, nulls, offset, totalRows);
+        }
+    }
+
+    // --- Double ---
+
+    private Block readDoubleBatch(int maxRows, BlockFactory blockFactory) {
+        LogicalTypeAnnotation logical = info.logicalType();
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
+            return readDecimalAsDoubleBatch(maxRows, decimal.getScale(), blockFactory);
+        }
+        if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+            return readFloat16Batch(maxRows, blockFactory);
+        }
+        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
+        double[] values = new double[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = readNonNullDoubles(values, 0, maxRows, isFloat);
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readDoubleValues(values, nulls, produced, fromPage, nonNull, isFloat);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private int readNonNullDoubles(double[] values, int offset, int maxRows, boolean isFloat) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (currentEncoding.usesDictionary()) {
+                if (isFloat) {
+                    dictDecoder.readFloats(values, offset + produced, fromPage, dictionary);
+                } else {
+                    dictDecoder.readDoubles(values, offset + produced, fromPage, dictionary);
+                }
+            } else {
+                if (isFloat) {
+                    plainDecoder.readFloats(values, offset + produced, fromPage);
+                } else {
+                    plainDecoder.readDoubles(values, offset + produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readDoubleValues(double[] values, BitSet nulls, int offset, int totalRows, int nonNullCount, boolean isFloat) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            if (currentEncoding.usesDictionary()) {
+                if (isFloat) {
+                    dictDecoder.readFloats(values, offset, nonNullCount, dictionary);
+                } else {
+                    dictDecoder.readDoubles(values, offset, nonNullCount, dictionary);
+                }
+            } else {
+                if (isFloat) {
+                    plainDecoder.readFloats(values, offset, nonNullCount);
+                } else {
+                    plainDecoder.readDoubles(values, offset, nonNullCount);
+                }
+            }
+            return;
+        }
+        double[] packed = new double[nonNullCount];
+        if (currentEncoding.usesDictionary()) {
+            if (isFloat) {
+                dictDecoder.readFloats(packed, 0, nonNullCount, dictionary);
+            } else {
+                dictDecoder.readDoubles(packed, 0, nonNullCount, dictionary);
+            }
+        } else {
+            if (isFloat) {
+                plainDecoder.readFloats(packed, 0, nonNullCount);
+            } else {
+                plainDecoder.readDoubles(packed, 0, nonNullCount);
+            }
+        }
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    private Block readDecimalAsDoubleBatch(int maxRows, int scale, BlockFactory blockFactory) {
+        double[] values = new double[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readDecimalValues(values, produced, fromPage, scale);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readDecimalValues(values, produced, nonNull, scale);
+                } else {
+                    double[] packed = new double[nonNull];
+                    readDecimalValues(packed, 0, nonNull, scale);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private void readDecimalValues(double[] values, int offset, int count, int scale) {
+        for (int i = 0; i < count; i++) {
+            BigInteger unscaled = switch (info.parquetType()) {
+                case INT32 -> {
+                    int[] tmp = new int[1];
+                    if (currentEncoding.usesDictionary()) {
+                        dictDecoder.readInts(tmp, 0, 1, dictionary);
+                    } else {
+                        plainDecoder.readInts(tmp, 0, 1);
+                    }
+                    yield BigInteger.valueOf(tmp[0]);
+                }
+                case INT64 -> {
+                    long[] tmp = new long[1];
+                    if (currentEncoding.usesDictionary()) {
+                        dictDecoder.readLongs(tmp, 0, 1, dictionary);
+                    } else {
+                        plainDecoder.readLongs(tmp, 0, 1);
+                    }
+                    yield BigInteger.valueOf(tmp[0]);
+                }
+                case BINARY, FIXED_LEN_BYTE_ARRAY -> {
+                    BytesRef[] tmp = new BytesRef[1];
+                    if (currentEncoding.usesDictionary()) {
+                        dictDecoder.readBinaries(tmp, 0, 1, dictionary);
+                    } else if (info.parquetType() == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+                        plainDecoder.readFixedBinaries(tmp, 0, 1, descriptor.getPrimitiveType().getTypeLength());
+                    } else {
+                        plainDecoder.readBinaries(tmp, 0, 1);
+                    }
+                    yield new BigInteger(tmp[0].bytes, tmp[0].offset, tmp[0].length);
+                }
+                default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
+            };
+            values[offset + i] = new BigDecimal(unscaled, scale).doubleValue();
+        }
+    }
+
+    private Block readFloat16Batch(int maxRows, BlockFactory blockFactory) {
+        double[] values = new double[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readFloat16Values(values, produced, fromPage);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readFloat16Values(values, produced, nonNull);
+                } else {
+                    double[] packed = new double[nonNull];
+                    readFloat16Values(packed, 0, nonNull);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.doubleColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private void readFloat16Values(double[] values, int offset, int count) {
+        BytesRef[] binaries = new BytesRef[count];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinaries(binaries, 0, count, dictionary);
+        } else {
+            plainDecoder.readFixedBinaries(binaries, 0, count, 2);
+        }
+        for (int i = 0; i < count; i++) {
+            byte[] bytes = binaries[i].bytes;
+            int off = binaries[i].offset;
+            short float16Bits = (short) ((bytes[off + 1] & 0xFF) << 8 | (bytes[off] & 0xFF));
+            values[offset + i] = Float.float16ToFloat(float16Bits);
+        }
+    }
+
+    // --- BytesRef (KEYWORD/TEXT) ---
+
+    private Block readBytesBatch(int maxRows, BlockFactory blockFactory) {
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        try (var builder = blockFactory.newBytesRefBlockBuilder(maxRows)) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                if (maxDefLevel == 0) {
+                    BytesRef[] vals = readBinaryValues(fromPage);
+                    for (int i = 0; i < fromPage; i++) {
+                        if (isUuid) {
+                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[i].bytes)));
+                        } else {
+                            builder.appendBytesRef(vals[i]);
+                        }
+                    }
+                } else {
+                    BitSet nulls = new BitSet(fromPage);
+                    int nonNull = defDecoder.readBatch(fromPage, nulls, 0);
+                    BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+                    int valIdx = 0;
+                    for (int i = 0; i < fromPage; i++) {
+                        if (nulls.get(i)) {
+                            builder.appendNull();
+                        } else if (isUuid) {
+                            builder.appendBytesRef(new BytesRef(OptimizedParquetColumnIterator.formatUuid(vals[valIdx++].bytes)));
+                        } else {
+                            builder.appendBytesRef(vals[valIdx++]);
+                        }
+                    }
+                }
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            return builder.build();
+        }
+    }
+
+    private BytesRef[] readBinaryValues(int count) {
+        BytesRef[] values = new BytesRef[count];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinaries(values, 0, count, dictionary);
+        } else if (info.parquetType() == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+            plainDecoder.readFixedBinaries(values, 0, count, descriptor.getPrimitiveType().getTypeLength());
+        } else {
+            plainDecoder.readBinaries(values, 0, count);
+        }
+        return values;
+    }
+
+    // --- Datetime ---
+
+    private Block readDatetimeBatch(int maxRows, BlockFactory blockFactory) {
+        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return readInt96Batch(maxRows, blockFactory);
+        }
+        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
+        long[] values = new long[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readDatetimeValues(values, produced, fromPage, isDate);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readDatetimeValues(values, produced, nonNull, isDate);
+                } else {
+                    long[] packed = new long[nonNull];
+                    readDatetimeValues(packed, 0, nonNull, isDate);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private void readDatetimeValues(long[] values, int offset, int count, boolean isDate) {
+        if (isDate) {
+            int[] intValues = new int[count];
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readInts(intValues, 0, count, dictionary);
+            } else {
+                plainDecoder.readInts(intValues, 0, count);
+            }
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = intValues[i] * MILLIS_PER_DAY;
+            }
+        } else {
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readLongs(values, offset, count, dictionary);
+            } else {
+                plainDecoder.readLongs(values, offset, count);
+            }
+            LogicalTypeAnnotation logicalType = info.logicalType();
+            if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+                switch (ts.getUnit()) {
+                    case MILLIS -> {
+                    } // no conversion needed
+                    case MICROS -> {
+                        for (int i = 0; i < count; i++) {
+                            values[offset + i] = values[offset + i] / 1_000;
+                        }
+                    }
+                    case NANOS -> {
+                        for (int i = 0; i < count; i++) {
+                            values[offset + i] = values[offset + i] / 1_000_000;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private Block readInt96Batch(int maxRows, BlockFactory blockFactory) {
+        long[] values = new long[maxRows];
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readInt96Values(values, produced, fromPage);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        BitSet nulls = new BitSet(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readInt96Values(values, produced, nonNull);
+                } else {
+                    long[] packed = new long[nonNull];
+                    readInt96Values(packed, 0, nonNull);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            return ColumnBlockConversions.longColumn(blockFactory, values, produced, true, false, null);
+        }
+        return ColumnBlockConversions.longColumn(blockFactory, values, produced, false, false, toBooleanArray(nulls, produced));
+    }
+
+    private void readInt96Values(long[] values, int offset, int count) {
+        BytesRef[] binaries = new BytesRef[count];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinaries(binaries, 0, count, dictionary);
+        } else {
+            plainDecoder.readFixedBinaries(binaries, 0, count, 12);
+        }
+        for (int i = 0; i < count; i++) {
+            ByteBuffer buf = ByteBuffer.wrap(binaries[i].bytes, binaries[i].offset, binaries[i].length).order(ByteOrder.LITTLE_ENDIAN);
+            long nanosOfDay = buf.getLong();
+            int julianDay = buf.getInt();
+            long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
+            values[offset + i] = epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
+        }
+    }
+
+    // --- Scatter utilities ---
+
+    private static void scatter(boolean[] packed, boolean[] output, BitSet nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(int[] packed, int[] output, BitSet nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(long[] packed, long[] output, BitSet nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(double[] packed, double[] output, BitSet nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static boolean[] toBooleanArray(BitSet nulls, int length) {
+        boolean[] result = new boolean[length];
+        for (int i = nulls.nextSetBit(0); i >= 0; i = nulls.nextSetBit(i + 1)) {
+            result[i] = true;
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetDataSourcePlugin.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,6 +40,17 @@ import java.util.Set;
  */
 public class ParquetDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
+    /**
+     * Node-level setting to enable the optimized Parquet reader pipeline.
+     * Can be overridden per-query via {@code WITH optimized_reader=true}.
+     */
+    public static final Setting<Boolean> OPTIMIZED_READER_SETTING = Setting.boolSetting(
+        "esql.parquet.optimized_reader",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     @Override
     public Set<FormatSpec> formatSpecs() {
         return Set.of(FormatSpec.of("parquet", ".parquet"));
@@ -45,6 +58,12 @@ public class ParquetDataSourcePlugin extends Plugin implements DataSourcePlugin 
 
     @Override
     public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
-        return Map.of("parquet", (s, blockFactory) -> new ParquetFormatReader(blockFactory));
+        boolean optimizedReader = OPTIMIZED_READER_SETTING.get(settings);
+        return Map.of("parquet", (s, blockFactory) -> new ParquetFormatReader(blockFactory, optimizedReader));
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(OPTIMIZED_READER_SETTING);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -364,7 +364,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int batchSize = context.batchSize();
         int rowLimit = context.rowLimit();
 
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
         FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
         ParquetReadOptions.Builder optionsBuilder = readOptionsBuilder();
         if (FilterCompat.isFilteringRequired(recordFilter)) {
@@ -411,7 +411,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 preloadedMetadata,
                 pushedExpressions,
                 pageLevelReader,
-                lateMaterialization
+                lateMaterialization,
+                object,
+                parquetInputFile
             );
         }
         return new ParquetColumnIterator(
@@ -544,7 +546,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         List<Attribute> resolvedAttributes,
         ErrorPolicy errorPolicy
     ) throws IOException {
-        InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
+        ParquetStorageObjectAdapter parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
         ParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd);
         if (FilterCompat.isFilteringRequired(recordFilter)) {
@@ -593,7 +595,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 preloadedMetadata,
                 pushedExpressions,
                 pageLevelReader,
-                lateMaterialization
+                lateMaterialization,
+                object,
+                parquetInputFile
             );
         }
         return new ParquetColumnIterator(

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -98,21 +98,27 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     private final ParquetPushedExpressions pushedExpressions;
     private final boolean optimizedReader;
     private final boolean pageLevelReader;
+    private final boolean lateMaterialization;
 
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
     static final String OPTIMIZED_READER_CONFIG_KEY = "optimized_reader";
     static final String PAGE_LEVEL_READER_CONFIG_KEY = "page_level_reader";
+    static final String LATE_MATERIALIZATION_CONFIG_KEY = "late_materialization";
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false, false);
+        this(blockFactory, FilterCompat.NOOP, null, false, false, false);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
-        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, false);
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, false, false);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader, boolean pageLevelReader) {
-        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, pageLevelReader);
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, pageLevelReader, false);
+    }
+
+    ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader, boolean pageLevelReader, boolean lateMaterialization) {
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, pageLevelReader, lateMaterialization);
     }
 
     private ParquetFormatReader(
@@ -120,22 +126,24 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         FilterCompat.Filter pushedFilter,
         ParquetPushedExpressions pushedExpressions,
         boolean optimizedReader,
-        boolean pageLevelReader
+        boolean pageLevelReader,
+        boolean lateMaterialization
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
         this.optimizedReader = optimizedReader;
         this.pageLevelReader = pageLevelReader;
+        this.lateMaterialization = lateMaterialization;
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null, optimizedReader, pageLevelReader);
+            return new ParquetFormatReader(blockFactory, filter, null, optimizedReader, pageLevelReader, lateMaterialization);
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
-            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, optimizedReader, pageLevelReader);
+            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, optimizedReader, pageLevelReader, lateMaterialization);
         }
         return this;
     }
@@ -147,6 +155,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
         boolean newOptimized = this.optimizedReader;
         boolean newPageLevel = this.pageLevelReader;
+        boolean newLateMat = this.lateMaterialization;
         Object optValue = config.get(OPTIMIZED_READER_CONFIG_KEY);
         if (optValue != null) {
             newOptimized = optValue instanceof Boolean b ? b : Booleans.parseBoolean(optValue.toString());
@@ -155,10 +164,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         if (pageValue != null) {
             newPageLevel = pageValue instanceof Boolean b ? b : Booleans.parseBoolean(pageValue.toString());
         }
-        if (newOptimized == this.optimizedReader && newPageLevel == this.pageLevelReader) {
+        Object lateMatValue = config.get(LATE_MATERIALIZATION_CONFIG_KEY);
+        if (lateMatValue != null) {
+            newLateMat = lateMatValue instanceof Boolean b ? b : Booleans.parseBoolean(lateMatValue.toString());
+        }
+        if (newOptimized == this.optimizedReader && newPageLevel == this.pageLevelReader && newLateMat == this.lateMaterialization) {
             return this;
         }
-        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, newOptimized, newPageLevel);
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, newOptimized, newPageLevel, newLateMat);
     }
 
     @Override
@@ -397,7 +410,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 columnInfos,
                 preloadedMetadata,
                 pushedExpressions,
-                pageLevelReader
+                pageLevelReader,
+                lateMaterialization
             );
         }
         return new ParquetColumnIterator(
@@ -578,7 +592,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 columnInfos,
                 preloadedMetadata,
                 pushedExpressions,
-                pageLevelReader
+                pageLevelReader,
+                lateMaterialization
             );
         }
         return new ParquetColumnIterator(

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -367,7 +367,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
         FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
         ParquetReadOptions.Builder optionsBuilder = readOptionsBuilder();
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
+        boolean skipParquetFilter = optimizedReader && pageLevelReader && pushedExpressions != null;
+        if (FilterCompat.isFilteringRequired(recordFilter) && skipParquetFilter == false) {
             optionsBuilder.withRecordFilter(recordFilter);
         }
         ParquetReadOptions options = optionsBuilder.build();
@@ -549,7 +550,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ParquetStorageObjectAdapter parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
         ParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd);
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
+        boolean skipParquetFilter = optimizedReader && pageLevelReader && pushedExpressions != null;
+        if (FilterCompat.isFilteringRequired(recordFilter) && skipParquetFilter == false) {
             optionsBuilder.withRecordFilter(recordFilter);
         }
         ParquetReadOptions options = optionsBuilder.build();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -97,37 +97,45 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     private final FilterCompat.Filter pushedFilter;
     private final ParquetPushedExpressions pushedExpressions;
     private final boolean optimizedReader;
+    private final boolean pageLevelReader;
 
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
     static final String OPTIMIZED_READER_CONFIG_KEY = "optimized_reader";
+    static final String PAGE_LEVEL_READER_CONFIG_KEY = "page_level_reader";
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false);
+        this(blockFactory, FilterCompat.NOOP, null, false, false);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
-        this(blockFactory, FilterCompat.NOOP, null, optimizedReader);
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, false);
+    }
+
+    ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader, boolean pageLevelReader) {
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader, pageLevelReader);
     }
 
     private ParquetFormatReader(
         BlockFactory blockFactory,
         FilterCompat.Filter pushedFilter,
         ParquetPushedExpressions pushedExpressions,
-        boolean optimizedReader
+        boolean optimizedReader,
+        boolean pageLevelReader
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
         this.optimizedReader = optimizedReader;
+        this.pageLevelReader = pageLevelReader;
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null, optimizedReader);
+            return new ParquetFormatReader(blockFactory, filter, null, optimizedReader, pageLevelReader);
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
-            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, optimizedReader);
+            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, optimizedReader, pageLevelReader);
         }
         return this;
     }
@@ -137,20 +145,20 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         if (config == null || config.isEmpty()) {
             return this;
         }
-        Object value = config.get(OPTIMIZED_READER_CONFIG_KEY);
-        if (value == null) {
+        boolean newOptimized = this.optimizedReader;
+        boolean newPageLevel = this.pageLevelReader;
+        Object optValue = config.get(OPTIMIZED_READER_CONFIG_KEY);
+        if (optValue != null) {
+            newOptimized = optValue instanceof Boolean b ? b : Booleans.parseBoolean(optValue.toString());
+        }
+        Object pageValue = config.get(PAGE_LEVEL_READER_CONFIG_KEY);
+        if (pageValue != null) {
+            newPageLevel = pageValue instanceof Boolean b ? b : Booleans.parseBoolean(pageValue.toString());
+        }
+        if (newOptimized == this.optimizedReader && newPageLevel == this.pageLevelReader) {
             return this;
         }
-        boolean enabled;
-        if (value instanceof Boolean b) {
-            enabled = b;
-        } else {
-            enabled = Booleans.parseBoolean(value.toString());
-        }
-        if (enabled == this.optimizedReader) {
-            return this;
-        }
-        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, enabled);
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, newOptimized, newPageLevel);
     }
 
     @Override
@@ -376,6 +384,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         String createdBy = fileMetaData.getCreatedBy();
         if (optimizedReader) {
             ColumnInfo[] columnInfos = buildColumnInfos(reader, projectedSchema, projectedAttributes, object.path().toString());
+            PreloadedRowGroupMetadata preloadedMetadata = PreloadedRowGroupMetadata.preload(reader, object);
             return new OptimizedParquetColumnIterator(
                 reader,
                 projectedSchema,
@@ -386,7 +395,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 createdBy,
                 object.path().toString(),
                 columnInfos,
-                PreloadedRowGroupMetadata.empty()
+                preloadedMetadata,
+                pushedExpressions,
+                pageLevelReader
             );
         }
         return new ParquetColumnIterator(
@@ -530,8 +541,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         FileMetaData fileMetaData = reader.getFileMetaData();
         MessageType parquetSchema = fileMetaData.getSchema();
-        // The framework passes planning-time resolved attributes for this query (AsyncExternalSourceOperatorFactory).
-        // Reuse them to avoid redundant schema conversion work per split. We still read Parquet metadata to drive row groups.
         final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
             ? resolvedAttributes
             : convertParquetSchemaToAttributes(parquetSchema);
@@ -556,6 +565,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         String createdBy = fileMetaData.getCreatedBy();
         if (optimizedReader) {
             ColumnInfo[] columnInfos = buildColumnInfos(reader, projectedSchema, projectedAttributes, object.path().toString());
+            PreloadedRowGroupMetadata preloadedMetadata = PreloadedRowGroupMetadata.preload(reader, object);
             return new OptimizedParquetColumnIterator(
                 reader,
                 projectedSchema,
@@ -566,7 +576,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 createdBy,
                 object.path().toString(),
                 columnInfos,
-                PreloadedRowGroupMetadata.empty()
+                preloadedMetadata,
+                pushedExpressions,
+                pageLevelReader
             );
         }
         return new ParquetColumnIterator(

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -95,28 +96,61 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     private final BlockFactory blockFactory;
     private final FilterCompat.Filter pushedFilter;
     private final ParquetPushedExpressions pushedExpressions;
+    private final boolean optimizedReader;
 
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
+    static final String OPTIMIZED_READER_CONFIG_KEY = "optimized_reader";
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null);
+        this(blockFactory, FilterCompat.NOOP, null, false);
     }
 
-    private ParquetFormatReader(BlockFactory blockFactory, FilterCompat.Filter pushedFilter, ParquetPushedExpressions pushedExpressions) {
+    ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
+        this(blockFactory, FilterCompat.NOOP, null, optimizedReader);
+    }
+
+    private ParquetFormatReader(
+        BlockFactory blockFactory,
+        FilterCompat.Filter pushedFilter,
+        ParquetPushedExpressions pushedExpressions,
+        boolean optimizedReader
+    ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
+        this.optimizedReader = optimizedReader;
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null);
+            return new ParquetFormatReader(blockFactory, filter, null, optimizedReader);
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
-            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs);
+            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, optimizedReader);
         }
         return this;
+    }
+
+    @Override
+    public ParquetFormatReader withConfig(Map<String, Object> config) {
+        if (config == null || config.isEmpty()) {
+            return this;
+        }
+        Object value = config.get(OPTIMIZED_READER_CONFIG_KEY);
+        if (value == null) {
+            return this;
+        }
+        boolean enabled;
+        if (value instanceof Boolean b) {
+            enabled = b;
+        } else {
+            enabled = Booleans.parseBoolean(value.toString());
+        }
+        if (enabled == this.optimizedReader) {
+            return this;
+        }
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, enabled);
     }
 
     @Override
@@ -340,6 +374,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
         String createdBy = fileMetaData.getCreatedBy();
+        if (optimizedReader) {
+            ColumnInfo[] columnInfos = buildColumnInfos(reader, projectedSchema, projectedAttributes, object.path().toString());
+            return new OptimizedParquetColumnIterator(
+                reader,
+                projectedSchema,
+                projectedAttributes,
+                batchSize,
+                blockFactory,
+                rowLimit,
+                createdBy,
+                object.path().toString(),
+                columnInfos,
+                PreloadedRowGroupMetadata.empty()
+            );
+        }
         return new ParquetColumnIterator(
             reader,
             projectedSchema,
@@ -505,6 +554,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
         String createdBy = fileMetaData.getCreatedBy();
+        if (optimizedReader) {
+            ColumnInfo[] columnInfos = buildColumnInfos(reader, projectedSchema, projectedAttributes, object.path().toString());
+            return new OptimizedParquetColumnIterator(
+                reader,
+                projectedSchema,
+                projectedAttributes,
+                batchSize,
+                blockFactory,
+                NO_LIMIT,
+                createdBy,
+                object.path().toString(),
+                columnInfos,
+                PreloadedRowGroupMetadata.empty()
+            );
+        }
         return new ParquetColumnIterator(
             reader,
             projectedSchema,
@@ -789,7 +853,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             columnReaders = new ColumnReader[columnInfos.length];
             for (int i = 0; i < columnInfos.length; i++) {
                 if (columnInfos[i] != null) {
-                    columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor);
+                    columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
                 }
             }
             return rowsRemainingInGroup > 0;
@@ -863,17 +927,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead) {
-            if (info.maxRepLevel > 0) {
+            if (info.maxRepLevel() > 0) {
                 return readListColumn(cr, info, rowsToRead);
             }
-            return switch (info.esqlType) {
-                case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel, rowsToRead);
-                case INTEGER -> readIntColumn(cr, info.maxDefLevel, rowsToRead);
+            return switch (info.esqlType()) {
+                case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel(), rowsToRead);
+                case INTEGER -> readIntColumn(cr, info.maxDefLevel(), rowsToRead);
                 case LONG -> {
-                    if (info.parquetType == PrimitiveType.PrimitiveTypeName.INT32) {
-                        yield readInt32WidenedToLongColumn(cr, info.maxDefLevel, rowsToRead);
+                    if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                        yield readInt32WidenedToLongColumn(cr, info.maxDefLevel(), rowsToRead);
                     }
-                    yield readLongColumn(cr, info.maxDefLevel, rowsToRead);
+                    yield readLongColumn(cr, info.maxDefLevel(), rowsToRead);
                 }
                 case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
                 case KEYWORD, TEXT -> readBytesRefColumn(cr, info, rowsToRead);
@@ -959,19 +1023,19 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readDoubleColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            LogicalTypeAnnotation logical = info.logicalType;
+            LogicalTypeAnnotation logical = info.logicalType();
             if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
                 return readDecimalAsDoubleColumn(cr, info, decimal.getScale(), rows);
             }
             if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
-                return readFloat16Column(cr, info.maxDefLevel, rows);
+                return readFloat16Column(cr, info.maxDefLevel(), rows);
             }
             double[] values = new double[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isFloat = info.parquetType == PrimitiveType.PrimitiveTypeName.FLOAT;
+            boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else {
@@ -984,18 +1048,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private Block readDecimalAsDoubleColumn(ColumnReader cr, ColumnInfo info, int scale, int rows) {
             double[] values = new double[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else {
-                    BigInteger unscaled = switch (info.parquetType) {
+                    BigInteger unscaled = switch (info.parquetType()) {
                         case INT32 -> BigInteger.valueOf(cr.getInteger());
                         case INT64 -> BigInteger.valueOf(cr.getLong());
                         case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
-                        default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType);
+                        default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
                     };
                     values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
                 }
@@ -1023,10 +1087,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            boolean isUuid = info.logicalType instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+            boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
             try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
                 for (int i = 0; i < rows; i++) {
-                    if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                    if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                         builder.appendNull();
                     } else if (isUuid) {
                         builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
@@ -1040,22 +1104,22 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            if (info.parquetType == PrimitiveType.PrimitiveTypeName.INT96) {
-                return readInt96TimestampColumn(cr, info.maxDefLevel, rows);
+            if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+                return readInt96TimestampColumn(cr, info.maxDefLevel(), rows);
             }
             long[] values = new long[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isDate = info.parquetType == PrimitiveType.PrimitiveTypeName.INT32;
+            boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else if (isDate) {
                     values[i] = cr.getInteger() * MILLIS_PER_DAY;
                 } else {
                     long raw = cr.getLong();
-                    values[i] = convertTimestampToMillis(raw, info.logicalType);
+                    values[i] = convertTimestampToMillis(raw, info.logicalType());
                 }
                 cr.consume();
             }
@@ -1104,8 +1168,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
          * null elements within lists correctly.
          */
         private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            DataType elementType = info.esqlType;
-            int maxDef = info.maxDefLevel;
+            DataType elementType = info.esqlType();
+            int maxDef = info.maxDefLevel();
             return switch (elementType) {
                 case INTEGER -> readListIntColumn(cr, maxDef, rows);
                 case LONG -> readListLongColumn(cr, maxDef, rows);
@@ -1330,16 +1394,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
             try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-                int maxDef = info.maxDefLevel;
+                int maxDef = info.maxDefLevel();
                 for (int row = 0; row < rows; row++) {
                     int def = cr.getCurrentDefinitionLevel();
                     if (def >= maxDef) {
                         builder.beginPositionEntry();
-                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                         cr.consume();
                         while (cr.getCurrentRepetitionLevel() > 0) {
                             if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                             }
                             cr.consume();
                         }
@@ -1353,7 +1417,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                                     builder.beginPositionEntry();
                                     hasValues = true;
                                 }
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                             }
                             cr.consume();
                         }
@@ -1396,14 +1460,42 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
     }
 
-    private record ColumnInfo(
-        ColumnDescriptor descriptor,
-        PrimitiveType.PrimitiveTypeName parquetType,
-        DataType esqlType,
-        int maxDefLevel,
-        int maxRepLevel,
-        LogicalTypeAnnotation logicalType
-    ) {}
+    /**
+     * Builds column metadata array for both baseline and optimized iterators.
+     * Validates planner types against the file schema and nulls out incompatible columns.
+     */
+    static ColumnInfo[] buildColumnInfos(
+        ParquetFileReader reader,
+        MessageType projectedSchema,
+        List<Attribute> attributes,
+        String fileLocation
+    ) {
+        ColumnInfo[] columnInfos = new ColumnInfo[attributes.size()];
+        Map<String, ColumnDescriptor> descByName = new HashMap<>();
+        for (ColumnDescriptor desc : projectedSchema.getColumns()) {
+            descByName.put(desc.getPath()[0], desc);
+        }
+        for (int i = 0; i < attributes.size(); i++) {
+            Attribute attr = attributes.get(i);
+            if (attr.dataType() == DataType.NULL || attr.dataType() == DataType.UNSUPPORTED) {
+                continue;
+            }
+            ColumnDescriptor desc = descByName.get(attr.name());
+            if (desc != null) {
+                LogicalTypeAnnotation logicalType = desc.getPrimitiveType().getLogicalTypeAnnotation();
+                columnInfos[i] = new ColumnInfo(
+                    desc,
+                    desc.getPrimitiveType().getPrimitiveTypeName(),
+                    attr.dataType(),
+                    desc.getMaxDefinitionLevel(),
+                    desc.getMaxRepetitionLevel(),
+                    logicalType
+                );
+            }
+        }
+        validatePlannerTypesAgainstFile(logger, fileLocation, reader, attributes, columnInfos);
+        return columnInfos;
+    }
 
     /**
      * Minimal GroupConverter that satisfies {@link ColumnReadStoreImpl}'s constructor.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -17,6 +17,12 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -41,8 +47,10 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -417,6 +425,42 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             return ne.name().equals(columnName);
         }
         return false;
+    }
+
+    /**
+     * Returns the set of column names referenced by any pushed expression. Used by late materialization
+     * (Stage 4) to classify columns into predicate (referenced in filter) vs projection-only.
+     */
+    Set<String> predicateColumnNames() {
+        Set<String> result = new HashSet<>();
+        for (Expression expr : expressions) {
+            collectColumnNames(expr, result);
+        }
+        return result;
+    }
+
+    private static void collectColumnNames(Expression expr, Set<String> names) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof And and) {
+            collectColumnNames(and.left(), names);
+            collectColumnNames(and.right(), names);
+        } else if (expr instanceof Or or) {
+            collectColumnNames(or.left(), names);
+            collectColumnNames(or.right(), names);
+        } else if (expr instanceof Not not) {
+            collectColumnNames(not.field(), names);
+        } else if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        }
     }
 
     /**
@@ -988,5 +1032,381 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             }
         }
         return Integer.compare(aLen, bLen);
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Block-level predicate evaluation (Stage 4: late materialization)
+    // -----------------------------------------------------------------------------------
+
+    /**
+     * Evaluates all pushed expressions against decoded predicate Blocks, producing a boolean mask
+     * of surviving rows. All expressions are AND-combined. RECHECK semantics: conservative
+     * evaluation — if an expression cannot be evaluated (unsupported type or structure), all rows
+     * are treated as surviving for that expression.
+     *
+     * @param predicateBlocks map of column name to decoded Block for predicate columns
+     * @param rowCount number of rows in the batch
+     * @return boolean array where {@code true} = row survives all predicates, or null if all rows survive
+     */
+    boolean[] evaluateFilter(Map<String, Block> predicateBlocks, int rowCount) {
+        boolean[] survivors = null;
+        for (Expression expr : expressions) {
+            boolean[] exprResult = evaluateExpression(expr, predicateBlocks, rowCount);
+            if (exprResult == null) {
+                continue;
+            }
+            if (survivors == null) {
+                survivors = exprResult;
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    survivors[i] = survivors[i] && exprResult[i];
+                }
+            }
+        }
+        return survivors;
+    }
+
+    private boolean[] evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            Object literal = literalValueOf(bc.right());
+            if (literal == null) {
+                return null;
+            }
+            return evaluateComparison(bc, block, literal, rowCount);
+        }
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateIn(inExpr, block, rowCount);
+        }
+        if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            boolean[] result = new boolean[rowCount];
+            for (int i = 0; i < rowCount; i++) {
+                result[i] = block.isNull(i);
+            }
+            return result;
+        }
+        if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            boolean[] result = new boolean[rowCount];
+            for (int i = 0; i < rowCount; i++) {
+                result[i] = block.isNull(i) == false;
+            }
+            return result;
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateRange(range, block, rowCount);
+        }
+        if (expr instanceof And and) {
+            boolean[] left = evaluateExpression(and.left(), blocks, rowCount);
+            boolean[] right = evaluateExpression(and.right(), blocks, rowCount);
+            if (left == null) return right;
+            if (right == null) return left;
+            for (int i = 0; i < rowCount; i++) {
+                left[i] = left[i] && right[i];
+            }
+            return left;
+        }
+        if (expr instanceof Or or) {
+            boolean[] left = evaluateExpression(or.left(), blocks, rowCount);
+            boolean[] right = evaluateExpression(or.right(), blocks, rowCount);
+            if (left == null || right == null) return null;
+            for (int i = 0; i < rowCount; i++) {
+                left[i] = left[i] || right[i];
+            }
+            return left;
+        }
+        if (expr instanceof Not not) {
+            boolean[] inner = evaluateExpression(not.field(), blocks, rowCount);
+            if (inner == null) return null;
+            for (int i = 0; i < rowCount; i++) {
+                inner[i] = !inner[i];
+            }
+            return inner;
+        }
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateStartsWith(sw, block, rowCount);
+        }
+        return null;
+    }
+
+    private boolean[] evaluateComparison(EsqlBinaryComparison bc, Block block, Object literal, int rowCount) {
+        boolean[] result = new boolean[rowCount];
+        DataType dt = bc.left().dataType();
+
+        if (block instanceof LongBlock lb) {
+            long litVal = toLongValue(literal, dt);
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    result[i] = compareResult(Long.compare(lb.getLong(lb.getFirstValueIndex(i)), litVal), bc);
+                }
+            }
+        } else if (block instanceof IntBlock ib) {
+            int litVal = ((Number) literal).intValue();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    result[i] = compareResult(Integer.compare(ib.getInt(ib.getFirstValueIndex(i)), litVal), bc);
+                }
+            }
+        } else if (block instanceof DoubleBlock db) {
+            double litVal = ((Number) literal).doubleValue();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    result[i] = compareResult(Double.compare(db.getDouble(db.getFirstValueIndex(i)), litVal), bc);
+                }
+            }
+        } else if (block instanceof BytesRefBlock bb) {
+            BytesRef litBytes = toByteRef(literal);
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    result[i] = compareResult(bb.getBytesRef(bb.getFirstValueIndex(i), scratch).compareTo(litBytes), bc);
+                }
+            }
+        } else if (block instanceof BooleanBlock boolBlock) {
+            boolean litVal = (Boolean) literal;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    result[i] = compareResult(Boolean.compare(boolBlock.getBoolean(boolBlock.getFirstValueIndex(i)), litVal), bc);
+                }
+            }
+        } else {
+            Arrays.fill(result, true);
+        }
+        return result;
+    }
+
+    private static long toLongValue(Object literal, DataType dt) {
+        if (literal instanceof Number n) {
+            return n.longValue();
+        }
+        return 0L;
+    }
+
+    private static BytesRef toByteRef(Object literal) {
+        if (literal instanceof BytesRef br) {
+            return br;
+        }
+        if (literal instanceof String s) {
+            return new BytesRef(s);
+        }
+        return new BytesRef(literal.toString());
+    }
+
+    private static boolean compareResult(int cmp, EsqlBinaryComparison bc) {
+        if (bc instanceof Equals) return cmp == 0;
+        if (bc instanceof NotEquals) return cmp != 0;
+        if (bc instanceof LessThan) return cmp < 0;
+        if (bc instanceof LessThanOrEqual) return cmp <= 0;
+        if (bc instanceof GreaterThan) return cmp > 0;
+        if (bc instanceof GreaterThanOrEqual) return cmp >= 0;
+        return true;
+    }
+
+    private boolean[] evaluateIn(In inExpr, Block block, int rowCount) {
+        boolean[] result = new boolean[rowCount];
+        List<Object> litValues = new ArrayList<>();
+        for (Expression option : inExpr.list()) {
+            if (option.foldable()) {
+                Object v = literalValueOf(option);
+                if (v != null) {
+                    litValues.add(v);
+                }
+            }
+        }
+        if (litValues.isEmpty()) {
+            Arrays.fill(result, true);
+            return result;
+        }
+
+        if (block instanceof LongBlock lb) {
+            DataType dt = inExpr.value().dataType();
+            long[] litLongs = new long[litValues.size()];
+            for (int j = 0; j < litValues.size(); j++) {
+                litLongs[j] = toLongValue(litValues.get(j), dt);
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    long val = lb.getLong(lb.getFirstValueIndex(i));
+                    boolean match = false;
+                    for (long lv : litLongs) {
+                        if (val == lv) {
+                            match = true;
+                            break;
+                        }
+                    }
+                    result[i] = match;
+                }
+            }
+        } else if (block instanceof IntBlock ib) {
+            int[] litInts = new int[litValues.size()];
+            for (int j = 0; j < litValues.size(); j++) {
+                litInts[j] = ((Number) litValues.get(j)).intValue();
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    int val = ib.getInt(ib.getFirstValueIndex(i));
+                    boolean match = false;
+                    for (int lv : litInts) {
+                        if (val == lv) {
+                            match = true;
+                            break;
+                        }
+                    }
+                    result[i] = match;
+                }
+            }
+        } else if (block instanceof BytesRefBlock bb) {
+            BytesRef[] litBytes = new BytesRef[litValues.size()];
+            for (int j = 0; j < litValues.size(); j++) {
+                litBytes[j] = toByteRef(litValues.get(j));
+            }
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    BytesRef val = bb.getBytesRef(bb.getFirstValueIndex(i), scratch);
+                    boolean match = false;
+                    for (BytesRef lv : litBytes) {
+                        if (val.bytesEquals(lv)) {
+                            match = true;
+                            break;
+                        }
+                    }
+                    result[i] = match;
+                }
+            }
+        } else {
+            Arrays.fill(result, true);
+        }
+        return result;
+    }
+
+    private boolean[] evaluateRange(Range range, Block block, int rowCount) {
+        boolean[] result = new boolean[rowCount];
+        Object lowerVal = range.lower().foldable() ? literalValueOf(range.lower()) : null;
+        Object upperVal = range.upper().foldable() ? literalValueOf(range.upper()) : null;
+        if (lowerVal == null && upperVal == null) {
+            Arrays.fill(result, true);
+            return result;
+        }
+
+        if (block instanceof LongBlock lb) {
+            DataType dt = range.value().dataType();
+            long lower = lowerVal != null ? toLongValue(lowerVal, dt) : Long.MIN_VALUE;
+            long upper = upperVal != null ? toLongValue(upperVal, dt) : Long.MAX_VALUE;
+            boolean includeLower = range.includeLower();
+            boolean includeUpper = range.includeUpper();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    long val = lb.getLong(lb.getFirstValueIndex(i));
+                    result[i] = (includeLower ? val >= lower : val > lower) && (includeUpper ? val <= upper : val < upper);
+                }
+            }
+        } else if (block instanceof IntBlock ib) {
+            int lower = lowerVal != null ? ((Number) lowerVal).intValue() : Integer.MIN_VALUE;
+            int upper = upperVal != null ? ((Number) upperVal).intValue() : Integer.MAX_VALUE;
+            boolean includeLower = range.includeLower();
+            boolean includeUpper = range.includeUpper();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    int val = ib.getInt(ib.getFirstValueIndex(i));
+                    result[i] = (includeLower ? val >= lower : val > lower) && (includeUpper ? val <= upper : val < upper);
+                }
+            }
+        } else if (block instanceof DoubleBlock db) {
+            double lower = lowerVal != null ? ((Number) lowerVal).doubleValue() : Double.NEGATIVE_INFINITY;
+            double upper = upperVal != null ? ((Number) upperVal).doubleValue() : Double.POSITIVE_INFINITY;
+            boolean includeLower = range.includeLower();
+            boolean includeUpper = range.includeUpper();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    double val = db.getDouble(db.getFirstValueIndex(i));
+                    result[i] = (includeLower ? val >= lower : val > lower) && (includeUpper ? val <= upper : val < upper);
+                }
+            }
+        } else {
+            Arrays.fill(result, true);
+        }
+        return result;
+    }
+
+    private boolean[] evaluateStartsWith(StartsWith sw, Block block, int rowCount) {
+        boolean[] result = new boolean[rowCount];
+        if (sw.prefix().foldable() == false) {
+            Arrays.fill(result, true);
+            return result;
+        }
+        Object prefixObj = literalValueOf(sw.prefix());
+        BytesRef prefix = prefixObj instanceof BytesRef br ? br : null;
+        if (prefix == null) {
+            Arrays.fill(result, true);
+            return result;
+        }
+
+        if (block instanceof BytesRefBlock bb) {
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    result[i] = false;
+                } else {
+                    BytesRef val = bb.getBytesRef(bb.getFirstValueIndex(i), scratch);
+                    result[i] = val.length >= prefix.length
+                        && Arrays.equals(
+                            val.bytes,
+                            val.offset,
+                            val.offset + prefix.length,
+                            prefix.bytes,
+                            prefix.offset,
+                            prefix.offset + prefix.length
+                        );
+                }
+            }
+        } else {
+            Arrays.fill(result, true);
+        }
+        return result;
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -8,9 +8,11 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -35,6 +37,8 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Les
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -366,5 +370,623 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             return Binary.fromConstantByteArray(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         }
         return Binary.fromString(value.toString());
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Dictionary-based row group pruning (Stage 1)
+    // -----------------------------------------------------------------------------------
+
+    /**
+     * Returns true if any pushed expression references the given column name.
+     */
+    boolean referencesColumn(String columnName) {
+        for (Expression expr : expressions) {
+            if (expressionReferencesColumn(expr, columnName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean expressionReferencesColumn(Expression expr, String columnName) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof And and) {
+            return expressionReferencesColumn(and.left(), columnName) || expressionReferencesColumn(and.right(), columnName);
+        }
+        if (expr instanceof Or or) {
+            return expressionReferencesColumn(or.left(), columnName) || expressionReferencesColumn(or.right(), columnName);
+        }
+        if (expr instanceof Not not) {
+            return expressionReferencesColumn(not.field(), columnName);
+        }
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        return false;
+    }
+
+    /**
+     * Evaluates all pushed expressions that reference the given column against every dictionary
+     * value. Returns true if <em>no</em> dictionary value satisfies any of the column's predicates,
+     * meaning the row group can be safely skipped.
+     *
+     * <p>Only simple leaf predicates on the target column are evaluated (equality, comparison,
+     * IN, range, starts_with). Compound predicates (AND/OR/NOT) are not evaluated against the
+     * dictionary — they fall through to parquet-java's built-in filtering.
+     *
+     * @param columnName the Parquet column path (dot-separated)
+     * @param dictionary the decoded dictionary for this column chunk
+     * @param primitiveType the Parquet primitive type of the column
+     * @return true if the row group should be skipped
+     */
+    boolean allDictionaryValuesRejected(String columnName, Dictionary dictionary, PrimitiveType primitiveType) {
+        for (Expression expr : expressions) {
+            if (isSimpleColumnPredicate(expr, columnName)) {
+                if (noDictionaryValueMatches(expr, columnName, dictionary, primitiveType)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSimpleColumnPredicate(Expression expr, String columnName) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            return ne.name().equals(columnName);
+        }
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne && sw.prefix().foldable()) {
+            return ne.name().equals(columnName);
+        }
+        return false;
+    }
+
+    /**
+     * Tests whether every dictionary value is rejected by the given expression.
+     * Returns true only when we can prove no value matches — false means "might match"
+     * (safe fallback: don't skip).
+     */
+    private static boolean noDictionaryValueMatches(
+        Expression expr,
+        String columnName,
+        Dictionary dictionary,
+        PrimitiveType primitiveType
+    ) {
+        int dictSize = dictionary.getMaxId() + 1;
+        if (dictSize <= 0) {
+            return false;
+        }
+
+        if (expr instanceof Equals eq && eq.left() instanceof NamedExpression && eq.right().foldable()) {
+            Object target = literalValueOf(eq.right());
+            if (target == null) {
+                return false;
+            }
+            return noDictionaryValueEquals(dictionary, dictSize, primitiveType, target);
+        }
+
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression) {
+            Set<Object> targets = new HashSet<>();
+            for (Expression item : inExpr.list()) {
+                Object val = literalValueOf(item);
+                if (val != null) {
+                    targets.add(val);
+                }
+            }
+            if (targets.isEmpty()) {
+                return false;
+            }
+            return noDictionaryValueIn(dictionary, dictSize, primitiveType, targets);
+        }
+
+        if (expr instanceof NotEquals ne && ne.left() instanceof NamedExpression && ne.right().foldable()) {
+            Object target = literalValueOf(ne.right());
+            if (target == null) {
+                return false;
+            }
+            return allDictionaryValuesEqual(dictionary, dictSize, primitiveType, target);
+        }
+
+        if (expr instanceof GreaterThan gt && gt.left() instanceof NamedExpression && gt.right().foldable()) {
+            Object bound = literalValueOf(gt.right());
+            if (bound == null) {
+                return false;
+            }
+            return noDictionaryValueSatisfiesComparison(dictionary, dictSize, primitiveType, bound, PredicateOp.GT);
+        }
+        if (expr instanceof GreaterThanOrEqual gte && gte.left() instanceof NamedExpression && gte.right().foldable()) {
+            Object bound = literalValueOf(gte.right());
+            if (bound == null) {
+                return false;
+            }
+            return noDictionaryValueSatisfiesComparison(dictionary, dictSize, primitiveType, bound, PredicateOp.GTE);
+        }
+        if (expr instanceof LessThan lt && lt.left() instanceof NamedExpression && lt.right().foldable()) {
+            Object bound = literalValueOf(lt.right());
+            if (bound == null) {
+                return false;
+            }
+            return noDictionaryValueSatisfiesComparison(dictionary, dictSize, primitiveType, bound, PredicateOp.LT);
+        }
+        if (expr instanceof LessThanOrEqual lte && lte.left() instanceof NamedExpression && lte.right().foldable()) {
+            Object bound = literalValueOf(lte.right());
+            if (bound == null) {
+                return false;
+            }
+            return noDictionaryValueSatisfiesComparison(dictionary, dictSize, primitiveType, bound, PredicateOp.LTE);
+        }
+
+        if (expr instanceof Range range && range.value() instanceof NamedExpression) {
+            Object lower = literalValueOf(range.lower());
+            Object upper = literalValueOf(range.upper());
+            if (lower == null || upper == null) {
+                return false;
+            }
+            return noDictionaryValueInRange(dictionary, dictSize, primitiveType, lower, upper, range.includeLower(), range.includeUpper());
+        }
+
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression && sw.prefix().foldable()) {
+            Object prefixVal = literalValueOf(sw.prefix());
+            if (prefixVal == null) {
+                return false;
+            }
+            return noDictionaryValueStartsWith(dictionary, dictSize, (BytesRef) prefixVal);
+        }
+
+        return false;
+    }
+
+    private static boolean noDictionaryValueEquals(Dictionary dict, int size, PrimitiveType type, Object target) {
+        for (int i = 0; i < size; i++) {
+            if (dictionaryValueEquals(dict, i, type, target)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean noDictionaryValueIn(Dictionary dict, int size, PrimitiveType type, Set<Object> targets) {
+        for (int i = 0; i < size; i++) {
+            for (Object target : targets) {
+                if (dictionaryValueEquals(dict, i, type, target)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean allDictionaryValuesEqual(Dictionary dict, int size, PrimitiveType type, Object target) {
+        for (int i = 0; i < size; i++) {
+            if (dictionaryValueEquals(dict, i, type, target) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean noDictionaryValueSatisfiesComparison(
+        Dictionary dict,
+        int size,
+        PrimitiveType type,
+        Object bound,
+        PredicateOp op
+    ) {
+        for (int i = 0; i < size; i++) {
+            int cmp = compareDictionaryValue(dict, i, type, bound);
+            if (cmp == Integer.MIN_VALUE) {
+                return false;
+            }
+            boolean matches = switch (op) {
+                case GT -> cmp > 0;
+                case GTE -> cmp >= 0;
+                case LT -> cmp < 0;
+                case LTE -> cmp <= 0;
+                case EQ, NOT_EQ -> throw new IllegalArgumentException("Use noDictionaryValueEquals for EQ/NOT_EQ");
+            };
+            if (matches) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean noDictionaryValueInRange(
+        Dictionary dict,
+        int size,
+        PrimitiveType type,
+        Object lower,
+        Object upper,
+        boolean includeLower,
+        boolean includeUpper
+    ) {
+        for (int i = 0; i < size; i++) {
+            int cmpLower = compareDictionaryValue(dict, i, type, lower);
+            int cmpUpper = compareDictionaryValue(dict, i, type, upper);
+            if (cmpLower == Integer.MIN_VALUE || cmpUpper == Integer.MIN_VALUE) {
+                return false;
+            }
+            boolean aboveLower = includeLower ? cmpLower >= 0 : cmpLower > 0;
+            boolean belowUpper = includeUpper ? cmpUpper <= 0 : cmpUpper < 0;
+            if (aboveLower && belowUpper) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean noDictionaryValueStartsWith(Dictionary dict, int size, BytesRef prefix) {
+        for (int i = 0; i < size; i++) {
+            try {
+                Binary bin = dict.decodeToBinary(i);
+                byte[] bytes = bin.getBytes();
+                if (bytes.length >= prefix.length) {
+                    boolean match = true;
+                    for (int j = 0; j < prefix.length; j++) {
+                        if (bytes[j] != prefix.bytes[prefix.offset + j]) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        return false;
+                    }
+                }
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Compares a dictionary value at the given index against a target value.
+     * Returns negative if dict &lt; target, 0 if equal, positive if dict &gt; target.
+     * Returns {@link Integer#MIN_VALUE} if comparison is not possible.
+     *
+     * <p>For DATETIME columns, the target (ESQL epoch millis) is converted to the column's
+     * physical unit before comparison, since dictionary values are already in physical units.
+     */
+    private static int compareDictionaryValue(Dictionary dict, int index, PrimitiveType type, Object target) {
+        try {
+            LogicalTypeAnnotation logical = type.getLogicalTypeAnnotation();
+            return switch (type.getPrimitiveTypeName()) {
+                case INT32 -> {
+                    int dictVal = dict.decodeToInt(index);
+                    if ((target instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    int targetVal;
+                    if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+                        targetVal = (int) Math.floorDiv(((Number) target).longValue(), MILLIS_PER_DAY);
+                    } else {
+                        targetVal = ((Number) target).intValue();
+                    }
+                    yield Integer.compare(dictVal, targetVal);
+                }
+                case INT64 -> {
+                    long dictVal = dict.decodeToLong(index);
+                    if ((target instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    long targetVal;
+                    if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
+                        targetVal = convertMillisToPhysical(((Number) target).longValue(), logical);
+                    } else {
+                        targetVal = ((Number) target).longValue();
+                    }
+                    yield Long.compare(dictVal, targetVal);
+                }
+                case FLOAT -> {
+                    if ((target instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    yield Float.compare(dict.decodeToFloat(index), ((Number) target).floatValue());
+                }
+                case DOUBLE -> {
+                    if ((target instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    yield Double.compare(dict.decodeToDouble(index), ((Number) target).doubleValue());
+                }
+                case BINARY, FIXED_LEN_BYTE_ARRAY -> {
+                    Binary bin = dict.decodeToBinary(index);
+                    if (target instanceof BytesRef br) {
+                        yield compareBinaryToBytes(bin, br);
+                    }
+                    yield Integer.MIN_VALUE;
+                }
+                default -> Integer.MIN_VALUE;
+            };
+        } catch (Exception e) {
+            return Integer.MIN_VALUE;
+        }
+    }
+
+    private static boolean dictionaryValueEquals(Dictionary dict, int index, PrimitiveType type, Object target) {
+        return compareDictionaryValue(dict, index, type, target) == 0;
+    }
+
+    private static int compareBinaryToBytes(Binary bin, BytesRef bytesRef) {
+        byte[] binBytes = bin.getBytes();
+        return compareBytesUnsigned(binBytes, 0, binBytes.length, bytesRef.bytes, bytesRef.offset, bytesRef.length);
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Page-level skipping via ColumnIndex (Stage 2)
+    // -----------------------------------------------------------------------------------
+
+    /**
+     * Evaluates all pushed expressions referencing the given column against a single page's
+     * min/max from the ColumnIndex. Returns true if the page <em>might</em> contain matching
+     * rows (safe default: true). Returns false only when we can prove no row in the page
+     * can match.
+     *
+     * <p>Only simple leaf predicates are evaluated. Compound predicates (AND/OR/NOT) are
+     * conservatively treated as "might match" to avoid incorrect page skipping.
+     *
+     * <p>DATETIME columns are supported: ESQL epoch millis literals are converted to the
+     * column's physical unit (days for DATE/INT32, millis/micros/nanos for TIMESTAMP/INT64)
+     * before comparison against ColumnIndex bounds. INT96 timestamps are not evaluated
+     * (deprecated format, rarely has ColumnIndex). Overflow from extreme timestamps
+     * (e.g., nanos beyond ~year 2262) safely falls back to "might match".
+     *
+     * @param columnName the column path
+     * @param columnIndex the ColumnIndex for this column
+     * @param pageIndex the page ordinal within the column chunk
+     * @param primitiveType the Parquet primitive type
+     * @return true if the page might contain matching rows
+     */
+    boolean pageCanMatch(String columnName, ColumnIndex columnIndex, int pageIndex, PrimitiveType primitiveType) {
+        if (columnIndex.getNullPages().get(pageIndex)) {
+            return true;
+        }
+        for (Expression expr : expressions) {
+            if (isSimpleColumnPredicate(expr, columnName)) {
+                if (pageRejectedByMinMax(expr, columnName, columnIndex, pageIndex, primitiveType) == false) {
+                    continue;
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if the page's min/max proves no value can match the expression.
+     */
+    private static boolean pageRejectedByMinMax(
+        Expression expr,
+        String columnName,
+        ColumnIndex columnIndex,
+        int pageIndex,
+        PrimitiveType primitiveType
+    ) {
+        ByteBuffer minBuf = columnIndex.getMinValues().get(pageIndex);
+        ByteBuffer maxBuf = columnIndex.getMaxValues().get(pageIndex);
+
+        if (expr instanceof Equals eq && eq.left() instanceof NamedExpression && eq.right().foldable()) {
+            Object target = literalValueOf(eq.right());
+            if (target == null) {
+                return false;
+            }
+            int cmpMin = compareValueToPageBound(target, minBuf, primitiveType);
+            int cmpMax = compareValueToPageBound(target, maxBuf, primitiveType);
+            if (cmpMin == Integer.MIN_VALUE || cmpMax == Integer.MIN_VALUE) {
+                return false;
+            }
+            return cmpMin < 0 || cmpMax > 0;
+        }
+
+        if (expr instanceof NotEquals ne && ne.left() instanceof NamedExpression && ne.right().foldable()) {
+            Object target = literalValueOf(ne.right());
+            if (target == null) {
+                return false;
+            }
+            int cmpMin = compareValueToPageBound(target, minBuf, primitiveType);
+            int cmpMax = compareValueToPageBound(target, maxBuf, primitiveType);
+            if (cmpMin == Integer.MIN_VALUE || cmpMax == Integer.MIN_VALUE) {
+                return false;
+            }
+            return cmpMin == 0 && cmpMax == 0;
+        }
+
+        if (expr instanceof GreaterThan gt && gt.left() instanceof NamedExpression && gt.right().foldable()) {
+            return pageRejectedByOrderedComparison(literalValueOf(gt.right()), maxBuf, primitiveType, PredicateOp.GT);
+        }
+
+        if (expr instanceof GreaterThanOrEqual gte && gte.left() instanceof NamedExpression && gte.right().foldable()) {
+            return pageRejectedByOrderedComparison(literalValueOf(gte.right()), maxBuf, primitiveType, PredicateOp.GTE);
+        }
+
+        if (expr instanceof LessThan lt && lt.left() instanceof NamedExpression && lt.right().foldable()) {
+            return pageRejectedByOrderedComparison(literalValueOf(lt.right()), minBuf, primitiveType, PredicateOp.LT);
+        }
+
+        if (expr instanceof LessThanOrEqual lte && lte.left() instanceof NamedExpression && lte.right().foldable()) {
+            return pageRejectedByOrderedComparison(literalValueOf(lte.right()), minBuf, primitiveType, PredicateOp.LTE);
+        }
+
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression) {
+            for (Expression item : inExpr.list()) {
+                Object val = literalValueOf(item);
+                if (val == null) {
+                    return false;
+                }
+                int cmpMin = compareValueToPageBound(val, minBuf, primitiveType);
+                int cmpMax = compareValueToPageBound(val, maxBuf, primitiveType);
+                if (cmpMin == Integer.MIN_VALUE || cmpMax == Integer.MIN_VALUE) {
+                    return false;
+                }
+                if (cmpMin >= 0 && cmpMax <= 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if (expr instanceof Range range && range.value() instanceof NamedExpression) {
+            Object lower = literalValueOf(range.lower());
+            Object upper = literalValueOf(range.upper());
+            if (lower == null || upper == null) {
+                return false;
+            }
+            int upperVsMin = compareValueToPageBound(upper, minBuf, primitiveType);
+            int lowerVsMax = compareValueToPageBound(lower, maxBuf, primitiveType);
+            if (upperVsMin == Integer.MIN_VALUE || lowerVsMax == Integer.MIN_VALUE) {
+                return false;
+            }
+            boolean upperBelowMin = range.includeUpper() ? upperVsMin < 0 : upperVsMin <= 0;
+            boolean lowerAboveMax = range.includeLower() ? lowerVsMax > 0 : lowerVsMax >= 0;
+            return upperBelowMin || lowerAboveMax;
+        }
+
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression && sw.prefix().foldable()) {
+            Object prefixVal = literalValueOf(sw.prefix());
+            if (prefixVal == null) {
+                return false;
+            }
+            BytesRef prefix = (BytesRef) prefixVal;
+            BytesRef upperBound = StringPrefixUtils.nextPrefixUpperBound(prefix);
+            int prefixVsMax = compareValueToPageBound(prefix, maxBuf, primitiveType);
+            if (prefixVsMax == Integer.MIN_VALUE) {
+                return false;
+            }
+            if (prefixVsMax > 0) {
+                return true;
+            }
+            if (upperBound != null) {
+                int upperVsMin = compareValueToPageBound(upperBound, minBuf, primitiveType);
+                if (upperVsMin == Integer.MIN_VALUE) {
+                    return false;
+                }
+                return upperVsMin <= 0;
+            }
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if an ordered comparison (GT, GTE, LT, LTE) rejects a page based on its bound.
+     * For GT/GTE, the relevant bound is max (if value &gt;= max, no row can be greater).
+     * For LT/LTE, the relevant bound is min (if value &lt;= min, no row can be less).
+     */
+    private static boolean pageRejectedByOrderedComparison(Object value, ByteBuffer boundBuf, PrimitiveType primitiveType, PredicateOp op) {
+        if (value == null) {
+            return false;
+        }
+        int cmp = compareValueToPageBound(value, boundBuf, primitiveType);
+        if (cmp == Integer.MIN_VALUE) {
+            return false;
+        }
+        return switch (op) {
+            case GT -> cmp >= 0;
+            case GTE -> cmp > 0;
+            case LT -> cmp <= 0;
+            case LTE -> cmp < 0;
+            case EQ, NOT_EQ -> false;
+        };
+    }
+
+    /**
+     * Compares a predicate value against a page boundary (min or max) from the ColumnIndex.
+     * Returns negative if value &lt; bound, 0 if equal, positive if value &gt; bound.
+     * Returns {@link Integer#MIN_VALUE} if comparison is not possible.
+     *
+     * <p>ColumnIndex stores min/max as raw byte buffers in the column's physical encoding.
+     * For DATETIME columns, ESQL epoch millis are converted to the physical unit (days for
+     * DATE/INT32, millis/micros/nanos for TIMESTAMP/INT64) before comparison. Overflow from
+     * extreme timestamps safely returns {@link Integer#MIN_VALUE} ("can't compare" → "might match").
+     */
+    private static int compareValueToPageBound(Object value, ByteBuffer boundBuf, PrimitiveType primitiveType) {
+        try {
+            ByteBuffer buf = boundBuf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+            LogicalTypeAnnotation logical = primitiveType.getLogicalTypeAnnotation();
+            return switch (primitiveType.getPrimitiveTypeName()) {
+                case INT32 -> {
+                    int boundVal = buf.getInt();
+                    if ((value instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    int targetVal;
+                    if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+                        targetVal = (int) Math.floorDiv(((Number) value).longValue(), MILLIS_PER_DAY);
+                    } else {
+                        targetVal = ((Number) value).intValue();
+                    }
+                    yield Integer.compare(targetVal, boundVal);
+                }
+                case INT64 -> {
+                    long boundVal = buf.getLong();
+                    if ((value instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    long targetVal;
+                    if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
+                        targetVal = convertMillisToPhysical(((Number) value).longValue(), logical);
+                    } else {
+                        targetVal = ((Number) value).longValue();
+                    }
+                    yield Long.compare(targetVal, boundVal);
+                }
+                case FLOAT -> {
+                    float boundVal = buf.getFloat();
+                    if ((value instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    yield Float.compare(((Number) value).floatValue(), boundVal);
+                }
+                case DOUBLE -> {
+                    double boundVal = buf.getDouble();
+                    if ((value instanceof Number) == false) {
+                        yield Integer.MIN_VALUE;
+                    }
+                    yield Double.compare(((Number) value).doubleValue(), boundVal);
+                }
+                case BINARY, FIXED_LEN_BYTE_ARRAY -> {
+                    byte[] boundBytes = new byte[buf.remaining()];
+                    buf.get(boundBytes);
+                    if (value instanceof BytesRef br) {
+                        yield compareBytesUnsigned(br.bytes, br.offset, br.length, boundBytes, 0, boundBytes.length);
+                    }
+                    yield Integer.MIN_VALUE;
+                }
+                default -> Integer.MIN_VALUE;
+            };
+        } catch (Exception e) {
+            return Integer.MIN_VALUE;
+        }
+    }
+
+    private static int compareBytesUnsigned(byte[] a, int aOff, int aLen, byte[] b, int bOff, int bLen) {
+        int len = Math.min(aLen, bLen);
+        for (int i = 0; i < len; i++) {
+            int cmp = (a[aOff + i] & 0xFF) - (b[bOff + i] & 0xFF);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return Integer.compare(aLen, bLen);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.NavigableMap;
 
 /**
  * Adapter that wraps a StorageObject to implement Parquet's InputFile interface.
@@ -35,6 +36,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     private final long length;
     private final FooterCacheKey footerCacheKey;
     private final int windowSize;
+    private volatile NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks;
 
     /** Default window size (4MB) for the sliding range cache. */
     static final int DEFAULT_WINDOW_SIZE = 4 * 1024 * 1024;
@@ -83,6 +85,22 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         this.footerCacheKey = buildFooterCacheKey(storageObject, this.length);
     }
 
+    /**
+     * Installs prefetched column chunk data that streams will consult before issuing I/O.
+     * The map keys are file positions; values contain the byte data at those positions.
+     * Thread-safe: uses volatile write; streams take a snapshot reference on creation.
+     */
+    void installPrefetchedData(NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks) {
+        this.prefetchedChunks = chunks;
+    }
+
+    /**
+     * Clears any installed prefetched data, allowing GC to reclaim the buffers.
+     */
+    void clearPrefetchedData() {
+        this.prefetchedChunks = null;
+    }
+
     @Override
     public long getLength() throws IOException {
         return length;
@@ -90,7 +108,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-        return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, windowSize);
+        return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, windowSize, prefetchedChunks);
     }
 
     static void clearFooterCacheForTests() {
@@ -120,18 +138,26 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private final long length;
         private final int windowSize;
         private final byte[] window;
+        private final NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks;
 
         private long windowStart;
         private int windowLength;
         private long position;
         private boolean closed;
 
-        RangeFirstSeekableInputStream(StorageObject storageObject, FooterCacheKey footerCacheKey, long length, int windowSize) {
+        RangeFirstSeekableInputStream(
+            StorageObject storageObject,
+            FooterCacheKey footerCacheKey,
+            long length,
+            int windowSize,
+            NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks
+        ) {
             this.storageObject = storageObject;
             this.footerCacheKey = footerCacheKey;
             this.length = length;
             this.windowSize = windowSize;
             this.window = new byte[windowSize];
+            this.prefetchedChunks = prefetchedChunks;
             this.windowStart = -1;
             this.windowLength = 0;
             this.position = 0;
@@ -173,6 +199,10 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
+            if (tryFillFromPrefetched(pos, (int) toRead)) {
+                return;
+            }
+
             FooterCacheEntry cached = FOOTER_CACHE.get(footerCacheKey);
             if (cached != null && cached.covers(pos, (int) toRead)) {
                 int from = (int) (pos - cached.startOffset());
@@ -191,6 +221,35 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             if (windowLength > 0 && windowStart + windowLength == length) {
                 FOOTER_CACHE.putTailIfEligible(footerCacheKey, windowStart, window, windowLength);
             }
+        }
+
+        /**
+         * Tries to fill the window from prefetched column chunk data. Finds the chunk whose
+         * range covers the requested position and copies data into the window buffer.
+         *
+         * @return true if the window was filled from prefetched data
+         */
+        private boolean tryFillFromPrefetched(long pos, int toRead) {
+            if (prefetchedChunks == null || prefetchedChunks.isEmpty()) {
+                return false;
+            }
+            Map.Entry<Long, ColumnChunkPrefetcher.PrefetchedChunk> entry = prefetchedChunks.floorEntry(pos);
+            if (entry == null) {
+                return false;
+            }
+            ColumnChunkPrefetcher.PrefetchedChunk chunk = entry.getValue();
+            if (chunk.covers(pos, toRead) == false) {
+                return false;
+            }
+            int offsetInChunk = (int) (pos - chunk.offset());
+            ByteBuffer src = chunk.data().duplicate();
+            src.position(offsetInChunk);
+            int available = src.remaining();
+            int toCopy = Math.min(toRead, available);
+            src.get(window, 0, toCopy);
+            windowStart = pos;
+            windowLength = toCopy;
+            return true;
         }
 
         private void ensureWindow() throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -26,27 +26,27 @@ final class PlainValueDecoder {
     }
 
     void readInts(int[] values, int offset, int count) {
-        for (int i = 0; i < count; i++) {
-            values[offset + i] = buffer.getInt();
-        }
+        buffer.asIntBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 2));
     }
 
     void readLongs(long[] values, int offset, int count) {
-        for (int i = 0; i < count; i++) {
-            values[offset + i] = buffer.getLong();
-        }
+        buffer.asLongBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 3));
     }
 
     void readFloats(double[] values, int offset, int count) {
+        float[] tmp = new float[count];
+        buffer.asFloatBuffer().get(tmp, 0, count);
+        buffer.position(buffer.position() + (count << 2));
         for (int i = 0; i < count; i++) {
-            values[offset + i] = buffer.getFloat();
+            values[offset + i] = tmp[i];
         }
     }
 
     void readDoubles(double[] values, int offset, int count) {
-        for (int i = 0; i < count; i++) {
-            values[offset + i] = buffer.getDouble();
-        }
+        buffer.asDoubleBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 3));
     }
 
     void readBooleans(boolean[] values, int offset, int count) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -105,4 +105,103 @@ final class PlainValueDecoder {
     void skipFixedBinaries(int count, int fixedLength) {
         buffer.position(buffer.position() + count * fixedLength);
     }
+
+    // --- Selective read methods: decode totalCount values but only store selected positions ---
+
+    void readIntsSelective(int[] output, int outOffset, RowSelection selection, int totalCount) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                output[outIdx++] = buffer.getInt();
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + 4);
+            }
+        }
+    }
+
+    void readLongsSelective(long[] output, int outOffset, RowSelection selection, int totalCount) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                output[outIdx++] = buffer.getLong();
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + 8);
+            }
+        }
+    }
+
+    void readFloatsSelective(double[] output, int outOffset, RowSelection selection, int totalCount) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                output[outIdx++] = buffer.getFloat();
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + 4);
+            }
+        }
+    }
+
+    void readDoublesSelective(double[] output, int outOffset, RowSelection selection, int totalCount) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                output[outIdx++] = buffer.getDouble();
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + 8);
+            }
+        }
+    }
+
+    void readBooleansSelective(boolean[] output, int outOffset, RowSelection selection, int totalCount) {
+        int basePos = buffer.position();
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                int pos = basePos + (i / 8);
+                output[outIdx++] = ((buffer.get(pos) >>> (i % 8)) & 1) != 0;
+                selIdx = selection.nextSelected(selIdx + 1);
+            }
+        }
+        buffer.position(basePos + (totalCount + 7) / 8);
+    }
+
+    void readBinariesSelective(BytesRef[] output, int outOffset, RowSelection selection, int totalCount) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            int length = buffer.getInt();
+            if (i == selIdx) {
+                byte[] copy = new byte[length];
+                buffer.get(copy);
+                output[outIdx++] = new BytesRef(copy);
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + length);
+            }
+        }
+    }
+
+    void readFixedBinariesSelective(BytesRef[] output, int outOffset, RowSelection selection, int totalCount, int fixedLength) {
+        int outIdx = outOffset;
+        int selIdx = selection.nextSelected(0);
+        for (int i = 0; i < totalCount; i++) {
+            if (i == selIdx) {
+                byte[] copy = new byte[fixedLength];
+                buffer.get(copy);
+                output[outIdx++] = new BytesRef(copy);
+                selIdx = selection.nextSelected(selIdx + 1);
+            } else {
+                buffer.position(buffer.position() + fixedLength);
+            }
+        }
+    }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Bulk PLAIN decoder over a little-endian value {@link ByteBuffer} for page-level Parquet reads.
+ * Fixed-width types (INT32, INT64, FLOAT, DOUBLE) are read contiguously; BOOLEAN uses 1 byte
+ * per value; BINARY is length-prefixed; FIXED_LEN_BYTE_ARRAY uses a fixed stride.
+ */
+final class PlainValueDecoder {
+
+    private ByteBuffer buffer;
+
+    void init(ByteBuffer valueBytes) {
+        this.buffer = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    void readInts(int[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = buffer.getInt();
+        }
+    }
+
+    void readLongs(long[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = buffer.getLong();
+        }
+    }
+
+    void readFloats(double[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = buffer.getFloat();
+        }
+    }
+
+    void readDoubles(double[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = buffer.getDouble();
+        }
+    }
+
+    void readBooleans(boolean[] values, int offset, int count) {
+        int basePos = buffer.position();
+        for (int i = 0; i < count; i++) {
+            int pos = basePos + (i / 8);
+            values[offset + i] = ((buffer.get(pos) >>> (i % 8)) & 1) != 0;
+        }
+        buffer.position(basePos + (count + 7) / 8);
+    }
+
+    void readBinaries(BytesRef[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            int length = buffer.getInt();
+            byte[] copy = new byte[length];
+            buffer.get(copy);
+            values[offset + i] = new BytesRef(copy);
+        }
+    }
+
+    void readFixedBinaries(BytesRef[] values, int offset, int count, int fixedLength) {
+        for (int i = 0; i < count; i++) {
+            byte[] copy = new byte[fixedLength];
+            buffer.get(copy);
+            values[offset + i] = new BytesRef(copy);
+        }
+    }
+
+    void skipInts(int count) {
+        buffer.position(buffer.position() + (count << 2));
+    }
+
+    void skipLongs(int count) {
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    void skipFloats(int count) {
+        buffer.position(buffer.position() + (count << 2));
+    }
+
+    void skipDoubles(int count) {
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    void skipBooleans(int count) {
+        buffer.position(buffer.position() + (count + 7) / 8);
+    }
+
+    void skipBinaries(int count) {
+        for (int i = 0; i < count; i++) {
+            int length = buffer.getInt();
+            buffer.position(buffer.position() + length);
+        }
+    }
+
+    void skipFixedBinaries(int count, int fixedLength) {
+        buffer.position(buffer.position() + count * fixedLength);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+
+import java.util.Map;
+
+/**
+ * Holds pre-fetched metadata for a Parquet file's row groups: column indexes, offset indexes,
+ * and dictionary pages. Populated in parallel via {@link CoalescedRangeReader} during the
+ * optimized reader's initialization phase.
+ *
+ * <p>This class is populated once during file open and then read concurrently during row group
+ * processing. All fields are effectively immutable after construction.
+ */
+final class PreloadedRowGroupMetadata {
+
+    /**
+     * Per-row-group, per-column metadata keyed by {@code "rowGroup:columnPath"}.
+     */
+    private final Map<String, ColumnIndex> columnIndexes;
+    private final Map<String, OffsetIndex> offsetIndexes;
+
+    PreloadedRowGroupMetadata(Map<String, ColumnIndex> columnIndexes, Map<String, OffsetIndex> offsetIndexes) {
+        this.columnIndexes = Map.copyOf(columnIndexes);
+        this.offsetIndexes = Map.copyOf(offsetIndexes);
+    }
+
+    static PreloadedRowGroupMetadata empty() {
+        return new PreloadedRowGroupMetadata(Map.of(), Map.of());
+    }
+
+    ColumnIndex getColumnIndex(int rowGroupOrdinal, String columnPath) {
+        return columnIndexes.get(key(rowGroupOrdinal, columnPath));
+    }
+
+    OffsetIndex getOffsetIndex(int rowGroupOrdinal, String columnPath) {
+        return offsetIndexes.get(key(rowGroupOrdinal, columnPath));
+    }
+
+    boolean hasColumnIndexes() {
+        return columnIndexes.isEmpty() == false;
+    }
+
+    boolean hasOffsetIndexes() {
+        return offsetIndexes.isEmpty() == false;
+    }
+
+    private static String key(int rowGroupOrdinal, String columnPath) {
+        return rowGroupOrdinal + ":" + columnPath;
+    }
+
+    static String key(int rowGroupOrdinal, org.apache.parquet.hadoop.metadata.ColumnChunkMetaData column) {
+        return key(rowGroupOrdinal, column.getPath().toDotString());
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -7,34 +7,217 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.internal.hadoop.metadata.IndexReference;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Holds pre-fetched metadata for a Parquet file's row groups: column indexes, offset indexes,
- * and dictionary pages. Populated in parallel via {@link CoalescedRangeReader} during the
- * optimized reader's initialization phase.
+ * and dictionary pages. When a {@link StorageObject} is provided, uses
+ * {@link CoalescedRangeReader} to batch all index byte ranges into minimal I/O requests —
+ * critical for remote storage (S3) where each GET has ~50-100ms latency.
  *
- * <p>This class is populated once during file open and then read concurrently during row group
+ * <p>This class is populated once during file open and then read during row group
  * processing. All fields are effectively immutable after construction.
  */
 final class PreloadedRowGroupMetadata {
 
-    /**
-     * Per-row-group, per-column metadata keyed by {@code "rowGroup:columnPath"}.
-     */
+    private static final Logger logger = LogManager.getLogger(PreloadedRowGroupMetadata.class);
+
     private final Map<String, ColumnIndex> columnIndexes;
     private final Map<String, OffsetIndex> offsetIndexes;
+    private final Map<String, DictionaryPage> dictionaryPages;
 
-    PreloadedRowGroupMetadata(Map<String, ColumnIndex> columnIndexes, Map<String, OffsetIndex> offsetIndexes) {
+    PreloadedRowGroupMetadata(
+        Map<String, ColumnIndex> columnIndexes,
+        Map<String, OffsetIndex> offsetIndexes,
+        Map<String, DictionaryPage> dictionaryPages
+    ) {
         this.columnIndexes = Map.copyOf(columnIndexes);
         this.offsetIndexes = Map.copyOf(offsetIndexes);
+        this.dictionaryPages = Map.copyOf(dictionaryPages);
     }
 
     static PreloadedRowGroupMetadata empty() {
-        return new PreloadedRowGroupMetadata(Map.of(), Map.of());
+        return new PreloadedRowGroupMetadata(Map.of(), Map.of(), Map.of());
+    }
+
+    /**
+     * Preloads column indexes and offset indexes for all row groups.
+     *
+     * <p>When a {@link StorageObject} is provided, all index byte ranges across all row groups
+     * are collected and fetched in a single batched {@link CoalescedRangeReader#readCoalesced}
+     * call — merging adjacent ranges and issuing parallel async reads. This reduces hundreds
+     * of sequential I/O operations to a handful of coalesced requests.
+     *
+     * <p><b>Threading model:</b> This method is called from {@code ParquetFormatReader.read()}
+     * and {@code readRange()}, which in production are always dispatched on the
+     * {@code esql_worker} thread pool by {@code AsyncExternalSourceOperatorFactory}
+     * ({@code executor.execute(() -> formatReader.read(...))}). The coalesced reads use
+     * {@code Runnable::run} as the async executor, which means:
+     * <ul>
+     *   <li><b>S3 / native async:</b> {@code S3StorageObject.readBytesAsync()} ignores the
+     *       executor entirely — the AWS SDK's Netty event loop handles I/O. Reads are truly
+     *       parallel and non-blocking.</li>
+     *   <li><b>Local / default async:</b> The default {@code StorageObject.readBytesAsync()}
+     *       wraps sync {@code newStream()} on the provided executor. With {@code Runnable::run},
+     *       this runs inline on the calling {@code esql_worker} thread. Local I/O is fast
+     *       enough that a dedicated thread pool adds more overhead than it saves.</li>
+     * </ul>
+     *
+     * <p>Falls back to {@link ParquetFileReader}'s sequential reading when no storage object
+     * is provided (e.g., in-memory test files).
+     */
+    static PreloadedRowGroupMetadata preload(ParquetFileReader reader, StorageObject storageObject) {
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        if (rowGroups.isEmpty()) {
+            return empty();
+        }
+
+        if (storageObject != null) {
+            try {
+                return preloadCoalesced(reader, rowGroups, storageObject);
+            } catch (Exception e) {
+                logger.debug("Coalesced metadata preload failed, falling back to sequential: {}", e.getMessage());
+            }
+        }
+        return preloadSequential(reader, rowGroups);
+    }
+
+    /**
+     * Batched preloading via {@link CoalescedRangeReader}. Collects all column index and
+     * offset index byte ranges across all row groups, fetches them in one coalesced batch,
+     * then parses each range into its typed index object.
+     */
+    private static PreloadedRowGroupMetadata preloadCoalesced(
+        ParquetFileReader reader,
+        List<BlockMetaData> rowGroups,
+        StorageObject storageObject
+    ) {
+        List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
+        record RangeMeta(CoalescedRangeReader.ByteRange range, int rowGroupIdx, ColumnChunkMetaData col, boolean isColumnIndex) {}
+        List<RangeMeta> rangeMetas = new ArrayList<>();
+
+        for (int rgIdx = 0; rgIdx < rowGroups.size(); rgIdx++) {
+            BlockMetaData block = rowGroups.get(rgIdx);
+            for (ColumnChunkMetaData col : block.getColumns()) {
+                IndexReference ciRef = col.getColumnIndexReference();
+                if (ciRef != null && ciRef.getLength() > 0) {
+                    var br = new CoalescedRangeReader.ByteRange(ciRef.getOffset(), ciRef.getLength());
+                    ranges.add(br);
+                    rangeMetas.add(new RangeMeta(br, rgIdx, col, true));
+                }
+                IndexReference oiRef = col.getOffsetIndexReference();
+                if (oiRef != null && oiRef.getLength() > 0) {
+                    var br = new CoalescedRangeReader.ByteRange(oiRef.getOffset(), oiRef.getLength());
+                    ranges.add(br);
+                    rangeMetas.add(new RangeMeta(br, rgIdx, col, false));
+                }
+            }
+        }
+
+        if (ranges.isEmpty()) {
+            return preloadSequential(reader, rowGroups);
+        }
+
+        logger.debug("Coalesced metadata preload: [{}] index ranges across [{}] row groups", ranges.size(), rowGroups.size());
+
+        PlainActionFuture<Map<CoalescedRangeReader.ByteRange, ByteBuffer>> future = new PlainActionFuture<>();
+        CoalescedRangeReader.readCoalesced(storageObject, ranges, CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP, Runnable::run, future);
+        Map<CoalescedRangeReader.ByteRange, ByteBuffer> fetched = future.actionGet();
+
+        Map<String, ColumnIndex> columnIndexes = new HashMap<>();
+        Map<String, OffsetIndex> offsetIndexes = new HashMap<>();
+
+        for (RangeMeta meta : rangeMetas) {
+            ByteBuffer buf = fetched.get(meta.range());
+            if (buf == null) {
+                continue;
+            }
+            String k = key(meta.rowGroupIdx(), meta.col());
+            byte[] bytes = new byte[buf.remaining()];
+            buf.get(bytes);
+            try {
+                if (meta.isColumnIndex()) {
+                    org.apache.parquet.format.ColumnIndex thriftCI = Util.readColumnIndex(new ByteArrayInputStream(bytes));
+                    if (thriftCI != null) {
+                        ColumnIndex ci = ParquetMetadataConverter.fromParquetColumnIndex(meta.col().getPrimitiveType(), thriftCI);
+                        if (ci != null) {
+                            columnIndexes.put(k, ci);
+                        }
+                    }
+                } else {
+                    org.apache.parquet.format.OffsetIndex thriftOI = Util.readOffsetIndex(new ByteArrayInputStream(bytes));
+                    if (thriftOI != null) {
+                        OffsetIndex oi = ParquetMetadataConverter.fromParquetOffsetIndex(thriftOI);
+                        if (oi != null) {
+                            offsetIndexes.put(k, oi);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug(
+                    "Failed to parse [{}] for [{}] in row group [{}]: {}",
+                    meta.isColumnIndex() ? "column index" : "offset index",
+                    meta.col().getPath(),
+                    meta.rowGroupIdx(),
+                    e.getMessage()
+                );
+            }
+        }
+
+        return new PreloadedRowGroupMetadata(columnIndexes, offsetIndexes, Map.of());
+    }
+
+    /**
+     * Sequential fallback using {@link ParquetFileReader}'s built-in methods.
+     */
+    private static PreloadedRowGroupMetadata preloadSequential(ParquetFileReader reader, List<BlockMetaData> rowGroups) {
+        Map<String, ColumnIndex> columnIndexes = new HashMap<>();
+        Map<String, OffsetIndex> offsetIndexes = new HashMap<>();
+
+        for (int rgIdx = 0; rgIdx < rowGroups.size(); rgIdx++) {
+            BlockMetaData block = rowGroups.get(rgIdx);
+            for (ColumnChunkMetaData col : block.getColumns()) {
+                String k = key(rgIdx, col);
+                try {
+                    ColumnIndex ci = reader.readColumnIndex(col);
+                    if (ci != null) {
+                        columnIndexes.put(k, ci);
+                    }
+                } catch (IOException e) {
+                    logger.debug("Failed to read column index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
+                }
+                try {
+                    OffsetIndex oi = reader.readOffsetIndex(col);
+                    if (oi != null) {
+                        offsetIndexes.put(k, oi);
+                    }
+                } catch (IOException e) {
+                    logger.debug("Failed to read offset index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
+                }
+            }
+        }
+
+        return new PreloadedRowGroupMetadata(columnIndexes, offsetIndexes, Map.of());
     }
 
     ColumnIndex getColumnIndex(int rowGroupOrdinal, String columnPath) {
@@ -43,6 +226,10 @@ final class PreloadedRowGroupMetadata {
 
     OffsetIndex getOffsetIndex(int rowGroupOrdinal, String columnPath) {
         return offsetIndexes.get(key(rowGroupOrdinal, columnPath));
+    }
+
+    DictionaryPage getDictionaryPage(int rowGroupOrdinal, String columnPath) {
+        return dictionaryPages.get(key(rowGroupOrdinal, columnPath));
     }
 
     boolean hasColumnIndexes() {
@@ -57,7 +244,7 @@ final class PreloadedRowGroupMetadata {
         return rowGroupOrdinal + ":" + columnPath;
     }
 
-    static String key(int rowGroupOrdinal, org.apache.parquet.hadoop.metadata.ColumnChunkMetaData column) {
+    static String key(int rowGroupOrdinal, ColumnChunkMetaData column) {
         return key(rowGroupOrdinal, column.getPath().toDotString());
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -254,6 +255,114 @@ final class RowRanges {
         }
         return density() > densityThreshold || transitionCount() > maxTransitions;
     }
+
+    /**
+     * Returns true if any selected range overlaps the half-open interval {@code [pageStart, pageEnd)}.
+     * O(log n) via binary search, allocation-free.
+     */
+    boolean overlaps(long pageStart, long pageEnd) {
+        if (starts.length == 0 || pageStart >= pageEnd) {
+            return false;
+        }
+        int idx = Arrays.binarySearch(starts, pageStart);
+        if (idx >= 0) {
+            return true;
+        }
+        int insertionPoint = -idx - 1;
+        // Check the range just before the insertion point — its end might extend past pageStart
+        if (insertionPoint > 0 && ends[insertionPoint - 1] > pageStart) {
+            return true;
+        }
+        // Check the range at the insertion point — its start might be before pageEnd
+        return insertionPoint < starts.length && starts[insertionPoint] < pageEnd;
+    }
+
+    /**
+     * Returns the first selected row in {@code [rangeStart, rangeEnd)}, or {@code -1} if none.
+     */
+    long firstSelectedInRange(long rangeStart, long rangeEnd) {
+        if (starts.length == 0 || rangeStart >= rangeEnd) {
+            return -1;
+        }
+        int idx = Arrays.binarySearch(starts, rangeStart);
+        int i;
+        if (idx >= 0) {
+            i = idx;
+        } else {
+            int insertionPoint = -idx - 1;
+            // The range before insertionPoint might contain rangeStart
+            if (insertionPoint > 0 && ends[insertionPoint - 1] > rangeStart) {
+                return rangeStart;
+            }
+            i = insertionPoint;
+        }
+        if (i < starts.length && starts[i] < rangeEnd) {
+            return Math.max(starts[i], rangeStart);
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the last selected row in {@code [rangeStart, rangeEnd)}, or {@code -1} if none.
+     */
+    long lastSelectedInRange(long rangeStart, long rangeEnd) {
+        if (starts.length == 0 || rangeStart >= rangeEnd) {
+            return -1;
+        }
+        // Find the last range that starts before rangeEnd
+        int idx = Arrays.binarySearch(starts, rangeEnd);
+        int i;
+        if (idx >= 0) {
+            i = idx - 1;
+        } else {
+            i = -idx - 2;
+        }
+        // Walk backwards to find a range that overlaps [rangeStart, rangeEnd)
+        while (i >= 0) {
+            if (ends[i] > rangeStart && starts[i] < rangeEnd) {
+                return Math.min(ends[i], rangeEnd) - 1;
+            }
+            if (ends[i] <= rangeStart) {
+                break;
+            }
+            i--;
+        }
+        return -1;
+    }
+
+    /**
+     * Finds the next contiguous run of selected rows starting from {@code pageOffset},
+     * within the next {@code maxRows} rows. Returns a {@link Run} describing how many
+     * rows to skip before the run and the run length.
+     *
+     * <p>If no selected rows remain in the window, returns a run with
+     * {@code skipBefore == maxRows} and {@code length == 0}.
+     */
+    Run nextRunInPage(long pageOffset, int maxRows) {
+        if (starts.length == 0 || maxRows <= 0) {
+            return new Run(maxRows, 0);
+        }
+        long windowEnd = pageOffset + maxRows;
+        long first = firstSelectedInRange(pageOffset, windowEnd);
+        if (first < 0) {
+            return new Run(maxRows, 0);
+        }
+        int skipBefore = (int) (first - pageOffset);
+
+        // Find which range contains 'first'
+        int idx = Arrays.binarySearch(starts, first);
+        int rangeIdx;
+        if (idx >= 0) {
+            rangeIdx = idx;
+        } else {
+            rangeIdx = -idx - 2;
+        }
+        long runEnd = Math.min(ends[rangeIdx], windowEnd);
+        int length = (int) (runEnd - first);
+        return new Run(skipBefore, length);
+    }
+
+    record Run(int skipBefore, int length) {}
 
     @Override
     public String toString() {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a set of selected row ranges within a row group as sorted, non-overlapping
+ * {@code [start, end)} intervals. Used for page-level skipping: after evaluating ColumnIndex
+ * min/max per data page, only pages whose row ranges intersect with the selected ranges
+ * need to be decoded.
+ *
+ * <p>Supports set operations (intersect, union) across predicate columns that may have
+ * different page boundaries, plus an anti-fragmentation check to avoid excessive range
+ * transitions that would negate the benefit of page skipping.
+ *
+ * <p>Inspired by Trino's {@code FilteredRowRangesIterator}, independently implemented.
+ */
+final class RowRanges {
+
+    static final double DEFAULT_DENSITY_THRESHOLD = 0.8;
+    static final int DEFAULT_MAX_TRANSITIONS = 32;
+
+    private final long[] starts;
+    private final long[] ends;
+    private final long totalRows;
+
+    private RowRanges(long[] starts, long[] ends, long totalRows) {
+        assert starts.length == ends.length;
+        this.starts = starts;
+        this.ends = ends;
+        this.totalRows = totalRows;
+    }
+
+    /**
+     * Creates a RowRanges covering all rows in the row group (no skipping).
+     */
+    static RowRanges all(long rowCount) {
+        if (rowCount <= 0) {
+            return new RowRanges(new long[0], new long[0], 0);
+        }
+        return new RowRanges(new long[] { 0 }, new long[] { rowCount }, rowCount);
+    }
+
+    /**
+     * Creates a RowRanges from a single range.
+     */
+    static RowRanges of(long start, long end, long totalRows) {
+        if (start >= end) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+        return new RowRanges(new long[] { start }, new long[] { end }, totalRows);
+    }
+
+    /**
+     * Creates a RowRanges from a list of non-overlapping, sorted ranges.
+     * The caller must ensure ranges are sorted by start and non-overlapping.
+     */
+    static RowRanges ofSorted(long[] starts, long[] ends, long totalRows) {
+        return new RowRanges(starts.clone(), ends.clone(), totalRows);
+    }
+
+    /**
+     * Creates a RowRanges by merging a list of potentially overlapping ranges.
+     * Ranges are sorted and merged into non-overlapping intervals.
+     */
+    static RowRanges fromUnsorted(List<long[]> ranges, long totalRows) {
+        if (ranges.isEmpty()) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+        ranges.sort((a, b) -> Long.compare(a[0], b[0]));
+
+        List<long[]> merged = new ArrayList<>();
+        long[] current = ranges.get(0);
+        for (int i = 1; i < ranges.size(); i++) {
+            long[] next = ranges.get(i);
+            if (next[0] <= current[1]) {
+                current = new long[] { current[0], Math.max(current[1], next[1]) };
+            } else {
+                merged.add(current);
+                current = next;
+            }
+        }
+        merged.add(current);
+
+        long[] starts = new long[merged.size()];
+        long[] ends = new long[merged.size()];
+        for (int i = 0; i < merged.size(); i++) {
+            starts[i] = merged.get(i)[0];
+            ends[i] = merged.get(i)[1];
+        }
+        return new RowRanges(starts, ends, totalRows);
+    }
+
+    /**
+     * Intersects this RowRanges with another, producing ranges that are in both sets.
+     * Both inputs must be sorted and non-overlapping.
+     */
+    RowRanges intersect(RowRanges other) {
+        if (isEmpty() || other.isEmpty()) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+
+        List<long[]> result = new ArrayList<>();
+        int i = 0, j = 0;
+        while (i < starts.length && j < other.starts.length) {
+            long overlapStart = Math.max(starts[i], other.starts[j]);
+            long overlapEnd = Math.min(ends[i], other.ends[j]);
+            if (overlapStart < overlapEnd) {
+                result.add(new long[] { overlapStart, overlapEnd });
+            }
+            if (ends[i] < other.ends[j]) {
+                i++;
+            } else {
+                j++;
+            }
+        }
+
+        long[] rs = new long[result.size()];
+        long[] re = new long[result.size()];
+        for (int k = 0; k < result.size(); k++) {
+            rs[k] = result.get(k)[0];
+            re[k] = result.get(k)[1];
+        }
+        return new RowRanges(rs, re, totalRows);
+    }
+
+    /**
+     * Unions this RowRanges with another, producing ranges that are in either set.
+     * Both inputs must be sorted and non-overlapping.
+     */
+    RowRanges union(RowRanges other) {
+        if (isEmpty()) {
+            return other;
+        }
+        if (other.isEmpty()) {
+            return this;
+        }
+
+        List<long[]> all = new ArrayList<>(starts.length + other.starts.length);
+        for (int i = 0; i < starts.length; i++) {
+            all.add(new long[] { starts[i], ends[i] });
+        }
+        for (int i = 0; i < other.starts.length; i++) {
+            all.add(new long[] { other.starts[i], other.ends[i] });
+        }
+        return fromUnsorted(all, totalRows);
+    }
+
+    /**
+     * Complements this RowRanges within [0, totalRows), producing ranges NOT in this set.
+     */
+    RowRanges complement() {
+        if (isEmpty()) {
+            return all(totalRows);
+        }
+
+        List<long[]> gaps = new ArrayList<>();
+        long prev = 0;
+        for (int i = 0; i < starts.length; i++) {
+            if (prev < starts[i]) {
+                gaps.add(new long[] { prev, starts[i] });
+            }
+            prev = ends[i];
+        }
+        if (prev < totalRows) {
+            gaps.add(new long[] { prev, totalRows });
+        }
+
+        long[] rs = new long[gaps.size()];
+        long[] re = new long[gaps.size()];
+        for (int k = 0; k < gaps.size(); k++) {
+            rs[k] = gaps.get(k)[0];
+            re[k] = gaps.get(k)[1];
+        }
+        return new RowRanges(rs, re, totalRows);
+    }
+
+    /**
+     * Returns the total number of selected rows across all ranges.
+     */
+    long selectedRowCount() {
+        long count = 0;
+        for (int i = 0; i < starts.length; i++) {
+            count += ends[i] - starts[i];
+        }
+        return count;
+    }
+
+    /**
+     * Returns the density: ratio of selected rows to total rows in the row group.
+     * A density of 1.0 means all rows are selected (no skipping benefit).
+     */
+    double density() {
+        if (totalRows <= 0) {
+            return 1.0;
+        }
+        return (double) selectedRowCount() / totalRows;
+    }
+
+    /**
+     * Returns the number of discrete intervals in this selection.
+     * High interval counts indicate fragmented selection that may not benefit from skipping.
+     */
+    int transitionCount() {
+        return starts.length;
+    }
+
+    boolean isEmpty() {
+        return starts.length == 0;
+    }
+
+    /**
+     * Returns true if this RowRanges covers all rows (equivalent to no skipping).
+     */
+    boolean isAll() {
+        return starts.length == 1 && starts[0] == 0 && ends[0] == totalRows;
+    }
+
+    int rangeCount() {
+        return starts.length;
+    }
+
+    long rangeStart(int index) {
+        return starts[index];
+    }
+
+    long rangeEnd(int index) {
+        return ends[index];
+    }
+
+    long totalRows() {
+        return totalRows;
+    }
+
+    /**
+     * Anti-fragmentation check: returns true if the selection is too dense or too fragmented
+     * to benefit from page-level skipping. In such cases, reading the full row group is cheaper
+     * than the overhead of range-based decode.
+     */
+    boolean shouldDiscard() {
+        return shouldDiscard(DEFAULT_DENSITY_THRESHOLD, DEFAULT_MAX_TRANSITIONS);
+    }
+
+    boolean shouldDiscard(double densityThreshold, int maxTransitions) {
+        if (isEmpty()) {
+            return false;
+        }
+        return density() > densityThreshold || transitionCount() > maxTransitions;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RowRanges{");
+        for (int i = 0; i < starts.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append('[').append(starts[i]).append(", ").append(ends[i]).append(')');
+        }
+        sb.append(", total=").append(totalRows).append('}');
+        return sb.toString();
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowSelection.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowSelection.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.BitSet;
+
+/**
+ * Tracks which rows within a batch survive predicate evaluation during late materialization.
+ * Wraps a {@link BitSet} with pre-computed cardinality and fast-path checks for the common
+ * "all selected" and "none selected" cases.
+ *
+ * <p>Used as a selection vector between Phase 1 (filter evaluation) and Phase 2 (selective
+ * materialization) of the two-phase late materialization pipeline. Non-predicate columns
+ * use this to skip non-surviving values at the byte level during decode.
+ */
+final class RowSelection {
+
+    private final BitSet selected;
+    private final int totalRows;
+    private final int selectedCount;
+
+    RowSelection(BitSet selected, int totalRows, int selectedCount) {
+        this.selected = selected;
+        this.totalRows = totalRows;
+        this.selectedCount = selectedCount;
+    }
+
+    static RowSelection all(int totalRows) {
+        BitSet bits = new BitSet(totalRows);
+        bits.set(0, totalRows);
+        return new RowSelection(bits, totalRows, totalRows);
+    }
+
+    static RowSelection none(int totalRows) {
+        return new RowSelection(new BitSet(totalRows), totalRows, 0);
+    }
+
+    /**
+     * Creates a RowSelection from a boolean survivor mask (true = selected).
+     */
+    static RowSelection fromMask(boolean[] mask, int count) {
+        BitSet bits = new BitSet(count);
+        int selected = 0;
+        for (int i = 0; i < count; i++) {
+            if (mask[i]) {
+                bits.set(i);
+                selected++;
+            }
+        }
+        return new RowSelection(bits, count, selected);
+    }
+
+    boolean isAllSelected() {
+        return selectedCount == totalRows;
+    }
+
+    boolean isNoneSelected() {
+        return selectedCount == 0;
+    }
+
+    int totalRows() {
+        return totalRows;
+    }
+
+    int selectedCount() {
+        return selectedCount;
+    }
+
+    int nextSelected(int fromIndex) {
+        return selected.nextSetBit(fromIndex);
+    }
+
+    boolean isSelected(int index) {
+        return selected.get(index);
+    }
+
+    /**
+     * Returns a view of this selection for rows {@code [offset, offset+length)}, re-indexed
+     * to start at 0. Used when a batch spans multiple Parquet pages.
+     */
+    RowSelection slice(int offset, int length) {
+        if (offset == 0 && length == totalRows) {
+            return this;
+        }
+        BitSet sliced = selected.get(offset, offset + length);
+        int slicedCount = sliced.cardinality();
+        return new RowSelection(sliced, length, slicedCount);
+    }
+
+    /**
+     * Converts this selection to a boolean array (true = selected) for compatibility
+     * with the existing {@link PageColumnReader#filterBlock} API.
+     */
+    boolean[] toBooleanArray() {
+        boolean[] result = new boolean[totalRows];
+        for (int i = selected.nextSetBit(0); i >= 0; i = selected.nextSetBit(i + 1)) {
+            result[i] = true;
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/SelectivePageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/SelectivePageReader.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.format.DataPageHeader;
+import org.apache.parquet.format.DataPageHeaderV2;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.PageType;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.SeekableInputStream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * A {@link PageReader} that reads only pages whose row span overlaps with the given
+ * {@link RowRanges}. Non-surviving pages incur zero I/O, zero decompression, and
+ * zero memory allocation — the reader seeks past them using the {@link OffsetIndex}.
+ *
+ * <p>This replaces parquet-java's {@code ColumnChunkPageReader} which eagerly parses
+ * all page headers and queues all compressed payloads at row-group open time. By
+ * reading directly from a {@link SeekableInputStream} (backed by prefetched data
+ * from {@link ParquetStorageObjectAdapter}), only surviving pages are touched.
+ */
+final class SelectivePageReader implements PageReader, Closeable {
+
+    private final SeekableInputStream input;
+    private final OffsetIndex offsetIndex;
+    private final RowRanges rowRanges;
+    private final CompressionCodecFactory.BytesInputDecompressor decompressor;
+    private final ColumnChunkMetaData columnMeta;
+    private final long rowGroupRowCount;
+    private final long totalValueCount;
+    private int currentPageIdx;
+    private boolean dictionaryRead;
+
+    SelectivePageReader(
+        SeekableInputStream input,
+        OffsetIndex offsetIndex,
+        RowRanges rowRanges,
+        CompressionCodecFactory.BytesInputDecompressor decompressor,
+        ColumnChunkMetaData columnMeta,
+        long rowGroupRowCount
+    ) {
+        this.input = input;
+        this.offsetIndex = offsetIndex;
+        this.rowRanges = rowRanges;
+        this.decompressor = decompressor;
+        this.columnMeta = columnMeta;
+        this.rowGroupRowCount = rowGroupRowCount;
+        this.totalValueCount = columnMeta.getValueCount();
+        this.currentPageIdx = 0;
+        this.dictionaryRead = false;
+    }
+
+    @Override
+    public DictionaryPage readDictionaryPage() {
+        if (dictionaryRead) {
+            return null;
+        }
+        dictionaryRead = true;
+        long dictOffset = columnMeta.getDictionaryPageOffset();
+        if (dictOffset <= 0) {
+            return null;
+        }
+        try {
+            input.seek(dictOffset);
+            PageHeader header = Util.readPageHeader(input);
+            if (header.getType() != PageType.DICTIONARY_PAGE) {
+                return null;
+            }
+            int compressedSize = header.getCompressed_page_size();
+            byte[] raw = new byte[compressedSize];
+            input.readFully(raw);
+            BytesInput decompressed = decompressor.decompress(BytesInput.from(raw), header.getUncompressed_page_size());
+            return new DictionaryPage(
+                decompressed,
+                header.getDictionary_page_header().getNum_values(),
+                fromFormatEncoding(header.getDictionary_page_header().getEncoding())
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read dictionary page for column " + columnMeta.getPath(), e);
+        }
+    }
+
+    @Override
+    public long getTotalValueCount() {
+        return totalValueCount;
+    }
+
+    @Override
+    public DataPage readPage() {
+        int pageCount = offsetIndex.getPageCount();
+        while (currentPageIdx < pageCount) {
+            int pageIdx = currentPageIdx++;
+
+            long pageRowStart = offsetIndex.getFirstRowIndex(pageIdx);
+            long pageRowEnd = (pageIdx + 1 < pageCount) ? offsetIndex.getFirstRowIndex(pageIdx + 1) : rowGroupRowCount;
+
+            if (rowRanges != null && rowRanges.overlaps(pageRowStart, pageRowEnd) == false) {
+                continue;
+            }
+
+            try {
+                long pageFileOffset = offsetIndex.getOffset(pageIdx);
+                input.seek(pageFileOffset);
+                PageHeader header = Util.readPageHeader(input);
+
+                int compressedSize = header.getCompressed_page_size();
+                int uncompressedSize = header.getUncompressed_page_size();
+                byte[] raw = new byte[compressedSize];
+                input.readFully(raw);
+
+                return switch (header.getType()) {
+                    case DATA_PAGE -> readDataPageV1(header, BytesInput.from(raw), compressedSize, uncompressedSize, pageIdx);
+                    case DATA_PAGE_V2 -> readDataPageV2(header, BytesInput.from(raw), compressedSize, uncompressedSize, pageIdx);
+                    default -> throw new IOException("Unexpected page type at page " + pageIdx + ": " + header.getType());
+                };
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read page " + (pageIdx) + " for column " + columnMeta.getPath(), e);
+            }
+        }
+        return null;
+    }
+
+    private DataPageV1 readDataPageV1(PageHeader header, BytesInput compressedBytes, int compressedSize, int uncompressedSize, int pageIdx)
+        throws IOException {
+        DataPageHeader dataHeader = header.getData_page_header();
+        BytesInput decompressed = decompressor.decompress(compressedBytes, uncompressedSize);
+        return new DataPageV1(
+            decompressed,
+            dataHeader.getNum_values(),
+            uncompressedSize,
+            offsetIndex.getFirstRowIndex(pageIdx),
+            indexRowCount(pageIdx),
+            fromFormatStatistics(dataHeader),
+            fromFormatEncoding(dataHeader.getRepetition_level_encoding()),
+            fromFormatEncoding(dataHeader.getDefinition_level_encoding()),
+            fromFormatEncoding(dataHeader.getEncoding())
+        );
+    }
+
+    private DataPageV2 readDataPageV2(PageHeader header, BytesInput compressedBytes, int compressedSize, int uncompressedSize, int pageIdx)
+        throws IOException {
+        DataPageHeaderV2 v2Header = header.getData_page_header_v2();
+        int rlSize = v2Header.getRepetition_levels_byte_length();
+        int dlSize = v2Header.getDefinition_levels_byte_length();
+        byte[] allBytes = compressedBytes.toByteArray();
+        BytesInput rlBytes = BytesInput.from(allBytes, 0, rlSize);
+        BytesInput dlBytes = BytesInput.from(allBytes, rlSize, dlSize);
+
+        int dataCompressedSize = compressedSize - rlSize - dlSize;
+        int dataUncompressedSize = uncompressedSize - rlSize - dlSize;
+        BytesInput dataBytes = BytesInput.from(allBytes, rlSize + dlSize, dataCompressedSize);
+
+        boolean isCompressed = v2Header.isIs_compressed();
+        BytesInput decompressedData = isCompressed ? decompressor.decompress(dataBytes, dataUncompressedSize) : dataBytes;
+
+        return DataPageV2.uncompressed(
+            v2Header.getNum_rows(),
+            v2Header.getNum_nulls(),
+            v2Header.getNum_values(),
+            offsetIndex.getFirstRowIndex(pageIdx),
+            rlBytes,
+            dlBytes,
+            fromFormatEncoding(v2Header.getEncoding()),
+            decompressedData,
+            fromFormatStatistics(v2Header)
+        );
+    }
+
+    private int indexRowCount(int pageIdx) {
+        long pageStart = offsetIndex.getFirstRowIndex(pageIdx);
+        long pageEnd = (pageIdx + 1 < offsetIndex.getPageCount()) ? offsetIndex.getFirstRowIndex(pageIdx + 1) : rowGroupRowCount;
+        return (int) (pageEnd - pageStart);
+    }
+
+    private static Encoding fromFormatEncoding(org.apache.parquet.format.Encoding formatEncoding) {
+        return Encoding.valueOf(formatEncoding.name());
+    }
+
+    private static org.apache.parquet.column.statistics.Statistics<?> fromFormatStatistics(DataPageHeader dataHeader) {
+        return null;
+    }
+
+    private static org.apache.parquet.column.statistics.Statistics<?> fromFormatStatistics(DataPageHeaderV2 v2Header) {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        input.close();
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasource.parquet.CoalescedRangeReader.ByteRange;
+import org.elasticsearch.xpack.esql.datasource.parquet.CoalescedRangeReader.MergedRange;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CoalescedRangeReaderTests extends ESTestCase {
+
+    public void testMergeAdjacentRanges() {
+        List<ByteRange> ranges = List.of(new ByteRange(0, 100), new ByteRange(100, 200), new ByteRange(300, 50));
+        // gap=0 means adjacent ranges (gap==0) are merged; all three are contiguous
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 0);
+        assertEquals(1, merged.size());
+        assertEquals(0, merged.get(0).offset());
+        assertEquals(350, merged.get(0).length());
+        assertEquals(3, merged.get(0).constituents().size());
+    }
+
+    public void testMergeOverlappingRanges() {
+        List<ByteRange> ranges = List.of(new ByteRange(0, 150), new ByteRange(100, 200));
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 0);
+        assertEquals(1, merged.size());
+        assertEquals(0, merged.get(0).offset());
+        assertEquals(300, merged.get(0).length());
+    }
+
+    public void testMergeWithGapBelowThreshold() {
+        List<ByteRange> ranges = List.of(new ByteRange(0, 100), new ByteRange(200, 100));
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 200);
+        assertEquals(1, merged.size());
+        assertEquals(0, merged.get(0).offset());
+        assertEquals(300, merged.get(0).length());
+    }
+
+    public void testMergeWithGapAboveThreshold() {
+        List<ByteRange> ranges = List.of(new ByteRange(0, 100), new ByteRange(200, 100));
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 50);
+        assertEquals(2, merged.size());
+    }
+
+    public void testMergeSingleRange() {
+        List<ByteRange> ranges = List.of(new ByteRange(500, 200));
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 1024);
+        assertEquals(1, merged.size());
+        assertEquals(500, merged.get(0).offset());
+        assertEquals(200, merged.get(0).length());
+    }
+
+    public void testMergeUnsortedRanges() {
+        List<ByteRange> ranges = List.of(new ByteRange(300, 50), new ByteRange(0, 100), new ByteRange(100, 200));
+        // All three are contiguous [0,100) [100,300) [300,350) -> one merged range
+        List<MergedRange> merged = CoalescedRangeReader.mergeRanges(ranges, 0);
+        assertEquals(1, merged.size());
+        assertEquals(0, merged.get(0).offset());
+        assertEquals(350, merged.get(0).length());
+    }
+
+    public void testReadCoalescedParallelDispatch() throws Exception {
+        byte[] data = new byte[1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xFF);
+        }
+
+        AtomicInteger asyncCallCount = new AtomicInteger();
+        StorageObject storageObject = new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) length);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+
+            @Override
+            public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+                asyncCallCount.incrementAndGet();
+                StorageObject.super.readBytesAsync(position, length, executor, listener);
+            }
+        };
+
+        // [0,100) and [100,300) are adjacent; [500,600) has gap=200 which exceeds maxCoalesceGap=50
+        List<ByteRange> ranges = List.of(new ByteRange(0, 100), new ByteRange(100, 200), new ByteRange(500, 100));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Map<ByteRange, ByteBuffer>> resultRef = new AtomicReference<>();
+        AtomicReference<Exception> failureRef = new AtomicReference<>();
+
+        CoalescedRangeReader.readCoalesced(storageObject, ranges, 50, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(Map<ByteRange, ByteBuffer> result) {
+                resultRef.set(result);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failureRef.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(failureRef.get());
+
+        Map<ByteRange, ByteBuffer> results = resultRef.get();
+        assertNotNull(results);
+        assertEquals(3, results.size());
+
+        // Adjacent ranges [0,100) and [100,300) should be merged into one async call
+        // Range [500,600) is separate -> 2 async calls total
+        assertEquals(2, asyncCallCount.get());
+
+        ByteBuffer buf0 = results.get(new ByteRange(0, 100));
+        assertNotNull(buf0);
+        assertEquals(100, buf0.remaining());
+        assertEquals((byte) 0, buf0.get(0));
+
+        ByteBuffer buf1 = results.get(new ByteRange(100, 200));
+        assertNotNull(buf1);
+        assertEquals(200, buf1.remaining());
+        assertEquals((byte) 100, buf1.get(0));
+
+        ByteBuffer buf2 = results.get(new ByteRange(500, 100));
+        assertNotNull(buf2);
+        assertEquals(100, buf2.remaining());
+        assertEquals((byte) (500 & 0xFF), buf2.get(0));
+    }
+
+    public void testReadCoalescedEmptyRanges() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Map<ByteRange, ByteBuffer>> resultRef = new AtomicReference<>();
+
+        CoalescedRangeReader.readCoalesced(null, List.of(), 0, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(Map<ByteRange, ByteBuffer> result) {
+                resultRef.set(result);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(resultRef.get());
+        assertTrue(resultRef.get().isEmpty());
+    }
+
+    public void testReadCoalescedFailure() throws Exception {
+        StorageObject failingObject = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new IOException("test failure");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                throw new IOException("test failure");
+            }
+
+            @Override
+            public long length() {
+                return 1000;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://fail.parquet");
+            }
+        };
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failureRef = new AtomicReference<>();
+
+        CoalescedRangeReader.readCoalesced(failingObject, List.of(new ByteRange(0, 100)), 0, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(Map<ByteRange, ByteBuffer> result) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failureRef.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(failureRef.get());
+        assertThat(failureRef.get().getMessage(), org.hamcrest.Matchers.containsString("test failure"));
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests for {@link ColumnChunkPrefetcher}: byte range computation, parallel dispatch,
+ * and async prefetch with failure handling.
+ */
+public class ColumnChunkPrefetcherTests extends ESTestCase {
+
+    public void testComputeColumnChunkRangesAllColumns() {
+        BlockMetaData block = createBlockWithColumns(
+            new ColMeta("col_a", 100, 500),
+            new ColMeta("col_b", 700, 300),
+            new ColMeta("col_c", 1100, 200)
+        );
+
+        List<CoalescedRangeReader.ByteRange> ranges = ColumnChunkPrefetcher.computeColumnChunkRanges(block, null);
+
+        assertThat(ranges.size(), equalTo(3));
+        assertThat(ranges.get(0), equalTo(new CoalescedRangeReader.ByteRange(100, 500)));
+        assertThat(ranges.get(1), equalTo(new CoalescedRangeReader.ByteRange(700, 300)));
+        assertThat(ranges.get(2), equalTo(new CoalescedRangeReader.ByteRange(1100, 200)));
+    }
+
+    public void testComputeColumnChunkRangesWithProjection() {
+        BlockMetaData block = createBlockWithColumns(
+            new ColMeta("col_a", 100, 500),
+            new ColMeta("col_b", 700, 300),
+            new ColMeta("col_c", 1100, 200)
+        );
+
+        List<CoalescedRangeReader.ByteRange> ranges = ColumnChunkPrefetcher.computeColumnChunkRanges(block, Set.of("col_a", "col_c"));
+
+        assertThat(ranges.size(), equalTo(2));
+        assertThat(ranges.get(0), equalTo(new CoalescedRangeReader.ByteRange(100, 500)));
+        assertThat(ranges.get(1), equalTo(new CoalescedRangeReader.ByteRange(1100, 200)));
+    }
+
+    public void testComputeColumnChunkRangesEmptyProjection() {
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 500));
+
+        List<CoalescedRangeReader.ByteRange> ranges = ColumnChunkPrefetcher.computeColumnChunkRanges(block, Set.of("nonexistent"));
+
+        assertThat(ranges.size(), equalTo(0));
+    }
+
+    public void testPrefetchReturnsCorrectData() throws Exception {
+        byte[] fileData = new byte[2000];
+        for (int i = 0; i < fileData.length; i++) {
+            fileData[i] = (byte) (i & 0xFF);
+        }
+
+        StorageObject storage = createStorageObject(fileData);
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 50), new ColMeta("col_b", 200, 60));
+
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = ColumnChunkPrefetcher.prefetch(
+            storage,
+            block,
+            null
+        );
+
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> result = future.get();
+        assertThat(result.size(), greaterThanOrEqualTo(2));
+
+        ColumnChunkPrefetcher.PrefetchedChunk chunkA = result.get(100L);
+        assertThat(chunkA, notNullValue());
+        assertThat(chunkA.covers(100, 50), equalTo(true));
+        byte[] expected = new byte[50];
+        System.arraycopy(fileData, 100, expected, 0, 50);
+        byte[] actual = new byte[50];
+        chunkA.data().duplicate().get(actual);
+        assertArrayEquals(expected, actual);
+    }
+
+    public void testPrefetchAsyncReturnsCorrectData() throws Exception {
+        byte[] fileData = new byte[1000];
+        for (int i = 0; i < fileData.length; i++) {
+            fileData[i] = (byte) (i & 0xFF);
+        }
+
+        StorageObject storage = createStorageObject(fileData);
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_x", 50, 100));
+
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = ColumnChunkPrefetcher.prefetchAsync(
+            storage,
+            block,
+            null
+        );
+
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> result = future.get();
+        assertThat(result.isEmpty(), equalTo(false));
+    }
+
+    public void testPrefetchConcurrentReadCalls() throws Exception {
+        AtomicInteger concurrentReads = new AtomicInteger(0);
+        AtomicInteger maxConcurrent = new AtomicInteger(0);
+
+        byte[] fileData = new byte[10000];
+        StorageObject storage = new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(fileData);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, fileData.length - position);
+                return new ByteArrayInputStream(fileData, pos, len);
+            }
+
+            @Override
+            public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+                int current = concurrentReads.incrementAndGet();
+                maxConcurrent.updateAndGet(m -> Math.max(m, current));
+                executor.execute(() -> {
+                    try (InputStream stream = newStream(position, length)) {
+                        byte[] bytes = stream.readAllBytes();
+                        listener.onResponse(ByteBuffer.wrap(bytes));
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    } finally {
+                        concurrentReads.decrementAndGet();
+                    }
+                });
+            }
+
+            @Override
+            public long length() {
+                return fileData.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("test://concurrent.parquet");
+            }
+        };
+
+        BlockMetaData block = createBlockWithColumns(new ColMeta("a", 100, 500), new ColMeta("b", 2000, 500), new ColMeta("c", 5000, 500));
+
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = ColumnChunkPrefetcher.prefetch(
+            storage,
+            block,
+            null
+        );
+
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> result = future.get();
+        assertThat(result.isEmpty(), equalTo(false));
+    }
+
+    public void testPrefetchFailureCompletesExceptionally() {
+        StorageObject failingStorage = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new IOException("Simulated failure");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                throw new IOException("Simulated failure");
+            }
+
+            @Override
+            public long length() {
+                return 10000;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("test://failing.parquet");
+            }
+        };
+
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col", 100, 500));
+
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = ColumnChunkPrefetcher.prefetchAsync(
+            failingStorage,
+            block,
+            null
+        );
+
+        assertTrue(future.isCompletedExceptionally());
+    }
+
+    public void testPrefetchedChunkCovers() {
+        ByteBuffer data = ByteBuffer.allocate(100);
+        ColumnChunkPrefetcher.PrefetchedChunk chunk = new ColumnChunkPrefetcher.PrefetchedChunk(200, 100, data);
+
+        assertTrue(chunk.covers(200, 50));
+        assertTrue(chunk.covers(200, 100));
+        assertTrue(chunk.covers(250, 50));
+        assertFalse(chunk.covers(199, 50));
+        assertFalse(chunk.covers(250, 51));
+        assertFalse(chunk.covers(300, 1));
+    }
+
+    public void testPrefetchEmptyRanges() throws Exception {
+        byte[] fileData = new byte[1000];
+        StorageObject storage = createStorageObject(fileData);
+        BlockMetaData block = new BlockMetaData();
+        block.setRowCount(0);
+
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = ColumnChunkPrefetcher.prefetch(
+            storage,
+            block,
+            null
+        );
+
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> result = future.get();
+        assertThat(result.isEmpty(), equalTo(true));
+    }
+
+    // --- helpers ---
+
+    private record ColMeta(String name, long startPos, long totalSize) {}
+
+    @SuppressWarnings("deprecation")
+    private static BlockMetaData createBlockWithColumns(ColMeta... cols) {
+        BlockMetaData block = new BlockMetaData();
+        block.setRowCount(100);
+        for (ColMeta col : cols) {
+            ColumnChunkMetaData chunk = ColumnChunkMetaData.get(
+                ColumnPath.get(col.name),
+                PrimitiveType.PrimitiveTypeName.INT64,
+                CompressionCodecName.UNCOMPRESSED,
+                Set.of(org.apache.parquet.column.Encoding.PLAIN),
+                org.apache.parquet.column.statistics.Statistics.createStats(
+                    Types.required(PrimitiveType.PrimitiveTypeName.INT64).named(col.name)
+                ),
+                col.startPos,
+                0,
+                100,
+                col.totalSize,
+                col.totalSize
+            );
+            block.addColumn(chunk);
+        }
+        return block;
+    }
+
+    private StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("test://test.parquet");
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -54,7 +54,9 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * Tests for the optimized Parquet reader feature flag and correctness parity with the baseline.
@@ -2401,6 +2403,117 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
 
         assertThat("late materialization with prefetch should return correct row count", totalRows, equalTo(199));
+    }
+
+    /**
+     * Stage 7B: SelectivePageReader parity — compares the optimized reader without
+     * SelectivePageReader (pageLevelReader=false) against the page-level reader with
+     * SelectivePageReader active (pageLevelReader=true, lateMat=true).
+     * Both use optimized=true to keep the same filtering level.
+     */
+    public void testSelectivePageReaderParity() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 1800L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader standardOptimized = new ParquetFormatReader(blockFactory, true);
+        standardOptimized = (ParquetFormatReader) standardOptimized.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader selectiveReader = new ParquetFormatReader(blockFactory, true, true, true);
+        selectiveReader = (ParquetFormatReader) selectiveReader.withPushedFilter(pushedExprs);
+
+        List<Page> standardPages = readAllPages(standardOptimized, storageObject);
+        List<Page> selectivePages = readAllPages(selectiveReader, storageObject);
+
+        int standardRows = standardPages.stream().mapToInt(Page::getPositionCount).sum();
+        int selectiveRows = selectivePages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat(
+            "SelectivePageReader (selective=" + selectiveRows + ") should produce <= standard (" + standardRows + ") rows",
+            selectiveRows,
+            lessThanOrEqualTo(standardRows)
+        );
+        assertThat("SelectivePageReader should produce at least the exact matching rows", selectiveRows, greaterThanOrEqualTo(199));
+    }
+
+    /**
+     * Stage 7B: SelectivePageReader with various filter selectivities — verifies that the
+     * selective reader never produces more rows than the standard optimized reader, and
+     * always produces at least as many as the exact count.
+     */
+    public void testSelectivePageReaderVaryingSelectivity() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        for (long threshold : new long[] { 100L, 500L, 1000L, 1500L, 1900L, 1999L }) {
+            ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+            GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, threshold, DataType.LONG));
+            ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+            ParquetFormatReader standardReader = new ParquetFormatReader(blockFactory, true);
+            standardReader = (ParquetFormatReader) standardReader.withPushedFilter(pushedExprs);
+
+            ParquetFormatReader selectiveReader = new ParquetFormatReader(blockFactory, true, true, true);
+            selectiveReader = (ParquetFormatReader) selectiveReader.withPushedFilter(pushedExprs);
+
+            List<Page> standardPages = readAllPages(standardReader, storageObject);
+            List<Page> selectivePages = readAllPages(selectiveReader, storageObject);
+
+            int standardRows = standardPages.stream().mapToInt(Page::getPositionCount).sum();
+            int selectiveRows = selectivePages.stream().mapToInt(Page::getPositionCount).sum();
+            int expectedExact = 2000 - (int) threshold - 1;
+            assertThat(
+                "SelectivePageReader (threshold=" + threshold + ") should produce <= standard (" + standardRows + ")",
+                selectiveRows,
+                lessThanOrEqualTo(standardRows)
+            );
+            assertThat(
+                "SelectivePageReader (threshold=" + threshold + ") should produce >= exact count (" + expectedExact + ")",
+                selectiveRows,
+                greaterThanOrEqualTo(expectedExact)
+            );
+        }
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -2527,6 +2527,423 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         assertPagesEqual(baselinePages, optimizedPages);
     }
 
+    // --- Stage 6: Columnar output polish — constant block detection tests ---
+
+    /**
+     * Stage 6: all-identical non-nullable long column should produce a constant block.
+     * This simulates partition columns where every value in a row group is the same.
+     */
+    public void testConstantBlockDetectionIdenticalLongs() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("partition_key")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("partition_key", 42L);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            LongBlock partBlock = page.getBlock(1);
+            if (partBlock.asVector() != null && partBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertThat(partBlock.getLong(0), equalTo(42L));
+            }
+        }
+        assertTrue("expected constant block for all-identical partition_key column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-identical non-nullable int column should produce a constant block.
+     */
+    public void testConstantBlockDetectionIdenticalInts() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("region")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("region", 7);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            IntBlock regionBlock = page.getBlock(1);
+            if (regionBlock.asVector() != null && regionBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertThat(regionBlock.getInt(0), equalTo(7));
+            }
+        }
+        assertTrue("expected constant block for all-identical region column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-identical non-nullable string column should produce a constant block.
+     */
+    public void testConstantBlockDetectionIdenticalStrings() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", "active");
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            BytesRefBlock statusBlock = page.getBlock(1);
+            if (statusBlock.asVector() != null && statusBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertThat(statusBlock.getBytesRef(0, new BytesRef()), equalTo(new BytesRef("active")));
+            }
+        }
+        assertTrue("expected constant block for all-identical status column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-identical non-nullable double column should produce a constant block.
+     */
+    public void testConstantBlockDetectionIdenticalDoubles() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("rate")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 70; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("rate", 3.14);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            DoubleBlock rateBlock = page.getBlock(1);
+            if (rateBlock.asVector() != null && rateBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertThat(rateBlock.getDouble(0), equalTo(3.14));
+            }
+        }
+        assertTrue("expected constant block for all-identical rate column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-identical non-nullable boolean column should produce a constant block.
+     */
+    public void testConstantBlockDetectionIdenticalBooleans() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("flag")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("flag", true);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            BooleanBlock flagBlock = page.getBlock(1);
+            if (flagBlock.asVector() != null && flagBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertTrue(flagBlock.getBoolean(0));
+            }
+        }
+        assertTrue("expected constant block for all-identical flag column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-null optional column should produce a constant null block.
+     * Verifies the all-null fast path returns ConstantNullBlock.
+     */
+    public void testConstantBlockDetectionAllNull() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("nullable_val")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("nullable_str")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("nullable_dbl")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        for (Page page : optimizedPages) {
+            for (int col = 1; col < page.getBlockCount(); col++) {
+                assertTrue("all-null column " + col + " should produce areAllValuesNull block", page.getBlock(col).areAllValuesNull());
+            }
+        }
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: mixed-value columns should NOT produce constant blocks (regression test).
+     */
+    public void testConstantBlockDetectionMixedValuesNotConstant() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("varying_long")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("varying_str")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("varying_long", (long) i);
+                g.add("varying_str", "val_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        for (Page page : optimizedPages) {
+            if (page.getPositionCount() > 1) {
+                LongBlock varyingLong = page.getBlock(1);
+                assertFalse(
+                    "varying long column should not be constant",
+                    varyingLong.asVector() != null && varyingLong.asVector().isConstant()
+                );
+                BytesRefBlock varyingStr = page.getBlock(2);
+                assertFalse(
+                    "varying string column should not be constant",
+                    varyingStr.asVector() != null && varyingStr.asVector().isConstant()
+                );
+            }
+        }
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: page-level reader should also produce constant blocks for identical values.
+     */
+    public void testConstantBlockDetectionPageLevelReader() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("partition_key")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("partition_key", 99L);
+                g.add("status", "ready");
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        boolean foundConstantLong = false;
+        boolean foundConstantStr = false;
+        for (Page page : pageLevelPages) {
+            LongBlock partBlock = page.getBlock(1);
+            if (partBlock.asVector() != null && partBlock.asVector().isConstant()) {
+                foundConstantLong = true;
+                assertThat(partBlock.getLong(0), equalTo(99L));
+            }
+            BytesRefBlock statusBlock = page.getBlock(2);
+            if (statusBlock.asVector() != null && statusBlock.asVector().isConstant()) {
+                foundConstantStr = true;
+                assertThat(statusBlock.getBytesRef(0, new BytesRef()), equalTo(new BytesRef("ready")));
+            }
+        }
+        assertTrue("expected constant block for partition_key in page-level reader", foundConstantLong);
+        assertTrue("expected constant block for status in page-level reader", foundConstantStr);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Stage 6: nullable column with some nulls and some identical values should NOT be constant.
+     */
+    public void testConstantBlockDetectionNullableMixedNotConstant() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("nullable_partition")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 3 != 0) {
+                    g.add("nullable_partition", 42L);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        for (Page page : optimizedPages) {
+            LongBlock partBlock = page.getBlock(1);
+            assertFalse(
+                "nullable column with mix of nulls and values should not be constant",
+                partBlock.asVector() != null && partBlock.asVector().isConstant()
+            );
+        }
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 6: all-identical empty string column should produce a constant block.
+     * Edge case: ensures BytesRef comparison works correctly for zero-length values.
+     */
+    public void testConstantBlockDetectionEmptyStrings() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("empty_col")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 40; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("empty_col", "");
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        boolean foundConstant = false;
+        for (Page page : optimizedPages) {
+            BytesRefBlock emptyBlock = page.getBlock(1);
+            if (emptyBlock.asVector() != null && emptyBlock.asVector().isConstant()) {
+                foundConstant = true;
+                assertThat(emptyBlock.getBytesRef(0, new BytesRef()), equalTo(new BytesRef("")));
+            }
+        }
+        assertTrue("expected constant block for all-identical empty string column", foundConstant);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
     /**
      * Creates a Parquet file with multiple row groups (small row group size forces splits).
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -2242,6 +2242,315 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         assertThat("integer predicate filter", totalRows, equalTo(40));
     }
 
+    // --- Stage 5: Parallel column chunk fetch + async row group prefetch tests ---
+
+    /**
+     * Stage 5 correctness parity: optimized reader with prefetch produces identical output
+     * to the baseline for a multi-row-group file.
+     */
+    public void testPrefetchCorrectnessParityMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 3000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 5: prefetch with pushed filter and multi-row-group file.
+     * The prefetch pipeline must work correctly alongside dictionary pruning and page skipping.
+     */
+    public void testPrefetchWithPushedFilterMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("value", i * 0.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 1500L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 5: prefetch with column projection — only projected columns should be fetched.
+     */
+    public void testPrefetchWithProjectionMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                g.add("age", 20 + (i % 50));
+                g.add("score", i * 1.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<String> projection = List.of("id", "score");
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject, projection);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject, projection);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 5: prefetch with late materialization on multi-row-group file.
+     */
+    public void testPrefetchWithLateMaterializationMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 1800L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(lateMatReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        assertThat("late materialization with prefetch should return correct row count", totalRows, equalTo(199));
+    }
+
+    /**
+     * Stage 5: single row group file — prefetch should not trigger (no next RG to prefetch).
+     * Correctness parity must hold.
+     */
+    public void testPrefetchSingleRowGroupFile() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 5: prefetch with nullable columns across multiple row groups.
+     */
+    public void testPrefetchNullableColumnsMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 3 != 0) {
+                    g.add("name", "user_" + i);
+                }
+                if (i % 5 != 0) {
+                    g.add("age", 20 + i);
+                }
+                if (i % 7 != 0) {
+                    g.add("score", i * 0.5);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Stage 5: row limit with multi-row-group file. Early termination must cancel pending prefetch.
+     */
+    public void testPrefetchWithRowLimitMultiRowGroup() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileMultiRowGroup(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 3000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        int rowLimit = 100;
+
+        List<Page> baselinePages;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, false).read(
+                storageObject,
+                FormatReadContext.builder().batchSize(1024).rowLimit(rowLimit).build()
+            )
+        ) {
+            baselinePages = collectPages(iter);
+        }
+
+        List<Page> optimizedPages;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
+                storageObject,
+                FormatReadContext.builder().batchSize(1024).rowLimit(rowLimit).build()
+            )
+        ) {
+            optimizedPages = collectPages(iter);
+        }
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Creates a Parquet file with multiple row groups (small row group size forces splits).
+     */
+    private byte[] createParquetFileMultiRowGroup(MessageType schema, GroupCreator groupCreator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(4L * 1024)
+                .withPageSize(256)
+                .withPageWriteChecksumEnabled(false)
+                .build()
+        ) {
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
     // --- Helpers ---
 
     private StorageObject createStorageObject(byte[] data) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -54,6 +54,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  * Tests for the optimized Parquet reader feature flag and correctness parity with the baseline.
@@ -1879,6 +1880,366 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
 
         assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    // --- Stage 4: Late materialization tests ---
+
+    /**
+     * Late materialization: filtered read with predicate on one column, projection on others.
+     * Verifies that results match the page-level reader (which decodes all columns then lets
+     * parquet-java's built-in filter drive row group selection).
+     */
+    public void testLateMaterializationBasicFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 300; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 200L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader pageLevelReader = new ParquetFormatReader(blockFactory, true, true);
+        pageLevelReader = (ParquetFormatReader) pageLevelReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pageLevelPages = readAllPages(pageLevelReader, storageObject);
+        List<Page> lateMatPages = readAllPages(lateMatReader, storageObject);
+
+        int pageLevelTotalRows = pageLevelPages.stream().mapToInt(Page::getPositionCount).sum();
+        int lateMatTotalRows = lateMatPages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // Late materialization should return fewer rows (only those matching id > 200)
+        assertThat("late materialization should produce fewer rows than page-level reader", lateMatTotalRows, lessThan(pageLevelTotalRows));
+        // Should return exactly 99 rows (id 201..299)
+        assertThat("late materialization should match expected surviving row count", lateMatTotalRows, equalTo(99));
+    }
+
+    /**
+     * Late materialization with no pushed filter: all columns decoded normally, no filtering.
+     * Results should match page-level reader exactly.
+     */
+    public void testLateMaterializationNoFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("count")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("count", i * 10);
+                g.add("score", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        // No pushed filter → lateMaterialization should effectively be disabled (no predicate columns)
+        ParquetFormatReader pageLevelReader = new ParquetFormatReader(blockFactory, true, true);
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+
+        List<Page> pageLevelPages = readAllPages(pageLevelReader, storageObject);
+        List<Page> lateMatPages = readAllPages(lateMatReader, storageObject);
+
+        assertPagesEqual(pageLevelPages, lateMatPages);
+    }
+
+    /**
+     * Late materialization with Equals on keyword column: only rows matching the string value
+     * should survive.
+     */
+    public void testLateMaterializationKeywordEquals() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 300; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, new BytesRef("active"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> lateMatPages = readAllPages(lateMatReader, storageObject);
+        int totalRows = lateMatPages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // 100 rows where status == "active" (every 3rd row: 0, 3, 6, ..., 297)
+        assertThat("late materialization should return only matching rows", totalRows, equalTo(100));
+    }
+
+    /**
+     * Late materialization with nullable columns: verifies null handling in predicate evaluation
+     * and block filtering.
+     */
+    public void testLateMaterializationNullableColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("filter_col")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("projection_col")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 5 != 0) {
+                    g.add("filter_col", (long) i);
+                }
+                if (i % 3 != 0) {
+                    g.add("projection_col", i * 0.1);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute filterAttr = new ReferenceAttribute(Source.EMPTY, "filter_col", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, filterAttr, new Literal(Source.EMPTY, 150L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> lateMatPages = readAllPages(lateMatReader, storageObject);
+        int totalRows = lateMatPages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // Rows where filter_col > 150: id 151,152,...,199 excluding multiples of 5 (null filter_col)
+        // Multiples of 5 from 155..195: 155,160,165,170,175,180,185,190,195 = 9 nulls
+        // Total: 49 - 9 = 40 surviving rows (null filter_col rows are eliminated by GT comparison)
+        int expectedNulls = 0;
+        int expectedSurvivors = 0;
+        for (int i = 0; i < 200; i++) {
+            if (i % 5 == 0) continue;
+            if (i > 150) expectedSurvivors++;
+        }
+        assertThat("late materialization with nullable filter column", totalRows, equalTo(expectedSurvivors));
+    }
+
+    /**
+     * Late materialization: predicate column also in projection. The predicate column Block
+     * should be decoded once and reused in the output Page.
+     */
+    public void testLateMaterializationPredicateInProjection() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 2.0);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        LessThan ltExpr = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 10L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(ltExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(lateMatReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        assertThat("predicate column (id) in projection, LessThan filter", totalRows, equalTo(10));
+
+        // Verify the id column values are 0..9
+        for (Page page : pages) {
+            LongBlock idBlock = page.getBlock(0);
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                long idVal = idBlock.getLong(idBlock.getFirstValueIndex(i));
+                assertThat("surviving id should be < 10", idVal, lessThan(10L));
+            }
+        }
+    }
+
+    /**
+     * Late materialization: all rows eliminated by filter. Projection columns should be skipped
+     * entirely (no decode).
+     */
+    public void testLateMaterializationAllRowsEliminated() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 99999L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(lateMatReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        assertThat("all rows eliminated by impossible filter", totalRows, equalTo(0));
+    }
+
+    /**
+     * Late materialization with boolean predicate column.
+     */
+    public void testLateMaterializationBooleanPredicate() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("flag")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("flag", i % 4 == 0);
+                g.add("score", i * 1.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute flagAttr = new ReferenceAttribute(Source.EMPTY, "flag", DataType.BOOLEAN);
+        Equals eqExpr = new Equals(Source.EMPTY, flagAttr, new Literal(Source.EMPTY, true, DataType.BOOLEAN));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(eqExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(lateMatReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // flag == true for every 4th row: 0, 4, 8, ..., 196 = 50 rows
+        assertThat("boolean predicate filter", totalRows, equalTo(50));
+    }
+
+    /**
+     * Late materialization with integer predicate column.
+     */
+    public void testLateMaterializationIntegerPredicate() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("category")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("category", i % 5);
+                g.add("id", (long) i);
+                g.add("score", i * 0.3);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute catAttr = new ReferenceAttribute(Source.EMPTY, "category", DataType.INTEGER);
+        Equals eqExpr = new Equals(Source.EMPTY, catAttr, new Literal(Source.EMPTY, 0, DataType.INTEGER));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(eqExpr));
+
+        ParquetFormatReader lateMatReader = new ParquetFormatReader(blockFactory, true, true, true);
+        lateMatReader = (ParquetFormatReader) lateMatReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(lateMatReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // category == 0 for every 5th row: 0, 5, 10, ..., 195 = 40 rows
+        assertThat("integer predicate filter", totalRows, equalTo(40));
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -30,10 +31,17 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Tests for the optimized Parquet reader feature flag and correctness parity with the baseline.
@@ -277,6 +286,303 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         assertPagesEqual(baselinePages, optimizedPages);
     }
 
+    /**
+     * Metadata preloading: optimized reader preloads column/offset indexes without breaking correctness.
+     */
+    public void testMetadataPreloadingDoesNotBreakCorrectness() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : "inactive");
+                g.add("value", i * 0.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Dictionary pruning: when a pushed filter matches no dictionary values, the row group is skipped.
+     * Verifies that a filter for a non-existent value returns zero rows.
+     */
+    public void testDictionaryPruningSkipsRowGroupNoMatch() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 2 == 0 ? "active" : "inactive");
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, new BytesRef("nonexistent"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(optimizedReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("dictionary pruning should skip all row groups for non-existent value", totalRows, equalTo(0));
+    }
+
+    /**
+     * Dictionary pruning: when a pushed filter matches some dictionary values, rows are returned.
+     */
+    public void testDictionaryPruningKeepsRowGroupWithMatch() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 2 == 0 ? "active" : "inactive");
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, new BytesRef("active"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(optimizedReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("dictionary pruning should keep row groups when values match", totalRows, greaterThan(0));
+    }
+
+    /**
+     * Dictionary pruning with integer column: no match means row group skipped.
+     */
+    public void testDictionaryPruningIntegerColumnNoMatch() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("category")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("category", i % 5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute catAttr = new ReferenceAttribute(Source.EMPTY, "category", DataType.INTEGER);
+        Equals equalsExpr = new Equals(Source.EMPTY, catAttr, new Literal(Source.EMPTY, 999, DataType.INTEGER));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(optimizedReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("dictionary pruning should skip row groups for non-existent integer value", totalRows, equalTo(0));
+    }
+
+    /**
+     * No pushed filter: optimized reader still works correctly (no dictionary pruning attempted).
+     */
+    public void testNoPushedFilterOptimizedReaderWorks() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Non-dictionary column: predicate on a non-dictionary-encoded column should not cause issues.
+     */
+    public void testNonDictionaryColumnFallsThrough() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 1.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute valAttr = new ReferenceAttribute(Source.EMPTY, "value", DataType.DOUBLE);
+        Equals equalsExpr = new Equals(Source.EMPTY, valAttr, new Literal(Source.EMPTY, 999.0, DataType.DOUBLE));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Coalesced metadata preloading: verifies that the coalesced path (via StorageObject + CoalescedRangeReader)
+     * produces identical results to the sequential path. The in-memory StorageObject supports readBytesAsync
+     * via the default sync wrapper, exercising the full coalesced pipeline.
+     */
+    public void testCoalescedMetadataPreloadingCorrectness() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("category")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("category", i % 10);
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Coalesced preloading with dictionary pruning: end-to-end test that the coalesced metadata
+     * fetch + dictionary evaluation work together correctly.
+     */
+    public void testCoalescedPreloadWithDictionaryPruning() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 4 == 0 ? "alpha" : (i % 4 == 1 ? "beta" : (i % 4 == 2 ? "gamma" : "delta")));
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(
+            Source.EMPTY,
+            statusAttr,
+            new Literal(Source.EMPTY, new BytesRef("nonexistent_value"), DataType.KEYWORD)
+        );
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(optimizedReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("coalesced preload + dictionary pruning should skip all row groups", totalRows, equalTo(0));
+    }
+
     // --- Helpers ---
 
     private List<Page> readAllPages(ParquetFormatReader reader, StorageObject storageObject) throws IOException {
@@ -381,6 +687,30 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         return outputStream.toByteArray();
     }
 
+    /**
+     * Creates a Parquet file with dictionary encoding enabled and column indexes written.
+     * Uses a small row group size to ensure dictionary pages are present.
+     */
+    private byte[] createParquetFileWithDictionary(MessageType schema, GroupCreator groupCreator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(true)
+                .withPageWriteChecksumEnabled(false)
+                .build()
+        ) {
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
     private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
         return new OutputFile() {
             @Override
@@ -433,6 +763,1125 @@ public class OptimizedParquetReaderTests extends ESTestCase {
             }
         };
     }
+
+    // --- Page-level skipping tests (Stage 2) ---
+
+    /**
+     * Page-level skipping with sorted data: a range predicate on a sorted column should skip
+     * pages whose min/max don't overlap with the predicate range. Correctness parity with baseline.
+     */
+    public void testPageSkippingSortedColumnCorrectnessParity() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 900L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping: predicate that matches no pages should return same results as baseline
+     * (which uses parquet-java's built-in statistics filtering).
+     */
+    public void testPageSkippingNoMatchingPages() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 99999L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> pages = readAllPages(optimizedReader, storageObject);
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("page-level skipping should return 0 rows for out-of-range predicate", totalRows, equalTo(0));
+    }
+
+    /**
+     * Page-level skipping with LessThan on sorted column: correctness parity.
+     */
+    public void testPageSkippingLessThanSortedColumn() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 10);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        LessThan ltExpr = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 50L, DataType.LONG));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(ltExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping with Equals on string column: correctness parity.
+     */
+    public void testPageSkippingEqualsStringColumn() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("category")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            String[] categories = { "alpha", "beta", "gamma", "delta" };
+            for (int i = 0; i < 400; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("category", categories[i / 100]);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute catAttr = new ReferenceAttribute(Source.EMPTY, "category", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, catAttr, new Literal(Source.EMPTY, new BytesRef("beta"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping: no pushed filter means no page skipping, correctness parity maintained.
+     */
+    public void testPageSkippingNoPushedFilter() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping with DATETIME (TIMESTAMP_MILLIS) column: the optimized reader should
+     * convert ESQL epoch millis to the physical unit before comparing against ColumnIndex min/max.
+     * Correctness parity with baseline.
+     */
+    public void testPageSkippingDatetimeTimestampMillis() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .named("test_schema");
+
+        long baseMillis = 1_700_000_000_000L; // ~2023-11-14
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("ts", baseMillis + i * 86_400_000L); // one day apart
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        long filterMillis = baseMillis + 450 * 86_400_000L;
+        ReferenceAttribute tsAttr = new ReferenceAttribute(Source.EMPTY, "ts", DataType.DATETIME);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, tsAttr, new Literal(Source.EMPTY, filterMillis, DataType.DATETIME));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping with DATE (INT32 days) column: ESQL epoch millis should be
+     * converted to days before comparing against ColumnIndex min/max.
+     */
+    public void testPageSkippingDateColumn() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.dateType())
+            .named("dt")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("dt", i); // days since epoch
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        long filterMillis = 450L * 86_400_000L; // day 450 in millis
+        ReferenceAttribute dtAttr = new ReferenceAttribute(Source.EMPTY, "dt", DataType.DATETIME);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, dtAttr, new Literal(Source.EMPTY, filterMillis, DataType.DATETIME));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Page-level skipping with TIMESTAMP_MICROS column: ESQL epoch millis should be
+     * converted to microseconds before comparing against ColumnIndex min/max.
+     */
+    public void testPageSkippingTimestampMicros() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .named("test_schema");
+
+        long baseMillis = 1_700_000_000_000L;
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                Group g = factory.newGroup();
+                g.add("ts", (baseMillis + i * 86_400_000L) * 1000L); // micros
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        long filterMillis = baseMillis + 450 * 86_400_000L;
+        ReferenceAttribute tsAttr = new ReferenceAttribute(Source.EMPTY, "ts", DataType.DATETIME);
+        GreaterThan gtExpr = new GreaterThan(Source.EMPTY, tsAttr, new Literal(Source.EMPTY, filterMillis, DataType.DATETIME));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Creates a Parquet file with column indexes and small page size to ensure multiple pages
+     * per row group, enabling page-level skipping tests.
+     */
+    private byte[] createParquetFileWithColumnIndexes(MessageType schema, GroupCreator groupCreator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(false)
+                .withPageSize(256)
+                .withRowGroupSize(64L * 1024)
+                .withPageWriteChecksumEnabled(false)
+                .build()
+        ) {
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    // --- Stage 3: Batch column reader tests ---
+
+    /**
+     * Batch reader: non-nullable columns use the fast path (no def-level check).
+     * Correctness parity with baseline.
+     */
+    public void testBatchReaderNonNullableColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("count")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("flag")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("count", i * 10);
+                g.add("score", i * 0.1);
+                g.add("flag", i % 2 == 0);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: nullable columns with mixed null/non-null values.
+     * Tests direct BitSet construction in BatchColumnReader.
+     */
+    public void testBatchReaderNullableColumnsWithNulls() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("nullable_long")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("nullable_int")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("nullable_double")
+            .optional(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("nullable_bool")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("nullable_str")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 150; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 3 != 0) {
+                    g.add("nullable_long", (long) (i * 100));
+                }
+                if (i % 4 != 0) {
+                    g.add("nullable_int", i * 10);
+                }
+                if (i % 5 != 0) {
+                    g.add("nullable_double", i * 0.5);
+                }
+                if (i % 7 != 0) {
+                    g.add("nullable_bool", i % 2 == 0);
+                }
+                if (i % 2 != 0) {
+                    g.add("nullable_str", "val_" + i);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: all-null optional columns should produce correct null blocks.
+     */
+    public void testBatchReaderAllNullColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("all_null_long")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("all_null_str")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: INT32 widened to LONG via planner type. Tests the INT32-as-LONG batch path.
+     */
+    public void testBatchReaderInt32WidenedToLong() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("small_int")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("nullable_small_int")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("small_int", i);
+                if (i % 3 != 0) {
+                    g.add("nullable_small_int", i * 2);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: FLOAT columns read as DOUBLE. Tests the float-to-double batch path.
+     */
+    public void testBatchReaderFloatAsDouble() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.FLOAT)
+            .named("float_val")
+            .optional(PrimitiveType.PrimitiveTypeName.FLOAT)
+            .named("nullable_float")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                Group g = factory.newGroup();
+                g.add("float_val", (float) (i * 0.25));
+                if (i % 4 != 0) {
+                    g.add("nullable_float", (float) (i * 1.5));
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: DATETIME columns (TIMESTAMP_MILLIS, TIMESTAMP_MICROS, DATE).
+     * Tests timestamp conversion in the batch path.
+     */
+    public void testBatchReaderDatetimeColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts_millis")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts_micros")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.dateType())
+            .named("dt")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("nullable_ts")
+            .named("test_schema");
+
+        long baseMillis = 1_700_000_000_000L;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("ts_millis", baseMillis + i * 1000L);
+                g.add("ts_micros", (baseMillis + i * 1000L) * 1000L);
+                g.add("dt", i);
+                if (i % 3 != 0) {
+                    g.add("nullable_ts", baseMillis + i * 60_000L);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: DECIMAL columns read as DOUBLE via the batch path.
+     */
+    public void testBatchReaderDecimalAsDouble() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .named("price_int")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.decimalType(4, 18))
+            .named("price_long")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .named("nullable_price")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                Group g = factory.newGroup();
+                g.add("price_int", i * 100 + 99);
+                g.add("price_long", (long) i * 10000 + 1234);
+                if (i % 3 != 0) {
+                    g.add("nullable_price", i * 50);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: mixed flat and list columns in the same file. Flat columns use BatchColumnReader,
+     * list columns fall back to the row-at-a-time path. Both must produce correct results.
+     */
+    public void testBatchReaderMixedFlatAndListColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .requiredList()
+            .requiredElement(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("tags")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("score", i * 0.5);
+                Group tagsList = g.addGroup("tags");
+                for (int j = 0; j < (i % 3) + 1; j++) {
+                    tagsList.addGroup("list").append("element", i * 10 + j);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader: large batch to test page boundary handling within BatchColumnReader.
+     * Uses a batch size larger than a single page to ensure page transitions work correctly.
+     */
+    public void testBatchReaderLargeBatchAcrossPages() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("data")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("data", "row_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Batch reader with pushed filter: verifies that batch decoding works correctly
+     * alongside dictionary pruning and page-level skipping.
+     */
+    public void testBatchReaderWithPushedFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 300; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, new BytesRef("active"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader optimizedReader = new ParquetFormatReader(blockFactory, true);
+        optimizedReader = (ParquetFormatReader) optimizedReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> optimizedPages = readAllPages(optimizedReader, storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    // --- Stage 3b: Page-level reader tests ---
+
+    /**
+     * Page-level reader: correctness parity with simple non-nullable types.
+     */
+    public void testPageLevelReaderSimpleTypes() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("active")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                g.add("age", 20 + (i % 50));
+                g.add("active", i % 2 == 0);
+                g.add("score", i * 1.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: correctness parity with nullable columns.
+     */
+    public void testPageLevelReaderNullableColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .optional(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("flag")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 3 != 0) {
+                    g.add("name", "user_" + i);
+                }
+                if (i % 5 != 0) {
+                    g.add("age", 20 + i);
+                }
+                if (i % 4 != 0) {
+                    g.add("flag", i % 2 == 0);
+                }
+                if (i % 7 != 0) {
+                    g.add("score", i * 0.5);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: INT32 widened to LONG and FLOAT widened to DOUBLE.
+     */
+    public void testPageLevelReaderTypeWidening() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("int_as_long")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("nullable_int_as_long")
+            .required(PrimitiveType.PrimitiveTypeName.FLOAT)
+            .named("float_as_double")
+            .optional(PrimitiveType.PrimitiveTypeName.FLOAT)
+            .named("nullable_float")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                Group g = factory.newGroup();
+                g.add("int_as_long", i * 100);
+                if (i % 3 != 0) {
+                    g.add("nullable_int_as_long", i * 50);
+                }
+                g.add("float_as_double", (float) (i * 0.25));
+                if (i % 4 != 0) {
+                    g.add("nullable_float", (float) (i * 1.5));
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: DATETIME columns (TIMESTAMP_MILLIS, TIMESTAMP_MICROS, DATE).
+     */
+    public void testPageLevelReaderDatetimeColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts_millis")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts_micros")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.dateType())
+            .named("dt")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("nullable_ts")
+            .named("test_schema");
+
+        long baseMillis = 1_700_000_000_000L;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("ts_millis", baseMillis + i * 1000L);
+                g.add("ts_micros", (baseMillis + i * 1000L) * 1000L);
+                g.add("dt", i);
+                if (i % 3 != 0) {
+                    g.add("nullable_ts", baseMillis + i * 60_000L);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: DECIMAL columns read as DOUBLE.
+     */
+    public void testPageLevelReaderDecimalAsDouble() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .named("price_int")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.decimalType(4, 18))
+            .named("price_long")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .named("nullable_price")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                Group g = factory.newGroup();
+                g.add("price_int", i * 100 + 99);
+                g.add("price_long", (long) i * 10000 + 1234);
+                if (i % 3 != 0) {
+                    g.add("nullable_price", i * 50);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: mixed flat + list columns. Flat columns use PageColumnReader,
+     * list columns fall back to ColumnReader row-at-a-time path.
+     */
+    public void testPageLevelReaderMixedFlatAndListColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .requiredList()
+            .requiredElement(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("tags")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("score", i * 0.5);
+                Group tagsList = g.addGroup("tags");
+                for (int j = 0; j < (i % 3) + 1; j++) {
+                    tagsList.addGroup("list").append("element", i * 10 + j);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: dictionary-encoded columns.
+     */
+    public void testPageLevelReaderDictionaryEncoded() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: large batch across multiple pages.
+     */
+    public void testPageLevelReaderLargeBatchAcrossPages() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("data")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithColumnIndexes(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("data", "row_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader with pushed filter: verifies page-level decode works alongside
+     * dictionary pruning and page-level skipping.
+     */
+    public void testPageLevelReaderWithPushedFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("status")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFileWithDictionary(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 300; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("status", i % 3 == 0 ? "active" : (i % 3 == 1 ? "inactive" : "pending"));
+                g.add("value", i * 0.1);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.KEYWORD);
+        Equals equalsExpr = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, new BytesRef("active"), DataType.KEYWORD));
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(equalsExpr));
+
+        ParquetFormatReader baselineReader = new ParquetFormatReader(blockFactory, false);
+        baselineReader = (ParquetFormatReader) baselineReader.withPushedFilter(pushedExprs);
+
+        ParquetFormatReader pageLevelReader = new ParquetFormatReader(blockFactory, true, true);
+        pageLevelReader = (ParquetFormatReader) pageLevelReader.withPushedFilter(pushedExprs);
+
+        List<Page> baselinePages = readAllPages(baselineReader, storageObject);
+        List<Page> pageLevelPages = readAllPages(pageLevelReader, storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    /**
+     * Page-level reader: all-null optional column.
+     */
+    public void testPageLevelReaderAllNullColumn() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("nullable_val")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> pageLevelPages = readAllPages(new ParquetFormatReader(blockFactory, true, true), storageObject);
+
+        assertPagesEqual(baselinePages, pageLevelPages);
+    }
+
+    // --- Helpers ---
 
     private StorageObject createStorageObject(byte[] data) {
         return new StorageObject() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for the optimized Parquet reader feature flag and correctness parity with the baseline.
+ */
+public class OptimizedParquetReaderTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testDefaultReaderIsBaseline() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of());
+        assertSame(reader, configured);
+    }
+
+    public void testWithConfigOptimizedReaderTrue() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", true));
+        assertNotSame(reader, configured);
+    }
+
+    public void testWithConfigOptimizedReaderFalse() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", false));
+        assertSame(reader, configured);
+    }
+
+    public void testWithConfigOptimizedReaderStringTrue() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", "true"));
+        assertNotSame(reader, configured);
+    }
+
+    public void testWithConfigNullConfig() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(null);
+        assertSame(reader, configured);
+    }
+
+    public void testWithConfigPreservesPushedFilter() throws Exception {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetFormatReader withFilter = (ParquetFormatReader) reader.withPushedFilter(null);
+        ParquetFormatReader withConfig = (ParquetFormatReader) withFilter.withConfig(Map.of("optimized_reader", true));
+        assertNotSame(withFilter, withConfig);
+    }
+
+    public void testNodeLevelSettingDefault() {
+        ParquetDataSourcePlugin plugin = new ParquetDataSourcePlugin();
+        Map<String, FormatReaderFactory> factories = plugin.formatReaders(Settings.EMPTY);
+        assertNotNull(factories.get("parquet"));
+    }
+
+    public void testNodeLevelSettingEnabled() {
+        ParquetDataSourcePlugin plugin = new ParquetDataSourcePlugin();
+        Settings settings = Settings.builder().put("esql.parquet.optimized_reader", true).build();
+        Map<String, FormatReaderFactory> factories = plugin.formatReaders(settings);
+        assertNotNull(factories.get("parquet"));
+    }
+
+    public void testWithConfigOverridesNodeDefault() {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);
+        ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", false));
+        assertNotSame(reader, configured);
+    }
+
+    /**
+     * Correctness parity: both baseline and optimized paths produce identical output for the same file.
+     */
+    public void testCorrectnessParitySimpleTypes() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("active")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                g.add("age", 20 + (i % 50));
+                g.add("active", i % 2 == 0);
+                g.add("score", i * 1.5);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Correctness parity with nullable columns.
+     */
+    public void testCorrectnessParityNullableColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 3 != 0) {
+                    g.add("name", "user_" + i);
+                }
+                if (i % 5 != 0) {
+                    g.add("age", 20 + i);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Correctness parity with column projection.
+     */
+    public void testCorrectnessParityWithProjection() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 30; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                g.add("age", 20 + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<String> projection = List.of("id", "name");
+
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject, projection);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject, projection);
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Correctness parity with row limit.
+     */
+    public void testCorrectnessParityWithRowLimit() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "user_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        int rowLimit = 10;
+
+        List<Page> baselinePages;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, false).read(
+                storageObject,
+                FormatReadContext.builder().batchSize(1024).rowLimit(rowLimit).build()
+            )
+        ) {
+            baselinePages = collectPages(iter);
+        }
+
+        List<Page> optimizedPages;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
+                storageObject,
+                FormatReadContext.builder().batchSize(1024).rowLimit(rowLimit).build()
+            )
+        ) {
+            optimizedPages = collectPages(iter);
+        }
+
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    // --- Helpers ---
+
+    private List<Page> readAllPages(ParquetFormatReader reader, StorageObject storageObject) throws IOException {
+        return readAllPages(reader, storageObject, null);
+    }
+
+    private List<Page> readAllPages(ParquetFormatReader reader, StorageObject storageObject, List<String> projection) throws IOException {
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(projection, 1024))) {
+            return collectPages(iter);
+        }
+    }
+
+    private List<Page> collectPages(CloseableIterator<Page> iter) {
+        List<Page> pages = new ArrayList<>();
+        while (iter.hasNext()) {
+            pages.add(iter.next());
+        }
+        return pages;
+    }
+
+    private void assertPagesEqual(List<Page> expected, List<Page> actual) {
+        assertThat("page count mismatch", actual.size(), equalTo(expected.size()));
+        for (int p = 0; p < expected.size(); p++) {
+            Page ep = expected.get(p);
+            Page ap = actual.get(p);
+            assertThat("block count mismatch in page " + p, ap.getBlockCount(), equalTo(ep.getBlockCount()));
+            assertThat("position count mismatch in page " + p, ap.getPositionCount(), equalTo(ep.getPositionCount()));
+            for (int b = 0; b < ep.getBlockCount(); b++) {
+                assertBlocksEqual(ep.getBlock(b), ap.getBlock(b), p, b);
+            }
+        }
+    }
+
+    private void assertBlocksEqual(
+        org.elasticsearch.compute.data.Block expected,
+        org.elasticsearch.compute.data.Block actual,
+        int page,
+        int block
+    ) {
+        String ctx = "page " + page + " block " + block;
+        assertThat(ctx + " position count", actual.getPositionCount(), equalTo(expected.getPositionCount()));
+        for (int pos = 0; pos < expected.getPositionCount(); pos++) {
+            boolean expNull = expected.isNull(pos);
+            boolean actNull = actual.isNull(pos);
+            assertThat(ctx + " null at " + pos, actNull, equalTo(expNull));
+            if (expNull == false) {
+                if (expected instanceof LongBlock lb && actual instanceof LongBlock lab) {
+                    assertThat(
+                        ctx + " long at " + pos,
+                        lab.getLong(lab.getFirstValueIndex(pos)),
+                        equalTo(lb.getLong(lb.getFirstValueIndex(pos)))
+                    );
+                } else if (expected instanceof IntBlock ib && actual instanceof IntBlock iab) {
+                    assertThat(
+                        ctx + " int at " + pos,
+                        iab.getInt(iab.getFirstValueIndex(pos)),
+                        equalTo(ib.getInt(ib.getFirstValueIndex(pos)))
+                    );
+                } else if (expected instanceof DoubleBlock db && actual instanceof DoubleBlock dab) {
+                    assertThat(
+                        ctx + " double at " + pos,
+                        dab.getDouble(dab.getFirstValueIndex(pos)),
+                        equalTo(db.getDouble(db.getFirstValueIndex(pos)))
+                    );
+                } else if (expected instanceof BooleanBlock bb && actual instanceof BooleanBlock bab) {
+                    assertThat(
+                        ctx + " boolean at " + pos,
+                        bab.getBoolean(bab.getFirstValueIndex(pos)),
+                        equalTo(bb.getBoolean(bb.getFirstValueIndex(pos)))
+                    );
+                } else if (expected instanceof BytesRefBlock brb && actual instanceof BytesRefBlock brab) {
+                    assertThat(
+                        ctx + " bytesref at " + pos,
+                        brab.getBytesRef(brab.getFirstValueIndex(pos), new org.apache.lucene.util.BytesRef()),
+                        equalTo(brb.getBytesRef(brb.getFirstValueIndex(pos), new org.apache.lucene.util.BytesRef()))
+                    );
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface GroupCreator {
+        List<Group> create(SimpleGroupFactory factory);
+    }
+
+    private byte[] createParquetFile(MessageType schema, GroupCreator groupCreator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        outputStream.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        outputStream.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        outputStream.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://test.parquet";
+            }
+        };
+    }
+
+    private StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://test.parquet");
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -767,6 +767,56 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         );
     }
 
+    // --- Stage 5: Prefetched data tests ---
+
+    public void testPrefetchedDataServesReads() throws IOException {
+        byte[] data = new byte[1000];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xFF);
+        }
+        StorageObject storageObject = createRangeReadStorageObject(data);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        byte[] prefetchedBytes = new byte[100];
+        System.arraycopy(data, 200, prefetchedBytes, 0, 100);
+        java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
+        chunks.put(200L, new ColumnChunkPrefetcher.PrefetchedChunk(200, 100, java.nio.ByteBuffer.wrap(prefetchedBytes)));
+        adapter.installPrefetchedData(chunks);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(200);
+            byte[] buffer = new byte[50];
+            stream.readFully(buffer);
+            byte[] expected = new byte[50];
+            System.arraycopy(data, 200, expected, 0, 50);
+            assertArrayEquals(expected, buffer);
+        }
+    }
+
+    public void testClearPrefetchedData() throws IOException {
+        byte[] data = new byte[500];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xFF);
+        }
+        StorageObject storageObject = createRangeReadStorageObject(data);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        byte[] prefetchedBytes = new byte[50];
+        java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
+        chunks.put(100L, new ColumnChunkPrefetcher.PrefetchedChunk(100, 50, java.nio.ByteBuffer.wrap(prefetchedBytes)));
+        adapter.installPrefetchedData(chunks);
+        adapter.clearPrefetchedData();
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(100);
+            byte[] buffer = new byte[10];
+            stream.readFully(buffer);
+            byte[] expected = new byte[10];
+            System.arraycopy(data, 100, expected, 0, 10);
+            assertArrayEquals(expected, buffer);
+        }
+    }
+
     private void randomBytes(byte[] data) {
         random().nextBytes(data);
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
@@ -229,4 +229,149 @@ public class RowRangesTests extends ESTestCase {
         assertTrue(str.contains("[100, 500)"));
         assertTrue(str.contains("total=1000"));
     }
+
+    public void testOverlapsEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertFalse(empty.overlaps(0, 100));
+    }
+
+    public void testOverlapsSingleRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertTrue(range.overlaps(200, 300));
+    }
+
+    public void testOverlapsSingleRangePartialOverlapAtStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(50, 150));
+    }
+
+    public void testOverlapsSingleRangePartialOverlapAtEnd() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(150, 250));
+    }
+
+    public void testOverlapsSingleRangeNoOverlapBefore() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(0, 50));
+    }
+
+    public void testOverlapsSingleRangeNoOverlapAfter() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(300, 400));
+    }
+
+    public void testOverlapsMultipleRangesFirst() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 500 }, new long[] { 100, 600 }, 1000);
+        assertTrue(ranges.overlaps(50, 80));
+    }
+
+    public void testOverlapsMultipleRangesMiddle() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200, 500 }, new long[] { 100, 300, 700 }, 1000);
+        assertTrue(ranges.overlaps(250, 280));
+    }
+
+    public void testOverlapsMultipleRangesGap() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200 }, new long[] { 100, 300 }, 1000);
+        assertFalse(ranges.overlaps(120, 180));
+    }
+
+    public void testOverlapsBoundaryPageStartEqualsRangeEnd() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(200, 300));
+    }
+
+    public void testOverlapsBoundaryPageEndEqualsRangeStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(0, 100));
+    }
+
+    public void testOverlapsBoundaryPageStartEqualsRangeStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(100, 150));
+    }
+
+    public void testFirstSelectedInRangeEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.firstSelectedInRange(0, 100), equalTo(-1L));
+    }
+
+    public void testFirstSelectedInRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(200, 400), equalTo(200L));
+    }
+
+    public void testFirstSelectedInRangeStartsBeforeSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(50, 200), equalTo(100L));
+    }
+
+    public void testFirstSelectedInRangeStartsInMiddleOfSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(150, 200), equalTo(150L));
+    }
+
+    public void testFirstSelectedInRangeNoSelectionInRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(0, 50), equalTo(-1L));
+    }
+
+    public void testFirstSelectedInRangeMultipleRangesSecondRange() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200 }, new long[] { 100, 350 }, 1000);
+        assertThat(ranges.firstSelectedInRange(250, 400), equalTo(250L));
+    }
+
+    public void testLastSelectedInRangeEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.lastSelectedInRange(0, 100), equalTo(-1L));
+    }
+
+    public void testLastSelectedInRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(200, 400), equalTo(399L));
+    }
+
+    public void testLastSelectedInRangeEndsAfterSelection() {
+        RowRanges range = RowRanges.of(100, 300, 1000);
+        assertThat(range.lastSelectedInRange(50, 500), equalTo(299L));
+    }
+
+    public void testLastSelectedInRangeEndsInMiddleOfSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(50, 250), equalTo(249L));
+    }
+
+    public void testLastSelectedInRangeNoSelectionInRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(0, 50), equalTo(-1L));
+    }
+
+    public void testLastSelectedInRangeMultipleRanges() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 150 }, new long[] { 100, 300 }, 1000);
+        assertThat(ranges.lastSelectedInRange(50, 250), equalTo(249L));
+    }
+
+    public void testNextRunInPageEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.nextRunInPage(0, 128), equalTo(new RowRanges.Run(128, 0)));
+    }
+
+    public void testNextRunInPageFullySelected() {
+        RowRanges all = RowRanges.all(1000);
+        assertThat(all.nextRunInPage(0, 64), equalTo(new RowRanges.Run(0, 64)));
+    }
+
+    public void testNextRunInPageLeadingGap() {
+        RowRanges range = RowRanges.of(5, 100, 1000);
+        assertThat(range.nextRunInPage(0, 50), equalTo(new RowRanges.Run(5, 45)));
+    }
+
+    public void testNextRunInPageNoSelectionInWindow() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertThat(range.nextRunInPage(0, 50), equalTo(new RowRanges.Run(50, 0)));
+    }
+
+    public void testNextRunInPageTruncatedToWindow() {
+        RowRanges range = RowRanges.of(0, 100, 1000);
+        assertThat(range.nextRunInPage(90, 20), equalTo(new RowRanges.Run(0, 10)));
+    }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RowRangesTests extends ESTestCase {
+
+    public void testAllCoversEntireRowGroup() {
+        RowRanges all = RowRanges.all(1000);
+        assertThat(all.selectedRowCount(), equalTo(1000L));
+        assertThat(all.density(), equalTo(1.0));
+        assertThat(all.rangeCount(), equalTo(1));
+        assertTrue(all.isAll());
+        assertFalse(all.isEmpty());
+    }
+
+    public void testEmptyRowGroup() {
+        RowRanges empty = RowRanges.all(0);
+        assertThat(empty.selectedRowCount(), equalTo(0L));
+        assertTrue(empty.isEmpty());
+    }
+
+    public void testSingleRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.selectedRowCount(), equalTo(400L));
+        assertThat(range.density(), equalTo(0.4));
+        assertThat(range.rangeCount(), equalTo(1));
+        assertThat(range.rangeStart(0), equalTo(100L));
+        assertThat(range.rangeEnd(0), equalTo(500L));
+        assertFalse(range.isAll());
+        assertFalse(range.isEmpty());
+    }
+
+    public void testEmptyRange() {
+        RowRanges range = RowRanges.of(500, 500, 1000);
+        assertTrue(range.isEmpty());
+        assertThat(range.selectedRowCount(), equalTo(0L));
+    }
+
+    public void testIntersectOverlapping() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges b = RowRanges.of(300, 800, 1000);
+        RowRanges result = a.intersect(b);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(300L));
+        assertThat(result.rangeEnd(0), equalTo(500L));
+        assertThat(result.selectedRowCount(), equalTo(200L));
+    }
+
+    public void testIntersectNoOverlap() {
+        RowRanges a = RowRanges.of(0, 100, 1000);
+        RowRanges b = RowRanges.of(200, 300, 1000);
+        RowRanges result = a.intersect(b);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testIntersectMultipleRanges() {
+        RowRanges a = RowRanges.ofSorted(new long[] { 0, 200, 500 }, new long[] { 100, 400, 700 }, 1000);
+        RowRanges b = RowRanges.ofSorted(new long[] { 50, 350 }, new long[] { 250, 600 }, 1000);
+        RowRanges result = a.intersect(b);
+        assertThat(result.rangeCount(), equalTo(4));
+        assertThat(result.rangeStart(0), equalTo(50L));
+        assertThat(result.rangeEnd(0), equalTo(100L));
+        assertThat(result.rangeStart(1), equalTo(200L));
+        assertThat(result.rangeEnd(1), equalTo(250L));
+        assertThat(result.rangeStart(2), equalTo(350L));
+        assertThat(result.rangeEnd(2), equalTo(400L));
+        assertThat(result.rangeStart(3), equalTo(500L));
+        assertThat(result.rangeEnd(3), equalTo(600L));
+    }
+
+    public void testIntersectWithEmpty() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertTrue(a.intersect(empty).isEmpty());
+        assertTrue(empty.intersect(a).isEmpty());
+    }
+
+    public void testUnionNonOverlapping() {
+        RowRanges a = RowRanges.of(0, 100, 1000);
+        RowRanges b = RowRanges.of(200, 300, 1000);
+        RowRanges result = a.union(b);
+        assertThat(result.rangeCount(), equalTo(2));
+        assertThat(result.selectedRowCount(), equalTo(200L));
+    }
+
+    public void testUnionOverlapping() {
+        RowRanges a = RowRanges.of(0, 200, 1000);
+        RowRanges b = RowRanges.of(100, 300, 1000);
+        RowRanges result = a.union(b);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(300L));
+        assertThat(result.selectedRowCount(), equalTo(300L));
+    }
+
+    public void testUnionWithEmpty() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        RowRanges result = a.union(empty);
+        assertThat(result.selectedRowCount(), equalTo(500L));
+    }
+
+    public void testComplement() {
+        RowRanges range = RowRanges.of(200, 800, 1000);
+        RowRanges complement = range.complement();
+        assertThat(complement.rangeCount(), equalTo(2));
+        assertThat(complement.rangeStart(0), equalTo(0L));
+        assertThat(complement.rangeEnd(0), equalTo(200L));
+        assertThat(complement.rangeStart(1), equalTo(800L));
+        assertThat(complement.rangeEnd(1), equalTo(1000L));
+        assertThat(complement.selectedRowCount(), equalTo(400L));
+    }
+
+    public void testComplementOfAll() {
+        RowRanges all = RowRanges.all(1000);
+        RowRanges complement = all.complement();
+        assertTrue(complement.isEmpty());
+    }
+
+    public void testComplementOfEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        RowRanges complement = empty.complement();
+        assertTrue(complement.isAll());
+        assertThat(complement.selectedRowCount(), equalTo(1000L));
+    }
+
+    public void testComplementMultipleRanges() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 100, 500 }, new long[] { 200, 600 }, 1000);
+        RowRanges complement = ranges.complement();
+        assertThat(complement.rangeCount(), equalTo(3));
+        assertThat(complement.rangeStart(0), equalTo(0L));
+        assertThat(complement.rangeEnd(0), equalTo(100L));
+        assertThat(complement.rangeStart(1), equalTo(200L));
+        assertThat(complement.rangeEnd(1), equalTo(500L));
+        assertThat(complement.rangeStart(2), equalTo(600L));
+        assertThat(complement.rangeEnd(2), equalTo(1000L));
+    }
+
+    public void testDensity() {
+        RowRanges range = RowRanges.of(0, 800, 1000);
+        assertThat(range.density(), equalTo(0.8));
+    }
+
+    public void testDensityZeroTotal() {
+        RowRanges range = RowRanges.of(0, 0, 0);
+        assertThat(range.density(), equalTo(1.0));
+    }
+
+    public void testAntiFragmentationHighDensity() {
+        RowRanges range = RowRanges.of(0, 900, 1000);
+        assertTrue(range.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationLowDensity() {
+        RowRanges range = RowRanges.of(0, 200, 1000);
+        assertFalse(range.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationTooManyTransitions() {
+        long[] starts = new long[40];
+        long[] ends = new long[40];
+        for (int i = 0; i < 40; i++) {
+            starts[i] = i * 25;
+            ends[i] = i * 25 + 10;
+        }
+        RowRanges fragmented = RowRanges.ofSorted(starts, ends, 1000);
+        assertTrue(fragmented.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationFewTransitions() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 500 }, new long[] { 100, 600 }, 1000);
+        assertFalse(ranges.shouldDiscard(0.8, 32));
+    }
+
+    public void testFromUnsortedMergesOverlapping() {
+        List<long[]> ranges = new ArrayList<>();
+        ranges.add(new long[] { 200, 400 });
+        ranges.add(new long[] { 0, 100 });
+        ranges.add(new long[] { 50, 250 });
+        RowRanges result = RowRanges.fromUnsorted(ranges, 1000);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(400L));
+    }
+
+    public void testFromUnsortedNonOverlapping() {
+        List<long[]> ranges = new ArrayList<>();
+        ranges.add(new long[] { 500, 600 });
+        ranges.add(new long[] { 0, 100 });
+        ranges.add(new long[] { 200, 300 });
+        RowRanges result = RowRanges.fromUnsorted(ranges, 1000);
+        assertThat(result.rangeCount(), equalTo(3));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(100L));
+        assertThat(result.rangeStart(1), equalTo(200L));
+        assertThat(result.rangeEnd(1), equalTo(300L));
+        assertThat(result.rangeStart(2), equalTo(500L));
+        assertThat(result.rangeEnd(2), equalTo(600L));
+    }
+
+    public void testFromUnsortedEmpty() {
+        RowRanges result = RowRanges.fromUnsorted(new ArrayList<>(), 1000);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testIntersectIdentity() {
+        RowRanges a = RowRanges.of(100, 500, 1000);
+        RowRanges result = a.intersect(RowRanges.all(1000));
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(100L));
+        assertThat(result.rangeEnd(0), equalTo(500L));
+    }
+
+    public void testToString() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        String str = range.toString();
+        assertTrue(str.contains("[100, 500)"));
+        assertTrue(str.contains("total=1000"));
+    }
+}

--- a/x-pack/plugin/esql-datasource-s3/build.gradle
+++ b/x-pack/plugin/esql-datasource-s3/build.gradle
@@ -45,7 +45,22 @@ dependencies {
   implementation "software.amazon.awssdk:sdk-core:${versions.awsv2sdk}"
   implementation "software.amazon.awssdk:sts:${versions.awsv2sdk}"
   implementation "software.amazon.awssdk:utils:${versions.awsv2sdk}"
-  
+
+  // AWS SDK async HTTP transport (for S3AsyncClient)
+  implementation "software.amazon.awssdk:netty-nio-client:${versions.awsv2sdk}"
+  runtimeOnly "io.netty:netty-buffer:${versions.netty}"
+  runtimeOnly "io.netty:netty-codec-dns:${versions.netty}"
+  runtimeOnly "io.netty:netty-codec-http2:${versions.netty}"
+  runtimeOnly "io.netty:netty-codec-http:${versions.netty}"
+  runtimeOnly "io.netty:netty-codec:${versions.netty}"
+  runtimeOnly "io.netty:netty-common:${versions.netty}"
+  runtimeOnly "io.netty:netty-handler:${versions.netty}"
+  runtimeOnly "io.netty:netty-resolver-dns:${versions.netty}"
+  runtimeOnly "io.netty:netty-resolver:${versions.netty}"
+  runtimeOnly "io.netty:netty-transport-classes-epoll:${versions.netty}"
+  runtimeOnly "io.netty:netty-transport-native-unix-common:${versions.netty}"
+  runtimeOnly "io.netty:netty-transport:${versions.netty}"
+
   // Apache HTTP client for AWS SDK (required by apache-client module)
   implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   
@@ -101,6 +116,20 @@ tasks.withType(org.elasticsearch.gradle.internal.AbstractDependenciesTask).confi
   mapping from: 'third-party-jackson-core', to: 'aws-sdk-2'
   mapping from: 'url-connection-client',    to: 'aws-sdk-2'
   mapping from: 'utils',                    to: 'aws-sdk-2'
+  mapping from: /netty-nio-client/,         to: 'aws-sdk-2'
+  /* Cannot use REGEX to match netty-* because netty-nio-client is an AWS package */
+  mapping from: /netty-buffer/,             to: 'netty'
+  mapping from: /netty-codec-dns/,          to: 'netty'
+  mapping from: /netty-codec-http2/,        to: 'netty'
+  mapping from: /netty-codec-http/,         to: 'netty'
+  mapping from: /netty-codec/,              to: 'netty'
+  mapping from: /netty-common/,             to: 'netty'
+  mapping from: /netty-handler/,            to: 'netty'
+  mapping from: /netty-resolver-dns/,       to: 'netty'
+  mapping from: /netty-resolver/,           to: 'netty'
+  mapping from: /netty-transport-classes-epoll/, to: 'netty'
+  mapping from: /netty-transport-native-unix-common/, to: 'netty'
+  mapping from: /netty-transport/,          to: 'netty'
 }
 
 tasks.named("thirdPartyAudit").configure {
@@ -111,7 +140,7 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.avalon.framework.logger.Logger',
     'org.apache.log.Hierarchy',
     'org.apache.log.Logger',
-    
+
     // We use the Apache HTTP client rather than AWS CRT, so these classes are not needed
     'software.amazon.awssdk.crt.CRT',
     'software.amazon.awssdk.crt.auth.credentials.Credentials',
@@ -155,10 +184,120 @@ tasks.named("thirdPartyAudit").configure {
     'software.amazon.awssdk.crtcore.CrtProxyConfiguration$Builder',
     'software.amazon.awssdk.crtcore.CrtProxyConfiguration$DefaultBuilder',
     'software.amazon.awssdk.crtcore.CrtProxyConfiguration',
-    
+
     // We don't use eventstream-based features
     'software.amazon.eventstream.HeaderValue',
     'software.amazon.eventstream.Message',
-    'software.amazon.eventstream.MessageDecoder'
+    'software.amazon.eventstream.MessageDecoder',
+
+    // Netty SSL (optional tcnative)
+    'io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod',
+    'io.netty.internal.tcnative.AsyncTask',
+    'io.netty.internal.tcnative.Buffer',
+    'io.netty.internal.tcnative.CertificateCallback',
+    'io.netty.internal.tcnative.CertificateCompressionAlgo',
+    'io.netty.internal.tcnative.CertificateVerifier',
+    'io.netty.internal.tcnative.Library',
+    'io.netty.internal.tcnative.ResultCallback',
+    'io.netty.internal.tcnative.SSL',
+    'io.netty.internal.tcnative.SSLContext',
+    'io.netty.internal.tcnative.SSLPrivateKeyMethod',
+    'io.netty.internal.tcnative.SSLSession',
+    'io.netty.internal.tcnative.SSLSessionCache',
+    'io.netty.internal.tcnative.SessionTicketKey',
+    'io.netty.internal.tcnative.SniHostNameMatcher',
+
+    // Netty optional dependencies
+    'org.conscrypt.AllocatedBuffer',
+    'org.conscrypt.BufferAllocator',
+    'org.conscrypt.Conscrypt',
+    'org.conscrypt.HandshakeListener',
+    'org.eclipse.jetty.alpn.ALPN',
+    'org.eclipse.jetty.alpn.ALPN$ClientProvider',
+    'org.eclipse.jetty.alpn.ALPN$ServerProvider',
+    'org.eclipse.jetty.npn.NextProtoNego',
+    'org.eclipse.jetty.npn.NextProtoNego$ClientProvider',
+    'org.eclipse.jetty.npn.NextProtoNego$ServerProvider',
+
+    // Netty optional compression
+    'com.aayushatharva.brotli4j.Brotli4jLoader',
+    'com.aayushatharva.brotli4j.decoder.DecoderJNI$Status',
+    'com.aayushatharva.brotli4j.decoder.DecoderJNI$Wrapper',
+    'com.aayushatharva.brotli4j.encoder.BrotliEncoderChannel',
+    'com.aayushatharva.brotli4j.encoder.Encoder$Mode',
+    'com.aayushatharva.brotli4j.encoder.Encoder$Parameters',
+    'com.github.luben.zstd.Zstd',
+    'com.github.luben.zstd.ZstdInputStreamNoFinalizer',
+    'com.github.luben.zstd.util.Native',
+    'com.jcraft.jzlib.Deflater',
+    'com.jcraft.jzlib.Inflater',
+    'com.jcraft.jzlib.JZlib',
+    'com.jcraft.jzlib.JZlib$WrapperType',
+    'com.ning.compress.BufferRecycler',
+    'com.ning.compress.lzf.ChunkDecoder',
+    'com.ning.compress.lzf.ChunkEncoder',
+    'com.ning.compress.lzf.LZFChunk',
+    'com.ning.compress.lzf.LZFEncoder',
+    'com.ning.compress.lzf.util.ChunkDecoderFactory',
+    'com.ning.compress.lzf.util.ChunkEncoderFactory',
+    'lzma.sdk.lzma.Encoder',
+
+    // Netty optional protobuf codec
+    'com.google.protobuf.ExtensionRegistry',
+    'com.google.protobuf.ExtensionRegistryLite',
+    'com.google.protobuf.MessageLite',
+    'com.google.protobuf.MessageLite$Builder',
+    'com.google.protobuf.MessageLiteOrBuilder',
+    'com.google.protobuf.Parser',
+    'com.google.protobuf.nano.CodedOutputByteBufferNano',
+    'com.google.protobuf.nano.MessageNano',
+
+    // Netty optional BouncyCastle for SSL
+    'org.bouncycastle.cert.X509v3CertificateBuilder',
+    'org.bouncycastle.cert.jcajce.JcaX509CertificateConverter',
+    'org.bouncycastle.openssl.PEMEncryptedKeyPair',
+    'org.bouncycastle.openssl.PEMParser',
+    'org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter',
+    'org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder',
+    'org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder',
+    'org.bouncycastle.operator.jcajce.JcaContentSignerBuilder',
+    'org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo',
+    'org.jboss.marshalling.ByteInput',
+    'org.jboss.marshalling.ByteOutput',
+    'org.jboss.marshalling.Marshaller',
+    'org.jboss.marshalling.MarshallerFactory',
+    'org.jboss.marshalling.MarshallingConfiguration',
+    'org.jboss.marshalling.Unmarshaller',
+
+    // Netty BlockHound integration (optional)
+    'reactor.blockhound.BlockHound$Builder',
+    'reactor.blockhound.integration.BlockHoundIntegration'
+  )
+
+  ignoreViolations(
+    // Netty uses sun.misc.Unsafe
+    'io.netty.util.internal.PlatformDependent0',
+    'io.netty.util.internal.PlatformDependent0$1',
+    'io.netty.util.internal.PlatformDependent0$2',
+    'io.netty.util.internal.PlatformDependent0$3',
+    'io.netty.util.internal.PlatformDependent0$4',
+    'io.netty.util.internal.PlatformDependent0$6',
+    'io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueConsumerNodeRef',
+    'io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueProducerNodeRef',
+    'io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields',
+    'io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields',
+    'io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields',
+    'io.netty.util.internal.shaded.org.jctools.queues.LinkedQueueNode',
+    'io.netty.util.internal.shaded.org.jctools.queues.MpmcArrayQueueConsumerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.MpmcArrayQueueProducerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField',
+    'io.netty.util.internal.shaded.org.jctools.queues.unpadded.MpscUnpaddedArrayQueueConsumerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.unpadded.MpscUnpaddedArrayQueueProducerIndexField',
+    'io.netty.util.internal.shaded.org.jctools.queues.unpadded.MpscUnpaddedArrayQueueProducerLimitField',
+    'io.netty.util.internal.shaded.org.jctools.util.UnsafeAccess',
+    'io.netty.util.internal.shaded.org.jctools.util.UnsafeLongArrayAccess',
+    'io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess',
   )
 }

--- a/x-pack/plugin/esql-datasource-s3/licenses/netty-LICENSE.txt
+++ b/x-pack/plugin/esql-datasource-s3/licenses/netty-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/x-pack/plugin/esql-datasource-s3/licenses/netty-NOTICE.txt
+++ b/x-pack/plugin/esql-datasource-s3/licenses/netty-NOTICE.txt
@@ -1,0 +1,116 @@
+
+                            The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2011 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.<component>.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+This product contains the extensions to Java Collections Framework which has
+been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+
+  * LICENSE:
+    * license/LICENSE.jsr166y.txt (Public Domain)
+  * HOMEPAGE:
+    * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+    * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+
+This product contains a modified version of Robert Harder's Public Domain
+Base64 Encoder and Decoder, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.base64.txt (Public Domain)
+  * HOMEPAGE:
+    * http://iharder.sourceforge.net/current/java/base64/
+
+This product contains a modified version of 'JZlib', a re-implementation of
+zlib in pure Java, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.jzlib.txt (BSD Style License)
+  * HOMEPAGE:
+    * http://www.jcraft.com/jzlib/
+
+This product contains a modified version of 'Webbit', a Java event based
+WebSocket and HTTP server:
+
+  * LICENSE:
+    * license/LICENSE.webbit.txt (BSD License)
+  * HOMEPAGE:
+    * https://github.com/joewalnes/webbit
+
+This product optionally depends on 'Protocol Buffers', Google's data
+interchange format, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.protobuf.txt (New BSD License)
+  * HOMEPAGE:
+    * http://code.google.com/p/protobuf/
+
+This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+a temporary self-signed X.509 certificate when the JVM does not provide the
+equivalent functionality.  It can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.bouncycastle.txt (MIT License)
+  * HOMEPAGE:
+    * http://www.bouncycastle.org/
+
+This product optionally depends on 'SLF4J', a simple logging facade for Java,
+which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.slf4j.txt (MIT License)
+  * HOMEPAGE:
+    * http://www.slf4j.org/
+
+This product optionally depends on 'Apache Commons Logging', a logging
+framework, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.commons-logging.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://commons.apache.org/logging/
+
+This product optionally depends on 'Apache Log4J', a logging framework,
+which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.log4j.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://logging.apache.org/log4j/
+
+This product optionally depends on 'JBoss Logging', a logging framework,
+which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
+  * HOMEPAGE:
+    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
+
+This product optionally depends on 'Apache Felix', an open source OSGi
+framework implementation, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.felix.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://felix.apache.org/

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourcePlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Data source plugin providing S3 storage support for ESQL.
@@ -30,7 +31,7 @@ public class S3DataSourcePlugin extends Plugin implements DataSourcePlugin {
     }
 
     @Override
-    public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+    public Map<String, StorageProviderFactory> storageProviders(Settings settings, ExecutorService executor) {
         StorageProviderFactory s3Factory = new StorageProviderFactory() {
             @Override
             public StorageProvider create(Settings settings) {

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -245,6 +245,20 @@ public final class S3StorageObject implements StorageObject {
         return key;
     }
 
+    /**
+     * Reads a byte range asynchronously via {@link S3AsyncClient}.
+     *
+     * <p>The AWS SDK's {@code S3AsyncClient} uses a Netty event loop for I/O. To avoid running
+     * listener callbacks on that Netty thread (which could block the event loop if listeners
+     * do non-trivial work), this method uses {@code whenCompleteAsync(..., executor)} to dispatch
+     * the completion callback onto the provided executor. This matches the pattern used by the
+     * inference plugin's SageMaker client ({@code thenAcceptAsync(..., UTILITY)}).
+     *
+     * <p>When the executor is {@code Runnable::run}, the callback runs inline on the Netty
+     * thread — acceptable when the listener is lightweight (e.g., storing a byte buffer in a map).
+     * In production, the calling {@code esql_worker} thread is typically blocked on
+     * {@code PlainActionFuture.actionGet()}, so dispatching to a pool thread avoids contention.
+     */
     @Override
     public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
         if (s3AsyncClient == null) {
@@ -266,7 +280,7 @@ public final class S3StorageObject implements StorageObject {
 
         GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(key).range(rangeHeader).build();
 
-        s3AsyncClient.getObject(request, AsyncResponseTransformer.toBytes()).whenComplete((responseBytes, throwable) -> {
+        s3AsyncClient.getObject(request, AsyncResponseTransformer.toBytes()).whenCompleteAsync((responseBytes, throwable) -> {
             if (throwable != null) {
                 Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
                 if (cause instanceof NoSuchKeyException) {
@@ -289,7 +303,7 @@ public final class S3StorageObject implements StorageObject {
             }
 
             listener.onResponse(ByteBuffer.wrap(responseBytes.asByteArray()));
-        });
+        }, executor);
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -41,9 +41,9 @@ public final class S3StorageObject implements StorageObject {
     private final String key;
     private final StoragePath path;
 
-    private Long cachedLength;
-    private Instant cachedLastModified;
-    private Boolean cachedExists;
+    private volatile Long cachedLength;
+    private volatile Instant cachedLastModified;
+    private volatile Boolean cachedExists;
 
     public S3StorageObject(S3Client s3Client, String bucket, String key, StoragePath path) {
         this(s3Client, null, bucket, key, path);

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
@@ -12,10 +12,12 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -40,19 +42,55 @@ import java.util.NoSuchElementException;
 
 /**
  * StorageProvider implementation for S3 using AWS SDK v2.
+ * <p>
+ * Maintains both a sync {@link S3Client} (Apache HTTP) and an async {@link S3AsyncClient}
+ * (Netty NIO, via {@code netty-nio-client} at {@code ${versions.awsv2sdk}}). The two clients
+ * serve different purposes:
+ * <ul>
+ *   <li><b>Sync client</b> — used for streaming reads ({@code newStream} returns a live
+ *       {@code ResponseInputStream} that reads on demand), metadata ({@code headObject}),
+ *       existence checks, and object listing. These operations are inherently blocking or
+ *       return streaming results that cannot be efficiently expressed as futures.</li>
+ *   <li><b>Async client</b> — used exclusively for {@code readBytesAsync} range reads in
+ *       {@link S3StorageObject}. When {@code ConcurrencyLimitedStorageObject} dispatches
+ *       multiple concurrent range reads, the Netty event loop handles them without blocking
+ *       a thread per request, reducing thread-pool pressure under load.</li>
+ * </ul>
+ * <p>
+ * Both clients share the same credentials, region, and endpoint configuration. The Netty
+ * jars are bundled with this plugin (classloader-isolated from the server and other plugins)
+ * at {@code ${versions.netty}}, matching the pattern used by the inference plugin.
  */
 public final class S3StorageProvider implements StorageProvider {
     private final S3Client s3Client;
+    private final S3AsyncClient s3AsyncClient;
     private final S3Configuration config;
 
     public S3StorageProvider(S3Configuration config) {
         this.config = config;
         this.s3Client = buildS3Client(config);
+        this.s3AsyncClient = buildS3AsyncClient(config);
+    }
+
+    /** Test-only constructor that accepts pre-built clients. */
+    S3StorageProvider(S3Client s3Client, S3AsyncClient s3AsyncClient) {
+        this.config = null;
+        this.s3Client = s3Client;
+        this.s3AsyncClient = s3AsyncClient;
     }
 
     private static S3Client buildS3Client(S3Configuration config) {
-        S3ClientBuilder builder = S3Client.builder();
+        return configureCommon(S3Client.builder(), config).build();
+    }
 
+    private static S3AsyncClient buildS3AsyncClient(S3Configuration config) {
+        return configureCommon(S3AsyncClient.builder(), config).httpClient(NettyNioAsyncHttpClient.builder().build()).build();
+    }
+
+    /**
+     * Applies credentials, region, endpoint, and profile settings common to both the sync and async S3 clients.
+     */
+    private static <B extends S3BaseClientBuilder<B, ?>> B configureCommon(B builder, S3Configuration config) {
         // Disable profile file loading to prevent the AWS SDK from reading ~/.aws/config
         // or the path set via AWS_CONFIG_FILE, which would be blocked by the entitlement system.
         ProfileFile emptyProfileFile = ProfileFile.aggregator().build();
@@ -82,7 +120,7 @@ public final class S3StorageProvider implements StorageProvider {
             builder.forcePathStyle(true);
         }
 
-        return builder.build();
+        return builder;
     }
 
     @Override
@@ -90,7 +128,7 @@ public final class S3StorageProvider implements StorageProvider {
         validateS3Scheme(path);
         String bucket = path.host();
         String key = extractKey(path);
-        return new S3StorageObject(s3Client, bucket, key, path);
+        return new S3StorageObject(s3Client, s3AsyncClient, bucket, key, path);
     }
 
     @Override
@@ -98,7 +136,7 @@ public final class S3StorageProvider implements StorageProvider {
         validateS3Scheme(path);
         String bucket = path.host();
         String key = extractKey(path);
-        return new S3StorageObject(s3Client, bucket, key, path, length);
+        return new S3StorageObject(s3Client, s3AsyncClient, bucket, key, path, length);
     }
 
     @Override
@@ -106,7 +144,7 @@ public final class S3StorageProvider implements StorageProvider {
         validateS3Scheme(path);
         String bucket = path.host();
         String key = extractKey(path);
-        return new S3StorageObject(s3Client, bucket, key, path, length, lastModified);
+        return new S3StorageObject(s3Client, s3AsyncClient, bucket, key, path, length, lastModified);
     }
 
     @Override
@@ -164,7 +202,11 @@ public final class S3StorageProvider implements StorageProvider {
 
     @Override
     public void close() throws IOException {
-        s3Client.close();
+        try {
+            s3Client.close();
+        } finally {
+            s3AsyncClient.close();
+        }
     }
 
     private String credentialHint() {

--- a/x-pack/plugin/esql-datasource-s3/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/esql-datasource-s3/src/main/plugin-metadata/entitlement-policy.yaml
@@ -4,3 +4,21 @@ ALL-UNNAMED:
   - files:
     - path: "/dev/null"
       mode: "read"
+software.amazon.awssdk.http.nio.netty:
+  - manage_threads
+  - outbound_network
+io.netty.common:
+  - outbound_network
+  - manage_threads
+  - inbound_network
+  - files:
+      - path: "/etc/os-release"
+        mode: "read"
+      - path: "/usr/lib/os-release"
+        mode: "read"
+      - path: "/proc/sys/net/core/somaxconn"
+        mode: read
+io.netty.transport:
+  - manage_threads
+  - outbound_network
+  - inbound_network

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectAsyncTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectAsyncTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for S3StorageObject async read paths and dual-client wiring.
+ */
+public class S3StorageObjectAsyncTests extends ESTestCase {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String KEY = "data/file.parquet";
+    private static final StoragePath PATH = StoragePath.of("s3://" + BUCKET + "/" + KEY);
+    private static final byte[] PAYLOAD = "Hello from S3 async".getBytes(StandardCharsets.UTF_8);
+
+    private final S3Client mockSyncClient = mock(S3Client.class);
+    private final S3AsyncClient mockAsyncClient = mock(S3AsyncClient.class);
+
+    public void testSupportsNativeAsyncWithAsyncClient() {
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, mockAsyncClient, BUCKET, KEY, PATH);
+        assertTrue(obj.supportsNativeAsync());
+    }
+
+    public void testSupportsNativeAsyncWithoutAsyncClient() {
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, BUCKET, KEY, PATH);
+        assertFalse(obj.supportsNativeAsync());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testReadBytesAsyncHappyPath() throws Exception {
+        GetObjectResponse response = GetObjectResponse.builder()
+            .contentRange("bytes 0-18/19")
+            .contentLength((long) PAYLOAD.length)
+            .lastModified(Instant.parse("2026-04-01T12:00:00Z"))
+            .build();
+        ResponseBytes<GetObjectResponse> responseBytes = ResponseBytes.fromByteArray(response, PAYLOAD);
+
+        when(mockAsyncClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
+            CompletableFuture.completedFuture(responseBytes)
+        );
+
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, mockAsyncClient, BUCKET, KEY, PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ByteBuffer> result = new AtomicReference<>();
+
+        obj.readBytesAsync(0, PAYLOAD.length, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer buffer) {
+                result.set(buffer);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        ByteBuffer buf = result.get();
+        byte[] bytes = new byte[buf.remaining()];
+        buf.get(bytes);
+        assertArrayEquals(PAYLOAD, bytes);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testReadBytesAsyncCachesMetadata() throws Exception {
+        Instant lastModified = Instant.parse("2026-04-01T12:00:00Z");
+        GetObjectResponse response = GetObjectResponse.builder().contentRange("bytes 0-18/1024").lastModified(lastModified).build();
+        ResponseBytes<GetObjectResponse> responseBytes = ResponseBytes.fromByteArray(response, PAYLOAD);
+
+        when(mockAsyncClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
+            CompletableFuture.completedFuture(responseBytes)
+        );
+
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, mockAsyncClient, BUCKET, KEY, PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        obj.readBytesAsync(0, PAYLOAD.length, Runnable::run, ActionListener.wrap(buf -> latch.countDown(), e -> fail()));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        assertEquals(1024L, obj.length());
+        assertEquals(lastModified, obj.lastModified());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testReadBytesAsyncNotFound() throws Exception {
+        CompletableFuture<ResponseBytes<GetObjectResponse>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(NoSuchKeyException.builder().statusCode(404).message("Not Found").build());
+
+        when(mockAsyncClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(failedFuture);
+
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, mockAsyncClient, BUCKET, KEY, PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(0, 10, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer buffer) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(IOException.class));
+        assertThat(error.get().getMessage(), containsString("Object not found"));
+    }
+
+    public void testReadBytesAsyncNegativePositionFails() throws Exception {
+        S3StorageObject obj = new S3StorageObject(mockSyncClient, mockAsyncClient, BUCKET, KEY, PATH);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(-1, 10, Runnable::run, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer buffer) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(IllegalArgumentException.class));
+        assertThat(error.get().getMessage(), containsString("position must be non-negative"));
+    }
+
+    public void testBothClientsClosedOnProviderClose() throws IOException {
+        S3Client syncClient = mock(S3Client.class);
+        S3AsyncClient asyncClient = mock(S3AsyncClient.class);
+
+        S3StorageProvider provider = new S3StorageProvider(syncClient, asyncClient);
+        provider.close();
+
+        verify(syncClient).close();
+        verify(asyncClient).close();
+    }
+
+    public void testAsyncClientClosedEvenIfSyncCloseThrows() {
+        S3Client syncClient = mock(S3Client.class);
+        S3AsyncClient asyncClient = mock(S3AsyncClient.class);
+
+        doThrow(new RuntimeException("sync close failed")).when(syncClient).close();
+
+        S3StorageProvider provider = new S3StorageProvider(syncClient, asyncClient);
+        expectThrows(RuntimeException.class, provider::close);
+
+        verify(asyncClient).close();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -15,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.concurrent.Executor;
 
 /**
  * A view over a byte range of a delegate {@link StorageObject}.
@@ -76,6 +78,30 @@ class RangeStorageObject implements StorageObject {
     @Override
     public StoragePath path() {
         return delegate.path();
+    }
+
+    @Override
+    public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+        if (position >= this.length) {
+            listener.onResponse(ByteBuffer.allocate(0));
+            return;
+        }
+        long cappedLength = Math.min(length, this.length - position);
+        delegate.readBytesAsync(Math.addExact(offset, position), cappedLength, executor, listener);
+    }
+
+    @Override
+    public void readBytesAsync(long position, ByteBuffer target, Executor executor, ActionListener<Integer> listener) {
+        if (position >= this.length) {
+            listener.onResponse(-1);
+            return;
+        }
+        delegate.readBytesAsync(Math.addExact(offset, position), target, executor, listener);
+    }
+
+    @Override
+    public boolean supportsNativeAsync() {
+        return delegate.supportsNativeAsync();
     }
 
     StorageObject rawDelegate() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -17,6 +18,10 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class RangeStorageObjectTests extends ESTestCase {
 
@@ -177,6 +182,113 @@ public class RangeStorageObjectTests extends ESTestCase {
         StorageObject delegate = new InMemoryStorageObject(FILE_BYTES);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RangeStorageObject(delegate, 0, -1));
         assertTrue(e.getMessage().contains("length must be >= 0"));
+    }
+
+    public void testSupportsNativeAsyncDelegatesToDelegate() {
+        StorageObject syncDelegate = new InMemoryStorageObject(FILE_BYTES);
+        RangeStorageObject syncRange = new RangeStorageObject(syncDelegate, 0, 10);
+        assertFalse(syncRange.supportsNativeAsync());
+
+        StorageObject asyncDelegate = new AsyncCapableStorageObject(FILE_BYTES);
+        RangeStorageObject asyncRange = new RangeStorageObject(asyncDelegate, 0, 10);
+        assertTrue(asyncRange.supportsNativeAsync());
+    }
+
+    public void testReadBytesAsyncAdjustsPosition() throws Exception {
+        StorageObject delegate = new AsyncCapableStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ByteBuffer> result = new AtomicReference<>();
+        Executor directExecutor = Runnable::run;
+
+        range.readBytesAsync(0, 6, directExecutor, new ActionListener<>() {
+            @Override
+            public void onResponse(ByteBuffer byteBuffer) {
+                result.set(byteBuffer);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        ByteBuffer buf = result.get();
+        byte[] bytes = new byte[buf.remaining()];
+        buf.get(bytes);
+        assertEquals("World!", new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    public void testReadBytesAsyncWithTargetBufferAdjustsPosition() throws Exception {
+        StorageObject delegate = new AsyncCapableStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Integer> bytesRead = new AtomicReference<>();
+        ByteBuffer target = ByteBuffer.allocate(6);
+        Executor directExecutor = Runnable::run;
+
+        range.readBytesAsync(0, target, directExecutor, new ActionListener<>() {
+            @Override
+            public void onResponse(Integer count) {
+                bytesRead.set(count);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        target.flip();
+        byte[] bytes = new byte[target.remaining()];
+        target.get(bytes);
+        assertEquals("World!", new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    public void testReadBytesAsyncPastRangeReturnsMinusOne() throws Exception {
+        StorageObject delegate = new AsyncCapableStorageObject(FILE_BYTES);
+        RangeStorageObject range = new RangeStorageObject(delegate, 7, 6);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Integer> bytesRead = new AtomicReference<>();
+        ByteBuffer target = ByteBuffer.allocate(10);
+        Executor directExecutor = Runnable::run;
+
+        range.readBytesAsync(6, target, directExecutor, new ActionListener<>() {
+            @Override
+            public void onResponse(Integer count) {
+                bytesRead.set(count);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected failure: " + e.getMessage());
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(Integer.valueOf(-1), bytesRead.get());
+    }
+
+    /**
+     * StorageObject that reports native async support for testing delegation.
+     */
+    private static class AsyncCapableStorageObject extends InMemoryStorageObject {
+        AsyncCapableStorageObject(byte[] data) {
+            super(data);
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return true;
+        }
     }
 
     private static class InMemoryStorageObject implements StorageObject {


### PR DESCRIPTION
Optimized Parquet reader pipeline behind the `optimized_reader` feature flag,
targeting significant performance improvements for S3 and local reads.

### Commits

1. **Wire native async reads for S3 and Azure** — enables non-blocking I/O by
   wiring S3AsyncClient (Netty NIO) and Azure BlobAsyncClient through the
   storage providers. Fixes RangeStorageObject async delegation.

2. **Add optimized Parquet reader feature flag (Stage 0)** — introduces the
   `optimized_reader` flag (node setting + per-query WITH clause),
   OptimizedParquetColumnIterator shell, CoalescedRangeReader for parallel
   async byte range fetching, and PreloadedRowGroupMetadata holder.

3. **Add batch column reader and page-level row ranges** — RowRanges for
   page-level skipping (Stage 2), PageColumnReader working directly with
   PageReader/DataPage for bulk decode, DefinitionLevelDecoder, PlainValueDecoder,
   DictionaryValueDecoder for type-specific bulk reads, and BatchColumnReader
   as a ColumnReader-based batch path. PreloadedRowGroupMetadata populated with
   column indexes and dictionary pages. S3StorageObject dispatches callbacks off
   the Netty thread via whenCompleteAsync.

4. **Add late materialization pipeline (Stage 4)** — two-phase decode: Phase 1
   decodes predicate columns and evaluates filter to build a RowSelection;
   Phase 2 selectively decodes projection columns at the byte level.

5. **Add parallel column chunk prefetch (Stage 5)** — CoalescedRangeReader
   prefetches column chunks from the next row group while the current one is
   being decoded.

6. **Add constant block detection (Stage 6)** — detects columns where all values
   in a batch are identical and returns a ConstantBlock instead.

7. **Add RowRanges-driven page skipping (Stage 7)** — SelectivePageReader skips
   pages whose row span has no surviving rows (zero I/O, zero decompression).

8. **Optimize decode hot path (~30-40% faster)** — bulk IntBuffer/LongBuffer/
   DoubleBuffer reads in PlainValueDecoder, word-oriented dictionary unpack
   with fast paths for common bit widths, combined def-level + value-tracking
   in DefinitionLevelDecoder, buffer pooling (DecodeBuffers), V1 page zero-copy,
   and zero-copy numeric blocks via ownership hand-off.

Developed with AI-assisted tooling