### PR TITLE
[9.4] Relax assertSearcherIsWarmedUp for FieldInfos and unmute SearchWithRandomIOExceptionsIT.testRandomDirectoryIOExceptions (#146240)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -193,9 +193,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
   method: testLookupMissingTable
   issue: https://github.com/elastic/elasticsearch/issues/144695
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/118733
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerStatsTests
   method: testRetriesAndOperationsAreTrackedSeparately
   issue: https://github.com/elastic/elasticsearch/issues/145281

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -144,6 +144,7 @@ public abstract class Engine implements Closeable {
     public static final String CAN_MATCH_SEARCH_SOURCE = "can_match";
     protected static final String DOC_STATS_SOURCE = "doc_stats";
     protected static final String SEGMENTS_STATS_SOURCE = "segments_stats";
+    protected static final String FIELD_HAS_VALUE_SOURCE = "field_has_value";
     public static final long UNKNOWN_PRIMARY_TERM = -1L;
     public static final String ROOT_DOC_FIELD_NAME = "__root_doc_for_nested";
 
@@ -284,7 +285,7 @@ public abstract class Engine implements Closeable {
      * @throws AlreadyClosedException if the shard is closed
      */
     public FieldInfos shardFieldInfos() {
-        try (var searcher = acquireSearcher("field_has_value")) {
+        try (var searcher = acquireSearcher(FIELD_HAS_VALUE_SOURCE)) {
             return FieldInfos.getMergedFieldInfos(searcher.getIndexReader());
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -552,6 +552,8 @@ public class InternalEngine extends Engine {
                 // we can access segment_stats while a shard is still in the recovering state.
                 case "segments":
                 case SEGMENTS_STATS_SOURCE:
+                    // FieldInfos can be accessed before the external reader is fully warmed up.
+                case FIELD_HAS_VALUE_SOURCE:
                     break;
                 default:
                     assert externalReaderManager.isWarmedUp : "searcher was not warmed up yet for source[" + source + "]";

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -4534,7 +4534,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
         @Override
         public void afterRefresh(boolean didRefresh) {
-            if (enableFieldHasValue && (didRefresh || fieldInfos == null)) {
+            if (enableFieldHasValue && didRefresh) {
                 FIELD_INFOS.setRelease(IndexShard.this, loadFieldInfos());
             }
         }


### PR DESCRIPTION
Backport of #146240 for 9.4

assertSearcherIsWarmedUp() asserts that the external reader has been warmed up before being accessed for searches, except for specific cases like gatherings segments stats or segments infos in which accessing a non-warmed up external reader are allowed. This assertion started to trip more frequently two weeks ago in the SearchWithRandomIOExceptionsIT testRandomDirectoryIOExceptions, causing the test to be muted on the main branch.

The assertion fails when a random IO exception is thrown on purpose by the test during a refresh. Then the ExternalReaderManager is not warmed up and its isWarmedUp flag remains false. But Lucene's ReferenceManager always calls the afterRefresh() method on refresh listeners, and in the case of RefreshFieldHasValueListener it triggered loadFieldInfos() since fieldInfos was null. loadFieldInfos() than called acquireSearcher("field_has_value") before warm-up, failing the assertion.

In this change the condition fieldInfos == null is removed from the RefreshFieldHasValueListener.afterRefresh() method in order to avoid calling loadFieldInfos() on a failed refresh. It should be ok since getFieldInfos() already handles lazy loading when fieldInfos is null.

I also think we should relax the assertion in assertSearcherIsWarmedUp() to allow FIELD_HAS_VALUE_SOURCE, so that if something like the Field Capabilities API calls loadFieldInfos()/getFieldInfos() before warm-up the assertion won't fail. I would expect that accessing FieldInfos is safe before warm-up, similar to segment stats/infos.

Relates #118733

Note: the assertion also tripped for that same test soon after it was refactored in #125650, causing the same test to fail on 8.x branch (8.16, then 8.17 at the time) in a different manner documented here that I'll address in a follow up.

