### PR TITLE
[8.19] Fix entitlements for JDK26

### DIFF
--- a/libs/entitlement/src/main26/java/org/elasticsearch/entitlement/config/MainInstrumentationProvider.java
+++ b/libs/entitlement/src/main26/java/org/elasticsearch/entitlement/config/MainInstrumentationProvider.java
@@ -28,7 +28,8 @@ public class MainInstrumentationProvider implements InstrumentationConfig {
             new SelectorProviderInstrumentation(),
             new SystemInstrumentation(),
             new ThreadInstrumentation(),
-            new StructuredTaskScopeInstrumentation()
+            new StructuredTaskScopeInstrumentation(),
+            new Java21Instrumentation()
         ).forEach(config -> config.init(registry));
     }
 }


### PR DESCRIPTION
The `main26` `MainInstrumentationProvider` was created in #142984 to handle JDK 26 bootstrap (dropping `DeprecatedNetworkInstrumentation` for the removed `MulticastSocket.send`). But it also dropped `Java21Instrumentation`, which meant FFM methods, `ForkJoinPool.setParallelism`, and new `FileSystemProvider` methods were not entitlement-checked on JDK 26 at all.

Turns out the JDK internal classes that `Java21Instrumentation` references (`AbstractLinker`, `AbstractMemorySegmentImpl`, `ValueLayouts.OfAddressImpl`) are fine on JDK 26 — on 9.x the same rules live in `SystemInstrumentation` and work. This just adds `Java21Instrumentation` back to the `main26` provider, matching what `main25` already has.
