### PR TITLE
[9.2] Remove Security Manager references from plugins (#146281)

### DIFF
--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeServiceImpl.java
@@ -19,7 +19,6 @@ import com.microsoft.windowsazure.management.compute.models.HostedServiceGetDeta
 import com.microsoft.windowsazure.management.configuration.ManagementConfiguration;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.cloud.azure.classic.AzureServiceRemoteException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -89,7 +88,6 @@ public class AzureComputeServiceImpl extends AbstractLifecycleComponent implemen
 
     @Override
     public HostedServiceGetDetailedResponse getServiceDetails() {
-        SpecialPermission.check();
         try {
             return client.getHostedServicesOperations().getDetailed(serviceName);
         } catch (Exception e) {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.discovery.ec2;
 
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -32,10 +31,6 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Reloa
 
     private static final Logger logger = LogManager.getLogger(Ec2DiscoveryPlugin.class);
     public static final String EC2_SEED_HOSTS_PROVIDER_NAME = "ec2";
-
-    static {
-        SpecialPermission.check();
-    }
 
     private final Settings settings;
     // protected for testing

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
@@ -44,11 +44,8 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -63,16 +60,6 @@ import static org.mockito.Mockito.mock;
 
 @ThreadLeakFilters(filters = { HdfsClientThreadLeakFilter.class })
 public class HdfsBlobStoreContainerTests extends ESTestCase {
-
-    private FileContext createTestContext() {
-        FileContext fileContext;
-        try {
-            fileContext = AccessController.doPrivileged((PrivilegedExceptionAction<FileContext>) () -> createContext(new URI("hdfs:///")));
-        } catch (PrivilegedActionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        return fileContext;
-    }
 
     @SuppressForbidden(reason = "lesser of two evils (the other being a bunch of JNI/classloader nightmares)")
     private FileContext createContext(URI uri) {
@@ -134,7 +121,7 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
     }
 
     public void testReadOnly() throws Exception {
-        FileContext fileContext = createTestContext();
+        FileContext fileContext = createContext(URI.create("hdfs:///"));
         // Constructor will not create dir if read only
         HdfsBlobStore hdfsBlobStore = new HdfsBlobStore(fileContext, "dir", 1024, true);
         FileContext.Util util = fileContext.util();
@@ -163,7 +150,7 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
     }
 
     public void testReadRange() throws Exception {
-        FileContext fileContext = createTestContext();
+        FileContext fileContext = createContext(URI.create("hdfs:///"));
         // Constructor will not create dir if read only
         HdfsBlobStore hdfsBlobStore = new HdfsBlobStore(fileContext, "dir", 1024, true);
         FileContext.Util util = fileContext.util();
@@ -194,7 +181,7 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
     }
 
     public void testReplicationFactor() throws Exception {
-        FileContext fileContext = createTestContext();
+        FileContext fileContext = createContext(URI.create("hdfs:///"));
         short replicationFactor = 8;
 
         HdfsBlobStore hdfsBlobStore = new HdfsBlobStore(fileContext, "dir", 1024, false, false, replicationFactor);
@@ -218,7 +205,7 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
     }
 
     public void testListBlobsByPrefix() throws Exception {
-        FileContext fileContext = createTestContext();
+        FileContext fileContext = createContext(URI.create("hdfs:///"));
         HdfsBlobStore hdfsBlobStore = new HdfsBlobStore(fileContext, "dir", 1024, false);
         FileContext.Util util = fileContext.util();
         Path root = fileContext.makeQualified(new Path("dir"));


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Remove Security Manager references from plugins (#146281)