### PR TITLE
Mute DataStreamIndexSettingsProviderTests class

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,6 +358,8 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
   method: testGetAdditionalIndexSettingsLookBackTime
   issue: https://github.com/elastic/elasticsearch/issues/146307
+- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
+  issue: https://github.com/elastic/elasticsearch/issues/146126
 
 # Examples:
 #


### PR DESCRIPTION
The original failure is in https://github.com/elastic/elasticsearch/issues/146126 which was originally caused by https://github.com/elastic/elasticsearch/pull/146064

This commit mutes those tests until a fix is released.
