### PR TITLE
Fix DataStreamIndexSettingsProviderTests setting count

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -53,6 +53,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
     private boolean expectedIndexDimensionsTsidOptimizationEnabled;
     private IndexVersion indexVersion;
     private boolean expectedDisabledSequenceNumbers;
+    private boolean expectedSyntheticId;
 
     @Before
     public void setup() {
@@ -67,14 +68,23 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             indexVersion = IndexVersionUtils.randomPreviousCompatibleVersion(IndexVersions.TSID_CREATED_DURING_ROUTING);
         }
         expectedDisabledSequenceNumbers = indexVersion.onOrAfter(IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT);
+        expectedSyntheticId = indexVersion.onOrAfter(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_DEFAULT_PROD);
         indexDimensionsTsidStrategyEnabledSetting = usually();
         expectedIndexDimensionsTsidOptimizationEnabled = indexDimensionsTsidStrategyEnabledSetting
             && indexVersion.onOrAfter(IndexVersions.TSID_CREATED_DURING_ROUTING);
     }
 
     int maybeAdjustIndexSettingCount(int baseCount) {
-        // We need to adjust to account for the seq_no removal and synthetic id settings
-        return expectedDisabledSequenceNumbers ? baseCount + 2 : baseCount;
+        // Adjust count independently: DISABLE_SEQUENCE_NUMBERS and SYNTHETIC_ID use different version thresholds
+        // (TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT and TIME_SERIES_USE_SYNTHETIC_ID_DEFAULT_PROD respectively)
+        int count = baseCount;
+        if (expectedDisabledSequenceNumbers) {
+            count++;
+        }
+        if (expectedSyntheticId) {
+            count++;
+        }
+        return count;
     }
 
     public void testGetAdditionalIndexSettings() throws Exception {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -268,15 +268,6 @@ tests:
 - class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
   method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
   issue: https://github.com/elastic/elasticsearch/issues/146106
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsNoMappings
-  issue: https://github.com/elastic/elasticsearch/issues/146108
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsIndexRoutingPathAlreadyDefined
-  issue: https://github.com/elastic/elasticsearch/issues/146109
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsMigrateToTsdb
-  issue: https://github.com/elastic/elasticsearch/issues/146112
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
   issue: https://github.com/elastic/elasticsearch/issues/146130
@@ -286,12 +277,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
   issue: https://github.com/elastic/elasticsearch/issues/146137
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGenerateRoutingPathFromDynamicTemplate
-  issue: https://github.com/elastic/elasticsearch/issues/146197
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsMappingsMerging
-  issue: https://github.com/elastic/elasticsearch/issues/146198
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=tsdb/25_id_generation/*}
   issue: https://github.com/elastic/elasticsearch/issues/146177
@@ -313,9 +298,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testMaxQueueLatencyMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/146283
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsLookAheadTime
-  issue: https://github.com/elastic/elasticsearch/issues/146305
 - class: org.elasticsearch.xpack.sql.qa.multi_node.RestSqlIT
   method: testAsyncTextPaginated
   issue: https://github.com/elastic/elasticsearch/issues/80089
@@ -328,11 +310,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.RestSqlIT
   method: testAsyncTextPaginated
   issue: https://github.com/elastic/elasticsearch/issues/80089
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsLookBackTime
-  issue: https://github.com/elastic/elasticsearch/issues/146307
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  issue: https://github.com/elastic/elasticsearch/issues/146126
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.resolve_cluster/20_resolve_system_index/Resolve system index via resolve/cluster}
   issue: https://github.com/elastic/elasticsearch/issues/146312


### PR DESCRIPTION
TIME_SERIES_USE_SYNTHETIC_ID_DEFAULT_PROD (9_093_0_00) and
TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT (9_094_0_00) have
different version thresholds. maybeAdjustIndexSettingCount was
incorrectly assuming both settings are added together, causing
off-by-one failures when the random index version falls between
the two thresholds.

Track expectedSyntheticId independently and increment the count
separately for each setting.

Closes #146126
Closes #146108
Closes #146109
Closes #146112
Closes #146197
Closes #146198
Closes #146305
Closes #146307

Assisted by Claude