### PR TITLE
[9.4] [ML] Fix test InferenceIT#testInferClassificationModel (#144919)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -52,9 +52,6 @@ tests:
 - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
   method: test50CredentialAutogenerationOnlyOnce
   issue: https://github.com/elastic/elasticsearch/issues/132878
-- class: org.elasticsearch.xpack.ml.integration.InferenceIT
-  method: testInferClassificationModel
-  issue: https://github.com/elastic/elasticsearch/issues/133448
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134667

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIT.java
@@ -49,6 +49,7 @@ public class InferenceIT extends ESRestTestCase {
     @After
     public void cleanUpData() throws Exception {
         new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+        waitForPendingTasks(adminClient());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ML] Fix test InferenceIT#testInferClassificationModel (#144919)