### PR TITLE
[9.2] [DiskBBQ] Fix offHeap size for empty indices (#146347)

### DIFF
--- a/docs/changelog/146347.yaml
+++ b/docs/changelog/146347.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 146347
+summary: "[DiskBBQ] Fix `offHeap` size for empty indices"
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
@@ -179,7 +179,7 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         final long centroidLength = input.readLong();
         final float[] globalCentroid = new float[info.getVectorDimension()];
         long postingListOffset = -1;
-        long postingListLength = -1;
+        long postingListLength = 0;
         float globalCentroidDp = 0;
         if (centroidLength > 0) {
             postingListOffset = input.readLong();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[DiskBBQ] Fix offHeap size for empty indices (#146347)](https://github.com/elastic/elasticsearch/pull/146347)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)