### PR TITLE
[Test] Fix CcrSeqNoPruningIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -217,9 +217,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testAverageWriteLoadMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/145855
-- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
-  method: testSeqNoPrunedOnLeaderAfterFollowerCatchesUp
-  issue: https://github.com/elastic/elasticsearch/issues/145877
 - class: org.elasticsearch.xpack.esql.spatial.SpatialCentroidAggregationIT
   method: testStCentroidAggregationWithShapes
   issue: https://github.com/elastic/elasticsearch/issues/145883

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -208,11 +208,24 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws IOException {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) {
+        persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
+    }
+
+    /**
+     * Persist the global checkpoint on all primary shards of the given index into disk.
+     * This makes sure that the persisted global checkpoint on those shards will equal to the in-memory value.
+     *
+     * This helper method is useful if you do not use replicas in your test setup.
+     *
+     * @param cluster the cluster containing the index
+     * @param index   the name of the index
+     */
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
-            for (String node : internalCluster().nodesInclude(index)) {
-                for (IndexService indexService : internalCluster().getInstance(IndicesService.class, node)) {
+            for (String node : cluster.nodesInclude(index)) {
+                for (IndexService indexService : cluster.getInstance(IndicesService.class, node)) {
                     for (IndexShard indexShard : indexService) {
                         if (indexShard.routingEntry().primary() == false) {
                             continue;

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrSeqNoPruningIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrSeqNoPruningIT.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.index.seqno.SequenceNumbersTestUtils.assertRetentionLeasesAdvanced;
 import static org.elasticsearch.index.seqno.SequenceNumbersTestUtils.assertShardsHaveSeqNoDocValues;
 import static org.elasticsearch.index.seqno.SequenceNumbersTestUtils.assertShardsSeqNoDocValuesCount;
+import static org.elasticsearch.index.seqno.SequenceNumbersTestUtils.persistGlobalCheckpointOnPrimaryShards;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
@@ -108,6 +109,8 @@ public class CcrSeqNoPruningIT extends CcrIntegTestCase {
 
         final long maxSeqNo = getMaxSeqNo(leaderClient(), leaderIndex);
         assertRetentionLeasesAdvanced(leaderClient(), leaderIndex, maxSeqNo + 1);
+        persistGlobalCheckpointOnPrimaryShards(getLeaderCluster(), leaderIndex);
+        flush(leaderClient(), leaderIndex);
 
         var forceMerge = leaderClient().admin().indices().prepareForceMerge(leaderIndex).setMaxNumSegments(1).get();
         assertThat(forceMerge.getFailedShards(), equalTo(0));
@@ -234,6 +237,8 @@ public class CcrSeqNoPruningIT extends CcrIntegTestCase {
         final long finalMaxSeqNo = getMaxSeqNo(leaderClient(), leaderIndex);
 
         assertRetentionLeasesAdvanced(leaderClient(), leaderIndex, finalMaxSeqNo + 1);
+        persistGlobalCheckpointOnPrimaryShards(getLeaderCluster(), leaderIndex);
+        flush(leaderClient(), leaderIndex);
 
         forceMerge = leaderClient().admin().indices().prepareForceMerge(leaderIndex).setMaxNumSegments(1).get();
         assertThat(forceMerge.getFailedShards(), equalTo(0));
@@ -253,5 +258,4 @@ public class CcrSeqNoPruningIT extends CcrIntegTestCase {
     private static long getMaxSeqNo(Client client, String index) {
         return client.admin().indices().prepareStats(index).get().getShards()[0].getSeqNoStats().getMaxSeqNo();
     }
-
 }


### PR DESCRIPTION
The CcrSeqNoPruningIT tests failed because seq_no doc values were not fully pruned during force merge.

PruningMergePolicy uses SoftDeletesPolicy.getMinRetainedSeqNo() to know which operations must be retained in the Lucene index and which operations can be pruned. This min retained seq no is computed from the persisted global checkpoint in the translog
(translog.getLastSyncedGlobalCheckpoint()) and the local checkpoint of the safe commit in Lucene. Both of those values should be up to date at the time of the force merge in the test to allow seq no to be fully pruned.

This change fixes the test by forcing the global checkpoint to be sync in the translog and also force a flush to have an up to date local checkpoint in the last commit.

Closes #145877
