### PR TITLE
[8.19] Round sinh result in spec tests (#141403)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -336,11 +336,12 @@ sinh
 ROW a=1.8 
 | EVAL sinh=SINH(a)
 // end::sinh[]
+| EVAL sinh=round(sinh, 10)
 ;
 
 // tag::sinh-result[]
 a:double | sinh:double
-     1.8 | 2.94217428809568
+     1.8 | 2.9421742881
 // end::sinh-result[]
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -671,10 +671,10 @@ a:integer | sin:double
 ;
 
 sinh
-ROW a=2 | EVAL sinh=SINH(a);
+ROW a=2 | EVAL sinh=round(SINH(a), 10);
 
 a:integer | sinh:double
-        2 | 3.626860407847019
+        2 | 3.6268604078
 ;
 
 asin


### PR DESCRIPTION
Some sinh tests are failing on JDK 26 due to increased precision. This change relaxes the tests by rounding and verifying results to 10 decimal places only.

Closes #141396
