### PR TITLE
Fix esql javadoc on windows

### DIFF
--- a/benchmarks/processor/src/main/java/org/elasticsearch/benchmark/ExtraParamProcessor.java
+++ b/benchmarks/processor/src/main/java/org/elasticsearch/benchmark/ExtraParamProcessor.java
@@ -18,10 +18,10 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 
 /**
- * Annotation processor that claims {@link ExtraParam} annotations so that
+ * Annotation processor that claims {@code ExtraParam} annotations so that
  * javac's {@code -Xlint:processing} check does not flag them as unprocessed.
  * The processor does nothing with the annotations — they are only consumed
- * at runtime by {@link Utils#possibleValues}.
+ * at runtime by {@code Utils#possibleValues}.
  */
 @SupportedAnnotationTypes("org.elasticsearch.benchmark.ExtraParam")
 public class ExtraParamProcessor extends AbstractProcessor {

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -529,7 +529,10 @@ tasks.withType(Javadoc).configureEach {
   opts.addBooleanOption('-allow-script-in-comments', true)
   // The inline style below is borrowed from Elastic's doc's primary stylesheet
   // the rest is standard activation for highlight.js
-  opts.header('''\
+  // Newlines are stripped from the header to avoid Windows javadoc argument
+  // parsing issues: the options file is parsed line-by-line, so CSS custom
+  // properties like --color-blue-elastic are misread as javadoc flags.
+  opts.header(('''\
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/default.min.css">
 <style>
   .snippet-container {
@@ -727,5 +730,5 @@ tasks.withType(Javadoc).configureEach {
 </style>
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/elastic/highlightjs-esql@1.2.2/dist/esql.min.js"></script>
-<script>hljs.highlightAll();</script>''')
+<script>hljs.highlightAll();</script>''').replaceAll(/[\r\n]+/, ''))
 }


### PR DESCRIPTION
It contains newlines and windows hates hates it.
