### PR TITLE
docs: fix typos in javadoc comments (seperate/exceded)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/package-info.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/package-info.java
@@ -19,7 +19,7 @@
  *     <li>Bucket aggregations - which group documents (e.g. a histogram)</li>
  *     <li>Metric aggregations - which compute a summary value from several
  *     documents (e.g. a sum)</li>
- *     <li>Pipeline aggregations - which run as a seperate step and compute
+ *     <li>Pipeline aggregations - which run as a separate step and compute
  *     values across buckets</li>
  * </ul>
  * Additionally there is a support sub package, which contains the type checking

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFallbackDocValues.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFallbackDocValues.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.xpack.logsdb.patterntext.PatternTextDocValues.ge
 
 /**
  * Values which exceed 32kb cannot be stored as sorted set doc values. Such values must be stored outside sorted set doc values.
- * This class relies on {@link PatternTextDocValues} but can fall back to values that were stored seperately because limit was exceded.
+ * This class relies on {@link PatternTextDocValues} but can fall back to values that were stored separately because limit was exceeded.
  * <p>
  * Depending on index version the raw values may be stored in binary doc values or stored fields.
  */

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -687,7 +687,7 @@ public class InferenceProcessor extends AbstractProcessor {
         }
 
         /**
-         * {@code outputField} can be a dot '.' seperated path of elements.
+         * {@code outputField} can be a dot '.' separated path of elements.
          * Extract the base path (everything before the last '.') and the final
          * element.
          * If {@code outputField} does not contain any dotted elements the base


### PR DESCRIPTION
Three small typo fixes in Java doc/comments:

- `server/.../search/aggregations/package-info.java`: `seperate step` → `separate step`
- `x-pack/plugin/ml/.../InferenceProcessor.java`: `dot '.' seperated path` → `dot '.' separated path`
- `x-pack/plugin/logsdb/.../PatternTextFallbackDocValues.java`: `stored seperately because limit was exceded` → `stored separately because limit was exceeded`

Comment-only change, no functional impact.