### PR TITLE
[9.3] ESQL: Fix starts_with/ends_with/like with special chars (#146348)

### DIFF
--- a/docs/changelog/146348.yaml
+++ b/docs/changelog/146348.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 130851
+pr: 146348
+summary: Fix starts_with/ends_with with special chars
+type: bug

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
@@ -222,6 +222,22 @@ public final class StringUtils {
     }
 
     /**
+     * Escapes Lucene wildcard metacharacters ({@code *}, {@code ?}, {@code \}) in a literal string
+     * so it can be safely embedded in a Lucene wildcard pattern.
+     */
+    public static String escapeWildcardLiteral(String literal) {
+        StringBuilder sb = new StringBuilder(literal.length());
+        for (int i = 0; i < literal.length(); i++) {
+            char c = literal.charAt(i);
+            if (c == '*' || c == '?' || c == '\\') {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /**
      * Translates a like pattern to a Lucene wildcard.
      * This methods pays attention to the custom escape char which gets converted into \ (used by Lucene).
      * <pre>

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.TestClustersThreadFilter;
@@ -22,6 +23,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.TestFeatureService;
 import org.elasticsearch.xpack.esql.AssertWarnings;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.qa.rest.ProfileLogger;
 import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.junit.After;
@@ -763,6 +765,33 @@ public class MultiClustersIT extends ESRestTestCase {
 
     private static boolean includeCCSMetadata() {
         return randomBoolean();
+    }
+
+    public void testStartsWithIndex() throws Exception {
+        assertRemoteIndexPredicate("STARTS_WITH(_index, \"" + REMOTE_CLUSTER_NAME + ":test-remote\")");
+    }
+
+    public void testEndsWithIndex() throws Exception {
+        assertRemoteIndexPredicate("ENDS_WITH(_index, \"remote-index\")");
+    }
+
+    private void assertRemoteIndexPredicate(String predicate) throws Exception {
+        assumeTrue(
+            "requires fix",
+            capabilitiesSupportedNewAndOld(List.of(EsqlCapabilities.Cap.FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX.capabilityName()))
+        );
+
+        boolean includeCCSMetadata = includeCCSMetadata();
+
+        Map<String, Object> result = run(LoggerMessageFormat.format(null, """
+            FROM test-local-index,*:test-remote-index METADATA _index
+            | WHERE {}
+            | STATS c = COUNT(*) BY _index
+            | SORT _index ASC
+            """, predicate), includeCCSMetadata);
+        var columns = List.of(Map.of("name", "c", "type", "long"), Map.of("name", "_index", "type", "keyword"));
+        var values = List.of(List.of(remoteDocs.size(), REMOTE_CLUSTER_NAME + ":" + remoteIndex));
+        assertResultMap(includeCCSMetadata, result, columns, values, false);
     }
 
     public static class ClusterSettingToggle implements AutoCloseable {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1541,6 +1541,196 @@ GTF            | Great Falls Int'l | 8                 | airports
 LUH            | Sahnewal          | 9                 | airports
 ;
 
+startsWithOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| WHERE STARTS_WITH(_index, "k8s-")
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+startsWithOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = STARTS_WITH(_index, "k8s-")
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+endsWithOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| WHERE ENDS_WITH(_index, "-downsampled")
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+endsWithOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = ENDS_WITH(_index, "-downsampled")
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+likeOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index LIKE "k8s-*"
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+likeOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index LIKE "k8s-*"
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+// https://github.com/elastic/elasticsearch/issues/146364
+likeSingleCharOnIndexWithMinusWhere-Ignore
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index LIKE "k8s?downsampled"
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+likeSingleCharOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index LIKE "k8s?downsampled"
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+likeListOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: like_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index LIKE ("k8s-*", "no_match*")
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+likeListOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: like_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index LIKE ("k8s-*", "no_match*")
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+likeSingleCharListOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: like_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index LIKE ("k8s?downsampled", "no_match")
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+likeSingleCharListOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: like_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index LIKE ("k8s?downsampled", "no_match")
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+rlikeOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index RLIKE "k8s-.*"
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+rlikeOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index RLIKE "k8s-.*"
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
+rlikeListOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: rlike_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| WHERE _index RLIKE ("k8s-.*", "no_match.*")
+| STATS c = COUNT(*);
+
+c:long
+27
+;
+
+rlikeListOnIndexWithMinusEval
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: rlike_with_list_of_patterns
+
+FROM k8s-downsampled METADATA _index
+| EVAL is_there = _index RLIKE ("k8s-.*", "no_match.*")
+| KEEP is_there
+| LIMIT 1;
+
+is_there:boolean
+true
+;
+
 toLowerRow#[skip:-8.12.99]
 // tag::to_lower[]
 ROW message = "Some Text"

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1972,6 +1972,12 @@ public class EsqlCapabilities {
          */
         FIX_PROPAGATE_NULLABLE_OR_DISJUNCTION,
 
+        /**
+         * Fix for {@code STARTS_WITH} and {@code ENDS_WITH} Lucene pushdown on {@code _index}: use wildcard escaping instead of
+         * query-parser escaping, and honour the {@code stringLikeOnIndex} flag so the wildcard query forces string matching on metadata
+         * fields.
+         */
+        FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -149,9 +149,9 @@ public class EndsWith extends EsqlScalarFunction implements TranslationAware.Sin
         var fieldName = handler.nameOf(str instanceof FieldAttribute fa ? fa.exactAttribute() : str);
 
         // TODO: Get the real FoldContext here
-        var wildcardQuery = "*" + QueryParser.escape(BytesRefs.toString(suffix.fold(FoldContext.small())));
+        var wildcardQuery = "*" + StringUtils.escapeWildcardLiteral(BytesRefs.toString(suffix.fold(FoldContext.small())));
 
-        return new WildcardQuery(source(), fieldName, wildcardQuery, false, false);
+        return new WildcardQuery(source(), fieldName, wildcardQuery, false, pushdownPredicates.flags().stringLikeOnIndex());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -146,9 +146,9 @@ public class StartsWith extends EsqlScalarFunction implements TranslationAware.S
         var fieldName = handler.nameOf(str instanceof FieldAttribute fa ? fa.exactAttribute() : str);
 
         // TODO: Get the real FoldContext here
-        var wildcardQuery = QueryParser.escape(BytesRefs.toString(prefix.fold(FoldContext.small()))) + "*";
+        var wildcardQuery = StringUtils.escapeWildcardLiteral(BytesRefs.toString(prefix.fold(FoldContext.small()))) + "*";
 
-        return new WildcardQuery(source(), fieldName, wildcardQuery, false, false);
+        return new WildcardQuery(source(), fieldName, wildcardQuery, false, pushdownPredicates.flags().stringLikeOnIndex());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFlags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFlags.java
@@ -84,6 +84,11 @@ public class EsqlFlags {
         this.roundToPushdownThreshold = settings.get(ESQL_ROUNDTO_PUSHDOWN_THRESHOLD);
     }
 
+    /**
+     * Controls whether {@code WHERE _index LIKE pattern} is consistent with the compute engine
+     * when pushed down to Lucene or uses legacy behavior that was not consistent.
+     * See https://github.com/elastic/elasticsearch/issues/129511.
+     */
     public boolean stringLikeOnIndex() {
         return stringLikeOnIndex;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithStaticTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
 
 import java.util.Map;
 
@@ -63,6 +64,47 @@ public class EndsWithStaticTests extends ESTestCase {
 
         Query query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*a\\*b\\?c\\\\", false, false)));
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*a\\*b\\?c\\\\", false, true)));
+    }
+
+    public void testLuceneQuery_OnlyEscapesWildcardChars() {
+        // Characters that are special in Lucene query-parser syntax but NOT in wildcard syntax.
+        // QueryParser.escape would escape these, but our wildcard escaping must leave them untouched.
+        for (String ch : new String[] { "+", "-", "!", "(", ")", "^", "\"", "~", "/" }) {
+            EndsWith function = new EndsWith(
+                Source.EMPTY,
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "field",
+                    new EsField("suffix", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+                ),
+                Literal.keyword(Source.EMPTY, "k8s" + ch + "idx")
+            );
+
+            Query query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
+
+            assertThat(
+                "character '" + ch + "' must not be escaped",
+                query,
+                equalTo(new WildcardQuery(Source.EMPTY, "field", "*k8s" + ch + "idx", false, true))
+            );
+        }
+    }
+
+    public void testLuceneQuery_StringLikeOnIndexFalse() {
+        EndsWith function = new EndsWith(
+            Source.EMPTY,
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("suffix", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            ),
+            Literal.keyword(Source.EMPTY, "test")
+        );
+
+        var predicates = LucenePushdownPredicates.forCanMatch(null, new EsqlFlags(false));
+        Query query = function.asQuery(predicates, TranslatorHandler.TRANSLATOR_HANDLER);
+
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*test", false, false)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithStaticTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
 
 import java.util.Map;
 
@@ -63,6 +64,47 @@ public class StartsWithStaticTests extends ESTestCase {
 
         var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "a\\*b\\?c\\\\*", false, false)));
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "a\\*b\\?c\\\\*", false, true)));
+    }
+
+    public void testLuceneQuery_OnlyEscapesWildcardChars() {
+        // Characters that are special in Lucene query-parser syntax but NOT in wildcard syntax.
+        // QueryParser.escape would escape these, but our wildcard escaping must leave them untouched.
+        for (String ch : new String[] { "+", "-", "!", "(", ")", "^", "\"", "~", "/" }) {
+            var function = new StartsWith(
+                Source.EMPTY,
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "field",
+                    new EsField("prefix", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+                ),
+                Literal.keyword(Source.EMPTY, "k8s" + ch + "idx")
+            );
+
+            var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
+
+            assertThat(
+                "character '" + ch + "' must not be escaped",
+                query,
+                equalTo(new WildcardQuery(Source.EMPTY, "field", "k8s" + ch + "idx*", false, true))
+            );
+        }
+    }
+
+    public void testLuceneQuery_StringLikeOnIndexFalse() {
+        var function = new StartsWith(
+            Source.EMPTY,
+            new FieldAttribute(
+                Source.EMPTY,
+                "field",
+                new EsField("prefix", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+            ),
+            Literal.keyword(Source.EMPTY, "test")
+        );
+
+        var predicates = LucenePushdownPredicates.forCanMatch(null, new EsqlFlags(false));
+        var query = function.asQuery(predicates, TranslatorHandler.TRANSLATOR_HANDLER);
+
+        assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "test*", false, false)));
     }
 }

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnDashedIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnDashedIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[cluster{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[cluster{f}#0],false]
+    \_ProjectExec[[cluster{f}#0]]
+      \_FieldExtractExec[cluster{f}#0]<[],[],[]>
+        \_EsQueryExec[k8s-downsampled], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "*-downsampled",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnDashedIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnDashedIndex/query.esql
@@ -1,0 +1,3 @@
+FROM k8s-downsampled METADATA _index
+| WHERE ends_with(_index, "-downsampled")
+| KEEP cluster

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "*data",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testEndsWithOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE ends_with(_index, "data")
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeListOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeListOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,11 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "expressionQueryBuilder" : {
+    "field" : "_index",
+    "expression" : "_index LIKE (\"sample*\", \"no_match*\")"
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeListOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeListOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE _index LIKE ("sample*", "no_match*")
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnDashedIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnDashedIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[cluster{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[cluster{f}#0],false]
+    \_ProjectExec[[cluster{f}#0]]
+      \_FieldExtractExec[cluster{f}#0]<[],[],[]>
+        \_EsQueryExec[k8s-downsampled], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "k8s-*",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnDashedIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnDashedIndex/query.esql
@@ -1,0 +1,3 @@
+FROM k8s-downsampled METADATA _index
+| WHERE _index LIKE "k8s-*"
+| KEEP cluster

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "sample*",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE _index LIKE "sample*"
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeSingleCharOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeSingleCharOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,28 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "bool" : {
+    "must" : [
+      {
+        "wildcard" : {
+          "_index" : {
+            "wildcard" : "sample_dat*",
+            "boost" : 0.0
+          }
+        }
+      },
+      {
+        "wildcard" : {
+          "_index" : {
+            "wildcard" : "sample_dat?",
+            "boost" : 0.0
+          }
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeSingleCharOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testLikeSingleCharOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE _index LIKE "sample_dat?"
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeListOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeListOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,11 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "expressionQueryBuilder" : {
+    "field" : "_index",
+    "expression" : "_index RLIKE (\"sample_.*\", \"no_match.*\")"
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeListOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeListOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE _index RLIKE ("sample_.*", "no_match.*")
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,9 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_LimitExec[1000[INTEGER],70]
+          \_FilterExec[RLIKE(_index{m}#1, "sample_.*", false)]
+            \_FieldExtractExec[_index{m}#1]<[],[],[]>
+              \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#2], limit[], sort[] estimatedRowSize[104] queryBuilderAndTags [[QueryBuilderAndTags[query=null, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testRlikeOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE _index RLIKE "sample_.*"
+| KEEP message

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnDashedIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnDashedIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[cluster{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[cluster{f}#0],false]
+    \_ProjectExec[[cluster{f}#0]]
+      \_FieldExtractExec[cluster{f}#0]<[],[],[]>
+        \_EsQueryExec[k8s-downsampled], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "k8s-*",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnDashedIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnDashedIndex/query.esql
@@ -1,0 +1,3 @@
+FROM k8s-downsampled METADATA _index
+| WHERE starts_with(_index, "k8s-")
+| KEEP cluster

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnMetadataIndex/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnMetadataIndex/local_physical_optimization.expected
@@ -1,0 +1,13 @@
+ProjectExec[[message{f}#0]]
+\_LimitExec[1000[INTEGER],null]
+  \_ExchangeExec[[message{f}#0],false]
+    \_ProjectExec[[message{f}#0]]
+      \_FieldExtractExec[message{f}#0]<[],[],[]>
+        \_EsQueryExec[sample_data], indexMode[standard], [_doc{f}#1], limit[1000], sort[] estimatedRowSize[54] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "wildcard" : {
+    "_index" : {
+      "wildcard" : "sample*",
+      "boost" : 0.0
+    }
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnMetadataIndex/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testStartsWithOnMetadataIndex/query.esql
@@ -1,0 +1,3 @@
+FROM sample_data METADATA _index
+| WHERE starts_with(_index, "sample")
+| KEEP message


### PR DESCRIPTION
Manual 9.3 backport of https://github.com/elastic/elasticsearch/pull/146348