### PR TITLE
Fix link format for EdgeNGramTokenFilter documentation

### DIFF
--- a/docs/reference/text-analysis/analysis-edgengram-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-edgengram-tokenfilter.md
@@ -13,7 +13,7 @@ For example, you can use the `edge_ngram` token filter to change `quick` to `qu`
 
 When not customized, the filter creates 1-character edge n-grams by default.
 
-This filter uses Lucene’s [EdgeNGramTokenFilter](https://lucene.apache.org/core/10_0_0/analysis/common/org/apache/lucene/analysis/ngram/EdgeNGramTokenFilter.md).
+This filter uses Lucene’s [EdgeNGramTokenFilter](https://lucene.apache.org/core/10_0_0/analysis/common/org/apache/lucene/analysis/ngram/EdgeNGramTokenFilter.html).
 
 ::::{note}
 The `edge_ngram` filter is similar to the [`ngram` token filter](/reference/text-analysis/analysis-ngram-tokenizer.md). However, the `edge_ngram` only outputs n-grams that start at the beginning of a token. These edge n-grams are useful for [search-as-you-type](/reference/elasticsearch/mapping-reference/search-as-you-type.md) queries.


### PR DESCRIPTION
Updated the link to the EdgeNGramTokenFilter documentation to use the correct HTML format.
