### PR TITLE
[9.4] Adjust DiskBBQ defaults to only apply to serverless (#146273)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTestUtils.java
@@ -91,6 +91,7 @@ public class DenseVectorFieldMapperTestUtils {
     public static DenseVectorFieldMapper.DenseVectorIndexOptions defaultDenseVectorIndexOptions(
         IndexVersion indexVersionCreated,
         boolean enterpriseLicense,
+        boolean statelessNode,
         Integer dims,
         DenseVectorFieldMapper.ElementType elementType,
         boolean experimentalFeaturesEnabled
@@ -104,7 +105,7 @@ public class DenseVectorFieldMapperTestUtils {
         final boolean defaultBBQHnsw = indexVersionCreated.onOrAfter(IndexVersions.DEFAULT_DENSE_VECTOR_TO_BBQ_HNSW);
         final boolean defaultBBQDisk = indexVersionCreated.onOrAfter(IndexVersions.DEFAULT_DENSE_VECTOR_TO_BBQ_DISK);
 
-        if (defaultBBQDisk && enterpriseLicense) {
+        if (defaultBBQDisk && enterpriseLicense && statelessNode) {
             int bits = dims < BBQ_DIMS_DEFAULT_THRESHOLD ? 4 : 1;
             return new DenseVectorFieldMapper.BBQIVFIndexOptions(
                 ES940DiskBBQVectorsFormat.DEFAULT_VECTORS_PER_CLUSTER,

--- a/x-pack/plugin/diskbbq/src/main/java/org/elasticsearch/xpack/diskbbq/DiskBBQPlugin.java
+++ b/x-pack/plugin/diskbbq/src/main/java/org/elasticsearch/xpack/diskbbq/DiskBBQPlugin.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.diskbbq;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.elasticsearch.Build;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
@@ -36,7 +37,11 @@ public class DiskBBQPlugin extends Plugin implements InternalVectorFormatProvide
         License.OperationMode.ENTERPRISE
     );
 
-    public DiskBBQPlugin(Settings settings) {}
+    private final boolean statelessNode;
+
+    public DiskBBQPlugin(Settings settings) {
+        this.statelessNode = DiscoveryNode.isStateless(settings);
+    }
 
     protected XPackLicenseState getLicenseState() {
         return XPackPlugin.getSharedLicenseState();
@@ -49,7 +54,7 @@ public class DiskBBQPlugin extends Plugin implements InternalVectorFormatProvide
             public boolean isVectorIndexTypeAllowed(IndexVersion indexVersionCreated, DenseVectorFieldMapper.VectorIndexType indexType) {
                 return indexType != DenseVectorFieldMapper.VectorIndexType.BBQ_DISK
                     || indexVersionCreated.onOrAfter(IndexVersions.DISK_BBQ_LICENSE_ENFORCEMENT) == false
-                    || DISK_BBQ_FEATURE.check(getLicenseState());
+                    || (statelessNode && DISK_BBQ_FEATURE.check(getLicenseState()));
             }
 
             @Override

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.diskbbq;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.elasticsearch.Build;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexSettings;
@@ -33,7 +34,8 @@ public class DiskBBQDenseVectorFieldMapperTests extends MapperServiceTestCase {
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return List.of(new TrialLicenseStateDiskBBQPlugin(Settings.EMPTY));
+        Settings statelessSettings = Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build();
+        return List.of(new TrialLicenseStateDiskBBQPlugin(statelessSettings));
     }
 
     public void testKnnBBQIVFVectorsFormat() throws IOException {

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.diskbbq;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -23,7 +24,8 @@ public class DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests extends Mapper
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return List.of(new BasicLicenseStateDiskBBQPlugin(Settings.EMPTY));
+        Settings statelessSettings = Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build();
+        return List.of(new BasicLicenseStateDiskBBQPlugin(statelessSettings));
     }
 
     public void testDoesNotDefaultToBBQDiskWhenUnlicensed() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Strings;
@@ -147,12 +148,15 @@ import static org.mockito.Mockito.when;
 
 public class SemanticTextFieldMapperTests extends MapperTestCase {
     private static class VariableLicenseDiskBBQPlugin extends DiskBBQPlugin {
+        private static final Settings STATELESS_SETTINGS = Settings.builder()
+            .put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true)
+            .build();
         static VariableLicenseDiskBBQPlugin BASIC = new VariableLicenseDiskBBQPlugin(
-            Settings.EMPTY,
+            STATELESS_SETTINGS,
             new XPackLicenseState(() -> 0L, new XPackLicenseStatus(License.OperationMode.BASIC, true, null))
         );
         static VariableLicenseDiskBBQPlugin ENTERPRISE = new VariableLicenseDiskBBQPlugin(
-            Settings.EMPTY,
+            STATELESS_SETTINGS,
             new XPackLicenseState(() -> 0L, new XPackLicenseStatus(License.OperationMode.ENTERPRISE, true, null))
         );
 
@@ -2032,6 +2036,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             defaultDenseVectorIndexOptions(
                 indexVersionCreated,
                 operationMode == License.OperationMode.ENTERPRISE,
+                true,
                 dims,
                 elementType,
                 experimentalFeaturesEnabled


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Adjust DiskBBQ defaults to only apply to serverless (#146273)