### PR TITLE
[9.4] [ML] Fix test ModelLoadingServiceTests#testExpiredModelsAreEvictedBeforeLoading (#144924)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -115,9 +115,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
   method: testExecute_Throws_WhenRateLimitedQueueIsFull
   issue: https://github.com/elastic/elasticsearch/issues/141231
-- class: org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingServiceTests
-  method: testExpiredModelsAreEvictedBeforeLoading
-  issue: https://github.com/elastic/elasticsearch/issues/141589
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -73,7 +73,6 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -510,7 +509,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         String justSmallEnoughModel = "just-small-enough-model";
         long cbBytes = 13;
         withTrainedModel(smallModel1, cbBytes / 2);
-        withTrainedModel(smallModel1, cbBytes / 2);
+        withTrainedModel(smallModel2, cbBytes / 2);
         long justSmallEnoughModelBytes = cbBytes - 1;
         withTrainedModel(justSmallEnoughModel, justSmallEnoughModelBytes);
         CircuitBreaker circuitBreaker = new CustomCircuitBreaker(cbBytes);
@@ -533,8 +532,8 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(smallModel1, smallModel2));
 
         assertBusy(() -> {
-            assertThat(circuitBreaker.getUsed(), greaterThan(0L));
-            assertThat(circuitBreaker.getTrippedCount(), equalTo(0L));
+            assertTrue(modelLoadingService.isModelCached(smallModel1));
+            assertTrue(modelLoadingService.isModelCached(smallModel2));
         }, 2, TimeUnit.SECONDS);
 
         AtomicBoolean modelLoaded = new AtomicBoolean(false);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ML] Fix test ModelLoadingServiceTests#testExpiredModelsAreEvictedBeforeLoading (#144924)