### PR TITLE
[Inference API] Fix failing test 141231

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -97,9 +97,6 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testSourceThrottling
   issue: https://github.com/elastic/elasticsearch/issues/141548
-- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
-  method: testExecute_Throws_WhenRateLimitedQueueIsFull
-  issue: https://github.com/elastic/elasticsearch/issues/141231
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -184,12 +184,12 @@ public class RequestExecutorServiceTests extends ESTestCase {
         assertTrue(thrownException.isExecutorShutdown());
     }
 
-    public void testExecute_Throws_WhenRateLimitedQueueIsFull() {
+    public void testExecute_Throws_WhenRateLimitedQueueIsFull() throws InterruptedException {
         var service = new RequestExecutorService(threadPool, null, createRequestExecutorServiceSettings(1), mock(RetryingHttpSender.class));
-        service.start();
 
+        // Enqueue before start() so the poller cannot drain the queue between submits (avoids rate-limit delay + timeout).
         service.execute(
-            RequestManagerTests.createMockWithRateLimitingEnabled(),
+            RequestManagerTests.createMockWithRateLimitingEnabled("id"),
             new EmbeddingsInput(List.of(), InputTypeTests.randomIngest()),
             null,
             new PlainActionFuture<>()
@@ -211,6 +211,10 @@ public class RequestExecutorServiceTests extends ESTestCase {
             )
         );
         assertFalse(thrownException.isExecutorShutdown());
+
+        service.shutdown();
+        service.start();
+        service.awaitTermination(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
     }
 
     public void testTaskThrowsError_CallsOnFailure() throws InterruptedException {


### PR DESCRIPTION
Fixes #141231

## Problem

`testExecute_Throws_WhenRateLimitedQueueIsFull` called `start()` before submitting work. The rate-limited poller could dequeue the first task between `execute()` calls, so the second task was accepted into the queue and then waited on the 1/min rate limiter while the mock sender never completed the listener. That surfaced as `ElasticsearchTimeoutException` instead of the expected `EsRejectedExecutionException` for a full queue.

## Fix

Submit both tasks before `start()`, matching other tests in the class, then shut down and await termination for cleanup. Remove the corresponding `muted-tests.yml` entry.