### PR TITLE
[8.19] [ML] Omit uncomputed model stats (#146186)

### DIFF
--- a/docs/changelog/146186.yaml
+++ b/docs/changelog/146186.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 146186
+summary: Omit uncomputed model stats
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -567,8 +567,12 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
                 createdByAnalyticsCount++;
             }
             estimatedOperations.add(trainedModelConfig.getEstimatedOperations());
-            if (statsToModelId.containsKey(trainedModelConfig.getModelId())) {
-                estimatedMemoryUsageBytes.add(statsToModelId.get(trainedModelConfig.getModelId()).getModelSizeStats().getModelSizeBytes());
+            var modelStats = statsToModelId.get(trainedModelConfig.getModelId());
+            if (modelStats != null) {
+                var modelSizeStats = modelStats.getModelSizeStats();
+                if (modelSizeStats != null) {
+                    estimatedMemoryUsageBytes.add(modelSizeStats.getModelSizeBytes());
+                }
             }
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportActionTests.java
@@ -54,4 +54,35 @@ public class MachineLearningUsageTransportActionTests extends ESTestCase {
         );
         assertThat(expectedModelMemoryUsage, is(actualMemoryUsage.asMap()));
     }
+
+    public void testAddTrainedModelStatsHandlesNullModelSizeStats() {
+        Map<String, Object> usage = new HashMap<>();
+
+        var deploymentConfig = TrainedModelConfigTests.createTestInstance("id1").build();
+        var stats = new GetTrainedModelsStatsAction.Response.TrainedModelStats(
+            "id1",
+            null, // set modelSizeStats as null
+            GetTrainedModelsStatsActionResponseTests.randomIngestStats(),
+            randomIntBetween(0, 10),
+            null,
+            null
+        );
+
+        var modelsResponse = new GetTrainedModelsAction.Response(
+            new QueryPage<>(List.of(deploymentConfig), 1, GetTrainedModelsAction.Response.RESULTS_FIELD)
+        );
+
+        var statsResponse = new GetTrainedModelsStatsAction.Response(
+            new QueryPage<>(List.of(stats), 1, GetTrainedModelsStatsAction.Response.RESULTS_FIELD)
+        );
+
+        MachineLearningUsageTransportAction.addTrainedModelStats(modelsResponse, statsResponse, usage);
+
+        StatsAccumulator emptyAccumulator = new StatsAccumulator();
+        @SuppressWarnings("unchecked")
+        var actualModelMemoryUsage = ((Map<String, Object>) usage.get("trained_models")).get(
+            TrainedModelConfig.MODEL_SIZE_BYTES.getPreferredName()
+        );
+        assertThat(actualModelMemoryUsage, is(emptyAccumulator.asMap()));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Omit uncomputed model stats (#146186)