### PR TITLE
Use DocValues.getSortedNumeric() instead of reader.getSortedNumericDocValues()

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesTerms.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesTerms.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiTerms;
@@ -37,8 +38,8 @@ class SortedSetDocValuesTerms extends Terms {
     public static Terms getTerms(IndexReader r, String field) throws IOException {
         final List<LeafReaderContext> leaves = r.leaves();
         if (leaves.size() == 1) {
-            SortedSetDocValues sortedSetDocValues = leaves.get(0).reader().getSortedSetDocValues(field);
-            if (sortedSetDocValues == null) {
+            SortedSetDocValues sortedSetDocValues = DocValues.getSortedSet(leaves.get(0).reader(), field);
+            if (sortedSetDocValues.getValueCount() == 0) {
                 return null;
             } else {
                 return new org.elasticsearch.index.mapper.SortedSetDocValuesTerms(sortedSetDocValues);
@@ -50,8 +51,8 @@ class SortedSetDocValuesTerms extends Terms {
 
         for (int leafIdx = 0; leafIdx < leaves.size(); leafIdx++) {
             LeafReaderContext ctx = leaves.get(leafIdx);
-            SortedSetDocValues sortedSetDocValues = ctx.reader().getSortedSetDocValues(field);
-            if (sortedSetDocValues != null) {
+            SortedSetDocValues sortedSetDocValues = DocValues.getSortedSet(ctx.reader(), field);
+            if (sortedSetDocValues.getValueCount() > 0) {
                 termsPerLeaf.add(new org.elasticsearch.index.mapper.SortedSetDocValuesTerms(sortedSetDocValues));
                 slicePerLeaf.add(new ReaderSlice(ctx.docBase, r.maxDoc(), leafIdx));
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -332,7 +332,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
                                 isMultiValue = true;
                             }
                         } else if (fieldContext.fieldType().hasDocValues()) {
-                            if (DocValues.unwrapSingleton(leaf.reader().getSortedNumericDocValues(fieldContext.field())) == null) {
+                            if (DocValues.unwrapSingleton(DocValues.getSortedNumeric(leaf.reader(), fieldContext.field())) == null) {
                                 isMultiValue = true;
                             }
                         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.lucene.query;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -135,7 +136,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
                 }
                 if (scorer.isDone() == false) {
                     // could not apply shortcut, trigger the search
-                    final LongValues values = numberType.multiValueMode(reader.getSortedNumericDocValues(fieldName));
+                    final LongValues values = numberType.multiValueMode(DocValues.getSortedNumeric(reader, fieldName));
                     final LeafCollector leafCollector = new LeafCollector() {
                         @Override
                         public void setScorer(Scorable scorer) {}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
@@ -225,7 +225,7 @@ public final class SingleValueMatchQuery extends Query {
             final int maxDoc = reader.maxDoc();
             final LeafFieldData lfd = fieldData.load(context);
             if (lfd instanceof LeafNumericFieldData) {
-                NumericDocValues singleton = DocValues.unwrapSingleton(reader.getSortedNumericDocValues(fieldData.getFieldName()));
+                NumericDocValues singleton = DocValues.unwrapSingleton(DocValues.getSortedNumeric(reader, fieldData.getFieldName()));
                 if (singleton != null) {
                     singleton.nextDoc();
                     if (singleton.docIDRunEnd() == maxDoc) {
@@ -239,7 +239,7 @@ public final class SingleValueMatchQuery extends Query {
                 }
                 return super.rewrite(indexSearcher);
             } else if (lfd instanceof LeafOrdinalsFieldData) {
-                SortedDocValues singleton = DocValues.unwrapSingleton(reader.getSortedSetDocValues(fieldData.getFieldName()));
+                SortedDocValues singleton = DocValues.unwrapSingleton(DocValues.getSortedSet(reader, fieldData.getFieldName()));
                 if (singleton != null) {
                     singleton.nextDoc();
                     if (singleton.docIDRunEnd() == maxDoc) {


### PR DESCRIPTION
This minor change helps with `multi_value = no`. 

When `multi_value = no`, single values are enforced by using single-valued alternatives to the typical doc values fields:
- `SortedNumericDocValuesField` -> `NumericDocValuesField`
- `SortedSetDocValuesField` - > `SortedDocValuesField`
- `MultiValuedBinaryDocValuesField` -> `BinaryDocValuesField`

This is a problem for `reader.getSortedSetDocValues()` and `reader.getSortedNumericDocValues()` since they explicitly look for `SortedNumericDocValuesField` and `SortedSetDocValuesField`, and will return `null` if missing. This is where `DocValues.getSortedNumeric()` and `DocValues.getSortedSet()` come in. They're multi-value agnostic and will work even with single values:

For example:
```Java
  public static SortedNumericDocValues getSortedNumeric(LeafReader reader, String field)
      throws IOException {
    // Looks for multi-valued field first
    SortedNumericDocValues dv = reader.getSortedNumericDocValues(field);
    if (dv == null) {
      // If missing, looks for a single-valued field
      NumericDocValues single = reader.getNumericDocValues(field);
      if (single == null) {
        checkField(reader, field, DocValuesType.SORTED_NUMERIC, DocValuesType.NUMERIC);
        return emptySortedNumeric();
      }
      return singleton(single);
    }
    return dv;
  }
```

This PR changes all paths that are impacted by `multi_value = no`.